### PR TITLE
Review: Remove dead _hdict hypotheses from Zstd spec theorems

### DIFF
--- a/Zip/Spec/Zstd.lean
+++ b/Zip/Spec/Zstd.lean
@@ -1527,7 +1527,6 @@ theorem decompressFrame_single_raw_content (data : ByteArray) (pos : Nat)
     (block : ByteArray) (afterBlock : Nat)
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
     (hparse : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr, afterHdr))
     (hbs : ¬ hdr.blockSize > 131072)
     (hws : ¬ (header.windowSize > 0 && hdr.blockSize.toUInt64 > header.windowSize))
@@ -1574,7 +1573,6 @@ theorem decompressFrame_single_rle_content (data : ByteArray) (pos : Nat)
     (block : ByteArray) (afterByte : Nat)
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
     (hparse : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr, afterHdr))
     (hbs : ¬ hdr.blockSize > 131072)
     (hws : ¬ (header.windowSize > 0 && hdr.blockSize.toUInt64 > header.windowSize))
@@ -1627,7 +1625,7 @@ theorem decompressFrame_two_raw_blocks_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -1694,7 +1692,7 @@ theorem decompressFrame_two_rle_blocks_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -1761,7 +1759,7 @@ theorem decompressFrame_raw_then_rle_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (raw, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -1828,7 +1826,7 @@ theorem decompressFrame_rle_then_raw_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (RLE, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -2340,7 +2338,6 @@ theorem decompressFrame_single_compressed_literals_content (data : ByteArray)
     (modes : Zip.Native.SequenceCompressionModes) (afterSeqHeader : Nat)
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
     (hparse : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr, afterHdr))
     (hbs : ¬ hdr.blockSize > 131072)
     (hws : ¬ (header.windowSize > 0 && hdr.blockSize.toUInt64 > header.windowSize))
@@ -2398,7 +2395,6 @@ theorem decompressFrame_single_compressed_sequences_content (data : ByteArray)
     (blockOutput : ByteArray) (newHist : Array Nat)
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
     (hparse : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr, afterHdr))
     (hbs : ¬ hdr.blockSize > 131072)
     (hws : ¬ (header.windowSize > 0 && hdr.blockSize.toUInt64 > header.windowSize))
@@ -2483,7 +2479,7 @@ theorem decompressFrame_compressed_lit_then_raw_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -2558,7 +2554,7 @@ theorem decompressFrame_compressed_lit_then_rle_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -2637,7 +2633,7 @@ theorem decompressFrame_compressed_seq_then_raw_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last, numSeq > 0)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -2743,7 +2739,7 @@ theorem decompressFrame_compressed_seq_then_compressed_lit_content (data : ByteA
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last, numSeq > 0)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -2868,7 +2864,7 @@ theorem decompressFrame_compressed_lit_then_compressed_seq_content (data : ByteA
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last, numSeq=0)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -2984,7 +2980,7 @@ theorem decompressFrame_raw_then_compressed_lit_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (raw, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -3057,7 +3053,7 @@ theorem decompressFrame_rle_then_compressed_lit_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (RLE, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -3355,7 +3351,7 @@ theorem decompressFrame_compressed_seq_then_rle_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last, numSeq > 0)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -3454,7 +3450,7 @@ theorem decompressFrame_two_compressed_literals_blocks_content (data : ByteArray
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -3562,7 +3558,7 @@ theorem decompressFrame_two_compressed_sequences_blocks_content (data : ByteArra
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last, numSeq > 0)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -3711,7 +3707,7 @@ theorem decompressFrame_raw_then_compressed_seq_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (raw, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -3816,7 +3812,7 @@ theorem decompressFrame_rle_then_compressed_seq_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data pos = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data pos = .ok (header, afterHeader))
-    (_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (RLE, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)

--- a/Zip/Spec/ZstdFrame.lean
+++ b/Zip/Spec/ZstdFrame.lean
@@ -372,7 +372,6 @@ theorem decompressZstd_single_raw_block_content (data : ByteArray)
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hend : pos' ≥ data.size)
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
     (hparse : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr, afterHdr))
     (hbs : ¬ hdr.blockSize > 131072)
     (hws : ¬ (header.windowSize > 0 && hdr.blockSize.toUInt64 > header.windowSize))
@@ -382,7 +381,7 @@ theorem decompressZstd_single_raw_block_content (data : ByteArray)
     Zip.Native.decompressZstd data = .ok block := by
   have hcontent := Zstd.Spec.decompressFrame_single_raw_content data 0 output pos'
     header afterHeader hdr afterHdr block afterBlock
-    hframe hh hdict hparse hbs hws htype hraw hlast
+    hframe hh hparse hbs hws htype hraw hlast
   subst hcontent
   exact decompressZstd_single_frame data output pos' hframe hend
 
@@ -397,7 +396,6 @@ theorem decompressZstd_single_rle_block_content (data : ByteArray)
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hend : pos' ≥ data.size)
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
     (hparse : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr, afterHdr))
     (hbs : ¬ hdr.blockSize > 131072)
     (hws : ¬ (header.windowSize > 0 && hdr.blockSize.toUInt64 > header.windowSize))
@@ -407,7 +405,7 @@ theorem decompressZstd_single_rle_block_content (data : ByteArray)
     Zip.Native.decompressZstd data = .ok block := by
   have hcontent := Zstd.Spec.decompressFrame_single_rle_content data 0 output pos'
     header afterHeader hdr afterHdr block afterByte
-    hframe hh hdict hparse hbs hws htype hrle hlast
+    hframe hh hparse hbs hws htype hrle hlast
   subst hcontent
   exact decompressZstd_single_frame data output pos' hframe hend
 
@@ -429,7 +427,7 @@ theorem decompressZstd_two_raw_blocks_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -454,7 +452,7 @@ theorem decompressZstd_two_raw_blocks_content (data : ByteArray)
   have hcontent := Zstd.Spec.decompressFrame_two_raw_blocks_content data 0 output pos'
     header afterHeader hdr1 afterHdr1 block1 afterBlock1
     hdr2 afterHdr2 block2 afterBlock2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hraw1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hraw1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hraw2 hlast2
   subst hcontent
   exact decompressZstd_single_frame data (block1 ++ block2) pos' hframe hend
@@ -475,7 +473,7 @@ theorem decompressZstd_two_rle_blocks_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -500,7 +498,7 @@ theorem decompressZstd_two_rle_blocks_content (data : ByteArray)
   have hcontent := Zstd.Spec.decompressFrame_two_rle_blocks_content data 0 output pos'
     header afterHeader hdr1 afterHdr1 block1 afterByte1
     hdr2 afterHdr2 block2 afterByte2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hrle1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hrle1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hrle2 hlast2
   subst hcontent
   exact decompressZstd_single_frame data (block1 ++ block2) pos' hframe hend
@@ -521,7 +519,7 @@ theorem decompressZstd_raw_then_rle_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (raw, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -546,7 +544,7 @@ theorem decompressZstd_raw_then_rle_content (data : ByteArray)
   have hcontent := Zstd.Spec.decompressFrame_raw_then_rle_content data 0 output pos'
     header afterHeader hdr1 afterHdr1 block1 afterBlock1
     hdr2 afterHdr2 block2 afterByte2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hraw1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hraw1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hrle2 hlast2
   subst hcontent
   exact decompressZstd_single_frame data (block1 ++ block2) pos' hframe hend
@@ -567,7 +565,7 @@ theorem decompressZstd_rle_then_raw_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (RLE, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -592,7 +590,7 @@ theorem decompressZstd_rle_then_raw_content (data : ByteArray)
   have hcontent := Zstd.Spec.decompressFrame_rle_then_raw_content data 0 output pos'
     header afterHeader hdr1 afterHdr1 block1 afterByte1
     hdr2 afterHdr2 block2 afterBlock2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hrle1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hrle1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hraw2 hlast2
   subst hcontent
   exact decompressZstd_single_frame data (block1 ++ block2) pos' hframe hend
@@ -613,7 +611,6 @@ theorem decompressZstd_single_compressed_literals (data : ByteArray)
     (modes : Zip.Native.SequenceCompressionModes) (afterSeqHeader : Nat)
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
     (hparse : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr, afterHdr))
     (hbs : ¬ hdr.blockSize > 131072)
     (hws : ¬ (header.windowSize > 0 && hdr.blockSize.toUInt64 > header.windowSize))
@@ -628,7 +625,7 @@ theorem decompressZstd_single_compressed_literals (data : ByteArray)
     Zip.Native.decompressZstd data = .ok literals := by
   have hcontent := Zstd.Spec.decompressFrame_single_compressed_literals_content data 0
     output pos' header afterHeader hdr afterHdr literals afterLiterals huffTree
-    modes afterSeqHeader hframe hh hdict hparse hbs hws htype hblockEnd hlit hseq hlast
+    modes afterSeqHeader hframe hh hparse hbs hws htype hblockEnd hlit hseq hlast
   subst hcontent
   exact decompressZstd_single_frame data output pos' hframe hend
 
@@ -650,7 +647,6 @@ theorem decompressZstd_single_compressed_sequences (data : ByteArray)
     (blockOutput : ByteArray) (newHist : Array Nat)
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
     (hparse : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr, afterHdr))
     (hbs : ¬ hdr.blockSize > 131072)
     (hws : ¬ (header.windowSize > 0 && hdr.blockSize.toUInt64 > header.windowSize))
@@ -676,7 +672,7 @@ theorem decompressZstd_single_compressed_sequences (data : ByteArray)
   have hcontent := Zstd.Spec.decompressFrame_single_compressed_sequences_content data 0
     output pos' header afterHeader hdr afterHdr literals afterLiterals huffTree
     numSeq modes afterSeqHeader llTable ofTable mlTable afterTables bbr sequences
-    blockOutput newHist hframe hh hdict hparse hbs hws htype hblockEnd hlit hseq
+    blockOutput newHist hframe hh hparse hbs hws htype hblockEnd hlit hseq
     hNumSeq hfse hbbr hdec hexec hlast
   subst hcontent
   exact decompressZstd_single_frame data output pos' hframe hend
@@ -702,7 +698,7 @@ theorem decompressZstd_compressed_lit_then_raw_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -731,7 +727,7 @@ theorem decompressZstd_compressed_lit_then_raw_content (data : ByteArray)
   have hcontent := Zstd.Spec.decompressFrame_compressed_lit_then_raw_content data 0 output pos'
     header afterHeader hdr1 afterHdr1 literals1 afterLiterals1 huffTree1
     modes1 afterSeqHeader1 hdr2 afterHdr2 block2 afterBlock2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hraw2 hlast2
   subst hcontent
   exact decompressZstd_single_frame data (literals1 ++ block2) pos' hframe hend
@@ -755,7 +751,7 @@ theorem decompressZstd_compressed_lit_then_rle_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -784,7 +780,7 @@ theorem decompressZstd_compressed_lit_then_rle_content (data : ByteArray)
   have hcontent := Zstd.Spec.decompressFrame_compressed_lit_then_rle_content data 0 output pos'
     header afterHeader hdr1 afterHdr1 literals1 afterLiterals1 huffTree1
     modes1 afterSeqHeader1 hdr2 afterHdr2 block2 afterByte2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hrle2 hlast2
   subst hcontent
   exact decompressZstd_single_frame data (literals1 ++ block2) pos' hframe hend
@@ -814,7 +810,7 @@ theorem decompressZstd_compressed_seq_then_compressed_lit_content (data : ByteAr
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last, numSeq > 0)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -857,7 +853,7 @@ theorem decompressZstd_compressed_seq_then_compressed_lit_content (data : ByteAr
     output pos' header afterHeader hdr1 afterHdr1 literals1 afterLiterals1 huffTree1
     numSeq1 modes1 afterSeqHeader1 llTable1 ofTable1 mlTable1 afterTables1 bbr1 sequences1
     blockOutput1 newHist1 hdr2 afterHdr2 literals2 afterLiterals2 huffTree2 modes2
-    afterSeqHeader2 hframe hh hdict hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1
+    afterSeqHeader2 hframe hh hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1
     hNumSeq1 hfse1 hbbr1 hdec1 hexec1 hnotlast1 hadv1 hoff2 hparse2 hbs2 hws2 htype2
     hblockEnd2 hlit2 hseq2 hlast2
   subst hcontent
@@ -888,7 +884,7 @@ theorem decompressZstd_compressed_lit_then_compressed_seq_content (data : ByteAr
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last, numSeq=0)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -935,7 +931,7 @@ theorem decompressZstd_compressed_lit_then_compressed_seq_content (data : ByteAr
     output pos' header afterHeader hdr1 afterHdr1 literals1 afterLiterals1 huffTree1
     modes1 afterSeqHeader1 hdr2 afterHdr2 literals2 afterLiterals2 huffTree2
     numSeq2 modes2 afterSeqHeader2 llTable2 ofTable2 mlTable2 afterTables2 bbr2 sequences2
-    blockOutput2 newHist2 hframe hh hdict hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1
+    blockOutput2 newHist2 hframe hh hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1
     hnotlast1 hadv1 hoff2 hparse2 hbs2 hws2 htype2 hblockEnd2 hlit2 hseq2 hNumSeq2
     hfse2 hbbr2 hdec2 hexec2 hlast2
   subst hcontent
@@ -960,7 +956,7 @@ theorem decompressZstd_raw_then_compressed_lit_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (raw, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -988,7 +984,7 @@ theorem decompressZstd_raw_then_compressed_lit_content (data : ByteArray)
   have hcontent := Zstd.Spec.decompressFrame_raw_then_compressed_lit_content data 0 output pos'
     header afterHeader hdr1 afterHdr1 block1 afterBlock1 hdr2 afterHdr2 literals2 afterLiterals2
     huffTree2 modes2 afterSeqHeader2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hraw1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hraw1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hblockEnd2 hlit2 hseq2 hlast2
   subst hcontent
   exact decompressZstd_single_frame data (block1 ++ literals2) pos' hframe hend
@@ -1012,7 +1008,7 @@ theorem decompressZstd_rle_then_compressed_lit_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (RLE, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -1040,7 +1036,7 @@ theorem decompressZstd_rle_then_compressed_lit_content (data : ByteArray)
   have hcontent := Zstd.Spec.decompressFrame_rle_then_compressed_lit_content data 0 output pos'
     header afterHeader hdr1 afterHdr1 block1 afterByte1 hdr2 afterHdr2 literals2 afterLiterals2
     huffTree2 modes2 afterSeqHeader2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hrle1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hrle1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hblockEnd2 hlit2 hseq2 hlast2
   subst hcontent
   exact decompressZstd_single_frame data (block1 ++ literals2) pos' hframe hend
@@ -1068,7 +1064,7 @@ theorem decompressZstd_compressed_seq_then_raw_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last, numSeq > 0)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -1108,7 +1104,7 @@ theorem decompressZstd_compressed_seq_then_raw_content (data : ByteArray)
     header afterHeader hdr1 afterHdr1 literals1 afterLiterals1 huffTree1
     numSeq1 modes1 afterSeqHeader1 llTable1 ofTable1 mlTable1 afterTables1 bbr1 sequences1
     blockOutput1 newHist1 hdr2 afterHdr2 block2 afterBlock2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1
+    hframe hh hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1
     hNumSeq1 hfse1 hbbr1 hdec1 hexec1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hraw2 hlast2
   subst hcontent
@@ -1137,7 +1133,7 @@ theorem decompressZstd_compressed_seq_then_rle_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (compressed, non-last, numSeq > 0)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -1177,7 +1173,7 @@ theorem decompressZstd_compressed_seq_then_rle_content (data : ByteArray)
     header afterHeader hdr1 afterHdr1 literals1 afterLiterals1 huffTree1
     numSeq1 modes1 afterSeqHeader1 llTable1 ofTable1 mlTable1 afterTables1 bbr1 sequences1
     blockOutput1 newHist1 hdr2 afterHdr2 block2 afterByte2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1
+    hframe hh hparse1 hbs1 hws1 htype1 hblockEnd1 hlit1 hseq1
     hNumSeq1 hfse1 hbbr1 hdec1 hexec1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hrle2 hlast2
   subst hcontent
@@ -1206,7 +1202,7 @@ theorem decompressZstd_raw_then_compressed_seq_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (raw, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -1249,7 +1245,7 @@ theorem decompressZstd_raw_then_compressed_seq_content (data : ByteArray)
     hdr2 afterHdr2 literals2 afterLiterals2 huffTree2
     numSeq2 modes2 afterSeqHeader2 llTable2 ofTable2 mlTable2 afterTables2 bbr2 sequences2
     blockOutput2 newHist2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hraw1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hraw1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hblockEnd2 hlit2 hseq2 hNumSeq2
     hfse2 hbbr2 hdec2 hexec2 hlast2
   subst hcontent
@@ -1278,7 +1274,7 @@ theorem decompressZstd_rle_then_compressed_seq_content (data : ByteArray)
     -- Frame hypotheses
     (hframe : Zip.Native.decompressFrame data 0 = .ok (output, pos'))
     (hh : Zip.Native.parseFrameHeader data 0 = .ok (header, afterHeader))
-    (hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0)
+
     -- Block 1 hypotheses (RLE, non-last)
     (hparse1 : Zip.Native.parseBlockHeader data afterHeader = .ok (hdr1, afterHdr1))
     (hbs1 : ¬ hdr1.blockSize > 131072)
@@ -1321,7 +1317,7 @@ theorem decompressZstd_rle_then_compressed_seq_content (data : ByteArray)
     hdr2 afterHdr2 literals2 afterLiterals2 huffTree2
     numSeq2 modes2 afterSeqHeader2 llTable2 ofTable2 mlTable2 afterTables2 bbr2 sequences2
     blockOutput2 newHist2
-    hframe hh hdict hparse1 hbs1 hws1 htype1 hrle1 hnotlast1 hadv1
+    hframe hh hparse1 hbs1 hws1 htype1 hrle1 hnotlast1 hadv1
     hoff2 hparse2 hbs2 hws2 htype2 hblockEnd2 hlit2 hseq2 hNumSeq2
     hfse2 hbbr2 hdec2 hexec2 hlast2
   subst hcontent

--- a/progress/20260311T120000_9a742051.md
+++ b/progress/20260311T120000_9a742051.md
@@ -1,0 +1,54 @@
+# Progress: Review — Remove dead _hdict hypotheses from Zstd spec theorems
+
+**Date**: 2026-03-11 12:00 UTC
+**Session**: review (9a742051)
+**Issue**: #1093 (skipped — stale; all deliverables already completed)
+
+## Accomplished
+
+### Skipped stale issue #1093
+- Both metadata validation theorems (`decompressZstd_single_frame_contentSize`,
+  `decompressZstd_single_frame_checksum`) already exist in `Zip/Spec/ZstdFrame.lean`
+- Issue #1088 already closed, PR #1092 already closed
+- Skipped with `coordination skip` and moved to proactive review
+
+### Proactive review: Zip/Spec/Zstd.lean (3896 lines) + Zip/Spec/ZstdFrame.lean (1358 lines)
+
+**Focus areas**: dead hypotheses, code quality, file structure
+
+**Dead hypothesis removal**: Removed `_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0`
+from 20 theorem signatures in `Zstd.lean` and 18 call sites in `ZstdFrame.lean`.
+
+This hypothesis was never used in any proof body — the dictionary check is handled by
+`split at hframe` which case-splits on the actual `decompressFrame` code path. Removing
+it makes all affected theorems strictly stronger (fewer preconditions required).
+
+**Metrics**:
+- Zstd.lean: 3900 → 3896 lines (−4 net after blank line cleanup)
+- ZstdFrame.lean: 1362 → 1358 lines (−4 net)
+- Sorry count: 4 (unchanged, all XxHash)
+- Build: clean (all Lean modules compile, linker step needs nix-shell)
+
+## Structural observations (future work)
+
+`Zip/Spec/Zstd.lean` at 3896 lines is nearly 4x the recommended 1000-line max.
+Recommended file split:
+
+| New File | Source Lines | Rationale |
+|---|---|---|
+| `Zstd/BlockComposition.lean` | 778-1279 (~500 lines) | Two-block composition theorems |
+| `Zstd/CompressedSequences.lean` | 1882-3436 (~1554 lines) | Compressed block content theorems |
+| `Zstd/FrameContent.lean` | 1518-1882 (~364 lines) | Frame-level content wrappers |
+
+Additional duplication patterns identified:
+- Two-block composition theorems (11 theorems) share identical proof structure
+- Frame-level content wrappers (6 theorems) have 95% identical structure
+- Compressed sequences section has highly repetitive parameter lists
+
+These would benefit from helper lemma extraction but require dedicated sessions.
+
+## Decisions
+
+- Skipped #1093 as stale rather than claiming fix credit for already-done work
+- Chose `_hdict` removal over file splitting — higher ROI for a single review session
+- Did not modify theorem statements beyond removing the dead hypothesis


### PR DESCRIPTION
## Summary

Remove unused `_hdict : header.dictionaryId = none ∨ header.dictionaryId = some 0` hypothesis from 20 theorem signatures in `Zip/Spec/Zstd.lean` and 18 call sites in `Zip/Spec/ZstdFrame.lean`. The hypothesis was never used in any proof body — dictionary checking is handled by `split at hframe` in all cases. This makes all affected theorems strictly stronger (fewer preconditions).

- Zstd.lean: 3900 → 3896 lines
- ZstdFrame.lean: 1362 → 1358 lines  
- Sorry count: 4 (unchanged, all XxHash)

Closes #1142

🤖 Prepared with Claude Code