### PR TITLE
Fix: master CI failing on lake exe test (Lean 4.29.1 regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
         run: lake -R build
 
       - name: Test
-        run: lake -R exe test
+        run: lake -R test

--- a/progress/20260418T065015_04cde431.md
+++ b/progress/20260418T065015_04cde431.md
@@ -1,0 +1,51 @@
+# Fix master CI: lake exe test → lake test
+
+- **Date (UTC)**: 2026-04-18T06:50
+- **Session**: 04cde431 (`/feature`)
+- **Issue**: #1493
+- **Branch**: `agent/04cde431`
+
+## Accomplished
+
+Switched the CI **Test** step in `.github/workflows/ci.yml` from
+`lake exe test` to `lake test` (the preferred option from the issue).
+
+## Why this fixes it
+
+Lean 4.29.1 validates the compiled Lake configuration more aggressively
+at `lake exe` time. On CI (even with a cache miss and a fresh build) the
+manifest written during `lake build` is newer than the compiled lakefile
+that `lake exe` is loaded against, so every run since commit `23b5822`
+fails with:
+
+> error: compiled configuration is invalid; run with '-R' to reconfigure
+
+`lake test` is a Lake-level command that uses the existing
+`testDriver := "test"` binding in `lakefile.lean` and handles
+reconfiguration cleanly, sidestepping the `lake exe` validation.
+
+## Local verification
+
+- `lake build && lake test` passes locally (nix-shell environment,
+  `testdata/` present, all benchmark/test output reaches
+  `All tests passed!`).
+- `lake exe test` also still passes locally — the regression is
+  CI-specific, so the actual validation is this PR's own CI run.
+
+## Decisions
+
+- Chose option 1 (`lake test`) over option 2 (`lake exe test -R`):
+  cleanest, no new flags, leverages the existing `testDriver` binding.
+- No CLAUDE.md update needed — local invocation guidance is unchanged
+  (contributors still use `lake build && lake exe test`; only CI
+  changed to the Lake-level `lake test` form).
+
+## Quality metrics
+
+- sorry count: unchanged (0 across all `Zip/` files)
+- Diff is one line in `.github/workflows/ci.yml`
+
+## Follow-ups
+
+Once master CI is green, PRs #1491 and #1492 should become mergeable
+after rebasing onto master.


### PR DESCRIPTION
Closes #1493

Session: `04cde431-6e37-4229-b33f-9f191e97ffea`

12dd165 doc: progress entry for CI fix (#1493)
3f44e52 fix: use lake test instead of lake exe test for Lean 4.29.1

🤖 Prepared with Claude Code