### PR TITLE
Review: final bare simp sweep + fix DeflateEncodeDynamicProps residual

### DIFF
--- a/Zip/Spec/DeflateDynamicHeader.lean
+++ b/Zip/Spec/DeflateDynamicHeader.lean
@@ -246,10 +246,12 @@ theorem writeDynamicHeader_spec (bw : BitWriter) (litLens distLens : List Nat)
     cases hcle : Deflate.Spec.encodeCLEntries clTable clEntries with
     | none =>
       -- bare simp: Option.bind chain with none
-      rw [hcle] at henc; simp at henc
+      rw [hcle] at henc; simp only [List.getD_eq_getElem?_getD, List.append_assoc,
+        Option.bind_eq_bind, Option.bind_none, Option.bind_fun_none, reduceCtorEq] at henc
     | some sb =>
-      -- bare simp: Option.bind chain with some
-      rw [hcle] at henc; simp at henc; exact ⟨sb, rfl, henc.symm⟩
+      rw [hcle] at henc; simp only [List.getD_eq_getElem?_getD, List.append_assoc,
+        Option.bind_eq_bind, Option.bind_some, Option.some.injEq] at henc
+      exact ⟨sb, rfl, henc.symm⟩
   obtain ⟨symbolBits, hcle_eq, hbits_eq⟩ := henc_cl
   subst hbits_eq
   -- Bounds needed throughout

--- a/Zip/Spec/DeflateEncodeDynamic.lean
+++ b/Zip/Spec/DeflateEncodeDynamic.lean
@@ -117,12 +117,12 @@ theorem take_countRun_eq_replicate (val : Nat) (xs : List Nat) (n : Nat) (hn : n
     split at hn
     · rename_i heq; simp only [beq_iff_eq] at heq; subst heq
       cases n with
-      | zero => simp
+      | zero => simp only [List.take_zero, List.replicate_zero]
       | succ n =>
         simp only [List.take_succ_cons, List.replicate_succ]
         exact congrArg (x :: ·) (ih n (by omega))
     · have : n = 0 := by omega
-      subst this; simp
+      subst this; simp only [List.take_zero, List.replicate_zero]
 
 private theorem drop_subset_valid {xs : List Nat} {n : Nat}
     (hvalid : ∀ y ∈ xs, y ≤ 15) : ∀ y ∈ xs.drop n, y ≤ 15 :=
@@ -215,8 +215,12 @@ theorem rlDecodeLengths_go_rlEncodeLengths_go (lengths : List Nat) (acc : List N
       by_cases hge3 : countRun x xs >= 3
       · -- literal + code 16: repeat previous 3-6
         rw [if_pos (by omega : countRun x xs ≥ 3)]
-        rw [Deflate.Spec.rlDecode_go_literal x 0 _ _ hx_valid, Deflate.Spec.rlDecode_go_code16 _ _ _ (by simp)]
-        rw [show (acc ++ [x]).getLast! = x from by simp]
+        rw [Deflate.Spec.rlDecode_go_literal x 0 _ _ hx_valid, Deflate.Spec.rlDecode_go_code16 _ _ _ (by
+          simp only [List.length_append, List.length_cons, List.length_nil, Nat.zero_add, gt_iff_lt,
+            Nat.zero_lt_succ])]
+        rw [show (acc ++ [x]).getLast! = x from by
+          simp only [List.getLast!_eq_getLast?_getD, List.getLast?_append, List.getLast?_singleton,
+            Option.some_or, Nat.default_eq_zero, Option.getD_some]]
         rw [show min (countRun x xs) 6 - 3 + 3 = min (countRun x xs) 6 from by omega]
         rw [rlDecodeLengths_go_rlEncodeLengths_go _ _ (drop_subset_valid hxs_valid)]
         simp only [List.append_assoc]

--- a/Zip/Spec/DeflateEncodeDynamicProps.lean
+++ b/Zip/Spec/DeflateEncodeDynamicProps.lean
@@ -23,7 +23,7 @@ private theorem codeLengthOrder_toList_eq_clPermutation :
     codeLengthOrder.toList = Deflate.Spec.clPermutation := by rfl
 
 theorem computeHCLEN_ge_four (clLens : List Nat) : computeHCLEN clLens ≥ 4 := by
-  simp [computeHCLEN]; omega
+  simp only [computeHCLEN, List.getD_eq_getElem?_getD, List.length_map, ge_iff_le]; omega
 
 theorem computeHCLEN_le_nineteen (clLens : List Nat) : computeHCLEN clLens ≤ 19 := by
   simp only [computeHCLEN]
@@ -107,7 +107,7 @@ theorem readCLLengths_writeCLLengths
       (List.replicate 19 0), rest) := by
   rw [writeCLLengths_eq_flatMap]
   have := readCLLengths_writeCLLengths_go clLens numCodeLen 0 (List.replicate 19 0) rest
-    (by simp) (by omega) hvals
+    (by simp only [List.reduceReplicate, List.length_cons, List.length_nil, Nat.zero_add, Nat.reduceAdd]) (by omega) hvals
   simp only [List.drop_zero] at this
   exact this
 
@@ -123,7 +123,7 @@ private theorem rlDecodeLengths_go_invalid_code
   split; · exact absurd (beq_iff_eq.mp ‹_›) h16
   split; · exact absurd (beq_iff_eq.mp ‹_›) h17
   split; · exact absurd (beq_iff_eq.mp ‹_›) h18
-  simp
+  simp only
 
 /-- `rlDecodeLengths.go` only appends to the accumulator, so the result
     is at least as long as the input accumulator. -/
@@ -136,19 +136,19 @@ private theorem rlDecodeLengths_go_mono (entries : List CLEntry) (acc result : L
     obtain ⟨code, extra⟩ := entry
     by_cases hle : code ≤ 15
     · rw [Deflate.Spec.rlDecode_go_literal code extra rest acc hle] at h
-      have := ih _ h; simp at this; omega
+      have := ih _ h; simp only [List.length_append, List.length_cons, List.length_nil, Nat.zero_add] at this; omega
     · by_cases h16 : code = 16
       · subst h16
         by_cases hg : 0 < acc.length
         · rw [Deflate.Spec.rlDecode_go_code16 extra rest acc hg] at h
-          have := ih _ h; simp at this; omega
+          have := ih _ h; simp only [List.getLast!_eq_getLast?_getD, Nat.default_eq_zero, List.length_append, List.length_replicate] at this; omega
         · exfalso; simp [rlDecodeLengths.go, hg, guard, bind, failure] at h
       · by_cases h17 : code = 17
         · subst h17; rw [Deflate.Spec.rlDecode_go_code17 extra rest acc] at h
-          have := ih _ h; simp at this; omega
+          have := ih _ h; simp only [List.length_append, List.length_replicate] at this; omega
         · by_cases h18 : code = 18
           · subst h18; rw [Deflate.Spec.rlDecode_go_code18 extra rest acc] at h
-            have := ih _ h; simp at this; omega
+            have := ih _ h; simp only [List.length_append, List.length_replicate] at this; omega
           · exact absurd h (rlDecodeLengths_go_invalid_code code extra rest acc hle h16 h17 h18 ▸ nofun)
 
 /-- When `rlDecodeLengths.go` succeeds on a non-empty list, the result is
@@ -160,19 +160,19 @@ private theorem rlDecodeLengths_go_strict_mono
   obtain ⟨code, extra⟩ := entry
   by_cases hle : code ≤ 15
   · rw [Deflate.Spec.rlDecode_go_literal code extra rest acc hle] at h
-    have := rlDecodeLengths_go_mono rest _ _ h; simp at this; omega
+    have := rlDecodeLengths_go_mono rest _ _ h; simp only [List.length_append, List.length_cons, List.length_nil, Nat.zero_add] at this; omega
   · by_cases h16 : code = 16
     · subst h16
       by_cases hg : 0 < acc.length
       · rw [Deflate.Spec.rlDecode_go_code16 extra rest acc hg] at h
-        have := rlDecodeLengths_go_mono rest _ _ h; simp at this; omega
+        have := rlDecodeLengths_go_mono rest _ _ h; simp only [List.getLast!_eq_getLast?_getD, Nat.default_eq_zero, List.length_append, List.length_replicate] at this; omega
       · exfalso; simp [rlDecodeLengths.go, hg, guard, bind, failure] at h
     · by_cases h17 : code = 17
       · subst h17; rw [Deflate.Spec.rlDecode_go_code17 extra rest acc] at h
-        have := rlDecodeLengths_go_mono rest _ _ h; simp at this; omega
+        have := rlDecodeLengths_go_mono rest _ _ h; simp only [List.length_append, List.length_replicate] at this; omega
       · by_cases h18 : code = 18
         · subst h18; rw [Deflate.Spec.rlDecode_go_code18 extra rest acc] at h
-          have := rlDecodeLengths_go_mono rest _ _ h; simp at this; omega
+          have := rlDecodeLengths_go_mono rest _ _ h; simp only [List.length_append, List.length_replicate] at this; omega
         · exact absurd h (rlDecodeLengths_go_invalid_code code extra rest acc hle h16 h17 h18 ▸ nofun)
 
 /-- Encoding CL entries then decoding with `decodeCLSymbols` recovers
@@ -247,16 +247,16 @@ private theorem encodeCLEntries_decodeCLSymbols_go
         · -- Literal code (0-15): no extra bits
           rw [if_pos (show code < 16 from by omega)]
           -- encodeCLExtra for code ≤ 15 is []
-          have h16f : (code == 16) = false := by simp; omega
-          have h17f : (code == 17) = false := by simp; omega
-          have h18f : (code == 18) = false := by simp; omega
+          have h16f : (code == 16) = false := by simp only [beq_eq_false_iff_ne, ne_eq]; omega
+          have h17f : (code == 17) = false := by simp only [beq_eq_false_iff_ne, ne_eq]; omega
+          have h18f : (code == 18) = false := by simp only [beq_eq_false_iff_ne, ne_eq]; omega
           simp only [encodeCLExtra, h16f, h17f, h18f,
             Bool.false_eq_true, ↓reduceIte, List.nil_append]
           -- rlDecodeLengths.go step for literal
           rw [Deflate.Spec.rlDecode_go_literal code extra restEntries acc hle] at hdec
           -- Apply IH
           exact ih restBits (acc ++ [code]) hrestBits hvalid_rest hdec
-            (by simp; omega)
+            (by simp only [List.length_append, List.length_cons, List.length_nil, Nat.zero_add]; omega)
         · -- Repeat codes (16, 17, 18)
           rw [if_neg (show ¬(code < 16) from by omega)]
           -- From hentry and ¬(code ≤ 15), code must be 16, 17, or 18
@@ -277,7 +277,7 @@ private theorem encodeCLEntries_decodeCLSymbols_go
                 (restBits ++ rest) (by omega)
               -- Discharge if acc.length == 0, readBitsLSB, and acc' bound
               have hne0 : (acc.length == 0) = false := by
-                cases acc with | nil => simp at haccpos | cons _ _ => rfl
+                cases acc with | nil => simp only [List.length_nil, gt_iff_lt, Nat.lt_irrefl] at haccpos | cons _ _ => rfl
               have hbound : acc.length + (extra + 3) ≤ totalCodes := by
                 have := hacc'; simp [List.length_append, List.length_replicate] at this; exact this
               simp [encodeCLExtra, hne0, hrb, List.append_assoc, hbound]
@@ -392,13 +392,13 @@ private theorem readCLLengths_recovers_clLens
     by_cases hmem : p ∈ positions
     · -- p was set by the foldl
       rw [List.foldl_set_getElem_mem positions _ _ p hmem hpos_nodup
-          (by simp; omega)
-          (fun q hq => by simp; exact hpos_bounds q hq)]
+          (by simp only [List.reduceReplicate, List.length_cons, List.length_nil, Nat.zero_add, Nat.reduceAdd]; omega)
+          (fun q hq => by simp only [List.reduceReplicate, List.length_cons, List.length_nil, Nat.zero_add, Nat.reduceAdd]; exact hpos_bounds q hq)]
       -- Goal: clLens.getD p 0 = clLens[p]
       exact (List.getElem_eq_getD 0).symm
     · -- p was NOT set; value is 0 from replicate
       rw [List.foldl_set_getElem_not_mem positions _ _ p hmem
-          (by simp; omega)]
+          (by simp only [List.reduceReplicate, List.length_cons, List.length_nil, Nat.zero_add, Nat.reduceAdd]; omega)]
       simp only [List.getElem_replicate]
       -- Need: clLens[p] = 0
       -- p ∉ positions = clPermutation.take numCodeLen
@@ -538,7 +538,7 @@ theorem encodeDynamicTrees_decodeDynamicTables
       by_cases hi : i < clLens.length
       · have := hclLens_bounded (clLens[i]) (List.getElem_mem ..)
         rw [List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hi, Option.getD_some]; omega
-      · rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (by omega)]; simp
+      · rw [List.getD_eq_getElem?_getD, List.getElem?_eq_none (by omega)]; simp only [Option.getD_none, Nat.zero_lt_succ]
     have hnum_le : numCodeLen ≤ 19 := computeHCLEN_le_nineteen clLens
     have htrailing : ∀ j, j ≥ numCodeLen → j < 19 →
         clLens.getD (Deflate.Spec.clPermutation.getD j 0) 0 = 0 :=
@@ -562,7 +562,7 @@ theorem encodeDynamicTrees_decodeDynamicTables
     -- RLE roundtrip
     have hrle : rlDecodeLengths.go clEntries [] = some allLens := by
       have := rlDecodeLengths_go_rlEncodeLengths_go allLens [] hallLens
-      simp at this
+      simp only [List.nil_append] at this
       exact this
     -- Entry validity
     have hvalid_entries : ∀ entry ∈ clEntries,
@@ -577,7 +577,7 @@ theorem encodeDynamicTrees_decodeDynamicTables
     -- Apply the main roundtrip theorem
     have hdecCL := encodeCLEntries_decodeCLSymbols_go clLens clTable clEntries
       symbolBits rest totalCodes []
-      hv htable hsymEnc hvalid_entries hrle htotalLen (by simp)
+      hv htable hsymEnc hvalid_entries hrle htotalLen (by simp only [List.length_nil, Nat.zero_le])
     -- Rewrite the goal to use hdecCL
     rw [show (List.map (fun x => (x.snd, x.fst)) (Huffman.Spec.allCodes clLens 7)) = clTable from rfl,
       hdecCL]
@@ -635,7 +635,7 @@ private theorem clFreqFoldl_pos (entries : List CLEntry) (code extra : Nat)
     (hmem : (code, extra) ∈ entries) :
     (entries.foldl clFreqFoldl acc).getD code 0 > 0 := by
   induction entries generalizing acc with
-  | nil => simp at hmem
+  | nil => simp only [List.not_mem_nil] at hmem
   | cons entry rest ih =>
     simp only [List.foldl_cons, clFreqFoldl]
     obtain ⟨c, e⟩ := entry

--- a/Zip/Spec/HuffmanKraft.lean
+++ b/Zip/Spec/HuffmanKraft.lean
@@ -21,7 +21,7 @@ private theorem kraft_ge_count (ls : List Nat) (maxBits len : Nat) :
     (ls.filter (· == len)).length * 2 ^ (maxBits - len) ≤
     ls.foldl (fun acc l => acc + 2 ^ (maxBits - l)) 0 := by
   induction ls with
-  | nil => simp
+  | nil => simp only [List.filter_nil, List.length_nil, Nat.zero_mul, List.foldl_nil, Std.le_refl]
   | cons x xs ih =>
     simp only [List.foldl_cons, Nat.zero_add]
     rw [List.foldl_add_init]
@@ -117,7 +117,8 @@ protected theorem countLengths_eq (lengths : List Nat) (maxBits b : Nat)
       Array.getElem_replicate, beq_iff_eq, Nat.zero_add]
   intro acc hsize
   induction lengths generalizing acc with
-  | nil => simp
+  | nil => simp only [gt_iff_lt, Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq,
+      Array.set!_eq_setIfInBounds, List.foldl_nil, Nat.add_zero]
   | cons l ls ih =>
     simp only [List.foldl_cons]
     split
@@ -257,7 +258,8 @@ private theorem kraftSumFrom_eq_kraft_foldl (lengths : List Nat) (maxBits : Nat)
     exact hv.2
   intro acc hsize
   induction lengths generalizing acc with
-  | nil => simp
+  | nil => simp only [gt_iff_lt, Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq,
+      Array.set!_eq_setIfInBounds, List.foldl_nil, List.filter_nil, Nat.add_zero]
   | cons l ls ih =>
     have hv_ls := Huffman.Spec.validLengths_cons hv
     simp only [List.foldl_cons]
@@ -302,7 +304,7 @@ protected theorem ncRec_shift (blCount : Array Nat) (b₁ b₂ : Nat) (h : b₁ 
         _ ≤ (Huffman.Spec.ncRec blCount k + blCount[k]!) * 2 :=
             Nat.mul_le_mul_right 2 (Nat.le_add_right _ _)
     | inr heq =>
-      subst heq; simp
+      subst heq; simp only [Nat.add_sub_cancel_left, Nat.pow_one, Std.le_refl]
 
 /-- The core ncRec bound: `ncRec blCount b + blCount[b]! ≤ 2^b` when the Kraft
     inequality holds for the full sum from 0. -/

--- a/Zip/Spec/InflateCorrect.lean
+++ b/Zip/Spec/InflateCorrect.lean
@@ -481,7 +481,7 @@ theorem inflateLoop_correct (br : Zip.Native.BitReader)
         simp only [show UInt32.toNat 0 = 0 from rfl]
         -- Extract decodeStored result from h
         split at h
-        · simp at h
+        · simp only [reduceCtorEq] at h
         · rename_i v hds; obtain ⟨out', br'⟩ := v; simp only [] at hds h
           -- Use decodeStored_correct to get spec result
           have ⟨storedBytes, rest, hspec_ds, hout, hrest⟩ :=
@@ -509,10 +509,10 @@ theorem inflateLoop_correct (br : Zip.Native.BitReader)
             simp only [hrest_lt, ↓reduceDIte]
             -- Discharge native WF guards
             split at h
-            · simp at h
+            · simp only [reduceCtorEq] at h
             · rename_i h_progress
               split at h
-              · simp at h
+              · simp only [reduceCtorEq] at h
               · rename_i h_range
                 -- Apply IH with decreased measure
                 have hinv := decodeStored_invariants br₂ output maxOutputSize out' br' hds
@@ -525,7 +525,7 @@ theorem inflateLoop_correct (br : Zip.Native.BitReader)
         simp only [show UInt32.toNat 1 = 1 from rfl]
         -- Extract decodeHuffman result from h
         split at h
-        · simp at h
+        · simp only [reduceCtorEq] at h
         · rename_i v hdh; obtain ⟨out', br'⟩ := v; simp only [] at hdh h
           -- Unfold decodeHuffman to get decodeHuffman.go
           unfold Zip.Native.Inflate.decodeHuffman at hdh
@@ -562,10 +562,10 @@ theorem inflateLoop_correct (br : Zip.Native.BitReader)
             simp only [hrest_lt, ↓reduceDIte]
             -- Discharge native WF guards
             split at h
-            · simp at h
+            · simp only [reduceCtorEq] at h
             · rename_i h_progress
               split at h
-              · simp at h
+              · simp only [reduceCtorEq] at h
               · rename_i h_range
                 -- Apply IH with decreased measure
                 have h_ih := ih (dataSize * 8 - br'.bitPos)
@@ -577,7 +577,7 @@ theorem inflateLoop_correct (br : Zip.Native.BitReader)
         simp only [show UInt32.toNat 2 = 2 from rfl]
         -- Extract decodeDynamicTrees + decodeHuffman from h
         split at h
-        · simp at h
+        · simp only [reduceCtorEq] at h
         · rename_i v hdt
           obtain ⟨litTree, distTree, br₃⟩ := v; simp only [] at hdt h
           -- Apply decodeDynamicTrees_correct
@@ -588,7 +588,7 @@ theorem inflateLoop_correct (br : Zip.Native.BitReader)
           rw [hbr₂_bits] at hspec_dt
           -- Now extract decodeHuffman from h
           split at h
-          · simp at h
+          · simp only [reduceCtorEq] at h
           · rename_i v₂ hdh; obtain ⟨out', br'⟩ := v₂; simp only [] at hdh h
             -- Unfold decodeHuffman to get decodeHuffman.go
             unfold Zip.Native.Inflate.decodeHuffman at hdh
@@ -620,10 +620,10 @@ theorem inflateLoop_correct (br : Zip.Native.BitReader)
               simp only [hrest_lt, ↓reduceDIte]
               -- Discharge native WF guards
               split at h
-              · simp at h
+              · simp only [reduceCtorEq] at h
               · rename_i h_progress
                 split at h
-                · simp at h
+                · simp only [reduceCtorEq] at h
                 · rename_i h_range
                   -- Apply IH with decreased measure
                   have h_ih := ih (dataSize * 8 - br'.bitPos)
@@ -632,7 +632,7 @@ theorem inflateLoop_correct (br : Zip.Native.BitReader)
                   rw [hrest] at h_ih
                   exact h_ih
       · -- Case 4: reserved (btype ≥ 3)
-        simp at h
+        simp only [reduceCtorEq] at h
 
 /-- **Main theorem**: If the native DEFLATE decompressor succeeds, then
     the formal specification also succeeds and produces the same output. -/

--- a/Zip/Spec/ZlibCorrect.lean
+++ b/Zip/Spec/ZlibCorrect.lean
@@ -274,7 +274,7 @@ theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
     rw [hep_val, hceq]
     simp only [ByteArray.size_append, htsz, hhsz]; omega
   have hendPos4 : ¬ (endPos + 4 > (ZlibEncode.compress data level).size) := by omega
-  have hba_eq : (⟨⟨data.data.toList⟩⟩ : ByteArray) = data := by simp
+  have hba_eq : (⟨⟨data.data.toList⟩⟩ : ByteArray) = data := by simp only [Array.toArray_toList]
   -- Adler32 trailer match: use endPos = 2 + deflated.size to read trailer bytes
   have hadler : (Adler32.Native.adler32 1 data ==
     (ZlibEncode.compress data level)[endPos]!.toUInt32 <<< 24 |||

--- a/ZipForStd/List.lean
+++ b/ZipForStd/List.lean
@@ -13,7 +13,7 @@ theorem foldl_add_init (f : Nat → Nat) (init : Nat) (ls : List Nat) :
     ls.foldl (fun acc l => acc + f l) init =
       init + ls.foldl (fun acc l => acc + f l) 0 := by
   induction ls generalizing init with
-  | nil => simp
+  | nil => simp only [foldl_nil, Nat.add_zero]
   | cons x xs ih => simp only [foldl_cons, Nat.zero_add]; rw [ih, ih (f x)]; omega
 
 /-- A `foldl` that counts elements equal to `b` commutes with the initial value. -/
@@ -21,7 +21,7 @@ theorem foldl_count_init (b : Nat) (init : Nat) (ls : List Nat) :
     ls.foldl (fun acc l => if (l == b) = true then acc + 1 else acc) init =
       init + ls.foldl (fun acc l => if (l == b) = true then acc + 1 else acc) 0 := by
   induction ls generalizing init with
-  | nil => simp
+  | nil => simp only [beq_iff_eq, foldl_nil, Nat.add_zero]
   | cons x xs ih =>
     simp only [foldl_cons, Nat.zero_add]
     split
@@ -34,7 +34,7 @@ theorem foldl_count_init (b : Nat) (init : Nat) (ls : List Nat) :
 theorem getLast?_getD_eq_getLast! [Inhabited α] (l : List α) (h : l.length > 0) :
     l.getLast?.getD default = l.getLast! := by
   induction l with
-  | nil => simp at h
+  | nil => simp only [length_nil, gt_iff_lt, Nat.lt_irrefl] at h
   | cons a as ih =>
     cases as with
     | nil => rfl
@@ -46,7 +46,7 @@ theorem getLast?_getD_eq_getLast! [Inhabited α] (l : List α) (h : l.length > 0
 theorem foldl_set_length (positions : List Nat) (f : Nat → α) (init : List α) :
     (positions.foldl (fun a pos => a.set pos (f pos)) init).length = init.length := by
   induction positions generalizing init with
-  | nil => simp
+  | nil => simp only [foldl_nil]
   | cons p ps ih => simp [ih, List.length_set]
 
 /-- At a position not in the fold list, the value is unchanged from init. -/
@@ -55,7 +55,7 @@ theorem foldl_set_getElem_not_mem (positions : List Nat) (f : Nat → α)
     (positions.foldl (fun a pos => a.set pos (f pos)) init)[p]'(by
       rw [foldl_set_length]; exact hlt) = init[p] := by
   induction positions generalizing init with
-  | nil => simp
+  | nil => simp only [foldl_nil]
   | cons q qs ih =>
     simp only [List.mem_cons, not_or] at hp
     simp only [List.foldl_cons]
@@ -70,7 +70,7 @@ theorem foldl_set_getElem_mem (positions : List Nat) (f : Nat → α)
     (positions.foldl (fun a pos => a.set pos (f pos)) init)[p]'(by
       rw [foldl_set_length]; exact hlt) = f p := by
   induction positions generalizing init with
-  | nil => simp at hp
+  | nil => simp only [not_mem_nil] at hp
   | cons q qs ih =>
     simp only [List.mem_cons] at hp
     simp only [List.foldl_cons]
@@ -130,10 +130,10 @@ theorem flatMap_drop_mul (l : List α) (f : α → List β)
     (k n : Nat) (hk : ∀ a, (f a).length = k) :
     (l.flatMap f).drop (n * k) = (l.drop n).flatMap f := by
   induction n generalizing l with
-  | zero => simp
+  | zero => simp only [Nat.zero_mul, drop_zero]
   | succ m ih =>
     cases l with
-    | nil => simp
+    | nil => simp only [flatMap_nil, drop_nil]
     | cons a rest =>
       simp only [flatMap_cons, drop_succ_cons]
       have hk_eq : (m + 1) * k = (f a).length + m * k := by
@@ -153,7 +153,7 @@ theorem flatMap_uniform_drop {f : α → List β} (hf : ∀ a, (f a).length = k)
     (l : List α) (i : Nat) (hi : i < l.length) :
     (l.flatMap f).drop (i * k) = f l[i] ++ (l.flatMap f).drop ((i + 1) * k) := by
   induction l generalizing i with
-  | nil => simp at hi
+  | nil => simp only [length_nil, Nat.not_lt_zero] at hi
   | cons b rest ih =>
     cases i with
     | zero =>


### PR DESCRIPTION
Closes #601

Session: `200410db-00d3-4399-a5e2-c23090d4e61a`

4094cab refactor: replace all bare simp calls with simp only across codebase

🤖 Prepared with Claude Code