### PR TITLE
Review: audit ZstdNative.lean test organization and coverage (1595 lines)

### DIFF
--- a/progress/20260304T235353Z_98e1cbbe.md
+++ b/progress/20260304T235353Z_98e1cbbe.md
@@ -1,0 +1,206 @@
+# Review: ZstdNative.lean test organization and coverage audit
+
+- **Date**: 2026-03-04T23:53Z
+- **Session**: 98e1cbbe (review)
+- **Issue**: #586
+- **Starting commit**: cf3b80e
+- **Sorry count**: 0 (unchanged)
+
+## Deliverable 1: Organization and Naming Audit
+
+### Test catalog (1595 lines, 1 monolithic function)
+
+All tests live inside `ZipTest.ZstdNative.tests : IO Unit`. No separate
+helper functions are defined in the file (helpers come from `ZipTest.Helpers`).
+
+| Lines | Component | Tests |
+|-------|-----------|-------|
+| 9–78 | Frame header parsing | Tests 1–9: empty/small/medium/large inputs, compression levels, position validation, invalid magic, truncation |
+| 79–122 | Block header & raw/RLE blocks | Tests 10–13: parseBlockHeader, decompressRLEBlock, decompressRawBlock, truncation |
+| 124–197 | decompressBlocks round-trip | Tests 14–19: empty, constant, single byte, all-zeros |
+| 198–251 | decompressZstd errors & decompressFrame | Tests 20–24: bad magic, truncation, skippable-only, frame position, content size |
+| 253–302 | Checksum verification | Tests 25–27: valid checksum, corrupted byte, empty with checksum |
+| 304–366 | Literals section | Tests 28–32: raw 1-byte/2-byte header, RLE, malformed compressed, treeless rejection |
+| 367–418 | Sequences header | Tests 33–38: 0/1-byte/2-byte/3-byte count, truncation |
+| 420–431 | Compressed block integration | Test 39: FFI-compressed data past header parsing |
+| 433–558 | executeSequences | Tests 40–44d: literals-only, non-overlapping match, overlap, repeat offset, shifted repeat, cross-block history, windowPrefix, prefix stripping |
+| 560–684 | Huffman weights/table building | Tests 45–54: parseHuffmanWeightsDirect, weightsToMaxBits, buildZstdHuffmanTable, parseHuffmanTreeDescriptor, truncation/error cases |
+| 686–766 | Extra bits tables | Tests 55–68: decodeLitLenValue, decodeMatchLenValue, decodeOffsetValue across boundary values and out-of-range |
+| 767–814 | Sequences header modes | Tests 69–71: modes parsing, 0-seq defaults, all-repeat mode |
+| 816–898 | Skippable frames & multi-frame | Tests 72–79: skipSkippableFrame, multi-frame concat, skippable+zstd ordering, trailing garbage, empty input |
+| 900–906 | Table sizes | Tests 80–81: litLenExtraBits (36 entries), matchLenExtraBits (53 entries) |
+| 908–995 | Huffman FSE-compressed + decode | **"Tests 74–75"** (renumbered): parseHuffmanTreeDescriptor on real data, decodeFseSymbolsAll smoke |
+| 997–1059 | Huffman symbol decoding | **"Tests 76–79"** (renumbered): decodeHuffmanSymbol, decodeHuffmanStream, Huffman integration, decodeFourHuffmanStreams |
+| 1061–1211 | Sequence decoding | Tests 84–87: decodeSequences single/multi/zero/extra-bits |
+| 1213–1287 | FSE table resolution | Unnamed: buildRleFseTable, resolveSingleFseTable (predefined/RLE/repeat), resolveSequenceFseTables (all-predefined/mixed) |
+| 1289–1330 | Compression mode integration | Unnamed: parseSequencesHeader on FFI level-3 data, insufficient data error |
+| 1332–1374 | Treeless literals | Unnamed: treeless roundtrip, no-previous-tree error |
+| 1376–1595 | Validation edge cases | Unnamed: dictionary rejection, checksum corruption, truncated frame, reserved descriptor bits, content size mismatch, max window, truncated header/FCS, reserved block type, raw overflow, RLE consumption, non-power-of-2 weights, skippable overflow, trailing 2 bytes |
+
+### Naming inconsistencies
+
+1. **Test number collisions**: Tests 74–79 appear twice — first at L834–898
+   (skippable/multi-frame) and again at L908–1059 (Huffman/FSE). This happened
+   because the Huffman/FSE tests were appended by a later session without
+   checking the existing numbering.
+
+2. **Missing numbers**: Tests 82–83 are skipped entirely (jump from 81 to 84).
+
+3. **Abandoned numbering**: After Test 87 (L1211), all subsequent tests drop
+   the `-- Test N:` convention entirely and use either `-- Test:` section headers
+   or no label at all.
+
+4. **Dominant pattern**: `-- Test N: description` (used consistently for tests
+   1–81, then 84–87). The later sections use `-- Test:` or `-- ===` section
+   headers. Both styles are readable but inconsistent.
+
+### Proposed reorganization
+
+Group tests by component rather than chronological order. Suggested sections:
+
+1. **Frame header parsing** (Tests 1–9 + reserved bits, truncated header/FCS, max window)
+2. **Block header parsing** (Tests 10, 13 + reserved block type)
+3. **Raw and RLE blocks** (Tests 11–12 + raw overflow, RLE consumption)
+4. **Literals section** (Tests 28–32, 37 + treeless)
+5. **Huffman weights and tables** (Tests 45–54 + non-power-of-2 implicit)
+6. **Huffman decoding** ("Tests 76–79" + integration)
+7. **Sequences header and modes** (Tests 33–36, 38, 69–71 + insufficient data)
+8. **Extra bits tables** (Tests 55–68, 80–81)
+9. **FSE table resolution** (buildRleFseTable, resolveSingle, resolveAll)
+10. **Sequence decoding** (Tests 84–87)
+11. **Sequence execution** (Tests 40–44d)
+12. **Block-level decompression** (Tests 14–15, 39)
+13. **Frame-level decompression** (Tests 16–27 + content size mismatch, dictionary rejection)
+14. **Multi-frame and skippable** (Tests 72–79 + skippable overflow, trailing garbage/bytes)
+15. **Malformed input edge cases** (remaining validation tests)
+
+Renumber all tests sequentially within each section. This reorganization would
+not change any test logic — only the order of test code within the function.
+
+### Dead code
+
+No dead code found. All test code executes sequentially within the single
+`tests` function. All imports (`ZipTest.Helpers`, `Zip.Native.ZstdFrame`,
+`Zip.Native.XxHash`) are used.
+
+## Deliverable 2: Test coverage analysis
+
+### ZstdFrame.lean coverage (48 public definitions)
+
+| Function | Tested | Notes |
+|----------|--------|-------|
+| `parseFrameHeader` | Direct | Tests 1–9 + many edge cases |
+| `parseBlockHeader` | Direct | Tests 10, 13 |
+| `decompressRawBlock` | Direct | Test 12 + raw overflow edge case |
+| `decompressRLEBlock` | Direct | Test 11 + RLE consumption edge case |
+| `parseHuffmanWeightsDirect` | Direct | Tests 45, 53 |
+| `weightsToMaxBits` | Direct | Tests 46–47, 54 |
+| `buildZstdHuffmanTable` | Direct | Tests 48–49 + non-power-of-2 |
+| `parseHuffmanWeightsFse` | Indirect | Via parseHuffmanTreeDescriptor on real data |
+| `parseHuffmanTreeDescriptor` | Direct | Tests 50–52, "74" |
+| `decodeHuffmanSymbol` | Direct | "Test 76" |
+| `decodeHuffmanStream` | Direct | "Test 77" |
+| `decodeFourHuffmanStreams` | Direct | "Test 79" (error case only) |
+| `parseLiteralsSection` | Direct | Tests 28–32, 37 |
+| `parseSequencesHeader` | Direct | Tests 33–36, 38, 69–71 + integration |
+| `decompressBlocks` | Direct | Tests 14–15 |
+| `decompressFrame` | Direct | Tests 23–24 |
+| `skipSkippableFrame` | Direct | Tests 72–74 + overflow |
+| `decompressZstd` | Direct | Tests 16–22 + many integration/edge tests |
+| `executeSequences` | Direct | Tests 40–44d |
+| `resolveOffset` | Indirect | Via executeSequences repeat-offset tests |
+| `litLenExtraBits` | Direct | Test 80 (size check) |
+| `matchLenExtraBits` | Direct | Test 81 (size check) |
+| `decodeLitLenValue` | Direct | Tests 55–59 |
+| `decodeMatchLenValue` | Direct | Tests 60–64 |
+| `decodeOffsetValue` | Direct | Tests 65–68 |
+| `decodeSequences` | Direct | Tests 84–87 |
+| `buildRleFseTable` | Direct | Unnamed test |
+| `resolveSingleFseTable` | Direct | Unnamed tests (predefined/RLE/repeat) |
+| `resolveSequenceFseTables` | Direct | Unnamed tests (all-predefined/mixed) |
+| `windowSizeFromDescriptor` | Indirect | Via parseFrameHeader + max window test |
+| `zstdMagic` | Indirect | Constant, tested via magic validation |
+| `ZstdFrameHeader` | Indirect | Structure, used throughout |
+| `ZstdBlockType` | Indirect | Enum, used in block tests |
+| `ZstdBlockHeader` | Indirect | Structure, used in block tests |
+| `HuffmanEntry` | Indirect | Structure, used in table tests |
+| `ZstdHuffmanTable` | Indirect | Structure, used in table tests |
+| `SequenceCompressionMode` | Indirect | Enum, used in modes tests |
+| `SequenceCompressionModes` | Indirect | Structure, used in modes tests |
+| `ZstdSequence` | Indirect | Structure, used in executeSequences tests |
+
+### Fse.lean coverage (from ZstdNative.lean)
+
+| Function | Tested here | Notes |
+|----------|-------------|-------|
+| `BackwardBitReader.init` | Direct | Tests 75, 76, 77, 84–87 |
+| `BackwardBitReader.readBits` | Indirect | Via decode functions |
+| `BackwardBitReader.isFinished` | Indirect | Via decode functions |
+| `decodeFseDistribution` | Not here | Tested in FseNative.lean |
+| `buildFseTable` | Not here | Tested in FseNative.lean |
+| `decodeFseSymbols` | Indirect | Via decodeFseSymbolsAll |
+| `decodeFseSymbolsAll` | Direct | "Test 75" |
+| `predefinedLitLenDistribution` | Direct | Via resolveSingleFseTable test |
+| `predefinedMatchLenDistribution` | Indirect | Via resolveSequenceFseTables |
+| `predefinedOffsetDistribution` | Indirect | Via resolveSequenceFseTables |
+| `buildPredefinedFseTables` | Not here | Not directly tested anywhere visible |
+
+### Coverage gaps
+
+1. **`decodeFourHuffmanStreams` happy path**: Only the error case (too-small data)
+   is tested. No test verifies successful 4-stream decoding with known input.
+   The integration test ("Test 78") may exercise it on real data but success
+   depends on the compressor's output format.
+
+2. **`parseHuffmanWeightsFse` isolation**: Only tested indirectly via
+   parseHuffmanTreeDescriptor on real FFI-compressed data. No crafted-input
+   unit test exists. Coverage depends on whether the FFI compressor produces
+   FSE-compressed Huffman weights at the chosen compression level.
+
+3. **`buildPredefinedFseTables`**: Not directly called in any test file.
+   The individual predefined distributions are tested via `resolveSingleFseTable`,
+   but the combined builder function has no direct test.
+
+4. **`fseCompressed` mode in resolveSequenceFseTables**: Only predefined and RLE
+   modes are tested. No test exercises FSE-compressed sequence tables from crafted
+   data. The integration test on FFI-compressed data may hit this path, but it's
+   not verified.
+
+5. **Large raw/RLE blocks**: decompressRawBlock and decompressRLEBlock are tested
+   with small sizes (3–5 bytes). No test exercises blocks near the 128KB maximum.
+
+### Tests that become integration tests after #552
+
+Once compressed block wiring lands, these tests should transition from
+"may-fail-gracefully" to "must-succeed":
+- Tests 14–19 (decompressBlocks/decompressZstd round-trips)
+- Tests 23–27 (decompressFrame + checksum)
+- Test 39 (compressed block on FFI data)
+- "Test 78" (Huffman integration)
+- Treeless literals roundtrip
+- Multi-frame tests (75–78)
+
+The `unless e.contains "compressed blocks not yet implemented"` guards in
+these tests should be removed when compressed blocks work end-to-end.
+
+### Recommendations for conformance test matrix (#575)
+
+1. Cover all combinations: {raw, RLE, compressed} blocks × {empty, small, medium, large} inputs
+2. Test window sizes: single-segment vs multi-segment frames
+3. Test all sequence compression modes: predefined, RLE, FSE-compressed
+4. Test treeless literals explicitly (not just via FFI output)
+5. Verify content size validation for all FCS field sizes (0, 1, 2, 4, 8 bytes)
+6. Add `decodeFourHuffmanStreams` happy-path test with crafted 4-stream input
+
+## Decisions
+
+- No code changes needed — no dead code found, no bugs found
+- The file works correctly as-is; reorganization is a separate refactoring task
+- Coverage gaps documented for future test sessions
+
+## What remains
+
+- Reorganization (renumbering + grouping by component) should be a separate
+  feature issue, not done in this review PR, as it touches every line
+- Coverage gaps listed above should be addressed in new test issues
+- Remove "compressed blocks not yet implemented" guards after #552 merges


### PR DESCRIPTION
Closes #586

Session: `98e1cbbe-7790-44dd-90b5-d294c27e0fc8`

e22d4a8 doc: review ZstdNative.lean test organization and coverage (1595 lines)

🤖 Prepared with Claude Code