### PR TITLE
chore: use needs-replan label for partial completions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -180,7 +180,7 @@ Session UUID is available as `$LEAN_ZIP_SESSION_ID` (exported by `./go`).
 |---------|-------------|
 | `coordination orient` | List unclaimed/claimed issues, open PRs, PRs needing attention |
 | `coordination plan "title"` | Create GitHub issue with agent-plan label; body from stdin |
-| `coordination create-pr N [--partial] ["title"]` | Push branch, create PR closing issue #N (custom title optional), enable auto-merge, swap `claimed` → `has-pr`. With `--partial`: uses "Partial progress on #N", returns issue to unclaimed queue |
+| `coordination create-pr N [--partial] ["title"]` | Push branch, create PR closing issue #N (custom title optional), enable auto-merge, swap `claimed` → `has-pr`. With `--partial`: uses "Partial progress on #N", adds `needs-replan` label |
 | `coordination claim-fix N` | Comment on failing PR #N claiming fix (30min cooldown) |
 | `coordination close-pr N "reason"` | Comment reason and close PR #N |
 | `coordination list-unclaimed` | List unclaimed agent-plan issues (FIFO order) |
@@ -197,6 +197,10 @@ worker claims it (adds label: `claimed`) → worker creates PR closing it
 Skipped issues (label: `skip`) can be revised by the next planner.
 Issues with `has-pr` appear in orient under "Issues with open PRs" and
 are excluded from `list-unclaimed` and `queue-depth`.
+**Partial completion**: worker uses `--partial` → label swaps to
+`needs-replan` (excluded from `list-unclaimed`). A planner creates a
+new issue for remaining work, then closes the `needs-replan` issue with
+a link to the new one. This preserves full history.
 
 **Dependencies**: Issues can declare `depends-on: #N` in their body.
 `coordination plan` auto-adds the `blocked` label if any dependency is

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -85,6 +85,27 @@ If the existing issue is already claimed, still add the body dependency and
 comment so the worker is aware, but don't add `blocked` (the worker can
 decide how to handle it).
 
+**Handling `needs-replan` issues**: When a worker makes partial progress, the
+issue gets a `needs-replan` label (excluded from `list-unclaimed`). During
+orientation, check for these:
+```
+gh issue list --repo kim-em/lean-zip --label needs-replan --state open --limit 10 \
+    --json number,title --jq '.[] | "#\(.number) \(.title)"'
+```
+For each `needs-replan` issue:
+1. Read the partial PR and progress entry to understand what was done
+2. Create a **new issue** for the remaining work, referencing the original:
+   - Include "Continues #N" and a link to the partial PR for context
+   - Describe only the remaining deliverables (what was NOT done)
+   - Add any new context learned from the partial attempt
+3. Close the original `needs-replan` issue with a comment linking forward:
+   ```
+   gh issue close <N> --repo kim-em/lean-zip \
+       --comment "Remaining work replanned in #<new-issue>. Partial progress in PR #<partial-pr>."
+   ```
+4. If other open issues had `depends-on: #<N>`, update them to depend on
+   the new issue instead
+
 **Filling gaps from partial completions**: When orientation reveals that a PR
 made partial progress on an issue (the issue was closed but deliverables remain
 unfinished, or a PR title doesn't match the issue scope):

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -105,7 +105,8 @@ Write a progress entry to `progress/<UTC-timestamp>_<UUID-prefix>.md` with:
   coordination create-pr <N> --partial "feat: prove helper lemmas for inflate_deflateFixed"
   ```
   This uses "Partial progress on #N" instead of "Closes #N" in the PR body,
-  and returns the issue to the unclaimed queue so a planner can reschedule it.
+  and adds a `needs-replan` label so the issue is held out of the unclaimed
+  queue until a planner re-scopes the remaining work.
 
 **If you completed all deliverables**, commit, push, and create a PR normally:
 ```

--- a/coordination
+++ b/coordination
@@ -36,7 +36,7 @@ gh auth status --hostname github.com >/dev/null 2>&1 || \
 _unclaimed_issues() {
     gh issue list --repo "$REPO" --label agent-plan --state open --limit 50 \
         --json number,title,labels,createdAt \
-        --jq '[.[] | select(.labels | all(.name != "claimed") and all(.name != "skip") and all(.name != "blocked") and all(.name != "has-pr"))] |
+        --jq '[.[] | select(.labels | all(.name != "claimed") and all(.name != "skip") and all(.name != "blocked") and all(.name != "has-pr") and all(.name != "needs-replan"))] |
               sort_by(.createdAt)'
 }
 
@@ -207,7 +207,11 @@ cmd_create_pr() {
         echo "PR #$existing_pr already exists for branch $BRANCH. Enabling auto-merge."
         gh pr merge "$existing_pr" --repo "$REPO" --auto --squash || \
             echo "warning: auto-merge not available (branch protection may not be set up)"
-        if [[ "$partial" != true ]]; then
+        if [[ "$partial" == true ]]; then
+            # Partial: needs-replan so planner can re-scope before another worker claims
+            gh issue edit "$issue_num" --repo "$REPO" --remove-label claimed --add-label needs-replan 2>/dev/null || true
+            echo "Issue #$issue_num marked needs-replan (partial completion)"
+        else
             gh issue edit "$issue_num" --repo "$REPO" --remove-label claimed --add-label has-pr 2>/dev/null || true
         fi
         return 0
@@ -238,9 +242,9 @@ EOF
 
     # Update issue labels
     if [[ "$partial" == true ]]; then
-        # Partial: remove claimed so issue returns to unclaimed queue
-        gh issue edit "$issue_num" --repo "$REPO" --remove-label claimed 2>/dev/null || true
-        echo "Issue #$issue_num returned to unclaimed queue (partial completion)"
+        # Partial: needs-replan so planner can re-scope before another worker claims
+        gh issue edit "$issue_num" --repo "$REPO" --remove-label claimed --add-label needs-replan 2>/dev/null || true
+        echo "Issue #$issue_num marked needs-replan (partial completion)"
     else
         # Full: claimed → has-pr
         gh issue edit "$issue_num" --repo "$REPO" --remove-label claimed --add-label has-pr 2>/dev/null || true


### PR DESCRIPTION
Improves the partial completion flow introduced in #116:

- `--partial` now adds `needs-replan` label instead of returning issue directly to unclaimed queue (prevents workers from re-claiming stale scope before a planner re-scopes)
- `_unclaimed_issues` excludes `needs-replan` from the queue
- Fix: existing-PR early-return path now correctly handles `--partial` label transition
- Planner instructions: close `needs-replan` issue and create a fresh issue for remaining work (preserves history via bidirectional links)

🤖 Prepared with Claude Code