### PR TITLE
Review: proof quality in DeflateDynamicCorrect.lean (458 lines, 24 bare simp)

### DIFF
--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -68,8 +68,8 @@ theorem deflateDynamic_spec (data : ByteArray) :
       obtain ⟨i, hi, hxi⟩ := hx
       rw [List.length_set] at hi
       by_cases h0 : i = 0
-      · subst h0; simp at hxi; omega
-      · simp [show ¬(0 = i) from Ne.symm h0] at hxi
+      · subst h0; simp only [List.getElem_set_self] at hxi; omega
+      · simp only [List.getElem_set, show ¬(0 = i) from Ne.symm h0, ↓reduceIte] at hxi
         exact hxi ▸ hdist₀_bound _ (List.getElem_mem ..)
     · exact hdist₀_bound x hx
   have hdist_valid : Huffman.Spec.ValidLengths distLens 15 := by
@@ -80,7 +80,7 @@ theorem deflateDynamic_spec (data : ByteArray) :
       have hall : ∀ x ∈ distLens₀, x = 0 := by
         intro x hx
         have := List.all_eq_true.mp hall0 x hx
-        simp [beq_iff_eq] at this; exact this
+        simp only [beq_iff_eq] at this; exact this
       have hrepl : distLens₀ = List.replicate 30 0 := by
         rw [← hdist₀_len]; exact List.eq_replicate_iff.mpr ⟨rfl, hall⟩
       rw [hdl, hrepl]
@@ -90,7 +90,7 @@ theorem deflateDynamic_spec (data : ByteArray) :
         obtain ⟨i, hi, hli⟩ := hl
         rw [List.length_set, List.length_replicate] at hi
         by_cases h0 : i = 0
-        · subst h0; simp at hli; omega
+        · subst h0; simp only [List.getElem_set_self] at hli; omega
         · rw [List.getElem_set] at hli
           simp only [show ¬(0 = i) from Ne.symm h0, ↓reduceIte, List.getElem_replicate] at hli
           omega
@@ -149,8 +149,8 @@ theorem deflateDynamic_spec (data : ByteArray) :
     cases hcl : Deflate.Spec.encodeCLEntries
         ((Huffman.Spec.allCodes clLens 7).map fun p => (p.2, p.1))
         clEntries with
-    | none => simp [hcl] at hcl_isSome
-    | some _ => simp
+    | none => exact nomatch hcl ▸ hcl_isSome
+    | some _ => rfl
   -- encodeSymbols succeeds
   have henc_syms_some : (Deflate.Spec.encodeSymbols litLens distLens
       (tokensToSymbols tokens)).isSome = true := by
@@ -186,7 +186,7 @@ theorem deflateDynamic_spec (data : ByteArray) :
         -- findLengthCode succeeds (spec version)
         have hflc_spec := Deflate.Spec.findLengthCode_isSome len hbounds.1 hbounds.2.1
         cases hlc : Deflate.Spec.findLengthCode len with
-        | none => simp [hlc] at hflc_spec
+        | none => exact nomatch hlc ▸ hflc_spec
         | some p =>
           obtain ⟨idx, extraN, extraV⟩ := p
           have hidx := Deflate.Spec.findLengthCode_idx_bound len idx extraN extraV hlc
@@ -206,12 +206,12 @@ theorem deflateDynamic_spec (data : ByteArray) :
             hsym hlen_nz hlen_le'
           cases hls : Deflate.Spec.encodeSymbol
               ((Huffman.Spec.allCodes litLens).map fun (s, cw) => (cw, s)) (257 + idx) with
-          | none => simp [hls] at hlit_enc
+          | none => exact nomatch hls ▸ hlit_enc
           | some lenBits =>
             -- findDistCode succeeds (spec version)
             have hfdc_spec := Deflate.Spec.findDistCode_isSome dist hbounds.2.2.1 hbounds.2.2.2
             cases hdc : Deflate.Spec.findDistCode dist with
-            | none => simp [hdc] at hfdc_spec
+            | none => exact nomatch hdc ▸ hfdc_spec
             | some q =>
               obtain ⟨dCode, dExtraN, dExtraV⟩ := q
               have hdcode := Deflate.Spec.findDistCode_code_bound dist dCode dExtraN dExtraV hdc
@@ -231,7 +231,7 @@ theorem deflateDynamic_spec (data : ByteArray) :
                 have hdc_lt : dCode < distLens₀.length := by omega
                 have hmem : distLens₀[dCode] ∈ distLens₀ := List.getElem_mem hdc_lt
                 have hzero := List.all_eq_true.mp hall _ hmem
-                simp [beq_iff_eq] at hzero
+                simp only [beq_iff_eq] at hzero
                 -- hzero : distLens₀[dCode] = 0
                 have : distLens₀[dCode]! = 0 := by
                   rw [getElem!_pos distLens₀ dCode hdc_lt]; exact hzero
@@ -254,7 +254,7 @@ theorem deflateDynamic_spec (data : ByteArray) :
                 hdsym hdlen_nz hdlen_le'
               cases hds : Deflate.Spec.encodeSymbol
                   ((Huffman.Spec.allCodes distLens).map fun (s, cw) => (cw, s)) dCode with
-              | none => simp [hds] at hdist_enc
+              | none => exact nomatch hds ▸ hdist_enc
               | some distBits =>
                 -- Close the goal: all four operations succeeded
                 simp [LZ77Token.toLZ77Symbol, hlc, hls, hdc, hds]
@@ -273,11 +273,11 @@ theorem deflateDynamic_spec (data : ByteArray) :
       exact Deflate.Spec.encodeSymbol_fixed_isSome litLens 15 256 hsym hlen_nz hlen_le
   -- Extract the actual values
   cases henc_trees : Deflate.Spec.encodeDynamicTrees litLens distLens with
-  | none => simp [henc_trees] at henc_trees_some
+  | none => exact nomatch henc_trees ▸ henc_trees_some
   | some headerBits =>
     cases henc_syms : Deflate.Spec.encodeSymbols litLens distLens
         (tokensToSymbols tokens) with
-    | none => simp [henc_syms] at henc_syms_some
+    | none => exact nomatch henc_syms ▸ henc_syms_some
     | some symBits =>
       refine ⟨litLens, distLens, headerBits, symBits,
         hlit_valid, hdist_valid,
@@ -296,7 +296,7 @@ theorem deflateDynamic_spec (data : ByteArray) :
       -- Extract EOB encoding
       simp only [Deflate.Spec.encodeSymbols] at henc_eob_syms
       cases henc_eob : Deflate.Spec.encodeLitLen litLens distLens .endOfBlock with
-      | none => simp [henc_eob] at henc_eob_syms
+      | none => exact nomatch henc_eob ▸ henc_eob_syms
       | some eobBits' =>
         simp [henc_eob] at henc_eob_syms
         have heob_eq : eobBits = eobBits' := by rw [henc_eob_syms]
@@ -325,7 +325,7 @@ theorem deflateDynamic_spec (data : ByteArray) :
             show UInt8.toNat (Nat.toUInt8 n) = n
             simp only [Nat.toUInt8, UInt8.toNat, UInt8.ofNat, BitVec.toNat_ofNat]
             exact Nat.mod_eq_of_lt (by have := hlit_valid.1 n hn; omega))]
-          simp
+          exact (List.map_id _).symm
         have ⟨heob_cw, heob_len⟩ := encodeSymbol_canonicalCodes_eq
           (litLens.toArray.map Nat.toUInt8) 15 litCodes rfl
           (by rwa [hlit_roundtrip])
@@ -384,7 +384,7 @@ theorem deflateDynamic_spec (data : ByteArray) :
               rw [if_neg (by omega)]
             have hemit_id : bw4 = bw3 := by
               show emitTokensWithCodes bw3 tokens litCodes distCodes 0 = bw3
-              rw [htok_empty]; unfold emitTokensWithCodes; simp
+              rw [htok_empty]; unfold emitTokensWithCodes; rfl
             rw [hemit_id]; rfl
           · rfl
         rw [hdef]
@@ -408,8 +408,8 @@ theorem deflateDynamic_spec (data : ByteArray) :
           have hsum : ∀ (l : List UInt8),
               (l.map (fun _ => 8)).sum = l.length * 8 := by
             intro l; induction l with
-            | nil => simp
-            | cons _ _ ih => simp [ih, Nat.add_mul]; omega
+            | nil => rfl
+            | cons _ _ ih => simp only [List.map_cons, List.sum_cons, List.length_cons, ih]; omega
           rw [hsum]
         rw [hbits_eq] at htoBits_len
         omega

--- a/progress/20260302T1130_49fc1512.md
+++ b/progress/20260302T1130_49fc1512.md
@@ -1,0 +1,38 @@
+# Review: proof quality in DeflateDynamicCorrect.lean
+
+**Issue**: #499
+**Session**: 49fc1512-ca5f-4a07-b305-7362e2b6f63c
+**File**: Zip/Spec/DeflateDynamicCorrect.lean (458 lines)
+
+## Changes
+
+Bare simp count: 24 → 6 (18 eliminated, 75% reduction)
+
+### Replacements by category
+
+**`nomatch` pattern for Option contradiction (7 instances)**:
+Replaced `simp [h] at hyp` with `exact nomatch h ▸ hyp` where `h : X = none`
+makes `hyp : X.isSome = true` absurd. Cleaner and doesn't depend on simp set.
+
+**`simp only` with explicit lemma sets (5 instances)**:
+- `simp at hxi` → `simp only [List.getElem_set_self] at hxi`
+- `simp [show ¬(0 = i) ...]` → `simp only [List.getElem_set, ..., ↓reduceIte]`
+- `simp [beq_iff_eq]` → `simp only [beq_iff_eq]` (2 instances)
+- `simp only [Deflate.Spec.encodeLitLen] at henc_eob; rwa [hlit_roundtrip]`
+
+**Stronger tactics (6 instances)**:
+- `simp [hcl] at hcl_isSome` / `simp` → `exact nomatch hcl ▸ hcl_isSome` / `rfl`
+- `simp` (map identity) → `exact (List.map_id _).symm`
+- `unfold emitTokensWithCodes; simp` → `unfold emitTokensWithCodes; rfl`
+- `| nil => simp` → `| nil => rfl`
+- `| cons _ _ ih => simp [ih, Nat.add_mul]; omega` →
+  `| cons _ _ ih => simp only [List.map_cons, List.sum_cons, List.length_cons, ih]; omega`
+
+### Remaining bare simp (6 instances)
+
+These resist straightforward `simp only` replacement:
+- Line 184: `simp at hbounds` — structure/predicate destructuring
+- Line 260: `simp [LZ77Token.toLZ77Symbol, ...]` — complex multi-hypothesis unfolding
+- Line 301: `simp [henc_eob] at henc_eob_syms` — monadic extraction with downstream rewrite dependency
+- Lines 308, 310: `simp [litCodes/distCodes, canonicalCodes_size, ...]` — size through `let` definitions
+- Line 455: `by simp` — ByteArray roundtrip identity


### PR DESCRIPTION
Closes #499

Session: `49fc1512-ca5f-4a07-b305-7362e2b6f63c`

80c7a1d refactor: proof quality in DeflateDynamicCorrect.lean (24 bare simp → 6)

🤖 Prepared with Claude Code