### PR TITLE
fix: Fix Huffman weight trimming and offset decode bugs — 48/48 conformance

### DIFF
--- a/Zip/Native/ZstdHuffman.lean
+++ b/Zip/Native/ZstdHuffman.lean
@@ -225,26 +225,20 @@ def parseHuffmanTreeDescriptor (data : ByteArray) (pos : Nat) :
     -- Direct 4-bit nibble representation: numWeights = headerByte - 127
     let numWeights := headerByte - 127
     let (weights, afterWeights) ← parseHuffmanWeightsDirect data (pos + 1) numWeights
-    -- Trim trailing zero weights (packed bytes may have a padding zero)
-    let mut trimmed := weights
-    while trimmed.size > 0 && trimmed.back! == 0 do
-      trimmed := trimmed.pop
-    if trimmed.size == 0 then
-      throw "Zstd: all Huffman weights are zero after trimming"
-    let table ← buildZstdHuffmanTable trimmed
+    -- Note: do NOT trim trailing zero weights — they are significant because the
+    -- implicit last symbol's identity depends on the weight array length.
+    -- parseHuffmanWeightsDirect already handles nibble padding via extract.
+    let table ← buildZstdHuffmanTable weights
     return (table, afterWeights)
   -- FSE-compressed representation: compressedSize = headerByte
   if headerByte == 0 then
     throw "Zstd: Huffman tree descriptor with 0 compressed size"
   let compressedSize := headerByte
   let (weights, afterWeights) ← parseHuffmanWeightsFse data pos compressedSize
-  -- Trim trailing zero weights
-  let mut trimmed := weights
-  while trimmed.size > 0 && trimmed.back! == 0 do
-    trimmed := trimmed.pop
-  if trimmed.size == 0 then
-    throw "Zstd: FSE-compressed Huffman weights are all zero after trimming"
-  let table ← buildZstdHuffmanTable trimmed
+  -- Note: do NOT trim trailing zero weights — they are significant because the
+  -- implicit last symbol's identity depends on the weight array length.
+  -- The FSE decoder produces exactly the right number of weights.
+  let table ← buildZstdHuffmanTable weights
   return (table, afterWeights)
 
 /-- Decode a single Huffman symbol from a backward bitstream using a flat table.

--- a/Zip/Native/ZstdSequence.lean
+++ b/Zip/Native/ZstdSequence.lean
@@ -272,11 +272,11 @@ def decodeMatchLenValue (code : Nat) (extraBits : UInt32) : Except String Nat :=
     throw s!"Zstd: match length code {code} out of range (max 52)"
 
 /-- Decode an offset FSE symbol code into an offset value (RFC 8878 §3.1.1.4).
-    For code ≥ 1: returns `(1 <<< code) + extraBits`. For code 0: returns
-    `extraBits` (used by repeat offset mechanism). -/
+    Offset_Value = (1 <<< code) + extraBits, where extraBits has `code` bits.
+    The formula applies uniformly to all codes including 0:
+    code 0 → (1 << 0) + 0 = 1 (repeat offset 1). -/
 def decodeOffsetValue (code : Nat) (extraBits : UInt32) : Nat :=
-  if code == 0 then extraBits.toNat
-  else (1 <<< code) + extraBits.toNat
+  (1 <<< code) + extraBits.toNat
 
 /-- Decode interleaved FSE sequences from a backward bitstream (RFC 8878 §4.1.1).
     Takes three FSE tables (litLen, offset, matchLen), a `BackwardBitReader`

--- a/Zip/Spec/ZstdSequence.lean
+++ b/Zip/Spec/ZstdSequence.lean
@@ -786,15 +786,13 @@ theorem decodeMatchLenValue_ge_three (code : Nat) (extraBits : UInt32) (n : Nat)
     exact Nat.le_trans (matchLen_baselines_ge_three code hlt) (Nat.le_add_right _ _)
   · exact nomatch h
 
-/-- When `code > 0`, `decodeOffsetValue` returns a positive value.
-    This follows from `1 <<< code > 0` for any natural `code`. -/
+/-- `decodeOffsetValue` always returns a positive value.
+    This follows from `(1 <<< code) ≥ 1` for any natural `code`. -/
 theorem decodeOffsetValue_positive (code : Nat) (extraBits : UInt32) (hcode : code > 0) :
     decodeOffsetValue code extraBits > 0 := by
   unfold decodeOffsetValue
-  split
-  · rename_i h; simp only [beq_iff_eq] at h; omega
-  · have : 1 <<< code ≥ 1 := by rw [Nat.one_shiftLeft]; exact Nat.one_le_two_pow
-    omega
+  have : 1 <<< code ≥ 1 := by rw [Nat.one_shiftLeft]; exact Nat.one_le_two_pow
+  omega
 
 /-- When `code ≥ 1`, `decodeOffsetValue` returns a value ≥ 2.
     This distinguishes non-repeat offsets (≥ 2) from repeat offsets (code 0).
@@ -802,14 +800,12 @@ theorem decodeOffsetValue_positive (code : Nat) (extraBits : UInt32) (hcode : co
 theorem decodeOffsetValue_ge_two (code : Nat) (extraBits : UInt32) (hcode : code ≥ 1) :
     decodeOffsetValue code extraBits ≥ 2 := by
   unfold decodeOffsetValue
-  split
-  · rename_i h; simp only [beq_iff_eq] at h; omega
-  · have : 1 <<< code ≥ 2 := by
-      rw [Nat.one_shiftLeft]
-      cases code with
-      | zero => omega
-      | succ n => rw [Nat.pow_succ]; have := Nat.one_le_two_pow (n := n); omega
-    omega
+  have : 1 <<< code ≥ 2 := by
+    rw [Nat.one_shiftLeft]
+    cases code with
+    | zero => omega
+    | succ n => rw [Nat.pow_succ]; have := Nat.one_le_two_pow (n := n); omega
+  omega
 
 /-- `executeSequences` output size characterization: when `executeSequences`
     succeeds with an empty window prefix, the output contains exactly the

--- a/ZipTest/ZstdConformance.lean
+++ b/ZipTest/ZstdConformance.lean
@@ -13,32 +13,20 @@ private def mkSequentialData (size : Nat) : ByteArray := Id.run do
     result := result.push (i % 256).toUInt8
   return result
 
-/-- Known pre-existing Huffman weight parsing bug. -/
-private def isKnownHuffmanBug (e : String) : Bool :=
-  e.contains "Huffman" || e.contains "power of 2"
-
-/-- Test a single FFI compress → native decompress roundtrip.
-    Returns .pass, .knownFail (pre-existing bug), or .fail (unexpected). -/
-private inductive TestResult | pass | knownFail | fail
-
+/-- Test a single FFI compress → native decompress roundtrip. -/
 private def testRoundtrip (input : ByteArray) (level : UInt8)
-    (label : String) (knownContentBug : Bool := false) : IO TestResult := do
+    (label : String) : IO Bool := do
   let compressed ← Zstd.compress input level
   match Zip.Native.decompressZstd compressed with
   | .ok result =>
     if result.data == input.data then
-      return .pass
-    else if knownContentBug then
-      return .knownFail
+      return true
     else
       IO.eprintln s!"  FAIL {label}: content mismatch (expected {input.size}, got {result.size})"
-      return .fail
+      return false
   | .error e =>
-    if isKnownHuffmanBug e then
-      return .knownFail
-    else
       IO.eprintln s!"  FAIL {label}: {e}"
-      return .fail
+      return false
 
 def ZipTest.ZstdConformance.tests : IO Unit := do
   -- === Conformance test matrix ===
@@ -48,7 +36,6 @@ def ZipTest.ZstdConformance.tests : IO Unit := do
   let patternNames := #["zeros", "sequential", "text", "prng"]
 
   let mut passed : Nat := 0
-  let mut knownFails : Nat := 0
   let mut failed : Nat := 0
 
   for level in levels do
@@ -61,16 +48,15 @@ def ZipTest.ZstdConformance.tests : IO Unit := do
           | 2 => mkTextData size
           | _ => mkPrngData size
         let label := s!"level={level} pattern={patName} size={sizeName size}"
-        -- Text pattern has known Huffman decode content mismatch
-        let isTextBug := patName == "text"
-        match ← testRoundtrip input level label (knownContentBug := isTextBug) with
-        | .pass => passed := passed + 1
-        | .knownFail => knownFails := knownFails + 1
-        | .fail => failed := failed + 1
+        if ← testRoundtrip input level label then
+          passed := passed + 1
+        else
+          failed := failed + 1
 
-  IO.println s!"Conformance matrix: {passed} passed, {knownFails} known failures (Huffman bug), {failed} unexpected failures"
+  let total := passed + failed
+  IO.println s!"Conformance matrix: {passed}/{total} passed, {failed} failures"
   if failed > 0 then
-    throw (IO.userError s!"Zstd conformance: {failed} unexpected test failures")
+    throw (IO.userError s!"Zstd conformance: {failed} test failures")
 
   -- === Multi-block frame tests ===
   -- 1MB input forces multiple blocks at most compression levels
@@ -78,10 +64,9 @@ def ZipTest.ZstdConformance.tests : IO Unit := do
   let bigInput := mkTextData bigSize
   for level in #[(1 : UInt8), 3] do
     let label := s!"multi-block level={level} size=1MB"
-    -- Text data has known Huffman decode content mismatch
-    match ← testRoundtrip bigInput level label (knownContentBug := true) with
-    | .pass => IO.println s!"  Multi-block {label}: OK"
-    | .knownFail => IO.println s!"  Multi-block {label}: known Huffman bug"
-    | .fail => throw (IO.userError s!"Multi-block test failed: {label}")
+    if ← testRoundtrip bigInput level label then
+      IO.println s!"  Multi-block {label}: OK"
+    else
+      throw (IO.userError s!"Multi-block test failed: {label}")
 
   IO.println "ZstdConformance tests: OK"

--- a/ZipTest/ZstdNativeComponents.lean
+++ b/ZipTest/ZstdNativeComponents.lean
@@ -469,9 +469,10 @@ def ZipTest.ZstdNativeComponents.tests : IO Unit := do
   let offVal20 := Zip.Native.decodeOffsetValue 20 0
   unless offVal20 == 1048576 do throw (IO.userError s!"offset code 20: expected 1048576, got {offVal20}")
 
-  -- Test 68: decodeOffsetValue — code 0, extraBits 5 → 5 (special case)
-  let offVal0 := Zip.Native.decodeOffsetValue 0 5
-  unless offVal0 == 5 do throw (IO.userError s!"offset code 0: expected 5, got {offVal0}")
+  -- Test 68: decodeOffsetValue — code 0, extraBits 0 → (1 << 0) + 0 = 1
+  -- Code 0 means 0 extra bits, so extraBits is always 0 in practice.
+  let offVal0 := Zip.Native.decodeOffsetValue 0 0
+  unless offVal0 == 1 do throw (IO.userError s!"offset code 0: expected 1, got {offVal0}")
 
   -- Test 69: parseSequencesHeader — modes parsing
   -- Construct: byte0 = 42 (small count), modes byte = 0b10_01_00_00 = 0x90

--- a/progress/20260306T1430_fce9dfb4.md
+++ b/progress/20260306T1430_fce9dfb4.md
@@ -1,0 +1,41 @@
+# Session fce9dfb4 — Recover PR #722: Fix Huffman/offset decode bugs
+
+**Date**: 2026-03-06 UTC
+**Issue**: #752 (recovering PR #722 / issue #703)
+**Branch**: `agent/fce9dfb4`
+**Type**: feature (PR recovery)
+**Status**: Complete
+
+## Summary
+
+Recovered the two bug fixes from PR #722 (which had merge conflicts) by
+applying them cleanly to current master. The fixes resolve the last 12
+failing Zstd conformance tests, bringing coverage from 36/48 to 48/48.
+
+### Bug 1: Huffman weight trailing zero trimming
+
+`parseHuffmanTreeDescriptor` incorrectly trimmed trailing zero weights.
+Zero weights are significant — the implicit last symbol's index equals
+`weights.size`, so trimming shifts which symbol gets the implicit weight.
+Removed both trimming blocks (direct and FSE paths).
+
+### Bug 2: Offset code 0 special case in `decodeOffsetValue`
+
+`decodeOffsetValue` had `if code == 0 then extraBits.toNat` instead of
+the uniform RFC 8878 formula `(1 <<< code) + extraBits`. For code 0,
+the correct result is 1 (repeat offset 1), not 0. Removed the special
+case — the formula works uniformly for all codes.
+
+## Changes
+
+- `Zip/Native/ZstdHuffman.lean` — Remove trailing zero weight trimming
+- `Zip/Native/ZstdSequence.lean` — Fix `decodeOffsetValue` code 0
+- `Zip/Spec/ZstdSequence.lean` — Update proofs for simplified definition
+- `ZipTest/ZstdConformance.lean` — Remove `knownContentBug` workarounds
+- `ZipTest/ZstdNativeComponents.lean` — Fix unit test for code 0
+
+## Metrics
+
+- Sorry count: 6 → 6 (unchanged)
+- Conformance tests: 36/48 → 48/48
+- All tests pass


### PR DESCRIPTION
Closes #752
Closes #703

Two bugs in the native Zstd decompressor caused 12/48 conformance test failures
(all text-pattern tests):

1. **Huffman weight trimming**: `parseHuffmanTreeDescriptor` trimmed trailing zero
   weights. Zero weights are significant — the implicit last symbol's identity depends
   on the weight array length. Trimming shifts which symbol gets the implicit weight,
   causing single-byte substitution errors in text data.

2. **Offset code 0**: `decodeOffsetValue` had a special case for code 0 returning
   `extraBits` instead of the uniform RFC 8878 formula `(1 <<< code) + extraBits`.
   For code 0 the correct result is 1 (repeat offset 1), not 0.

Both fixes recovered from PR #722 (which had merge conflicts), applied cleanly to
current master. Conformance tests now pass 48/48. Sorry count unchanged at 6.

🤖 Prepared with Claude Code