### PR TITLE
Review: audit ZstdFrame.lean code quality and splitting plan (1059 lines)

### DIFF
--- a/progress/20260304T233504Z_436b36a4.md
+++ b/progress/20260304T233504Z_436b36a4.md
@@ -1,0 +1,199 @@
+# Review: ZstdFrame.lean code quality and splitting plan
+
+- **Date**: 2026-03-04T23:35Z
+- **Session**: 436b36a4 (review)
+- **Issue**: #580
+- **Starting sorry count**: 0
+- **Ending sorry count**: 0 (no code changes)
+
+## Splitting Plan
+
+The 1059-line file has three natural extraction targets. Recommended split
+**after** compressed block sequence wiring (#552) stabilizes.
+
+### 1. `Zip/Native/ZstdHuffman.lean` (~270 lines)
+
+Extract lines 194-575: all Huffman tree parsing, table building, and literal
+decoding.
+
+**Types to move:**
+- `HuffmanEntry` (line 195)
+- `ZstdHuffmanTable` (line 203)
+
+**Functions to move:**
+- `parseHuffmanWeightsDirect` (line 214)
+- `weightsToMaxBits` (line 228)
+- `buildZstdHuffmanTable` (line 252)
+- `parseHuffmanWeightsFse` (line 336)
+- `parseHuffmanTreeDescriptor` (line 360)
+- `decodeHuffmanSymbol` (line 393)
+- `decodeHuffmanStream` (line 407)
+- `decodeFourHuffmanStreams` (line 421)
+- `parseCompressedLiteralsHeader` (line 462, private)
+- `decodeHuffmanLiterals` (line 497, private)
+- `parseLiteralsSection` (line 512)
+
+**Imports needed:** `Zip.Binary`, `Zip.Native.Fse` (BitReader,
+BackwardBitReader, decodeFseDistribution, buildFseTable, decodeFseSymbolsAll)
+
+### 2. `Zip/Native/ZstdSequence.lean` (~250 lines)
+
+Extract lines 762-1057: all sequence types, extra bits tables, FSE sequence
+decoding, and sequence execution.
+
+**Types to move:**
+- `ZstdSequence` (line 763)
+
+**Functions to move:**
+- `resolveOffset` (line 781)
+- `copyMatch` (line 822, private)
+- `executeSequences` (line 843)
+- `litLenExtraBits` (line 878)
+- `matchLenExtraBits` (line 892)
+- `decodeLitLenValue` (line 909)
+- `decodeMatchLenValue` (line 919)
+- `decodeOffsetValue` (line 929)
+- `decodeSequences` (line 942)
+- `buildRleFseTable` (line 1011)
+- `resolveSingleFseTable` (line 1021)
+- `resolveSequenceFseTables` (line 1048)
+
+**Imports needed:** `Zip.Binary`, `Zip.Native.Fse` (FseTable,
+BackwardBitReader, BitReader, decodeFseDistribution, buildFseTable,
+predefined*Distribution constants)
+
+### 3. `Zip/Native/ZstdFrame.lean` (remaining ~540 lines)
+
+Keep the frame/block-level orchestration code:
+
+**Types staying:**
+- `ZstdFrameHeader`, `ZstdBlockType`, `ZstdBlockHeader`
+- `SequenceCompressionMode`, `SequenceCompressionModes`
+
+**Functions staying:**
+- `zstdMagic`, `windowSizeFromDescriptor`, `parseFrameHeader`
+- `parseBlockHeader`, `decompressRawBlock`, `decompressRLEBlock`
+- `modeFromBits`, `parseSequencesHeader`
+- `decompressBlocks`, `decompressFrame`, `skipSkippableFrame`, `decompressZstd`
+
+**Updated imports:** `Zip.Binary`, `Zip.Native.XxHash`,
+`Zip.Native.ZstdHuffman`, `Zip.Native.ZstdSequence`
+
+### When to split
+
+After the compressed block sequence wiring PR (#552) and any related PRs
+(#568, #577) land. Those PRs modify `decompressBlocks` to call
+`resolveSequenceFseTables` + `decodeSequences` + `executeSequences`, so
+splitting during that work would create unnecessary merge conflicts. Once the
+sequence decoding pipeline is wired end-to-end, the file should stabilize
+enough for the split.
+
+## Docstring Audit
+
+**All 43 public and private definitions have docstrings.** Excellent coverage.
+
+**One stale docstring:** The module-level docstring (lines 5-24) says "sequence
+decoding (FSE) is not yet supported" but the file now contains
+`decodeSequences`, `executeSequences`, `resolveSequenceFseTables`, etc. These
+building blocks exist but aren't wired into `decompressBlocks` yet. The
+docstring should be updated to say "sequence decoding building blocks exist but
+are not yet wired into the block decompression pipeline".
+
+## Error Message Audit
+
+**41 error messages reviewed. Overall quality is good:** messages consistently
+identify the failure point, include context values (offsets, sizes, expected
+values), and follow a clear pattern.
+
+**One inconsistency:** Lower-level Huffman functions (lines 217, 235, 262, 272,
+327, 341, 363, 374, 380, 387) use prefix "Zstd Huffman:" while all other
+errors use "Zstd:". Higher-level Huffman code (lines 426, 435, 542) correctly
+uses "Zstd:". Should normalize to "Zstd:" everywhere, moving "Huffman" into the
+descriptive text (e.g., "Zstd: Huffman weights all zero").
+
+## Naming Conventions
+
+All naming follows Lean conventions:
+- Types: PascalCase (`ZstdFrameHeader`, `HuffmanEntry`, etc.)
+- Functions: camelCase (`parseFrameHeader`, `buildZstdHuffmanTable`, etc.)
+- Constants: camelCase (`zstdMagic`, `litLenExtraBits`)
+- Constructors: camelCase (`.raw`, `.rle`, `.compressed`, `.predefined`, etc.)
+- Field names: camelCase throughout
+
+No issues found.
+
+## Edge Case Concerns
+
+1. **No window size validation**: `parseFrameHeader` computes `windowSize` but
+   never validates it against `WINDOW_SIZE_MAX` (RFC 8878 recommends decoders
+   support at least 8 MB). A malicious frame could claim window size 2^41,
+   causing unreasonable memory allocation. Should add a configurable max window
+   size check.
+
+2. **Window size 0**: If `singleSegment = true` and `contentSize = none` (which
+   can happen when `fcsFlag = 0` and `singleSegment = true` — content size is
+   1 byte per fcsSize logic, so this actually can't happen; the 1-byte FCS
+   always provides a value). After re-analysis: not actually reachable. No
+   issue.
+
+3. **Empty frames**: A frame with first block having `lastBlock = true` and raw
+   block size 0 would produce empty output. `decompressBlocks` handles this
+   correctly — the while loop runs once, outputs 0 bytes, and exits.
+
+4. **Infinite loop potential**: `decompressBlocks` has `while !done do` with no
+   fuel bound, but each iteration advances `off` by at least 3 bytes (block
+   header), so parsing eventually fails with "not enough data" on malformed
+   input. Safe in practice.
+
+## Refactoring Opportunities
+
+1. **`decompressRLEBlock` (line 189-191)**: Uses byte-by-byte `push` loop.
+   Should use `ByteArray.mk (Array.replicate sz byte)` for consistency with
+   `parseLiteralsSection` (line 574) and better performance on large RLE blocks
+   (up to 128KB per RFC).
+
+2. **Duplicated weight trimming**: `parseHuffmanTreeDescriptor` has identical
+   trim-trailing-zeros logic at lines 370-374 and 382-387. Could extract a
+   `trimTrailingZeros` helper, though it's only 2 occurrences.
+
+3. **Duplicated modes parsing**: `parseSequencesHeader` has identical 4-line
+   blocks parsing compression modes from a byte at lines 620-624, 633-637, and
+   647-651. Could extract a helper function that takes `data`, `pos`, and byte
+   count, returning `(numSeq, modes, newPos)`.
+
+4. **Verbose derivation comments**: `buildZstdHuffmanTable` lines 280-289
+   contain a working-through-the-math comment block that could be condensed to
+   2-3 lines stating the final result.
+
+## Potential Issues
+
+1. **`buildZstdHuffmanTable` (line 325)**: Silently ignores table overflow for
+   the last symbol (`if sym != lastSymbol then` suppresses the error). The math
+   guarantees total entries = tableSize, so overflow should never happen. This
+   guard could mask a bug in weight computation. Consider removing the special
+   case and letting overflow error for any symbol.
+
+2. **`resolveOffset` (lines 802, 818)**: Returns `(1, history)` for the `| _ =>`
+   catch-all cases, with comment "unreachable". If reached due to a bug
+   (rawOffset = 0), this silently produces offset 1 instead of erroring. Since
+   the function returns `Nat × Array Nat` (not `Except`), consider changing the
+   signature to `Except String (Nat × Array Nat)` or adding a `dbg_trace`
+   warning.
+
+3. **`decodeHuffmanSymbol` (line 393-403)**: The "read maxBits, then re-read
+   numBits from original position" workaround is correct but fragile. If
+   `BackwardBitReader` ever gains a `putBack` or `advance` method, this should
+   be simplified.
+
+## Decisions
+
+- No code changes made (review-only session as specified in the issue)
+- All findings documented here for future sessions
+- Splitting should be a separate issue created by the next planner
+
+## Quality Metrics
+
+- Sorry count: 0 → 0 (unchanged)
+- No bugs found requiring immediate fixes
+- Code quality is good overall; the file is well-structured with clear section
+  boundaries that will make future splitting straightforward


### PR DESCRIPTION
Closes #580

Session: `436b36a4-1fbf-4192-b9b9-9a2d4dd91a29`

7a436bb doc: review ZstdFrame.lean code quality and splitting plan (1059 lines)

🤖 Prepared with Claude Code