### PR TITLE
Track E: Prove xxHash64_empty — characterize xxHash64 short-input path

### DIFF
--- a/Zip/Native/XxHash.lean
+++ b/Zip/Native/XxHash.lean
@@ -52,31 +52,42 @@ def PRIME64_5 : UInt64 := 0x27D4EB2F165667C5
   let h := h * PRIME64_3
   h ^^^ (h >>> 32)
 
+/-- Process remaining 8-byte chunks. -/
+def processRemaining8 (h : UInt64) (data : ByteArray) (pos endPos : Nat) : UInt64 × Nat :=
+  if pos + 8 ≤ endPos then
+    let lane := readU64LE data pos
+    let h := h ^^^ round 0 lane
+    let h := rotl h 27 * PRIME64_1 + PRIME64_4
+    processRemaining8 h data (pos + 8) endPos
+  else
+    (h, pos)
+termination_by endPos - pos
+
+/-- Process remaining 1-byte chunks. -/
+def processRemaining1 (h : UInt64) (data : ByteArray) (pos endPos : Nat) : UInt64 :=
+  if pos < endPos then
+    let lane := data[pos]!.toUInt64
+    let h := h ^^^ (lane * PRIME64_5)
+    let h := rotl h 11 * PRIME64_1
+    processRemaining1 h data (pos + 1) endPos
+  else
+    h
+termination_by endPos - pos
+
 /-- Process remaining bytes after full 32-byte stripes.
     Handles 8-byte, 4-byte, and 1-byte chunks. -/
-def processRemaining (acc : UInt64) (data : ByteArray) (off len : Nat) : UInt64 := Id.run do
-  let mut h := acc
-  let mut pos := off
+def processRemaining (acc : UInt64) (data : ByteArray) (off len : Nat) : UInt64 :=
   let endPos := off + len
-  -- 8-byte chunks
-  while pos + 8 ≤ endPos do
-    let lane := readU64LE data pos
-    h := h ^^^ round 0 lane
-    h := rotl h 27 * PRIME64_1 + PRIME64_4
-    pos := pos + 8
-  -- 4-byte chunk
-  if pos + 4 ≤ endPos then
-    let lane := readU32LE data pos
-    h := h ^^^ (lane * PRIME64_1)
-    h := rotl h 23 * PRIME64_2 + PRIME64_3
-    pos := pos + 4
-  -- 1-byte chunks
-  while pos < endPos do
-    let lane := data[pos]!.toUInt64
-    h := h ^^^ (lane * PRIME64_5)
-    h := rotl h 11 * PRIME64_1
-    pos := pos + 1
-  return h
+  let (h, pos) := processRemaining8 acc data off endPos
+  let (h, pos) :=
+    if pos + 4 ≤ endPos then
+      let lane := readU32LE data pos
+      let h := h ^^^ (lane * PRIME64_1)
+      let h := rotl h 23 * PRIME64_2 + PRIME64_3
+      (h, pos + 4)
+    else
+      (h, pos)
+  processRemaining1 h data pos endPos
 
 /-- Compute XXH64 hash of a `ByteArray` with the given seed.
     Follows the xxHash specification exactly:

--- a/Zip/Spec/XxHash.lean
+++ b/Zip/Spec/XxHash.lean
@@ -114,6 +114,28 @@ def ValidProcessRemaining (acc : UInt64) (data : ByteArray) (off len : Nat)
 instance : Decidable (ValidProcessRemaining acc data off len result) :=
   inferInstanceAs (Decidable (_ = _))
 
+/-! ## Helper lemmas -/
+
+/-- processRemaining8 is a no-op when endPos = pos (8-byte loop skipped). -/
+theorem processRemaining8_self (h : UInt64) (data : ByteArray) (pos : Nat) :
+    XxHash64.processRemaining8 h data pos pos = (h, pos) := by
+  unfold XxHash64.processRemaining8
+  simp [show ¬(pos + 8 ≤ pos) from by omega]
+
+/-- processRemaining1 is a no-op when endPos = pos (1-byte loop skipped). -/
+theorem processRemaining1_self (h : UInt64) (data : ByteArray) (pos : Nat) :
+    XxHash64.processRemaining1 h data pos pos = h := by
+  unfold XxHash64.processRemaining1
+  simp [show ¬(pos < pos) from by omega]
+
+/-- processRemaining is a no-op when len = 0: all three phases
+    (8-byte, 4-byte, 1-byte) are immediately skipped. -/
+theorem processRemaining_zero (acc : UInt64) (data : ByteArray) (off : Nat) :
+    XxHash64.processRemaining acc data off 0 = acc := by
+  simp [XxHash64.processRemaining, Nat.add_zero,
+        processRemaining8_self, processRemaining1_self,
+        show ¬(off + 4 ≤ off) from by omega]
+
 /-! ## Specification theorems -/
 
 /-- The prime constants are correct. -/
@@ -135,7 +157,7 @@ theorem xxHash64_deterministic (data : ByteArray) (seed : UInt64) :
 theorem xxHash64_empty (seed : UInt64) :
     XxHash64.xxHash64 ByteArray.empty seed =
       XxHash64.avalanche (seed + XxHash64.PRIME64_5) := by
-  sorry
+  simp [XxHash64.xxHash64, processRemaining_zero]
 
 /-- `xxHash64Upper32` is defined as the upper 32 bits of `xxHash64 data 0`. -/
 theorem xxHash64Upper32_eq (data : ByteArray) :


### PR DESCRIPTION
Closes #636

Session: `56e1d588-ce4f-488e-8f63-983d560b1ab8`

19f767c feat: prove xxHash64_empty — characterize xxHash64 short-input path

🤖 Prepared with Claude Code