### PR TITLE
Review: bare simp residuals in DeflateDynamicCorrect.lean (4), Adler32.lean (4), DeflateStoredCorrect.lean (3)

### DIFF
--- a/Zip/Spec/Adler32.lean
+++ b/Zip/Spec/Adler32.lean
@@ -48,7 +48,7 @@ def unpack (v : UInt32) : State :=
 /-- `updateList` over a concatenation equals sequential application. -/
 theorem updateList_append (s : State) (xs ys : List UInt8) :
     updateList s (xs ++ ys) = updateList (updateList s xs) ys := by
-  simp [updateList, List.foldl_append]
+  simp only [updateList, List.foldl_append]
 
 /-- Empty input leaves the state unchanged. -/
 theorem updateList_nil (s : State) : updateList s [] = s := rfl
@@ -65,13 +65,13 @@ def Valid (s : State) : Prop := s.1 < MOD_ADLER ∧ s.2 < MOD_ADLER
 /-- The first component of `updateByte` is less than MOD_ADLER. -/
 theorem updateByte_fst_lt (s : State) (b : UInt8) :
     (updateByte s b).1 < MOD_ADLER := by
-  simp [updateByte, MOD_ADLER]
+  simp only [updateByte, MOD_ADLER]
   omega
 
 /-- The second component of `updateByte` is less than MOD_ADLER. -/
 theorem updateByte_snd_lt (s : State) (b : UInt8) :
     (updateByte s b).2 < MOD_ADLER := by
-  simp [updateByte, MOD_ADLER]
+  simp only [updateByte, MOD_ADLER]
   omega
 
 /-- `updateByte` preserves validity. -/
@@ -81,7 +81,8 @@ theorem updateByte_valid (s : State) (b : UInt8) :
 
 /-- The initial state is valid. -/
 theorem init_valid : Valid init := by
-  simp [Valid, init, MOD_ADLER]
+  simp only [Valid, init, MOD_ADLER]
+  omega
 
 /-- `updateList` preserves validity. -/
 theorem updateList_valid (s : State) (hs : Valid s) (data : List UInt8) :

--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -257,7 +257,9 @@ theorem deflateDynamic_spec (data : ByteArray) :
               | none => exact nomatch hds ▸ hdist_enc
               | some distBits =>
                 -- Close the goal: all four operations succeeded
-                simp [LZ77Token.toLZ77Symbol, hlc, hls, hdc, hds]
+                simp only [LZ77Token.toLZ77Symbol, hlc, hls, hdc, hds,
+                  Option.pure_def, Option.bind_eq_bind, Option.bind_some,
+                  Option.isSome_some, List.append_assoc]
     | inr heob =>
       subst heob
       -- Need: encodeLitLen litLens distLens .endOfBlock succeeds
@@ -298,16 +300,18 @@ theorem deflateDynamic_spec (data : ByteArray) :
       cases henc_eob : Deflate.Spec.encodeLitLen litLens distLens .endOfBlock with
       | none => exact nomatch henc_eob ▸ henc_eob_syms
       | some eobBits' =>
-        simp [henc_eob] at henc_eob_syms
+        simp only [henc_eob,
+          Option.pure_def, Option.bind_eq_bind, Option.bind_some,
+          List.append_nil, Option.some.injEq] at henc_eob_syms
         have heob_eq : eobBits = eobBits' := by rw [henc_eob_syms]
         -- Build canonical codes (same as in deflateDynamic)
         let litCodes := canonicalCodes (litLens.toArray.map Nat.toUInt8)
         let distCodes := canonicalCodes (distLens.toArray.map Nat.toUInt8)
         -- Size properties
         have hlit_codes_size : litCodes.size = litLens.length := by
-          simp [litCodes, canonicalCodes_size, List.size_toArray]
+          simp only [litCodes, canonicalCodes_size, Array.size_map, List.size_toArray]
         have hdist_codes_size : distCodes.size = distLens.length := by
-          simp [distCodes, canonicalCodes_size, List.size_toArray]
+          simp only [distCodes, canonicalCodes_size, Array.size_map, List.size_toArray]
         -- Code length bounds
         have hlit_lengths_arr_le := Deflate.toUInt8Array_le litLens hlit_bound
         have hdist_lengths_arr_le := Deflate.toUInt8Array_le distLens hdist_bound

--- a/Zip/Spec/DeflateStoredCorrect.lean
+++ b/Zip/Spec/DeflateStoredCorrect.lean
@@ -97,8 +97,9 @@ theorem readBits_1_at_0 (data : ByteArray) (pos : Nat)
   simp only [Except.ok.injEq, Prod.mk.injEq]
   rw [getElem!_pos data pos hpos]
   constructor
-  · -- bare simp: concrete bit computation
-    simp [UInt32.shiftRight_zero, UInt32.shiftLeft_zero, UInt32.zero_or]
+  · -- concrete bit computation
+    simp only [show (Nat.toUInt32 0 : UInt32) = 0 from by decide,
+      UInt32.shiftRight_zero, UInt32.shiftLeft_zero, UInt32.zero_or]
   · trivial
 
 /-- Reading 2 bits starting at bitOff 1 within the same byte.
@@ -120,8 +121,11 @@ theorem readBits_2_at_1 (data : ByteArray) (pos : Nat)
   rw [getElem!_pos data pos hpos]
   simp only [Except.ok.injEq, Prod.mk.injEq]
   constructor
-  · -- bare simp: concrete bit computation
-    simp [UInt32.shiftLeft_zero, UInt32.zero_or]
+  · -- concrete bit computation
+    simp only [show (Nat.toUInt32 0 : UInt32) = 0 from by decide,
+      show (Nat.toUInt32 1 : UInt32) = 1 from by decide,
+      show (Nat.toUInt32 2 : UInt32) = 2 from by decide,
+      UInt32.shiftLeft_zero, UInt32.zero_or]
     generalize data[pos].toUInt32 = x
     bv_decide
   · trivial
@@ -190,8 +194,8 @@ theorem decodeStored_on_block (compressed : ByteArray) (brPos : Nat)
       hnlen_lo, hnlen_hi, uint16_le_roundtrip] at hru2
   -- Step 3: blockLen.toUInt16.toNat = blockLen
   have hbl_toNat : blockLen.toUInt16.toNat = blockLen := by
-    -- bare simp: UInt16 modular arithmetic via BitVec internals
-    simp [Nat.mod_eq_of_lt (show blockLen < 65536 from by omega)]
+    -- UInt16 modular arithmetic: blockLen.toUInt16.toNat = blockLen % 65536
+    exact Nat.mod_eq_of_lt (show blockLen < 65536 from by omega)
   -- Step 4: Compose everything
   simp only [Inflate.decodeStored, bind, Except.bind, hru1, hru2]
   -- XOR check: a ^^^ (a ^^^ 0xFFFF) = 0xFFFF

--- a/progress/20260302T1300_37570775.md
+++ b/progress/20260302T1300_37570775.md
@@ -1,0 +1,33 @@
+# Review: bare simp in Adler32, DeflateDynamicCorrect, DeflateStoredCorrect
+
+**Session**: 37570775
+**Issue**: #533
+**Type**: review
+
+## Changes
+
+Replaced 11 bare `simp` calls with targeted alternatives across 3 files:
+
+### Adler32.lean (4 bare simps → 0)
+- `simp [updateList, ...]` → `simp only [updateList, List.foldl_append]`
+- `simp [updateByte, MOD_ADLER]` → `simp only [updateByte, MOD_ADLER]` (×2)
+- `simp [Valid, init, MOD_ADLER]` → `simp only [Valid, init, MOD_ADLER]` + `omega`
+
+### DeflateDynamicCorrect.lean (4 bare simps → 0)
+- `simp [LZ77Token.toLZ77Symbol, hlc, hls, hdc, hds]` → `simp only [...]` with
+  `Option.pure_def, Option.bind_eq_bind, Option.bind_some, Option.isSome_some,
+  List.append_assoc`
+- `simp [henc_eob] at henc_eob_syms` → `simp only [henc_eob, Option.pure_def,
+  Option.bind_eq_bind, Option.bind_some, List.append_nil, Option.some.injEq]`
+- `simp [litCodes, ...]` / `simp [distCodes, ...]` → added `Array.size_map`
+
+### DeflateStoredCorrect.lean (3 bare simps → 0)
+- Added `show (Nat.toUInt32 0 : UInt32) = 0 from by decide` to normalize
+  `Nat.toUInt32` before `UInt32.shiftRight_zero` etc.
+- Changed `simp [Nat.mod_eq_of_lt ...]` → `exact Nat.mod_eq_of_lt (by omega)`
+- Added explicit `Nat.toUInt32` normalization before `bv_decide`
+
+## Verification
+- `lake build` passes (0 errors, 0 warnings from changed files)
+- `lake exe test` passes (all tests)
+- Zero bare simps remain in target files


### PR DESCRIPTION
Closes #533

Session: `ccdfd00f-1021-45d8-9bbc-021351b1b377`

c28d320 refactor: replace 11 bare simps in Adler32, DeflateDynamicCorrect, DeflateStoredCorrect

🤖 Prepared with Claude Code