### PR TITLE
refactor: GzipCorrect + ZlibCorrect proof quality audit

### DIFF
--- a/Zip/Spec/GzipCorrect.lean
+++ b/Zip/Spec/GzipCorrect.lean
@@ -83,10 +83,8 @@ theorem compress_eq (data : ByteArray) (level : UInt8) :
     ∃ (header trailer : ByteArray),
       header.size = 10 ∧ trailer.size = 8 ∧
       compress data level = header ++ Deflate.deflateRaw data level ++ trailer := by
-  simp only [compress]
-  split
-  · exact ⟨_, _, rfl, rfl, rfl⟩
-  · split <;> exact ⟨_, _, rfl, rfl, rfl⟩
+  unfold compress
+  split <;> first | exact ⟨_, _, rfl, rfl, rfl⟩ | (split <;> exact ⟨_, _, rfl, rfl, rfl⟩)
 
 /-- Decomposition with concrete trailer: `compress` = header(10) ++ deflateRaw ++ trailer
     where `readUInt32LE trailer 0 = crc32 0 data` and `readUInt32LE trailer 4 = isize`. -/
@@ -97,9 +95,9 @@ private theorem compress_trailer (data : ByteArray) (level : UInt8) :
       Binary.readUInt32LE trailer 0 = Crc32.Native.crc32 0 data ∧
       Binary.readUInt32LE trailer 4 = data.size.toUInt32 := by
   unfold compress
-  split
-  · exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32LE_bytes _, Binary.readUInt32LE_bytes _⟩
-  · split <;> exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32LE_bytes _, Binary.readUInt32LE_bytes _⟩
+  split <;>
+    first | exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32LE_bytes _, Binary.readUInt32LE_bytes _⟩
+          | (split <;> exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32LE_bytes _, Binary.readUInt32LE_bytes _⟩)
 
 /-- CRC32 trailer match: `readUInt32LE` at endPos reads `crc32 0 data`. -/
 theorem compress_crc32 (data : ByteArray) (level : UInt8) :
@@ -221,8 +219,6 @@ theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
   obtain ⟨endPos', hinflRaw'⟩ :=
     inflateRaw_complete (header ++ Deflate.deflateRaw data level) 10 _
       data.data.toList hdata_le hspec_hd
-  have hep_le : endPos' ≤ (header ++ Deflate.deflateRaw data level).size :=
-    inflateRaw_endPos_le _ _ _ _ _ hinflRaw'
   -- By suffix invariance, inflateRaw on (header ++ deflated) ++ trailer gives same endPos'
   have hinflRaw'' : Inflate.inflateRaw ((header ++ Deflate.deflateRaw data level) ++ trailer)
       10 (1024 * 1024 * 1024) = .ok (⟨⟨data.data.toList⟩⟩, endPos') :=

--- a/Zip/Spec/ZlibCorrect.lean
+++ b/Zip/Spec/ZlibCorrect.lean
@@ -83,11 +83,7 @@ theorem compress_header_check (data : ByteArray) (level : UInt8) :
         simp only [ByteArray.size_append]; rw [zlib_header_size]; omega),
       Binary.getElem!_append_left _ _ 1 (by rw [zlib_header_size]; omega)]
   -- Split on all four flevel branches to get concrete values
-  split
-  · decide
-  · split
-    · decide
-    · split <;> decide
+  split <;> first | decide | (split <;> first | decide | (split <;> decide))
 
 /-- The CM field (low nibble of CMF) is 8. -/
 theorem compress_cm (data : ByteArray) (level : UInt8) :
@@ -106,11 +102,7 @@ theorem compress_no_fdict (data : ByteArray) (level : UInt8) :
   rw [Binary.getElem!_append_left _ _ 1 (by
         simp only [ByteArray.size_append]; rw [zlib_header_size]; omega),
       Binary.getElem!_append_left _ _ 1 (by rw [zlib_header_size]; omega)]
-  split
-  · decide
-  · split
-    · decide
-    · split <;> decide
+  split <;> first | decide | (split <;> first | decide | (split <;> decide))
 
 /-- Decomposition: `compress` = header (2 bytes) ++ deflateRaw ++ trailer (4 bytes). -/
 theorem compress_eq (data : ByteArray) (level : UInt8) :
@@ -118,11 +110,9 @@ theorem compress_eq (data : ByteArray) (level : UInt8) :
       header.size = 2 ∧ trailer.size = 4 ∧
       compress data level = header ++ Deflate.deflateRaw data level ++ trailer := by
   unfold compress
-  split
-  · exact ⟨_, _, rfl, rfl, rfl⟩
-  · split
-    · exact ⟨_, _, rfl, rfl, rfl⟩
-    · split <;> exact ⟨_, _, rfl, rfl, rfl⟩
+  split <;> first
+    | exact ⟨_, _, rfl, rfl, rfl⟩
+    | (split <;> first | exact ⟨_, _, rfl, rfl, rfl⟩ | (split <;> exact ⟨_, _, rfl, rfl, rfl⟩))
 
 private theorem compress_trailer (data : ByteArray) (level : UInt8) :
     ∃ (header trailer : ByteArray),
@@ -132,11 +122,10 @@ private theorem compress_trailer (data : ByteArray) (level : UInt8) :
        trailer[2]!.toUInt32 <<< 8 ||| trailer[3]!.toUInt32) =
       Adler32.Native.adler32 1 data := by
   unfold compress
-  split
-  · exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32BE_bytes _⟩
-  · split
-    · exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32BE_bytes _⟩
-    · split <;> exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32BE_bytes _⟩
+  split <;> first
+    | exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32BE_bytes _⟩
+    | (split <;> first | exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32BE_bytes _⟩
+                       | (split <;> exact ⟨_, _, rfl, rfl, rfl, Binary.readUInt32BE_bytes _⟩))
 
 /-- Adler32 trailer match: reading 4 bytes big-endian at endPos gives `adler32 1 data`. -/
 theorem compress_adler32 (data : ByteArray) (level : UInt8) :

--- a/progress/20260312T1555_5760ed68.md
+++ b/progress/20260312T1555_5760ed68.md
@@ -1,0 +1,40 @@
+# Progress: Review GzipCorrect + ZlibCorrect proof quality audit
+
+**Date**: 2026-03-12T15:55 UTC
+**Session**: review
+**Issue**: #1341
+
+## What was accomplished
+
+Proof quality audit of `Zip/Spec/GzipCorrect.lean` and `Zip/Spec/ZlibCorrect.lean`.
+
+### GzipCorrect.lean (272 → 268 lines, -4)
+- `compress_eq`: Replaced `simp only [compress]` with `unfold compress` for consistency;
+  merged identical two-level split branches using `<;> first`
+- `compress_trailer`: Merged identical two-level split branches using `<;> first`
+- `gzip_decompressSingle_compress`: Removed dead hypothesis `hep_le` (was
+  `endPos' ≤ (header ++ deflateRaw).size`, never referenced by name or fed to omega)
+
+### ZlibCorrect.lean (255 → 244 lines, -11)
+- `compress_header_check`: Merged three-level split with identical `decide` closers
+- `compress_no_fdict`: Merged three-level split with identical `decide` closers
+- `compress_eq`: Merged three-level split with identical `exact ⟨_, _, rfl, rfl, rfl⟩` closers
+- `compress_trailer`: Merged three-level split with identical closers
+
+### Quality metrics
+- Bare simp: 0 → 0 (already clean from prior PRs)
+- Sorry count: 4 → 4 (all XxHash, unchanged)
+- Net line reduction: 15 lines (-4 GzipCorrect, -11 ZlibCorrect)
+
+## Decisions
+
+- Issue's bare simp counts (~15/~16) were stale — both files were already at 0 bare simp.
+  Proceeded with proof compression audit instead of skipping.
+- Left `show Deflate.Spec.decode ... = some p.1.data.toList` wrapper in
+  `inflate_to_spec_decode` — it appears necessary for type unification after `rw [← h]`.
+
+## Patterns
+
+- Identical split branches are common in compress-related proofs because `compress` matches
+  on compression level (2-3 branches for gzip, 3-4 for zlib). The `<;> first | X | (split <;> X)`
+  pattern compresses these effectively.


### PR DESCRIPTION
Closes #1341

Session: `db0210e1-4453-4d60-9a28-0c9d4cc67286`

e9bb78e refactor: GzipCorrect + ZlibCorrect proof quality audit

🤖 Prepared with Claude Code