### PR TITLE
Fix deflateDynamic stack overflow: use lz77GreedyIter for level 5+

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -124,7 +124,7 @@ where
 /-- Compress data using dynamic Huffman codes and greedy LZ77 (Level 5).
     Produces a single DEFLATE block with BFINAL=1, BTYPE=10. -/
 def deflateDynamic (data : ByteArray) (windowSize : Nat := 32768) : ByteArray :=
-  let tokens := lz77Greedy data windowSize
+  let tokens := lz77GreedyIter data windowSize
   let (litFreqs, distFreqs) := tokenFreqs tokens
   -- Convert frequencies to (symbol, freq) pairs
   let litFreqPairs := (List.range litFreqs.size).map fun i => (i, litFreqs[i]!)

--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -368,7 +368,8 @@ theorem deflateDynamic_spec (data : ByteArray) :
         have hdef : deflateDynamic data =
             (bw4.writeHuffCode litCodes[256]!.1 litCodes[256]!.2).flush := by
           unfold deflateDynamic
-          -- After unfold, we have `let (litFreqs, distFreqs) := tokenFreqs tokens; ...`
+          rw [lz77GreedyIter_eq_lz77Greedy]
+          -- After unfold + rewrite, we have `let (litFreqs, distFreqs) := tokenFreqs tokens; ...`
           -- This is definitionally equal to using .1/.2, and `let (code, len) := litCodes[256]!`
           -- is definitionally equal to using .1/.2. So `split` on the `if` suffices.
           split

--- a/progress/20260301T235500Z_a341e8a3.md
+++ b/progress/20260301T235500Z_a341e8a3.md
@@ -1,0 +1,31 @@
+# Progress: fix deflateDynamic stack overflow
+
+**Date**: 2026-03-01 23:55 UTC
+**Session**: feature
+**Issue**: #370
+
+## Accomplished
+
+Switched `deflateDynamic` (Level 5+ compressor) from non-tail-recursive
+`lz77Greedy` to tail-recursive `lz77GreedyIter`, fixing stack overflow
+on inputs above ~50KB.
+
+### Changes
+
+1. **Zip/Native/DeflateDynamic.lean**: Changed `lz77Greedy data windowSize`
+   to `lz77GreedyIter data windowSize` (1-line change).
+
+2. **Zip/Spec/DeflateDynamicCorrect.lean**: Added
+   `rw [lz77GreedyIter_eq_lz77Greedy]` after `unfold deflateDynamic` in
+   `deflateDynamic_spec` to rewrite back to `lz77Greedy` for downstream
+   proof compatibility. Same pattern used in `inflate_deflateFixedIter`.
+
+3. **DeflateRoundtrip.lean**: No changes needed — its proofs go through
+   `deflateDynamic_spec` whose statement is unchanged (still references
+   `lz77Greedy`).
+
+## Quality metrics
+
+- Sorry count: 2 (unchanged — InflateComplete.lean:1, InflateLoopBounds.lean:1)
+- All tests pass
+- Build succeeds


### PR DESCRIPTION
Closes #370

Session: `08c6562c-36bb-4ab4-8825-bc6b2ac73d06`

5856564 fix: use lz77GreedyIter in deflateDynamic to prevent stack overflow

🤖 Prepared with Claude Code