### PR TITLE
Spec-level full dynamic block header encoder (encodeDynamicTrees)

### DIFF
--- a/progress/20260223T111622_dcb2c5fc.md
+++ b/progress/20260223T111622_dcb2c5fc.md
@@ -1,0 +1,46 @@
+# Progress: Spec-level full dynamic block header encoder
+
+- **Date**: 2026-02-23T11:16 UTC
+- **Session**: dcb2c5fc (worker, implementation)
+- **Issue**: #71
+
+## What was accomplished
+
+Implemented `encodeDynamicTrees` and supporting definitions in
+`Zip/Spec/DeflateEncode.lean`, completing the DEFLATE dynamic block
+header encode pipeline.
+
+### New definitions
+- `clPermutation` — CL code length alphabet order (matches decode-side `codeLengthOrder`)
+- `clSymbolFreqs` — count CL symbol frequencies from `CLEntry` list
+- `encodeCLExtra` — encode extra bits for CL entries (codes 16/17/18)
+- `writeCLLengths` — write CL code lengths in permuted order as 3-bit values
+- `encodeCLEntries` — encode CL entries using Huffman table + extra bits
+- `computeHCLEN` — determine number of CL code lengths to transmit
+- `encodeDynamicTrees` — full dynamic block header encoder composing all building blocks
+
+### Roundtrip theorem stated
+- `encodeDynamicTrees_decodeDynamicTables` — states that encoding then decoding
+  recovers the original lit/len and distance code lengths. Proof is `sorry`
+  (intentional — deferred to a follow-up session).
+
+### Verified via `#eval`
+- Simple case (257 uniform lit codes + 1 dist code): roundtrip succeeds
+- Fixed Huffman lengths (288 lit + 30 dist codes): roundtrip succeeds
+- Sanity checks removed before commit
+
+## Decisions
+- Changed input size guards from the plan's `litLens.length ≤ 286` / `distLens.length ≤ 30`
+  to `≤ 288` / `≤ 32` to match the actual RFC 1951 limits (HLIT is 5 bits → 0-31 → 257-288,
+  HDIST is 5 bits → 0-31 → 1-32)
+- Added `import Zip.Spec.HuffmanEncode` to access `computeCodeLengths`
+
+## Sorry count
+- Before: 11 (HuffmanEncode: 1, DeflateFixedCorrect: 5, DeflateStoredCorrect: 5)
+- After: 12 (+1 intentional: `encodeDynamicTrees_decodeDynamicTables`)
+
+## What remains
+- `DeflateEncode.lean` is now 1222 lines — a future review session should consider
+  splitting it (e.g., dynamic header encoding into a separate file)
+- Proving `encodeDynamicTrees_decodeDynamicTables` (separate session)
+- Integrating `encodeDynamicTrees` into a full dynamic block encoder


### PR DESCRIPTION
Closes #71

Session: `dcb2c5fc-cc73-4915-aa58-8be1a7278108`

0ab1861 feat: spec-level dynamic block header encoder (encodeDynamicTrees)

🤖 Prepared with Claude Code