### PR TITLE
Track E: Prove decodeFseDistribution_sum_correct — FSE distribution cell count invariant

### DIFF
--- a/Zip/Native/Fse.lean
+++ b/Zip/Native/Fse.lean
@@ -89,30 +89,34 @@ def readProbValue (br : BitReader) (remaining : Nat) :
 
 /-- Main loop for FSE distribution decoding. Processes symbols one at a time,
     reading probability values and handling zero-repeat sequences.
-    Uses fuel for termination. -/
+    Uses fuel for termination.
+
+    Written without `do` notation for clean equation lemmas in proofs. -/
 def decodeFseLoop (br : BitReader) (remaining : Nat) (probs : Array Int32)
     (symbolNum : Nat) (maxSymbols : Nat) : Nat →
     Except String (Nat × Array Int32 × Nat × BitReader)
   | 0 => .error "FSE: distribution loop exceeded maximum iterations"
-  | fuel + 1 => do
+  | fuel + 1 =>
     if ¬(remaining > 0 ∧ symbolNum < maxSymbols) then
-      return (remaining, probs, symbolNum, br)
-    let (val, br) ← readProbValue br remaining
-    let prob : Int32 := Int32.ofNat val - 1
-    if prob == 0 then
-      let (probs, symbolNum, br) ←
-        decodeZeroRepeats br (probs.push 0) (symbolNum + 1) maxSymbols 1000
-      decodeFseLoop br remaining probs symbolNum maxSymbols fuel
+      .ok (remaining, probs, symbolNum, br)
     else
-      let probs := probs.push prob
-      let symbolNum := symbolNum + 1
-      if prob == -1 then
-        decodeFseLoop br (remaining - 1) probs symbolNum maxSymbols fuel
-      else
-        let probNat := int32ToNat prob
-        if probNat > remaining then
-          throw s!"FSE: probability {prob} exceeds remaining {remaining}"
-        decodeFseLoop br (remaining - probNat) probs symbolNum maxSymbols fuel
+      match readProbValue br remaining with
+      | .error e => .error e
+      | .ok (val, br) =>
+        let prob : Int32 := Int32.ofNat val - 1
+        if (prob == 0) = true then
+          match decodeZeroRepeats br (probs.push 0) (symbolNum + 1) maxSymbols 1000 with
+          | .error e => .error e
+          | .ok (probs, symbolNum, br) =>
+            decodeFseLoop br remaining probs symbolNum maxSymbols fuel
+        else if (prob == -1) = true then
+          decodeFseLoop br (remaining - 1) (probs.push prob) (symbolNum + 1) maxSymbols fuel
+        else
+          let probNat := int32ToNat prob
+          if probNat > remaining then
+            .error s!"FSE: probability {prob} exceeds remaining {remaining}"
+          else
+            decodeFseLoop br (remaining - probNat) (probs.push prob) (symbolNum + 1) maxSymbols fuel
 
 /-- Decode an FSE distribution (normalized probabilities) from a bitstream.
     `maxSymbols` is the maximum number of symbols allowed (e.g. 256 for literals,
@@ -122,17 +126,21 @@ def decodeFseLoop (br : BitReader) (remaining : Nat) (probs : Array Int32)
     0 = symbol not present. -/
 def decodeFseDistribution (br : Zip.Native.BitReader) (maxSymbols : Nat)
     (maxAccLog : Nat := 11) :
-    Except String (Array Int32 × Nat × Zip.Native.BitReader) := do
-  let (accRaw, br) ← br.readBits 4
-  let accuracyLog := accRaw.toNat + 5
-  if accuracyLog > maxAccLog then
-    throw s!"FSE: accuracy log {accuracyLog} exceeds maximum {maxAccLog}"
-  let tableSize := 1 <<< accuracyLog
-  let (remaining, probs, _, br) ←
-    decodeFseLoop br tableSize #[] 0 maxSymbols 10000
-  if remaining != 0 then
-    throw s!"FSE: probabilities don't sum to table size: {remaining} remaining"
-  return (probs, accuracyLog, br)
+    Except String (Array Int32 × Nat × Zip.Native.BitReader) :=
+  match br.readBits 4 with
+  | .error e => .error e
+  | .ok (accRaw, br) =>
+    let accuracyLog := accRaw.toNat + 5
+    if accuracyLog > maxAccLog then
+      .error s!"FSE: accuracy log {accuracyLog} exceeds maximum {maxAccLog}"
+    else
+      match decodeFseLoop br (1 <<< accuracyLog) #[] 0 maxSymbols 10000 with
+      | .error e => .error e
+      | .ok (remaining, probs, _, br) =>
+        if remaining != 0 then
+          .error s!"FSE: probabilities don't sum to table size: {remaining} remaining"
+        else
+          .ok (probs, accuracyLog, br)
 
 /-- Build an FSE decoding table from a probability distribution.
     `probs` is the array from `decodeFseDistribution`.

--- a/Zip/Spec/Fse.lean
+++ b/Zip/Spec/Fse.lean
@@ -72,6 +72,124 @@ instance {table : Array FseCell} {accuracyLog numSymbols : Nat} :
     Decidable (ValidFseTable table accuracyLog numSymbols) :=
   inferInstanceAs (Decidable (_ ∧ _ ∧ _))
 
+/-! ## cellCount helper lemmas -/
+
+/-- cellCount of a push reduces to a single if-then-else. -/
+theorem cellCount_push (dist : Array Int32) (p : Int32) :
+    cellCount (dist.push p) =
+      if p.toInt > 0 then cellCount dist + p.toInt.toNat
+      else if p == -1 then cellCount dist + 1
+      else cellCount dist := by
+  simp [cellCount]
+
+@[simp] theorem cellCount_push_zero (dist : Array Int32) :
+    cellCount (dist.push 0) = cellCount dist := by
+  simp [cellCount_push]
+
+@[simp] theorem cellCount_empty : cellCount #[] = 0 := by
+  simp [cellCount]
+
+/-! ## Loop invariant lemmas for decodeFseDistribution -/
+
+open Zip.Native in
+/-- Pushing zeros preserves `cellCount`. -/
+theorem pushZeros_cellCount (probs : Array Int32) (sym n ms : Nat) :
+    cellCount (pushZeros probs sym n ms).1 = cellCount probs := by
+  induction n generalizing probs sym with
+  | zero => rfl
+  | succ n ih =>
+    unfold pushZeros
+    split
+    · rw [ih]; exact cellCount_push_zero probs
+    · rfl
+
+open Zip.Native in
+/-- The zero-repeat inner loop only pushes zeros, so `cellCount` is preserved. -/
+theorem decodeZeroRepeats_cellCount
+    {br : BitReader} {probs : Array Int32} {sym ms fuel : Nat}
+    {probs' : Array Int32} {sym' : Nat} {br' : BitReader}
+    (h : decodeZeroRepeats br probs sym ms fuel = .ok (probs', sym', br')) :
+    cellCount probs' = cellCount probs := by
+  induction fuel generalizing br probs sym with
+  | zero => simp [decodeZeroRepeats] at h
+  | succ fuel ih =>
+    unfold decodeZeroRepeats at h
+    dsimp only [Bind.bind, Except.bind] at h
+    cases hrb : br.readBits 2 with
+    | error e => rw [hrb] at h; dsimp only [Bind.bind, Except.bind] at h; exact nomatch h
+    | ok val =>
+      rw [hrb] at h; dsimp only [Bind.bind, Except.bind] at h
+      split at h
+      · -- repeatCount == 3, recursive call
+        have hpc := pushZeros_cellCount probs sym val.1.toNat ms
+        rw [ih h, hpc]
+      · -- repeatCount != 3, done
+        simp only [Except.ok.injEq, Prod.mk.injEq] at h
+        obtain ⟨rfl, _, _⟩ := h
+        exact pushZeros_cellCount probs sym val.1.toNat ms
+
+open Zip.Native in
+/-- Main loop invariant: `remaining + cellCount probs` is preserved across
+    all iterations of `decodeFseLoop`. -/
+theorem decodeFseLoop_invariant
+    {br : BitReader} {rem : Nat} {probs : Array Int32}
+    {sym ms : Nat} {fuel : Nat}
+    {rem' : Nat} {probs' : Array Int32} {sym' : Nat} {br' : BitReader}
+    (h : decodeFseLoop br rem probs sym ms fuel = .ok (rem', probs', sym', br')) :
+    rem' + cellCount probs' = rem + cellCount probs := by
+  induction fuel generalizing br rem probs sym with
+  | zero => simp [decodeFseLoop] at h
+  | succ fuel ih =>
+    -- Use equation lemma to unfold one level (no do-notation artifacts)
+    rw [decodeFseLoop.eq_2] at h
+    -- Split on loop exit condition
+    by_cases hcond : ¬(rem > 0 ∧ sym < ms)
+    · -- Loop exits: return unchanged state
+      rw [if_pos hcond] at h
+      simp only [Except.ok.injEq, Prod.mk.injEq] at h
+      obtain ⟨rfl, rfl, _, _⟩ := h; rfl
+    · -- Loop continues
+      rw [if_neg hcond] at h
+      -- Split on readProbValue
+      cases hrpv : readProbValue br rem with
+      | error e => simp [hrpv] at h
+      | ok val =>
+        simp only [hrpv] at h
+        -- Split on prob == 0
+        by_cases hp0 : (Int32.ofNat val.fst - 1 == 0) = true
+        · rw [if_pos hp0] at h
+          -- Zero probability: split on decodeZeroRepeats
+          cases hzr : decodeZeroRepeats val.2 (probs.push 0) (sym + 1) ms 1000 with
+          | error e => simp [hzr] at h
+          | ok val₂ =>
+            simp only [hzr] at h
+            rw [ih h, decodeZeroRepeats_cellCount hzr, cellCount_push_zero]
+        · rw [if_neg hp0] at h
+          -- Split on prob == -1
+          by_cases hp1 : (Int32.ofNat val.fst - 1 == -1) = true
+          · rw [if_pos hp1] at h
+            rw [ih h, cellCount_push]
+            have heq : Int32.ofNat val.fst - 1 = -1 := eq_of_beq hp1
+            rw [heq]
+            simp only [show ((-1 : Int32).toInt > 0) = False from by decide,
+                        show ((-1 : Int32) == -1) = true from by decide,
+                        ↓reduceIte]
+            omega
+          · rw [if_neg hp1] at h
+            -- Split on probNat > remaining
+            by_cases hgt : int32ToNat (Int32.ofNat val.fst - 1) > rem
+            · rw [if_pos hgt] at h; exact nomatch h
+            · rw [if_neg hgt] at h
+              rw [ih h, cellCount_push]
+              by_cases hpos : (Int32.ofNat val.fst - 1).toInt > 0
+              · rw [if_pos hpos]
+                simp only [int32ToNat, show ¬(Int32.ofNat val.fst - 1).toInt < 0 from by omega,
+                            ↓reduceIte] at hgt ⊢
+                omega
+              · rw [if_neg hpos, if_neg hp1]
+                simp only [int32ToNat]
+                split <;> omega
+
 /-! ## Correctness of predefined distributions -/
 
 open Zip.Native in
@@ -92,9 +210,7 @@ theorem predefined_offset_valid :
 /-! ## Correctness of `decodeFseDistribution`
 
 These theorems relate the output of `decodeFseDistribution` to the
-validity predicates defined above. The proofs require unfolding the
-monadic `do` block and reasoning about its control flow, which is
-deferred to a future session. -/
+validity predicates defined above. -/
 
 open Zip.Native in
 /-- When `decodeFseDistribution` succeeds, the returned accuracy log is
@@ -107,23 +223,20 @@ theorem decodeFseDistribution_accuracyLog_ge
     5 ≤ al := by
   unfold decodeFseDistribution at _h
   cases hrd : br.readBits 4 with
-  | error e => rw [hrd] at _h; dsimp only [Bind.bind, Except.bind] at _h; exact nomatch _h
+  | error e => simp [hrd] at _h
   | ok val =>
-    rw [hrd] at _h; dsimp only [Bind.bind, Except.bind] at _h
-    -- Peel through: if > maxAccLog, match pure, match forIn, if != 0, match pure
-    split at _h
-    · exact nomatch _h
-    · split at _h
-      · exact nomatch _h
-      · split at _h
+    simp only [hrd] at _h
+    by_cases hgt : val.fst.toNat + 5 > maxAccLog
+    · rw [if_pos hgt] at _h; exact nomatch _h
+    · rw [if_neg hgt] at _h
+      cases hdl : decodeFseLoop val.snd (1 <<< (val.fst.toNat + 5)) #[] 0 maxSymbols 10000 with
+      | error e => simp [hdl] at _h
+      | ok dlval =>
+        simp only [hdl] at _h
+        split at _h
         · exact nomatch _h
-        · split at _h
-          · exact nomatch _h
-          · split at _h
-            · exact nomatch _h
-            · simp only [Pure.pure, Except.pure, Except.ok.injEq, Prod.mk.injEq] at _h
-              obtain ⟨_, rfl, _⟩ := _h
-              omega
+        · simp only [Except.ok.injEq, Prod.mk.injEq] at _h
+          obtain ⟨_, rfl, _⟩ := _h; omega
 
 open Zip.Native in
 /-- When `decodeFseDistribution` succeeds, the returned accuracy log does
@@ -136,22 +249,20 @@ theorem decodeFseDistribution_accuracyLog_le
     al ≤ maxAccLog := by
   unfold decodeFseDistribution at _h
   cases hrd : br.readBits 4 with
-  | error e => rw [hrd] at _h; dsimp only [Bind.bind, Except.bind] at _h; exact nomatch _h
+  | error e => simp [hrd] at _h
   | ok val =>
-    rw [hrd] at _h; dsimp only [Bind.bind, Except.bind] at _h
-    split at _h
-    · exact nomatch _h
-    · split at _h
-      · exact nomatch _h
-      · split at _h
+    simp only [hrd] at _h
+    by_cases hgt : val.fst.toNat + 5 > maxAccLog
+    · rw [if_pos hgt] at _h; exact nomatch _h
+    · rw [if_neg hgt] at _h
+      cases hdl : decodeFseLoop val.snd (1 <<< (val.fst.toNat + 5)) #[] 0 maxSymbols 10000 with
+      | error e => simp [hdl] at _h
+      | ok dlval =>
+        simp only [hdl] at _h
+        split at _h
         · exact nomatch _h
-        · split at _h
-          · exact nomatch _h
-          · split at _h
-            · exact nomatch _h
-            · simp only [Pure.pure, Except.pure, Except.ok.injEq, Prod.mk.injEq] at _h
-              obtain ⟨_, rfl, _⟩ := _h
-              omega
+        · simp only [Except.ok.injEq, Prod.mk.injEq] at _h
+          obtain ⟨_, rfl, _⟩ := _h; omega
 
 open Zip.Native in
 /-- When `decodeFseDistribution` succeeds, the cell count of the returned
@@ -163,6 +274,25 @@ theorem decodeFseDistribution_sum_correct
     {probs : Array Int32} {al : Nat} {br' : BitReader}
     (_h : decodeFseDistribution br maxSymbols maxAccLog = .ok (probs, al, br')) :
     cellCount probs = 1 <<< al := by
-  sorry
+  unfold decodeFseDistribution at _h
+  cases hrd : br.readBits 4 with
+  | error e => simp [hrd] at _h
+  | ok val =>
+    simp only [hrd] at _h
+    by_cases hgt : val.fst.toNat + 5 > maxAccLog
+    · rw [if_pos hgt] at _h; exact nomatch _h
+    · rw [if_neg hgt] at _h
+      cases hdl : decodeFseLoop val.snd (1 <<< (val.fst.toNat + 5)) #[] 0 maxSymbols 10000 with
+      | error e => simp [hdl] at _h
+      | ok dlval =>
+        simp only [hdl] at _h
+        by_cases hrem : dlval.1 != 0
+        · rw [if_pos hrem] at _h; exact nomatch _h
+        · rw [if_neg hrem] at _h
+          simp only [Except.ok.injEq, Prod.mk.injEq] at _h
+          obtain ⟨rfl, rfl, _⟩ := _h
+          have hinv := decodeFseLoop_invariant hdl
+          simp at hinv hrem
+          omega
 
 end Zstd.Spec.Fse


### PR DESCRIPTION
Closes #605

Session: `8919ec94-c816-4753-ae0b-81000353866d`

7fa170f feat: prove decodeFseDistribution_sum_correct — FSE cell count invariant
155a2e6 refactor: extract decodeFseDistribution loops into explicit recursion

🤖 Prepared with Claude Code