### PR TITLE
Track E: decompressBlocksWF two-block composition — raw and RLE multi-block output

### DIFF
--- a/Zip/Spec/Zstd.lean
+++ b/Zip/Spec/Zstd.lean
@@ -734,6 +734,90 @@ theorem decompressBlocksWF_rle_step (data : ByteArray) (off : Nat)
     bind, Except.bind, pure, Except.pure, ↓reduceIte, Bool.false_eq_true]
   exact heq
 
+/-! ## decompressBlocksWF two-block composition theorems -/
+
+/-- When `decompressBlocksWF` encounters two consecutive raw blocks (first non-last,
+    second last), the output is `output ++ block1 ++ block2` at the position after
+    the second block. Composes `decompressBlocksWF_raw_step` and
+    `decompressBlocksWF_single_raw`. -/
+theorem decompressBlocksWF_two_raw_blocks (data : ByteArray) (off : Nat)
+    (windowSize : UInt64) (output : ByteArray)
+    (prevHuff : Option Zip.Native.ZstdHuffmanTable)
+    (prevFse : Zip.Native.PrevFseTables) (history : Array Nat)
+    -- Block 1 (non-last raw)
+    (hdr1 : Zip.Native.ZstdBlockHeader) (afterHdr1 : Nat)
+    (block1 : ByteArray) (afterBlock1 : Nat)
+    -- Block 2 (last raw)
+    (hdr2 : Zip.Native.ZstdBlockHeader) (afterHdr2 : Nat)
+    (block2 : ByteArray) (afterBlock2 : Nat)
+    -- Block 1 hypotheses
+    (hoff1 : ¬ data.size ≤ off)
+    (hparse1 : Zip.Native.parseBlockHeader data off = .ok (hdr1, afterHdr1))
+    (hbs1 : ¬ hdr1.blockSize > 131072)
+    (hws1 : ¬ (windowSize > 0 && hdr1.blockSize.toUInt64 > windowSize))
+    (htype1 : hdr1.blockType = .raw)
+    (hraw1 : Zip.Native.decompressRawBlock data afterHdr1 hdr1.blockSize
+               = .ok (block1, afterBlock1))
+    (hnotlast1 : hdr1.lastBlock = false)
+    (hadv1 : ¬ afterBlock1 ≤ off)
+    -- Block 2 hypotheses
+    (hoff2 : ¬ data.size ≤ afterBlock1)
+    (hparse2 : Zip.Native.parseBlockHeader data afterBlock1 = .ok (hdr2, afterHdr2))
+    (hbs2 : ¬ hdr2.blockSize > 131072)
+    (hws2 : ¬ (windowSize > 0 && hdr2.blockSize.toUInt64 > windowSize))
+    (htype2 : hdr2.blockType = .raw)
+    (hraw2 : Zip.Native.decompressRawBlock data afterHdr2 hdr2.blockSize
+               = .ok (block2, afterBlock2))
+    (hlast2 : hdr2.lastBlock = true) :
+    Zip.Native.decompressBlocksWF data off windowSize output prevHuff prevFse history
+      = .ok (output ++ block1 ++ block2, afterBlock2) := by
+  rw [decompressBlocksWF_raw_step data off windowSize output prevHuff prevFse history
+    hdr1 afterHdr1 block1 afterBlock1 hoff1 hparse1 hbs1 hws1 htype1 hraw1 hnotlast1 hadv1]
+  rw [decompressBlocksWF_single_raw data afterBlock1 windowSize (output ++ block1) prevHuff
+    prevFse history hdr2 afterHdr2 block2 afterBlock2 hoff2 hparse2 hbs2 hws2 htype2 hraw2
+    hlast2]
+
+/-- When `decompressBlocksWF` encounters two consecutive RLE blocks (first non-last,
+    second last), the output is `output ++ block1 ++ block2` at the position after
+    the second block's byte. Composes `decompressBlocksWF_rle_step` and
+    `decompressBlocksWF_single_rle`. -/
+theorem decompressBlocksWF_two_rle_blocks (data : ByteArray) (off : Nat)
+    (windowSize : UInt64) (output : ByteArray)
+    (prevHuff : Option Zip.Native.ZstdHuffmanTable)
+    (prevFse : Zip.Native.PrevFseTables) (history : Array Nat)
+    -- Block 1 (non-last RLE)
+    (hdr1 : Zip.Native.ZstdBlockHeader) (afterHdr1 : Nat)
+    (block1 : ByteArray) (afterByte1 : Nat)
+    -- Block 2 (last RLE)
+    (hdr2 : Zip.Native.ZstdBlockHeader) (afterHdr2 : Nat)
+    (block2 : ByteArray) (afterByte2 : Nat)
+    -- Block 1 hypotheses
+    (hoff1 : ¬ data.size ≤ off)
+    (hparse1 : Zip.Native.parseBlockHeader data off = .ok (hdr1, afterHdr1))
+    (hbs1 : ¬ hdr1.blockSize > 131072)
+    (hws1 : ¬ (windowSize > 0 && hdr1.blockSize.toUInt64 > windowSize))
+    (htype1 : hdr1.blockType = .rle)
+    (hrle1 : Zip.Native.decompressRLEBlock data afterHdr1 hdr1.blockSize
+               = .ok (block1, afterByte1))
+    (hnotlast1 : hdr1.lastBlock = false)
+    (hadv1 : ¬ afterByte1 ≤ off)
+    -- Block 2 hypotheses
+    (hoff2 : ¬ data.size ≤ afterByte1)
+    (hparse2 : Zip.Native.parseBlockHeader data afterByte1 = .ok (hdr2, afterHdr2))
+    (hbs2 : ¬ hdr2.blockSize > 131072)
+    (hws2 : ¬ (windowSize > 0 && hdr2.blockSize.toUInt64 > windowSize))
+    (htype2 : hdr2.blockType = .rle)
+    (hrle2 : Zip.Native.decompressRLEBlock data afterHdr2 hdr2.blockSize
+               = .ok (block2, afterByte2))
+    (hlast2 : hdr2.lastBlock = true) :
+    Zip.Native.decompressBlocksWF data off windowSize output prevHuff prevFse history
+      = .ok (output ++ block1 ++ block2, afterByte2) := by
+  rw [decompressBlocksWF_rle_step data off windowSize output prevHuff prevFse history
+    hdr1 afterHdr1 block1 afterByte1 hoff1 hparse1 hbs1 hws1 htype1 hrle1 hnotlast1 hadv1]
+  rw [decompressBlocksWF_single_rle data afterByte1 windowSize (output ++ block1) prevHuff
+    prevFse history hdr2 afterHdr2 block2 afterByte2 hoff2 hparse2 hbs2 hws2 htype2 hrle2
+    hlast2]
+
 /-- When `decompressBlocksWF` encounters a single last compressed block with
     numSeq == 0 (literals only, no sequence commands), the result is the
     accumulated output extended by the literal data at position blockEnd. -/

--- a/progress/20260308T170000Z_6626fe38.md
+++ b/progress/20260308T170000Z_6626fe38.md
@@ -1,0 +1,32 @@
+# Progress: Track E two-block composition theorems
+
+- **Date**: 2026-03-08T17:00Z
+- **Session**: 6626fe38 (feature)
+- **Issue**: #972
+
+## Accomplished
+
+Added two composition theorems to `Zip/Spec/Zstd.lean`:
+
+1. **`decompressBlocksWF_two_raw_blocks`**: Two consecutive raw blocks (non-last + last)
+   produce `output ++ block1 ++ block2`. Proof: `rw [raw_step]; rw [single_raw]`.
+
+2. **`decompressBlocksWF_two_rle_blocks`**: Two consecutive RLE blocks (non-last + last)
+   produce `output ++ block1 ++ block2`. Proof: `rw [rle_step]; rw [single_rle]`.
+
+Both proofs are 4 lines each — no `ByteArray.append_assoc` needed since
+`output ++ block1 ++ block2` is left-associated by default and matches the
+`(output ++ block1) ++ block2` produced by the step+single composition.
+
+## Quality metrics
+
+- Sorry count: 4 → 4 (unchanged, all in XxHash)
+- Tests: all pass, conformance 48/48
+- No new files, no removed theorems
+
+## Decisions
+
+- Placed theorems in a new section `/-! ## decompressBlocksWF two-block composition theorems -/`
+  between step theorems and compressed block theorems.
+- `ByteArray.append_assoc` was initially included but Lean reported "no goals to be solved"
+  since the associativity matches already — removed for cleaner proofs.


### PR DESCRIPTION
Closes #972

Add two composition theorems to `Zip/Spec/Zstd.lean`:

- `decompressBlocksWF_two_raw_blocks`: two consecutive raw blocks (non-last + last) produce `output ++ block1 ++ block2`
- `decompressBlocksWF_two_rle_blocks`: two consecutive RLE blocks (non-last + last) produce `output ++ block1 ++ block2`

Each proof is 4 lines: apply the step theorem, then the single-block theorem. No `ByteArray.append_assoc` needed since `++` is left-associated.

🤖 Prepared with Claude Code