### PR TITLE
Prove canonicalCodes ↔ allCodes Huffman code correspondence

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -20,6 +20,7 @@ import Zip.Spec.BitstreamCorrect
 import Zip.Spec.BitstreamWriteCorrect
 import Zip.Spec.BitWriterCorrect
 import Zip.Spec.HuffmanCorrect
+import Zip.Spec.HuffmanEncodeCorrect
 import Zip.Spec.DecodeCorrect
 import Zip.Spec.DynamicTreesCorrect
 import Zip.Spec.InflateCorrect

--- a/Zip/Spec/HuffmanEncodeCorrect.lean
+++ b/Zip/Spec/HuffmanEncodeCorrect.lean
@@ -1,0 +1,386 @@
+import Zip.Spec.HuffmanCorrect
+import Zip.Native.Deflate
+
+/-!
+# Canonical Codes Encode Correctness
+
+Proves that `canonicalCodes` (used by the native DEFLATE compressor) assigns
+the same code values as `codeFor` (the spec's per-symbol code computation).
+This bridges native encoding to spec decoding: the codes written by the
+compressor correspond to leaves in the Huffman tree built by the decompressor.
+-/
+
+namespace Deflate.Correctness
+
+/-! ### Array helper lemmas -/
+
+/-- `Array.set!` at a different index preserves the element (pairs). -/
+private theorem array_set_ne_pair (arr : Array (UInt16 × UInt8)) (i j : Nat)
+    (v : UInt16 × UInt8) (hij : i ≠ j) :
+    (arr.set! i v)[j]! = arr[j]! := by
+  simp [Array.getElem!_eq_getD, Array.getD_eq_getD_getElem?,
+        Array.set!_eq_setIfInBounds, Array.getElem?_setIfInBounds_ne hij]
+
+/-- `Array.set!` at the same index replaces the value (pairs). -/
+private theorem array_set_self_pair (arr : Array (UInt16 × UInt8)) (i : Nat)
+    (v : UInt16 × UInt8) (hi : i < arr.size) :
+    (arr.set! i v)[i]! = v := by
+  simp [Array.getElem!_eq_getD, Array.getD_eq_getD_getElem?,
+        Array.set!_eq_setIfInBounds, Array.getElem?_setIfInBounds_self_of_lt hi]
+
+/-- `Array.set!` at a different index preserves the element (UInt32). -/
+private theorem array_set_ne_u32 (arr : Array UInt32) (i j : Nat) (v : UInt32) (hij : i ≠ j) :
+    (arr.set! i v)[j]! = arr[j]! := by
+  simp [Array.getElem!_eq_getD, Array.getD_eq_getD_getElem?,
+        Array.set!_eq_setIfInBounds, Array.getElem?_setIfInBounds_ne hij]
+
+/-- `Array.set!` at the same index replaces the value (UInt32). -/
+private theorem array_set_self_u32 (arr : Array UInt32) (i : Nat) (v : UInt32) (hi : i < arr.size) :
+    (arr.set! i v)[i]! = v := by
+  simp [Array.getElem!_eq_getD, Array.getD_eq_getD_getElem?,
+        Array.set!_eq_setIfInBounds, Array.getElem?_setIfInBounds_self_of_lt hi]
+
+/-- `codeFor` returns `some` for symbols with valid nonzero length. -/
+private theorem codeFor_some (lsList : List Nat) (maxBits : Nat) (s : Nat)
+    (hs : s < lsList.length) (hlen : lsList[s] ≠ 0) (hle : lsList[s] ≤ maxBits) :
+    ∃ cw, Huffman.Spec.codeFor lsList maxBits s = some cw := by
+  simp only [Huffman.Spec.codeFor, show s < lsList.length from hs, ↓reduceDIte]
+  simp only [show (lsList[s] == 0 || decide (lsList[s] > maxBits)) = false from by
+    simp [hlen]; omega]
+  exact ⟨_, rfl⟩
+
+/-! ### Size preservation -/
+
+/-- `canonicalCodes.go` preserves the result array size. -/
+private theorem canonicalCodes_go_size (lengths : Array UInt8) (nextCode : Array UInt32)
+    (i : Nat) (result : Array (UInt16 × UInt8)) :
+    (Zip.Native.Deflate.canonicalCodes.go lengths nextCode i result).size = result.size := by
+  unfold Zip.Native.Deflate.canonicalCodes.go
+  split
+  · dsimp only []
+    split
+    · rw [canonicalCodes_go_size]
+      simp [Array.set!_eq_setIfInBounds, Array.setIfInBounds]; split <;> simp_all
+    · exact canonicalCodes_go_size lengths nextCode (i + 1) result
+  · rfl
+termination_by lengths.size - i
+
+/-! ### Main loop invariant -/
+
+/-- Loop invariant for `canonicalCodes.go`. Given that:
+    - The `nextCode` array tracks `ncSpec + partial offset` (NC invariant)
+    - Entries at positions `< i` are already correct
+    - Entries at positions `≥ i` are still `(0, 0)` (initial value)
+    The final result has correct entries for all positions. -/
+private theorem canonicalCodes_go_inv
+    (lengths : Array UInt8) (nextCode : Array UInt32) (i : Nat)
+    (result : Array (UInt16 × UInt8))
+    (lsList : List Nat) (hlsList : lsList = lengths.toList.map UInt8.toNat)
+    (maxBits : Nat) (hmb : maxBits < 16)
+    (blCount : Array Nat) (hblCount : blCount = Huffman.Spec.countLengths lsList maxBits)
+    (ncSpec : Array Nat) (hncSpec : ncSpec = Huffman.Spec.nextCodes blCount maxBits)
+    (hv : Huffman.Spec.ValidLengths lsList maxBits)
+    (hresSize : result.size = lengths.size)
+    (hncSize : nextCode.size ≥ maxBits + 1)
+    -- NC invariant
+    (hnc : ∀ b, 1 ≤ b → b ≤ maxBits →
+      nextCode[b]!.toNat = ncSpec[b]! +
+        (lsList.take i).foldl (fun acc l => if (l == b) = true then acc + 1 else acc) 0)
+    -- Result entries at positions < i are correct
+    (hprev : ∀ j, j < i → (hjs : j < lengths.size) →
+      if lengths[j] > 0 then
+        result[j]!.2 = lengths[j] ∧
+        result[j]!.1.toNat = ncSpec[lengths[j].toNat]! +
+          (lsList.take j).foldl (fun acc l => if (l == lengths[j].toNat) = true then acc + 1 else acc) 0
+      else result[j]! = (0, 0))
+    -- Entries at positions ≥ i are (0, 0)
+    (hfut : ∀ j, i ≤ j → j < lengths.size → result[j]! = (0, 0))
+    -- Target
+    (j : Nat) (hjs : j < lengths.size) :
+    let final := Zip.Native.Deflate.canonicalCodes.go lengths nextCode i result
+    if lengths[j] > 0 then
+      final[j]!.2 = lengths[j] ∧
+      final[j]!.1.toNat = ncSpec[lengths[j].toNat]! +
+        (lsList.take j).foldl (fun acc l => if (l == lengths[j].toNat) = true then acc + 1 else acc) 0
+    else final[j]! = (0, 0) := by
+  unfold Zip.Native.Deflate.canonicalCodes.go
+  split
+  · -- i < lengths.size
+    rename_i hi
+    dsimp only []
+    by_cases hlen_pos : lengths[i] > 0
+    · -- lengths[i] > 0: insert case
+      simp only [hlen_pos, ↓reduceIte]
+      -- Bridge UInt8 comparison to Nat
+      have hlen_pos_nat : 0 < lengths[i].toNat := hlen_pos
+      -- Common setup
+      have hls_len : i < lsList.length := by simp [hlsList, hi]
+      have hls_i : lsList[i] = lengths[i].toNat := by
+        simp only [hlsList, List.getElem_map, Array.getElem_toList]; rfl
+      have hlen_le : lengths[i].toNat ≤ maxBits := by
+        rw [← hls_i]; exact hv.1 _ (List.getElem_mem hls_len)
+      -- Code value from NC invariant
+      have hcode_val := hnc lengths[i].toNat (by omega) hlen_le
+      -- Partial count ≤ total count (for bounding)
+      have h_partial_le : (lsList.take i).foldl
+          (fun acc l => if (l == lengths[i].toNat) = true then acc + 1 else acc) 0 ≤
+          lsList.foldl
+          (fun acc l => if (l == lengths[i].toNat) = true then acc + 1 else acc) 0 := by
+        rw [show lsList.foldl
+          (fun acc l => if (l == lengths[i].toNat) = true then acc + 1 else acc) 0 =
+          (lsList.drop i).foldl
+            (fun acc l => if (l == lengths[i].toNat) = true then acc + 1 else acc)
+            ((lsList.take i).foldl
+              (fun acc l => if (l == lengths[i].toNat) = true then acc + 1 else acc) 0)
+          from by rw [← List.foldl_append, List.take_append_drop]]
+        exact Huffman.Spec.count_foldl_mono _ _ _
+      -- Full bound: nc + total_count ≤ 2^len
+      have h_npc := Huffman.Spec.nextCodes_plus_count_le lsList maxBits
+        lengths[i].toNat hv (by omega) hlen_le
+      rw [← hblCount, ← hncSpec] at h_npc
+      have h_pow := Nat.pow_le_pow_right (by omega : 0 < 2)
+        (show lengths[i].toNat ≤ 31 from by omega)
+      -- Apply recursive case
+      exact canonicalCodes_go_inv lengths
+        (nextCode.set! lengths[i].toNat (nextCode[lengths[i].toNat]! + 1))
+        (i + 1)
+        (result.set! i ((nextCode[lengths[i].toNat]!).toUInt16, lengths[i]))
+        lsList hlsList maxBits hmb blCount hblCount ncSpec hncSpec hv
+        (by -- hresSize: set! preserves array size
+          simp [Array.set!_eq_setIfInBounds, Array.setIfInBounds, hresSize]
+          split <;> simp_all)
+        (by -- hncSize: set! preserves array size
+          simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds]
+          split
+          · simp_all
+          · exact hncSize)
+        (by -- hnc': NC invariant after increment
+          intro b hb1 hb15
+          rw [List.take_add_one]
+          simp only [List.getElem?_eq_getElem hls_len, Option.toList,
+                     List.foldl_append, List.foldl_cons, List.foldl_nil, hls_i]
+          by_cases hbeq : lengths[i].toNat = b
+          · -- b = len: both sides incremented
+            subst hbeq
+            simp only [beq_self_eq_true, ↓reduceIte]
+            rw [array_set_self_u32 _ _ _ (show lengths[i].toNat < nextCode.size from by omega)]
+            rw [UInt32.toNat_add, show (1 : UInt32).toNat = 1 from rfl,
+                Nat.mod_eq_of_lt (by omega), hcode_val]
+            omega
+          · -- b ≠ len: unchanged
+            have hf : ¬((lengths[i].toNat == b) = true) := by
+              rw [beq_iff_eq]; exact hbeq
+            simp only [if_neg hf]
+            rw [array_set_ne_u32 _ _ _ _ hbeq]
+            exact hnc b hb1 hb15)
+        (by -- hprev': entries < i+1 are correct
+          intro k hk hks
+          by_cases hk_eq : k = i
+          · -- k = i: newly set entry
+            simp only [hk_eq]
+            rw [array_set_self_pair result i _ (show i < result.size from by omega)]
+            simp only [hlen_pos, ↓reduceIte]
+            refine ⟨trivial, ?_⟩
+            -- UInt32 → UInt16 → Nat faithfulness
+            change (nextCode[lengths[i].toNat]!).toUInt16.toNat = _
+            rw [show ∀ (x : UInt32), x.toUInt16.toNat = x.toNat % 65536 from fun _ => rfl,
+                hcode_val, Nat.mod_eq_of_lt]
+            -- ncSpec + partial count < 65536
+            have : 2 ^ lengths[i].toNat ≤ 32768 :=
+              Nat.pow_le_pow_right (by omega) (show lengths[i].toNat ≤ 15 from by omega)
+            omega
+          · -- k < i: preserved by set! at different index
+            rw [array_set_ne_pair result i k _ (Ne.symm hk_eq)]
+            exact hprev k (by omega) hks)
+        (by -- hfut': entries at ≥ i+1 are still (0,0)
+          intro k hk hks
+          rw [array_set_ne_pair result i k _ (by omega)]
+          exact hfut k (by omega) hks)
+        j hjs
+    · -- lengths[i] = 0: skip case
+      simp only [hlen_pos, ↓reduceIte]
+      have hlen_zero_nat : ¬(0 < lengths[i].toNat) := hlen_pos
+      have hls_len : i < lsList.length := by simp [hlsList, hi]
+      have hls_val : lsList[i] = 0 := by
+        have h0 : lengths[i].toNat = 0 := by omega
+        simp [hlsList]; exact h0
+      exact canonicalCodes_go_inv lengths nextCode (i + 1) result
+        lsList hlsList maxBits hmb blCount hblCount ncSpec hncSpec hv hresSize hncSize
+        (by -- NC: lsList[i] = 0 doesn't change count for any b ≥ 1
+          intro b hb1 hb15
+          rw [hnc b hb1 hb15]; congr 1
+          rw [List.take_add_one]
+          simp only [List.getElem?_eq_getElem hls_len, Option.toList,
+                     List.foldl_append, List.foldl_cons, List.foldl_nil, hls_val]
+          have : ¬((0 == b) = true) := by rw [beq_iff_eq]; omega
+          simp [this])
+        (by -- hprev: extend to cover i (which has length 0)
+          intro k hk hks
+          by_cases hk_eq : k = i
+          · simp only [hk_eq]
+            have hfut_i := hfut i Nat.le.refl hi
+            simp [hlen_pos, hfut_i]
+          · exact hprev k (by omega) hks)
+        (by -- hfut: positions ≥ i+1 still (0,0)
+          intro k hk hks
+          exact hfut k (by omega) hks)
+        j hjs
+  · -- i ≥ lengths.size: base case
+    exact hprev j (by omega) hjs
+termination_by lengths.size - i
+
+/-! ### Initial NC invariant -/
+
+/-- Prove the initial NC invariant for `nextCode = ncSpec.map (·.toUInt32)`. -/
+private theorem initial_nc_invariant
+    (lsList : List Nat) (maxBits : Nat) (hmb : maxBits < 32)
+    (hv : Huffman.Spec.ValidLengths lsList maxBits)
+    (ncSpec : Array Nat) (hncSpec : ncSpec = Huffman.Spec.nextCodes
+      (Huffman.Spec.countLengths lsList maxBits) maxBits)
+    (b : Nat) (hb1 : 1 ≤ b) (hb15 : b ≤ maxBits) :
+    (ncSpec.map (fun (n : Nat) => n.toUInt32))[b]!.toNat = ncSpec[b]! := by
+  have hbs : b < ncSpec.size := by
+    rw [hncSpec, Huffman.Spec.nextCodes_size]; omega
+  simp only [Array.getElem!_eq_getD, Array.getD_eq_getD_getElem?]
+  rw [Array.getElem?_map, Array.getElem?_eq_getElem hbs]
+  simp only [Option.map_some, Option.getD_some]
+  have h_npc := Huffman.Spec.nextCodes_plus_count_le lsList maxBits b hv (by omega) hb15
+  rw [← hncSpec] at h_npc
+  simp only [Array.getElem!_eq_getD, Array.getD_eq_getD_getElem?,
+             Array.getElem?_eq_getElem hbs, Option.getD_some] at h_npc
+  have h_pow := Nat.pow_le_pow_right (by omega : 0 < 2) (show b ≤ 31 from by omega)
+  show ncSpec[b].toUInt32.toNat = ncSpec[b]
+  rw [show ∀ n : Nat, n.toUInt32.toNat = n % 2 ^ 32 from fun _ => rfl,
+      Nat.mod_eq_of_lt (by omega)]
+
+/-! ### Top-level correspondence theorems -/
+
+/-- For symbols with non-zero code length, `canonicalCodes` produces the same
+    code value as spec's `codeFor`. The UInt16 stored by `canonicalCodes` equals
+    the numeric code value, and `natToBits` of this value gives the spec codeword.
+    Requires `maxBits < 16` for UInt16 faithfulness. -/
+protected theorem canonicalCodes_correct_pos (lengths : Array UInt8) (maxBits : Nat)
+    (hv : Huffman.Spec.ValidLengths (lengths.toList.map UInt8.toNat) maxBits)
+    (hmb : maxBits < 16)
+    (i : Nat) (hi : i < lengths.size) (hlen : lengths[i] > 0) :
+    ∃ cw, Huffman.Spec.codeFor (lengths.toList.map UInt8.toNat) maxBits i = some cw ∧
+      cw = Huffman.Spec.natToBits
+        (Zip.Native.Deflate.canonicalCodes lengths maxBits)[i]!.1.toNat
+        lengths[i].toNat ∧
+      (Zip.Native.Deflate.canonicalCodes lengths maxBits)[i]!.2 = lengths[i] := by
+  let lsList := lengths.toList.map UInt8.toNat
+  have hlen_pos_nat : 0 < lengths[i].toNat := hlen
+  have hls_len : i < lsList.length := by simp [lsList, hi]
+  have hls_i : lsList[i] = lengths[i].toNat := by
+    simp only [lsList, List.getElem_map, Array.getElem_toList]; rfl
+  have hlen_le : lengths[i].toNat ≤ maxBits := by
+    rw [← hls_i]; exact hv.1 _ (List.getElem_mem hls_len)
+  -- codeFor succeeds
+  obtain ⟨cw, hcf⟩ := codeFor_some lsList maxBits i hls_len (by rw [hls_i]; omega) (by rw [hls_i]; omega)
+  refine ⟨cw, hcf, ?_, ?_⟩
+  · -- cw = natToBits of the stored code value
+    obtain ⟨_, _, hcw⟩ := Huffman.Spec.codeFor_spec hcf
+    -- Rewrite lsList[i] to lengths[i].toNat in hcw
+    rw [hls_i] at hcw
+    rw [hcw]; congr 1
+    -- Get the invariant result
+    simp only [Zip.Native.Deflate.canonicalCodes]
+    let ncSpec := Huffman.Spec.nextCodes (Huffman.Spec.countLengths lsList maxBits) maxBits
+    have hinv := canonicalCodes_go_inv lengths
+      (ncSpec.map fun (n : Nat) => n.toUInt32)
+      0 (Array.replicate lengths.size (0, 0))
+      lsList rfl maxBits hmb _ rfl ncSpec rfl hv
+      (Array.size_replicate ..)
+      (by -- hncSize
+        have : (ncSpec.map fun (n : Nat) => n.toUInt32).size = ncSpec.size := Array.size_map ..
+        rw [this, show ncSpec = Huffman.Spec.nextCodes _ _ from rfl,
+            Huffman.Spec.nextCodes_size]; omega)
+      (by -- Initial NC
+        intro b hb1 hb15
+        simp only [List.take_zero, List.foldl_nil, Nat.add_zero]
+        exact initial_nc_invariant lsList maxBits (by omega) hv ncSpec rfl b hb1 hb15)
+      (by intro k hk; omega)
+      (by intro k _ hks; simp [show k < lengths.size from hks])
+      i hi
+    simp only [hlen, ↓reduceIte] at hinv
+    exact hinv.2.symm
+  · -- Length matches
+    simp only [Zip.Native.Deflate.canonicalCodes]
+    let ncSpec := Huffman.Spec.nextCodes (Huffman.Spec.countLengths lsList maxBits) maxBits
+    have hinv := canonicalCodes_go_inv lengths
+      (ncSpec.map fun (n : Nat) => n.toUInt32)
+      0 (Array.replicate lengths.size (0, 0))
+      lsList rfl maxBits hmb _ rfl ncSpec rfl hv
+      (Array.size_replicate ..)
+      (by have : (ncSpec.map fun (n : Nat) => n.toUInt32).size = ncSpec.size := Array.size_map ..
+          rw [this, show ncSpec = Huffman.Spec.nextCodes _ _ from rfl,
+              Huffman.Spec.nextCodes_size]; omega)
+      (by intro b hb1 hb15
+          simp only [List.take_zero, List.foldl_nil, Nat.add_zero]
+          exact initial_nc_invariant lsList maxBits (by omega) hv ncSpec rfl b hb1 hb15)
+      (by intro k hk; omega)
+      (by intro k _ hks; simp [show k < lengths.size from hks])
+      i hi
+    simp only [hlen, ↓reduceIte] at hinv
+    exact hinv.1
+
+/-- For symbols with zero code length, `canonicalCodes` stores `(0, 0)`. -/
+protected theorem canonicalCodes_correct_zero (lengths : Array UInt8) (maxBits : Nat)
+    (hv : Huffman.Spec.ValidLengths (lengths.toList.map UInt8.toNat) maxBits)
+    (hmb : maxBits < 16)
+    (i : Nat) (hi : i < lengths.size) (hlen : ¬(lengths[i] > 0)) :
+    (Zip.Native.Deflate.canonicalCodes lengths maxBits)[i]! = (0, 0) := by
+  let lsList := lengths.toList.map UInt8.toNat
+  let ncSpec := Huffman.Spec.nextCodes (Huffman.Spec.countLengths lsList maxBits) maxBits
+  simp only [Zip.Native.Deflate.canonicalCodes]
+  have hinv := canonicalCodes_go_inv lengths
+    (ncSpec.map fun (n : Nat) => n.toUInt32)
+    0 (Array.replicate lengths.size (0, 0))
+    lsList rfl maxBits hmb _ rfl ncSpec rfl hv
+    (Array.size_replicate ..)
+    (by have : (ncSpec.map fun (n : Nat) => n.toUInt32).size = ncSpec.size := Array.size_map ..
+        rw [this, show ncSpec = Huffman.Spec.nextCodes _ _ from rfl,
+            Huffman.Spec.nextCodes_size]; omega)
+    (by intro b hb1 hb15
+        simp only [List.take_zero, List.foldl_nil, Nat.add_zero]
+        exact initial_nc_invariant lsList maxBits (by omega) hv ncSpec rfl b hb1 hb15)
+    (by intro k hk; omega)
+    (by intro k _ hks; simp [show k < lengths.size from hks])
+    i hi
+  simp only [hlen, ↓reduceIte] at hinv
+  exact hinv
+
+/-- Bridge theorem: the tree built by `fromLengths` has a leaf at the codeword
+    stored by `canonicalCodes`, connecting the native encoder to the decoder. -/
+protected theorem canonicalCodes_hasLeaf (lengths : Array UInt8)
+    (maxBits : Nat) (hmb : maxBits < 16)
+    (tree : Zip.Native.HuffTree)
+    (htree : Zip.Native.HuffTree.fromLengths lengths maxBits = .ok tree)
+    (hv : Huffman.Spec.ValidLengths (lengths.toList.map UInt8.toNat) maxBits)
+    (i : Nat) (hi : i < lengths.size) (hlen : lengths[i] > 0) :
+    let codes := Zip.Native.Deflate.canonicalCodes lengths maxBits
+    TreeHasLeaf tree
+      (Huffman.Spec.natToBits codes[i]!.1.toNat codes[i]!.2.toNat)
+      i.toUInt16 := by
+  intro codes
+  let lsList := lengths.toList.map UInt8.toNat
+  have hls_len : i < lsList.length := by simp [lsList, hi]
+  have hls_i : lsList[i] = lengths[i].toNat := by
+    simp only [lsList, List.getElem_map, Array.getElem_toList]; rfl
+  obtain ⟨cw, hcf, hcw, hlen_eq⟩ :=
+    Deflate.Correctness.canonicalCodes_correct_pos lengths maxBits hv hmb i hi hlen
+  -- The tree has a leaf for this codeword
+  have hmem : (i, cw) ∈ Huffman.Spec.allCodes lsList maxBits := by
+    rw [Huffman.Spec.allCodes_mem_iff]
+    exact ⟨hls_len, hcf⟩
+  have hleaf := Deflate.Correctness.fromLengths_hasLeaf lengths maxBits (by omega) tree htree hv i cw hmem
+  -- Connect cw to the natToBits of canonicalCodes values
+  rw [hcw] at hleaf
+  -- hleaf: TreeHasLeaf tree (natToBits (canonicalCodes ...)[i]!.1.toNat lengths[i].toNat) ...
+  -- goal: TreeHasLeaf tree (natToBits codes[i]!.1.toNat codes[i]!.2.toNat) ...
+  -- codes = canonicalCodes lengths maxBits by let binding
+  rw [hlen_eq]
+  -- goal: TreeHasLeaf tree (natToBits codes[i]!.1.toNat lengths[i].toNat) ...
+  exact hleaf
+
+end Deflate.Correctness

--- a/progress/20260223T_1a7c6bc9.md
+++ b/progress/20260223T_1a7c6bc9.md
@@ -1,0 +1,50 @@
+# Progress: canonicalCodes ↔ allCodes Huffman code correspondence
+
+- **Date**: 2026-02-23 UTC
+- **Session type**: Worker (implementation)
+- **Issue**: #83
+
+## What was accomplished
+
+Created `Zip/Spec/HuffmanEncodeCorrect.lean` with complete proofs (0 sorries):
+
+1. **`canonicalCodes_go_size`**: Size preservation — `canonicalCodes.go` preserves
+   the result array size through recursion.
+
+2. **`canonicalCodes_go_inv`**: Main loop invariant proving that at each step:
+   - NextCode array tracks `ncSpec + partial offset` (NC invariant)
+   - Processed entries match spec's `codeFor` computation
+   - Unprocessed entries remain `(0, 0)`
+
+3. **`initial_nc_invariant`**: Proves the initial NextCode state
+   (`ncSpec.map (·.toUInt32)`) satisfies the NC invariant.
+
+4. **`canonicalCodes_correct_pos`**: For symbols with nonzero code length,
+   `canonicalCodes` produces the same code value as `codeFor`.
+   Requires `maxBits < 16` for UInt16 faithfulness.
+
+5. **`canonicalCodes_correct_zero`**: For symbols with zero code length,
+   `canonicalCodes` stores `(0, 0)`.
+
+6. **`canonicalCodes_hasLeaf`**: Bridge theorem connecting the native encoder's
+   stored codes to decoder tree leaves via `fromLengths_hasLeaf`.
+
+## Key proof techniques
+
+- **`by_cases` instead of `split` for nested `if`**: After `unfold` + `dsimp`,
+  the goal has multiple `if` expressions. `split` captures the outermost one
+  (from the conclusion), not the function body's. `by_cases hlen_pos : lengths[i] > 0`
+  explicitly targets the correct condition.
+
+- **`simp only [hk_eq]` for dependent type rewriting**: `rw [hk_eq]` fails on
+  `lengths[k]` because the array access depends on `hks : k < lengths.size`.
+  `simp only [hk_eq]` handles dependent type rewriting via congr lemmas.
+
+- **UInt16 faithfulness bound**: `maxBits < 16` ensures `ncSpec + count ≤ 2^len
+  ≤ 2^15 = 32768 < 65536 = 2^16`, making `UInt32.toUInt16.toNat` faithful.
+
+## Sorry count
+
+- Start: 10
+- End: 10
+- Delta: 0 (new file has 0 sorries; no existing sorries changed)


### PR DESCRIPTION
Closes #83

Session: `1a7c6bc9-571b-4cf0-9f63-bbbaba250fcc`

365b2f4 feat: Prove canonicalCodes ↔ allCodes Huffman code correspondence (#83)

🤖 Prepared with Claude Code