### PR TITLE
Review: DeflateEncodeDynamic.lean — convert 7 bare simp to simp only

### DIFF
--- a/progress/20260308T_9a742051.md
+++ b/progress/20260308T_9a742051.md
@@ -1,0 +1,37 @@
+# Progress: DeflateEncodeDynamic.lean bare simp review
+
+**Date**: 2026-03-08 UTC
+**Session**: `9a742051` (review)
+**Issue**: #854
+
+## What was done
+
+Converted all 7 bare `simp` calls in `Zip/Spec/DeflateEncodeDynamic.lean` to
+`simp only [...]` with explicit lemma lists. Also combined consecutive `rw`
+calls in `countRun_take` (-1 line).
+
+### Conversions
+
+| Location | Original | Replacement |
+|----------|----------|-------------|
+| `countRun_le_length` nil | `simp [countRun]` | `simp only [countRun, List.length_nil, Nat.le_refl]` |
+| `countRun_take` nil | `simp [countRun]` | `simp only [countRun, List.take_nil, List.replicate_zero]` |
+| `take_countRun_eq_replicate` nil (2 calls) | `simp [countRun] at hn; simp [hn]` | `simp only [countRun] at hn` + `Nat.le_zero.mp` + `simp only [...]` |
+| `replicate_drop_eq_cons_zero` (rw arg) | `by simp [countRun]; omega` | `by simp only [countRun, beq_self_eq_true, ↓reduceIte]; omega` |
+| `replicate_drop_eq_cons_zero` (succ case) | `simp [List.drop_succ_cons]` | `simp only [List.drop_succ_cons, Nat.add_sub_cancel]` |
+| `rlDecodeLengths_go_rlEncodeLengths_go` nil | `simp [rlEncodeLengths.go, rlDecodeLengths.go]` | `simp only [rlEncodeLengths.go, rlDecodeLengths.go, List.append_nil]` |
+| `rlEncodeLengths_go_valid` nil | `simp [rlEncodeLengths.go]` | `simp only [rlEncodeLengths.go, List.not_mem_nil, false_implies, implies_true]` |
+
+### PR #811 consistency
+
+PR #811 converted 5 `simp_all` calls (different tactic). The 7 bare `simp`
+calls addressed here are a separate set that was not covered by #811.
+
+## Quality metrics
+
+- **Bare simp**: 7 → 0 (all converted)
+- **Sorry count**: 4 → 4 (unchanged, all in XxHash.lean)
+- **Line count**: 424 → 426 (+2, expected from explicit lemma lists)
+- **All theorem signatures unchanged**
+- **Build**: clean, no warnings in target file
+- **Tests**: all pass


### PR DESCRIPTION
Closes #854

Convert all 7 bare `simp` calls in `Zip/Spec/DeflateEncodeDynamic.lean` to `simp only [...]` with explicit lemma lists. Also combines consecutive `rw` calls in `countRun_take`.

**Conversions**: 7/7 bare simp → simp only
**Sorry count**: 4 → 4 (unchanged)
**Line count**: 424 → 426 (+2)
**All theorem signatures unchanged**

PR #811 previously reviewed 5 `simp_all` calls in this file — the 7 bare `simp` calls addressed here are a separate set.

🤖 Prepared with Claude Code