### PR TITLE
Track E: Prove decompressFrame position advancement — compose parseFrameHeader and decompressBlocksWF

### DIFF
--- a/Zip/Spec/Zstd.lean
+++ b/Zip/Spec/Zstd.lean
@@ -574,4 +574,46 @@ theorem windowSizeFromDescriptor_pos (d : UInt8) :
     Zip.Native.windowSizeFromDescriptor d > 0 := by
   exact Nat.lt_of_lt_of_le (by decide : (0 : UInt64) < 1024) (windowSizeFromDescriptor_ge_1024 d)
 
+/-! ## Frame-level position advancement -/
+
+/-- When `decompressFrame` succeeds, the returned position is strictly greater
+    than the input position. This follows from `parseFrameHeader_pos_gt`
+    (header ≥ 6 bytes) and `decompressBlocksWF_pos_gt` (blocks ≥ 3 bytes),
+    plus an optional 4-byte checksum. -/
+theorem decompressFrame_pos_gt (data : ByteArray) (pos : Nat)
+    (output : ByteArray) (pos' : Nat)
+    (h : Zip.Native.decompressFrame data pos = .ok (output, pos')) :
+    pos' > pos := by
+  unfold Zip.Native.decompressFrame at h
+  cases hph : Zip.Native.parseFrameHeader data pos with
+  | error e => simp only [hph, bind, Except.bind] at h; exact nomatch h
+  | ok val =>
+    obtain ⟨header, afterHeader⟩ := val
+    have hgt1 := parseFrameHeader_pos_gt _ _ _ _ hph
+    simp only [hph, bind, Except.bind, pure, Except.pure] at h
+    -- Dictionary check then decompressBlocks
+    split at h  -- dictionaryId
+    · -- some dictId
+      split at h  -- dictId != 0
+      · exact nomatch h
+      · unfold Zip.Native.decompressBlocks at h
+        cases hdb : Zip.Native.decompressBlocksWF data afterHeader header.windowSize
+            ByteArray.empty none {} #[1, 4, 8] with
+        | error e => simp only [hdb] at h; exact nomatch h
+        | ok val2 =>
+          obtain ⟨content, afterBlocks⟩ := val2
+          have hgt2 := decompressBlocksWF_pos_gt _ _ _ _ _ _ _ _ _ hdb
+          simp only [hdb] at h
+          grind
+    · -- none
+      unfold Zip.Native.decompressBlocks at h
+      cases hdb : Zip.Native.decompressBlocksWF data afterHeader header.windowSize
+          ByteArray.empty none {} #[1, 4, 8] with
+      | error e => simp only [hdb] at h; exact nomatch h
+      | ok val2 =>
+        obtain ⟨content, afterBlocks⟩ := val2
+        have hgt2 := decompressBlocksWF_pos_gt _ _ _ _ _ _ _ _ _ hdb
+        simp only [hdb] at h
+        grind
+
 end Zstd.Spec

--- a/progress/20260306T1500_a5d08793.md
+++ b/progress/20260306T1500_a5d08793.md
@@ -1,0 +1,32 @@
+# Progress: Fix PR #763 merge conflicts — decompressFrame position advancement
+
+- **Date**: 2026-03-06 15:00 UTC (original), recovery 2026-03-06T16:00Z
+- **Session**: a5d08793 (feature, PR recovery)
+- **Issue**: #769 (fixes PR #763, closes #737)
+
+## Accomplished
+
+- Recovered PR #763 by cherry-picking the proof commit (`b6335d5`) onto current
+  master. The original PR had 6 commits but 5 were already on master (PR #753
+  merged, skill/doc updates landed via PR #756).
+- `decompressFrame_pos_gt` in `Zip/Spec/Zstd.lean`: when `decompressFrame`
+  succeeds, the returned position is strictly greater than the input position.
+- Proof composes `parseFrameHeader_pos_gt` and `decompressBlocksWF_pos_gt` through
+  the monadic bind chain, using `cases` for intermediate results and `grind` for
+  the remaining checksum/content-size case analysis.
+
+## Recovery approach
+
+- Cherry-pick rebase pattern (per agent-pr-recovery skill): only the content
+  commit needed to be cherry-picked since all doc/skill commits were already
+  incorporated into master via other PRs.
+- Cherry-pick applied cleanly — no conflicts. The proof appends to the end of
+  `Zip/Spec/Zstd.lean` which wasn't modified by the intervening PRs.
+
+## Quality metrics
+
+- Sorry count: 4 (unchanged — XxHash:3, Fse:1)
+- Conformance: 48/48 passed
+- All tests pass
+- No new sorry introduced
+- `decompressFrame_pos_gt` compiles without sorry


### PR DESCRIPTION
Closes #737

Session: `ac501e76-7830-43cb-88c1-a87ec668db18`

b6335d5 feat: Prove decompressFrame position advancement — pos_gt composition
7c77510 Track E: Prove parseFrameHeader position advancement — pos_gt and minimum bound (#753)
5deeca7 doc: add progress entry for meditate session #751
1cb4078 doc: update lean-wf-recursion with non-advancement guard pattern
6f7e937 doc: update lean-zstd-spec-pattern with position-advancement proof patterns

🤖 Prepared with Claude Code