### PR TITLE
Track E: consolidate parseSequencesHeader and wire modes into decompressBlocks

### DIFF
--- a/.claude/skills/lean-zstd-patterns/SKILL.md
+++ b/.claude/skills/lean-zstd-patterns/SKILL.md
@@ -130,10 +130,9 @@ Literal lengths and match lengths use baseline + extra bits encoding.
 Tables are defined as constant arrays (`litLenExtraBits`, `matchLenExtraBits`)
 following RFC 8878 Table 15 and Table 17.
 
-Keep the original `parseSequencesHeader` intact when adding new parsing
-functions. Add `parseSequencesHeaderWithModes` as a separate function to
-avoid disrupting existing callers. This pattern — extending without
-modifying — is important when existing tests depend on the original API.
+`parseSequencesHeader` returns `(numSeq, compressionModes, posAfterHeader)`.
+When `numSeq == 0`, modes default to `predefined`. The compression modes
+are needed by `resolveSequenceFseTables` to construct FSE decode tables.
 
 ## Huffman Tree Descriptor
 

--- a/Zip/Native/ZstdFrame.lean
+++ b/Zip/Native/ZstdFrame.lean
@@ -557,29 +557,68 @@ def parseLiteralsSection (data : ByteArray) (pos : Nat) :
     let result := ByteArray.mk (Array.replicate regenSize byte)
     pure (result, afterHeader + 1)
 
+/-- Compression mode for one of the three sequence symbol types
+    (RFC 8878 §3.1.1.3.2). -/
+inductive SequenceCompressionMode where
+  | predefined   -- 0: use default distribution
+  | rle           -- 1: single repeated symbol
+  | fseCompressed -- 2: custom FSE distribution in bitstream
+  | repeat        -- 3: reuse previous block's table
+  deriving Repr, BEq
+
+/-- Parsed compression modes for the three sequence symbol types. -/
+structure SequenceCompressionModes where
+  litLenMode  : SequenceCompressionMode
+  offsetMode  : SequenceCompressionMode
+  matchLenMode : SequenceCompressionMode
+  deriving Repr
+
+/-- Convert a 2-bit mode value to `SequenceCompressionMode`. -/
+private def modeFromBits (bits : UInt8) : SequenceCompressionMode :=
+  match bits.toNat with
+  | 0 => .predefined
+  | 1 => .rle
+  | 2 => .fseCompressed
+  | _ => .repeat
+
 /-- Parse the Sequences_Section header (RFC 8878 §3.1.1.3.2).
-    Returns (numberOfSequences, position after header including compression modes byte).
-    If numberOfSequences is 0, the block has only literals (no sequences to decode). -/
+    Returns (numberOfSequences, compressionModes, position after header).
+    If numberOfSequences is 0, compression modes are all `predefined` (no modes
+    byte present) and the block has only literals. -/
 def parseSequencesHeader (data : ByteArray) (pos : Nat) :
-    Except String (Nat × Nat) := do
+    Except String (Nat × SequenceCompressionModes × Nat) := do
   if data.size < pos + 1 then
     throw "Zstd: not enough data for sequences header"
   let byte0 := data[pos]!.toNat
+  let defaultModes : SequenceCompressionModes :=
+    { litLenMode := .predefined, offsetMode := .predefined, matchLenMode := .predefined }
   if byte0 == 0 then
     -- 0 sequences: no compression modes byte follows
-    pure (0, pos + 1)
+    pure (0, defaultModes, pos + 1)
   else if byte0 < 128 then
     -- 1-byte count + compression modes byte
     if data.size < pos + 2 then
       throw "Zstd: not enough data for sequence compression modes"
-    pure (byte0, pos + 2)
+    let modesByte := data[pos + 1]!
+    let modes : SequenceCompressionModes := {
+      litLenMode := modeFromBits ((modesByte >>> 6) &&& 3)
+      offsetMode := modeFromBits ((modesByte >>> 4) &&& 3)
+      matchLenMode := modeFromBits ((modesByte >>> 2) &&& 3)
+    }
+    pure (byte0, modes, pos + 2)
   else if byte0 < 255 then
     -- 2-byte count: ((byte0 - 128) << 8) + byte1, then compression modes
     if data.size < pos + 3 then
       throw "Zstd: truncated sequences header"
     let byte1 := data[pos + 1]!.toNat
     let numSeq := ((byte0 - 128) <<< 8) + byte1
-    pure (numSeq, pos + 3)
+    let modesByte := data[pos + 2]!
+    let modes : SequenceCompressionModes := {
+      litLenMode := modeFromBits ((modesByte >>> 6) &&& 3)
+      offsetMode := modeFromBits ((modesByte >>> 4) &&& 3)
+      matchLenMode := modeFromBits ((modesByte >>> 2) &&& 3)
+    }
+    pure (numSeq, modes, pos + 3)
   else
     -- 3-byte count (byte0 == 255): byte1 + (byte2 << 8) + 0x7F00, then compression modes
     if data.size < pos + 4 then
@@ -587,12 +626,18 @@ def parseSequencesHeader (data : ByteArray) (pos : Nat) :
     let byte1 := data[pos + 1]!.toNat
     let byte2 := data[pos + 2]!.toNat
     let numSeq := byte1 + (byte2 <<< 8) + 0x7F00
-    pure (numSeq, pos + 4)
+    let modesByte := data[pos + 3]!
+    let modes : SequenceCompressionModes := {
+      litLenMode := modeFromBits ((modesByte >>> 6) &&& 3)
+      offsetMode := modeFromBits ((modesByte >>> 4) &&& 3)
+      matchLenMode := modeFromBits ((modesByte >>> 2) &&& 3)
+    }
+    pure (numSeq, modes, pos + 4)
 
 /-- Decompress all blocks in a Zstd frame starting at `pos` (after the frame header).
     Loops through block headers, dispatches on block type, and accumulates output.
     Returns the decompressed content and position after the last block.
-    Currently returns an error for compressed blocks (not yet implemented). -/
+    Compressed blocks with sequences are not yet fully wired (returns error). -/
 def decompressBlocks (data : ByteArray) (pos : Nat) : Except String (ByteArray × Nat) := do
   let mut off := pos
   let mut output := ByteArray.empty
@@ -612,7 +657,7 @@ def decompressBlocks (data : ByteArray) (pos : Nat) : Except String (ByteArray �
     | .compressed =>
       let blockEnd := off + hdr.blockSize.toNat
       let (literals, afterLiterals) ← parseLiteralsSection data off
-      let (numSeq, _afterSeqHeader) ← parseSequencesHeader data afterLiterals
+      let (numSeq, _modes, _afterSeqHeader) ← parseSequencesHeader data afterLiterals
       if numSeq == 0 then
         -- No sequences: block is pure literals
         output := output ++ literals
@@ -847,83 +892,6 @@ def decodeMatchLenValue (code : Nat) (extraBits : UInt32) : Except String Nat :=
 def decodeOffsetValue (code : Nat) (extraBits : UInt32) : Nat :=
   if code == 0 then extraBits.toNat
   else (1 <<< code) + extraBits.toNat
-
-/-- Compression mode for one of the three sequence symbol types
-    (RFC 8878 §3.1.1.3.2). -/
-inductive SequenceCompressionMode where
-  | predefined   -- 0: use default distribution
-  | rle           -- 1: single repeated symbol
-  | fseCompressed -- 2: custom FSE distribution in bitstream
-  | repeat        -- 3: reuse previous block's table
-  deriving Repr, BEq
-
-/-- Parsed compression modes for the three sequence symbol types. -/
-structure SequenceCompressionModes where
-  litLenMode  : SequenceCompressionMode
-  offsetMode  : SequenceCompressionMode
-  matchLenMode : SequenceCompressionMode
-  deriving Repr
-
-/-- Convert a 2-bit mode value to `SequenceCompressionMode`. -/
-private def modeFromBits (bits : UInt8) : SequenceCompressionMode :=
-  match bits.toNat with
-  | 0 => .predefined
-  | 1 => .rle
-  | 2 => .fseCompressed
-  | _ => .repeat
-
-/-- Parse the Sequences_Section header (RFC 8878 §3.1.1.3.2).
-    Returns (numberOfSequences, compressionModes, position after header).
-    If numberOfSequences is 0, compression modes are all `predefined` (no modes
-    byte present) and the block has only literals. -/
-def parseSequencesHeaderWithModes (data : ByteArray) (pos : Nat) :
-    Except String (Nat × SequenceCompressionModes × Nat) := do
-  if data.size < pos + 1 then
-    throw "Zstd: not enough data for sequences header"
-  let byte0 := data[pos]!.toNat
-  let defaultModes : SequenceCompressionModes :=
-    { litLenMode := .predefined, offsetMode := .predefined, matchLenMode := .predefined }
-  if byte0 == 0 then
-    -- 0 sequences: no compression modes byte follows
-    pure (0, defaultModes, pos + 1)
-  else if byte0 < 128 then
-    -- 1-byte count + compression modes byte
-    if data.size < pos + 2 then
-      throw "Zstd: not enough data for sequence compression modes"
-    let modesByte := data[pos + 1]!
-    let modes : SequenceCompressionModes := {
-      litLenMode := modeFromBits ((modesByte >>> 6) &&& 3)
-      offsetMode := modeFromBits ((modesByte >>> 4) &&& 3)
-      matchLenMode := modeFromBits ((modesByte >>> 2) &&& 3)
-    }
-    pure (byte0, modes, pos + 2)
-  else if byte0 < 255 then
-    -- 2-byte count: ((byte0 - 128) << 8) + byte1, then compression modes
-    if data.size < pos + 3 then
-      throw "Zstd: truncated sequences header"
-    let byte1 := data[pos + 1]!.toNat
-    let numSeq := ((byte0 - 128) <<< 8) + byte1
-    let modesByte := data[pos + 2]!
-    let modes : SequenceCompressionModes := {
-      litLenMode := modeFromBits ((modesByte >>> 6) &&& 3)
-      offsetMode := modeFromBits ((modesByte >>> 4) &&& 3)
-      matchLenMode := modeFromBits ((modesByte >>> 2) &&& 3)
-    }
-    pure (numSeq, modes, pos + 3)
-  else
-    -- 3-byte count (byte0 == 255): byte1 + (byte2 << 8) + 0x7F00, then compression modes
-    if data.size < pos + 4 then
-      throw "Zstd: truncated sequences header"
-    let byte1 := data[pos + 1]!.toNat
-    let byte2 := data[pos + 2]!.toNat
-    let numSeq := byte1 + (byte2 <<< 8) + 0x7F00
-    let modesByte := data[pos + 3]!
-    let modes : SequenceCompressionModes := {
-      litLenMode := modeFromBits ((modesByte >>> 6) &&& 3)
-      offsetMode := modeFromBits ((modesByte >>> 4) &&& 3)
-      matchLenMode := modeFromBits ((modesByte >>> 2) &&& 3)
-    }
-    pure (numSeq, modes, pos + 4)
 
 /-- Decode interleaved FSE sequences from a backward bitstream (RFC 8878 §4.1.1).
     Takes three FSE tables (litLen, offset, matchLen), a `BackwardBitReader`

--- a/ZipTest/FseNative.lean
+++ b/ZipTest/FseNative.lean
@@ -263,7 +263,7 @@ def ZipTest.FseNative.tests : IO Unit := do
         match Zip.Native.parseLiteralsSection compressed blockDataStart with
         | .ok (_, afterLiterals) =>
           match Zip.Native.parseSequencesHeader compressed afterLiterals with
-          | .ok (numSeq, afterSeqHeader) =>
+          | .ok (numSeq, _modes, afterSeqHeader) =>
             if numSeq > 0 then
               -- Read the compression modes byte (just before afterSeqHeader)
               -- The modes byte contains 2-bit fields for LL, OF, ML compression modes

--- a/ZipTest/ZstdNative.lean
+++ b/ZipTest/ZstdNative.lean
@@ -367,7 +367,7 @@ def ZipTest.ZstdNative.tests : IO Unit := do
   -- Test 33: parseSequencesHeader with 0 sequences
   let zeroSeqInput := ByteArray.mk #[0x00]
   match Zip.Native.parseSequencesHeader zeroSeqInput 0 with
-  | .ok (numSeq, endPos) =>
+  | .ok (numSeq, _modes, endPos) =>
     unless numSeq == 0 do
       throw (IO.userError s!"0 seq: expected 0, got {numSeq}")
     unless endPos == 1 do
@@ -378,7 +378,7 @@ def ZipTest.ZstdNative.tests : IO Unit := do
   -- byte0 = 42, followed by compression modes byte
   let smallSeqInput := ByteArray.mk #[42, 0x00]
   match Zip.Native.parseSequencesHeader smallSeqInput 0 with
-  | .ok (numSeq, endPos) =>
+  | .ok (numSeq, _modes, endPos) =>
     unless numSeq == 42 do
       throw (IO.userError s!"42 seq: expected 42, got {numSeq}")
     unless endPos == 2 do
@@ -389,7 +389,7 @@ def ZipTest.ZstdNative.tests : IO Unit := do
   -- byte0 = 200 (>= 128, < 255): numSeq = (200 - 128) << 8 + byte1 = 72 * 256 + 50 = 18482
   let medSeqInput := ByteArray.mk #[200, 50, 0x00]
   match Zip.Native.parseSequencesHeader medSeqInput 0 with
-  | .ok (numSeq, endPos) =>
+  | .ok (numSeq, _modes, endPos) =>
     unless numSeq == 18482 do
       throw (IO.userError s!"2byte seq: expected 18482, got {numSeq}")
     unless endPos == 3 do
@@ -400,7 +400,7 @@ def ZipTest.ZstdNative.tests : IO Unit := do
   -- byte0 = 255: numSeq = byte1 + (byte2 << 8) + 0x7F00 = 10 + (1 << 8) + 32512 = 32778
   let largeSeqInput := ByteArray.mk #[255, 10, 1, 0x00]
   match Zip.Native.parseSequencesHeader largeSeqInput 0 with
-  | .ok (numSeq, endPos) =>
+  | .ok (numSeq, _modes, endPos) =>
     unless numSeq == 32778 do
       throw (IO.userError s!"3byte seq: expected 32778, got {numSeq}")
     unless endPos == 4 do
@@ -707,11 +707,11 @@ def ZipTest.ZstdNative.tests : IO Unit := do
   let offVal0 := Zip.Native.decodeOffsetValue 0 5
   unless offVal0 == 5 do throw (IO.userError s!"offset code 0: expected 5, got {offVal0}")
 
-  -- Test 69: parseSequencesHeaderWithModes — modes parsing
+  -- Test 69: parseSequencesHeader — modes parsing
   -- Construct: byte0 = 42 (small count), modes byte = 0b10_01_00_00 = 0x90
   -- litLen=FSE_Compressed(2), offset=RLE(1), matchLen=Predefined(0), reserved=0
   let modesInput := ByteArray.mk #[42, 0x90]
-  match Zip.Native.parseSequencesHeaderWithModes modesInput 0 with
+  match Zip.Native.parseSequencesHeader modesInput 0 with
   | .ok (numSeq, modes, endPos) =>
     unless numSeq == 42 do
       throw (IO.userError s!"modes: expected numSeq 42, got {numSeq}")
@@ -725,9 +725,9 @@ def ZipTest.ZstdNative.tests : IO Unit := do
       throw (IO.userError "modes: expected matchLenMode = predefined")
   | .error e => throw (IO.userError s!"modes parsing failed: {e}")
 
-  -- Test 70: parseSequencesHeaderWithModes — 0 sequences returns default modes
+  -- Test 70: parseSequencesHeader — 0 sequences returns default modes
   let zeroModesInput := ByteArray.mk #[0x00]
-  match Zip.Native.parseSequencesHeaderWithModes zeroModesInput 0 with
+  match Zip.Native.parseSequencesHeader zeroModesInput 0 with
   | .ok (numSeq, modes, endPos) =>
     unless numSeq == 0 do
       throw (IO.userError s!"zero modes: expected numSeq 0, got {numSeq}")
@@ -741,10 +741,10 @@ def ZipTest.ZstdNative.tests : IO Unit := do
       throw (IO.userError "zero modes: expected matchLenMode = predefined")
   | .error e => throw (IO.userError s!"zero modes parsing failed: {e}")
 
-  -- Test 71: parseSequencesHeaderWithModes — all repeat mode (0xFF modes byte)
+  -- Test 71: parseSequencesHeader — all repeat mode (0xFF modes byte)
   -- byte0 = 1 (1 sequence), modes = 0xFF → litLen=repeat(3), offset=repeat(3), matchLen=repeat(3)
   let repeatModesInput := ByteArray.mk #[1, 0xFF]
-  match Zip.Native.parseSequencesHeaderWithModes repeatModesInput 0 with
+  match Zip.Native.parseSequencesHeader repeatModesInput 0 with
   | .ok (numSeq, modes, _) =>
     unless numSeq == 1 do
       throw (IO.userError s!"repeat modes: expected numSeq 1, got {numSeq}")
@@ -1228,5 +1228,48 @@ def ZipTest.ZstdNative.tests : IO Unit := do
     unless mlTable.accuracyLog == 6 do
       throw (IO.userError s!"resolveAll mixed: matchLen accuracyLog expected 6, got {mlTable.accuracyLog}")
   | .error e => throw (IO.userError s!"resolveAll mixed failed: {e}")
+
+  -- === Compression mode integration tests on real zstd data ===
+
+  -- Test: parseSequencesHeader on FFI-compressed data at level 3
+  -- Level 3 should produce compressed blocks with sequences
+  let modeTestData := ByteArray.mk (Array.replicate 256 0x41 ++ Array.replicate 256 0x42)
+  let modeCompressed ← Zstd.compress modeTestData 3
+  match Zip.Native.parseFrameHeader modeCompressed 0 with
+  | .ok (_, modeHeaderEnd) =>
+    match Zip.Native.parseBlockHeader modeCompressed modeHeaderEnd with
+    | .ok (modeBlkHdr, modeBlockStart) =>
+      if modeBlkHdr.blockType == .compressed then do
+        match Zip.Native.parseLiteralsSection modeCompressed modeBlockStart with
+        | .ok (_, modeAfterLit) =>
+          match Zip.Native.parseSequencesHeader modeCompressed modeAfterLit with
+          | .ok (modeNumSeq, modes, _) =>
+            -- Compressed data at level 3 should have sequences
+            unless modeNumSeq > 0 do
+              throw (IO.userError s!"mode integration: expected sequences > 0, got {modeNumSeq}")
+            -- Verify each mode is a valid value (not checked by type system alone since
+            -- modeFromBits always succeeds, but confirms parsing is coherent)
+            let validMode (m : Zip.Native.SequenceCompressionMode) : Bool :=
+              m == .predefined || m == .rle || m == .fseCompressed || m == .repeat
+            unless validMode modes.litLenMode do
+              throw (IO.userError "mode integration: invalid litLenMode")
+            unless validMode modes.offsetMode do
+              throw (IO.userError "mode integration: invalid offsetMode")
+            unless validMode modes.matchLenMode do
+              throw (IO.userError "mode integration: invalid matchLenMode")
+          | .error e => throw (IO.userError s!"mode integration parseSeqHeader: {e}")
+        | .error e =>
+          -- Compressed literals may not be parseable yet, skip
+          IO.println s!"  mode integration: literals parse: {e} (OK)"
+      else
+        IO.println s!"  mode integration: block type {repr modeBlkHdr.blockType}, not compressed (OK)"
+    | .error e => throw (IO.userError s!"mode integration parseBlockHeader: {e}")
+  | .error e => throw (IO.userError s!"mode integration parseFrameHeader: {e}")
+
+  -- Test: parseSequencesHeader with insufficient data returns error
+  let shortInput := ByteArray.mk #[42]  -- needs modes byte but only has count
+  match Zip.Native.parseSequencesHeader shortInput 0 with
+  | .ok _ => throw (IO.userError "short input: should have failed")
+  | .error _ => pure ()
 
   IO.println "ZstdNative tests: OK"

--- a/progress/20260304T1700_520.md
+++ b/progress/20260304T1700_520.md
@@ -1,0 +1,41 @@
+# Progress: Consolidate parseSequencesHeader and wire modes into decompressBlocks
+
+**Date**: 2026-03-04
+**Session**: f7b76ae2
+**Type**: feature
+**Issue**: #520
+
+## Accomplished
+
+Consolidated the two `parseSequencesHeader` function variants in
+`Zip/Native/ZstdFrame.lean` into one, and updated all callers.
+
+### Changes
+
+- **Removed** old `parseSequencesHeader` (returned `Nat × Nat`, discarded modes)
+- **Renamed** `parseSequencesHeaderWithModes` → `parseSequencesHeader`
+  (returns `Nat × SequenceCompressionModes × Nat`)
+- **Moved** `SequenceCompressionMode`, `SequenceCompressionModes`, `modeFromBits`,
+  and `parseSequencesHeader` before `decompressBlocks` (was defined after it)
+- **Updated `decompressBlocks`** to destructure the 3-tuple, extracting modes
+  (unused for now, available for future sequence decoding wiring)
+- **Updated tests 33-38** in `ZipTest/ZstdNative.lean` to match 3-tuple return
+- **Updated tests 69-71** to use renamed `parseSequencesHeader`
+- **Updated `ZipTest/FseNative.lean`** integration test to match 3-tuple return
+- **Added integration test**: compresses data at level 3 via FFI, parses frame/block,
+  verifies `parseSequencesHeader` returns valid compression modes on real data
+- **Added edge case test**: verifies truncated input (missing modes byte) returns error
+- **Updated skill**: `lean-zstd-patterns/SKILL.md` updated to reflect consolidation
+
+### Files modified
+
+- `Zip/Native/ZstdFrame.lean` — consolidated function, moved definitions
+- `ZipTest/ZstdNative.lean` — updated callers, added integration tests
+- `ZipTest/FseNative.lean` — updated caller
+- `.claude/skills/lean-zstd-patterns/SKILL.md` — updated guidance
+
+## Metrics
+
+- Build: passes
+- Tests: all pass
+- Net line change: ~30 lines removed (code duplication eliminated)


### PR DESCRIPTION
Closes #520

Session: `d476ae60-203f-447c-bdc4-0a47323cffce`

ad24f9f refactor: consolidate parseSequencesHeader variants (#520)

🤖 Prepared with Claude Code