### PR TITLE
Feature: Proven-bounds in Deflate.lean — canonicalCodes + findTableCode + Inflate.insertLoop

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -68,10 +68,13 @@ where
     if h : i < lengths.size then
       let len := lengths[i]
       if len > 0 then
-        let code := nextCode[len.toNat]!
-        let result' := result.set! i (code.toUInt16, len)
-        let nextCode' := nextCode.set! len.toNat (code + 1)
-        go lengths nextCode' (i + 1) result'
+        if hlen : len.toNat < nextCode.size then
+          let code := nextCode[len.toNat]
+          let result' := result.set! i (code.toUInt16, len)
+          let nextCode' := nextCode.set! len.toNat (code + 1)
+          go lengths nextCode' (i + 1) result'
+        else
+          go lengths nextCode (i + 1) result
       else
         go lengths nextCode (i + 1) result
     else result
@@ -92,9 +95,13 @@ private theorem canonicalCodes_go_size (lengths : Array UInt8) (nextCode : Array
   · simp only [hi, ↓reduceDIte]
     by_cases hlen : lengths[i] > 0
     · simp only [hlen, ↓reduceIte]
-      exact canonicalCodes_go_size lengths _ (i + 1) _ (by
-        simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds]
-        split <;> simp [Array.size_set, hrs])
+      by_cases hnc : lengths[i].toNat < nextCode.size
+      · simp only [hnc, ↓reduceDIte]
+        exact canonicalCodes_go_size lengths _ (i + 1) _ (by
+          simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds]
+          split <;> simp [Array.size_set, hrs])
+      · simp only [show ¬(lengths[i].toNat < nextCode.size) from hnc, ↓reduceDIte]
+        exact canonicalCodes_go_size lengths nextCode (i + 1) result hrs
     · simp only [show ¬(lengths[i] > 0) from hlen, ↓reduceIte]
       exact canonicalCodes_go_size lengths nextCode (i + 1) result hrs
   · simp only [show ¬(i < lengths.size) from hi, ↓reduceDIte]; exact hrs

--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -120,16 +120,16 @@ private theorem canonicalCodes_size' (lengths : Array UInt8) (maxBits : Nat) :
 def findTableCode.go (baseTable : Array UInt16) (extraTable : Array UInt8)
     (value : Nat) (i : Nat) (hsize : baseTable.size ≤ extraTable.size) :
     Option (Nat × Nat × UInt32) :=
-  if i + 1 < baseTable.size then
-    if baseTable[i + 1]!.toNat > value then
-      let extra := extraTable[i]!.toNat
-      let extraVal := (value - baseTable[i]!.toNat).toUInt32
+  if h1 : i + 1 < baseTable.size then
+    if baseTable[i + 1].toNat > value then
+      let extra := (extraTable[i]'(by omega)).toNat
+      let extraVal := (value - (baseTable[i]'(by omega)).toNat).toUInt32
       some (i, extra, extraVal)
     else
       findTableCode.go baseTable extraTable value (i + 1) hsize
-  else if i < baseTable.size then
-    let extra := extraTable[i]!.toNat
-    let extraVal := (value - baseTable[i]!.toNat).toUInt32
+  else if h2 : i < baseTable.size then
+    let extra := (extraTable[i]'(by omega)).toNat
+    let extraVal := (value - baseTable[i].toNat).toUInt32
     some (i, extra, extraVal)
   else
     none

--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -50,10 +50,13 @@ def insertLoop (lengths : Array UInt8) (nextCode : Array UInt32)
   if h : start < lengths.size then
     let len := lengths[start]
     if len > 0 then
-      let c := nextCode[len.toNat]!
-      let tree' := tree.insert c len.toNat start.toUInt16
-      let nextCode' := nextCode.set! len.toNat (c + 1)
-      insertLoop lengths nextCode' (start + 1) tree'
+      if hlen : len.toNat < nextCode.size then
+        let c := nextCode[len.toNat]
+        let tree' := tree.insert c len.toNat start.toUInt16
+        let nextCode' := nextCode.set! len.toNat (c + 1)
+        insertLoop lengths nextCode' (start + 1) tree'
+      else
+        insertLoop lengths nextCode (start + 1) tree
     else
       insertLoop lengths nextCode (start + 1) tree
   else (tree, nextCode)

--- a/Zip/Spec/DeflateFixedTables.lean
+++ b/Zip/Spec/DeflateFixedTables.lean
@@ -202,16 +202,21 @@ private theorem findTableCode_go_of_first_match
       by_cases h_next : idx + 1 < baseTable.size
       · -- Has next entry: check upper bound
         have hgt := hmatch h_next
-        simp only [show idx + 1 < baseTable.size from h_next,
-          show baseTable[idx + 1]!.toNat > value from hgt, ↓reduceIte]
+        have hb1' : baseTable[idx + 1]'h_next = baseTable[idx + 1]! :=
+          (getElem!_pos baseTable (idx + 1) h_next).symm
+        rw [dif_pos h_next, hb1', if_pos hgt,
+            getElem!_pos extraTable idx (by omega),
+            getElem!_pos baseTable idx hidx]
       · -- Last entry
-        simp only [show ¬(idx + 1 < baseTable.size) from h_next,
-          show idx < baseTable.size from hidx, ↓reduceIte]
+        rw [dif_neg h_next, dif_pos hidx,
+            getElem!_pos extraTable idx (by omega),
+            getElem!_pos baseTable idx hidx]
     · -- Skip: search passes through this index
       have hlt_idx : i < idx := by omega
       obtain ⟨h_next_i, h_le_i⟩ := hskip i hlt_idx
-      simp only [show i + 1 < baseTable.size from h_next_i,
-        show ¬(baseTable[i + 1]!.toNat > value) from by omega, ↓reduceIte]
+      have hb1' : baseTable[i + 1]'h_next_i = baseTable[i + 1]! :=
+        (getElem!_pos baseTable (i + 1) h_next_i).symm
+      rw [dif_pos h_next_i, hb1', if_neg (by omega : ¬ baseTable[i + 1]!.toNat > value)]
       exact ih (i + 1) (by omega : i + 1 ≤ idx) (by omega)
 
 /-! ## findLengthCode / findDistCode agreement -/

--- a/Zip/Spec/EmitTokensCorrect.lean
+++ b/Zip/Spec/EmitTokensCorrect.lean
@@ -336,28 +336,33 @@ private theorem canonicalCodes_go_snd_le (lengths : Array UInt8) (nextCode : Arr
   · simp only [hi, ↓reduceDIte] at hj ⊢
     by_cases hlen : lengths[i] > 0
     · simp only [hlen, ↓reduceIte] at hj ⊢
-      let val := (nextCode[lengths[i].toNat]!.toUInt16, lengths[i])
-      have hsize' : (result.set! i val).size = lengths.size := by
-        simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds]
-        split <;> simp only [Array.size_set, hsize]
-      have hresult' : ∀ k, k < (result.set! i val).size →
-          (result.set! i val)[k]!.2.toNat ≤ bound := by
-        intro k hk
-        by_cases heq : k = i
-        · rw [heq, getElem!_pos (result.set! i val) i (by rw [hsize']; exact hi)]
-          simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds,
-            show i < result.size from by rw [hsize]; exact hi, ↓reduceDIte,
-            Array.getElem_set, ↓reduceIte, val]
-          rw [← getElem!_pos lengths i hi]
-          exact hlengths i hi
-        · rw [getElem!_pos (result.set! i val) k (by rw [hsize']; omega)]
-          simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds,
-            show i < result.size from by rw [hsize]; exact hi, ↓reduceDIte,
-            Array.getElem_set, show ¬(i = k) from (Ne.symm heq), ↓reduceIte]
-          rw [← getElem!_pos result k (by rw [hsize]; omega)]
-          exact hresult k (by rw [hsize]; omega)
-      exact canonicalCodes_go_snd_le lengths _ (i + 1) _ bound hsize' hresult'
-        hlengths j hj
+      by_cases hnc : lengths[i].toNat < nextCode.size
+      · simp only [hnc, ↓reduceDIte] at hj ⊢
+        let val := (nextCode[lengths[i].toNat].toUInt16, lengths[i])
+        have hsize' : (result.set! i val).size = lengths.size := by
+          simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds]
+          split <;> simp only [Array.size_set, hsize]
+        have hresult' : ∀ k, k < (result.set! i val).size →
+            (result.set! i val)[k]!.2.toNat ≤ bound := by
+          intro k hk
+          by_cases heq : k = i
+          · rw [heq, getElem!_pos (result.set! i val) i (by rw [hsize']; exact hi)]
+            simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds,
+              show i < result.size from by rw [hsize]; exact hi, ↓reduceDIte,
+              Array.getElem_set, ↓reduceIte, val]
+            rw [← getElem!_pos lengths i hi]
+            exact hlengths i hi
+          · rw [getElem!_pos (result.set! i val) k (by rw [hsize']; omega)]
+            simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds,
+              show i < result.size from by rw [hsize]; exact hi, ↓reduceDIte,
+              Array.getElem_set, show ¬(i = k) from (Ne.symm heq), ↓reduceIte]
+            rw [← getElem!_pos result k (by rw [hsize]; omega)]
+            exact hresult k (by rw [hsize]; omega)
+        exact canonicalCodes_go_snd_le lengths _ (i + 1) _ bound hsize' hresult'
+          hlengths j hj
+      · simp only [hnc, ↓reduceDIte] at hj ⊢
+        exact canonicalCodes_go_snd_le lengths nextCode (i + 1) result bound hsize hresult
+          hlengths j hj
     · simp only [show ¬(lengths[i] > 0) from hlen, ↓reduceIte] at hj ⊢
       exact canonicalCodes_go_snd_le lengths nextCode (i + 1) result bound hsize hresult
         hlengths j hj

--- a/Zip/Spec/EmitTokensCorrect.lean
+++ b/Zip/Spec/EmitTokensCorrect.lean
@@ -266,11 +266,15 @@ theorem findTableCode_go_extraN (baseTable : Array UInt16)
     extraN = extraTable[idx]!.toNat := by
   unfold findTableCode.go at h
   split at h
-  · split at h
-    · simp only [Option.some.injEq, Prod.mk.injEq] at h; rw [← h.1]; exact h.2.1.symm
+  · rename_i h1
+    split at h
+    · simp only [Option.some.injEq, Prod.mk.injEq] at h
+      rw [← h.1, getElem!_pos extraTable i (by omega)]; exact h.2.1.symm
     · exact findTableCode_go_extraN baseTable extraTable value (i + 1) idx extraN extraV hsize h
   · split at h
-    · simp only [Option.some.injEq, Prod.mk.injEq] at h; rw [← h.1]; exact h.2.1.symm
+    · rename_i h2
+      simp only [Option.some.injEq, Prod.mk.injEq] at h
+      rw [← h.1, getElem!_pos extraTable i (by omega)]; exact h.2.1.symm
     · exact nomatch h
 termination_by baseTable.size - i
 

--- a/Zip/Spec/Huffman.lean
+++ b/Zip/Spec/Huffman.lean
@@ -102,7 +102,7 @@ private theorem nextCodes_go_size (blCount : Array Nat) (maxBits : Nat)
   termination_by maxBits + 1 - bits
 
 /-- `nextCodes` returns an array of size `maxBits + 1`. -/
-protected theorem nextCodes_size (blCount : Array Nat) (maxBits : Nat) :
+@[simp] protected theorem nextCodes_size (blCount : Array Nat) (maxBits : Nat) :
     (nextCodes blCount maxBits).size = maxBits + 1 :=
   nextCodes_go_size blCount maxBits _ 1 0 (Array.size_replicate ..)
 

--- a/Zip/Spec/HuffmanCorrectLoop.lean
+++ b/Zip/Spec/HuffmanCorrectLoop.lean
@@ -152,6 +152,9 @@ private theorem insertLoop_forward
       have hlen_le : lengths[start].toNat ≤ maxBits := by
         rw [← hls_start]; exact hv.1 _ (List.getElem_mem hls_len)
       have hlen_pos_nat : 0 < lengths[start].toNat := hlen_pos
+      have hlen_lt : lengths[start].toNat < nextCode.size := by omega
+      simp only [hlen_lt, ↓reduceDIte,
+        ← getElem!_pos nextCode lengths[start].toNat hlen_lt]
       obtain ⟨cw_s, hcf_s⟩ := codeFor_some lsList maxBits start hls_len
         (by rw [hls_start]; omega) (by rw [hls_start]; omega)
       have hcw_s : cw_s = Huffman.Spec.natToBits
@@ -241,6 +244,9 @@ private theorem insertLoop_backward
       have hlen_le : lengths[start].toNat ≤ maxBits := by
         rw [← hls_start]; exact hv.1 _ (List.getElem_mem hls_len)
       have hlen_pos_nat : 0 < lengths[start].toNat := hlen_pos
+      have hlen_lt : lengths[start].toNat < nextCode.size := by omega
+      simp only [hlen_lt, ↓reduceDIte,
+        ← getElem!_pos nextCode lengths[start].toNat hlen_lt] at h
       obtain ⟨cw_s, hcf_s⟩ := codeFor_some lsList maxBits start hls_len
         (by rw [hls_start]; omega) (by rw [hls_start]; omega)
       have hcw_s : cw_s = Huffman.Spec.natToBits

--- a/Zip/Spec/HuffmanEncodeCorrect.lean
+++ b/Zip/Spec/HuffmanEncodeCorrect.lean
@@ -22,7 +22,9 @@ protected theorem canonicalCodes_go_size (lengths : Array UInt8) (nextCode : Arr
   split
   · dsimp only []
     split
-    · rw [Deflate.Correctness.canonicalCodes_go_size, Array.size_set!]
+    · split
+      · rw [Deflate.Correctness.canonicalCodes_go_size, Array.size_set!]
+      · exact Deflate.Correctness.canonicalCodes_go_size lengths nextCode (i + 1) result
     · exact Deflate.Correctness.canonicalCodes_go_size lengths nextCode (i + 1) result
   · rfl
 termination_by lengths.size - i
@@ -81,6 +83,10 @@ private theorem canonicalCodes_go_inv
         simp only [hlsList, List.getElem_map, Array.getElem_toList]
       have hlen_le : lengths[i].toNat ≤ maxBits := by
         rw [← hls_i]; exact hv.1 _ (List.getElem_mem hls_len)
+      -- The new bounds guard is discharged by hlen_le + hncSize
+      have hlen_lt : lengths[i].toNat < nextCode.size := by omega
+      simp only [hlen_lt, ↓reduceDIte,
+        ← getElem!_pos nextCode lengths[i].toNat hlen_lt]
       -- Code value from NC invariant
       have hcode_val := hnc lengths[i].toNat (by omega) hlen_le
       have h_partial_le := count_foldl_take_le lsList lengths[i].toNat i

--- a/progress/20260418T070243Z_a70022be.md
+++ b/progress/20260418T070243Z_a70022be.md
@@ -1,0 +1,44 @@
+# Session 20260418T070243Z — a70022be
+
+**Session type**: feature
+**Issue**: #1490 — Proven-bounds in Deflate.lean (canonicalCodes + findTableCode + Inflate.insertLoop)
+
+## What was accomplished
+
+Converted 7 target `]!` patterns to proven-bounds:
+- `findTableCode.go` (5 patterns, Deflate.lean): outer guard `if h1 : i + 1 < baseTable.size`, inner guard `if h2 : i < baseTable.size`, with `'(by omega)` index proofs bridging `hsize` to `extraTable`.
+- `canonicalCodes.go` (1 pattern, Deflate.lean): added `if hlen : len.toNat < nextCode.size` guard with fallthrough that recurses without update.
+- `insertLoop` (1 pattern, Inflate.lean): same guard pattern as canonicalCodes.
+
+Tagged `Huffman.Spec.nextCodes_size` with `@[simp]` per issue request.
+
+## Spec proofs repaired
+
+- `findTableCode_go_of_first_match` (DeflateFixedTables.lean): switched to explicit `dif_pos`/`dif_neg` + `getElem!_pos` bridges, because old `simp only [↓reduceIte]` no longer fires on the new `dite`.
+- `findTableCode_go_extraN` (EmitTokensCorrect.lean): added `rename_i` + `rw [← h.1, getElem!_pos ...]` to bridge new proven-bounds to `!` form.
+- `canonicalCodes_go_size`, `canonicalCodes_go_snd_le` (EmitTokensCorrect.lean + HuffmanEncodeCorrect.lean): added `by_cases hnc : lengths[i].toNat < nextCode.size` to split the new dite; both branches preserve size/bound.
+- `canonicalCodes_go_inv` (HuffmanEncodeCorrect.lean): discharged the new dite with `hlen_le` + `hncSize` → `simp only [hlen_lt, ↓reduceDIte, ← getElem!_pos ...]`.
+- `insertLoop_forward`, `insertLoop_backward` (HuffmanCorrectLoop.lean): same discharge pattern — the new dite is unreachable under `ValidLengths` + `hncSize`, so `simp only [hlen_lt, ↓reduceDIte, ← getElem!_pos nextCode ... hlen_lt]` reduces it and rewrites proven-bounds back to `!` form, letting the rest of the proof proceed unchanged.
+
+## Key pattern
+
+When adding a bounds guard `if hlen : idx < arr.size` before an access that was `arr[idx]!`:
+1. In the guarded code, use `arr[idx]` (proven-bounds, auto-discharges via `hlen`).
+2. In spec proofs that previously manipulated `arr[idx]!`, add:
+   ```lean
+   have hlen_lt : idx < arr.size := by omega  -- from invariants
+   simp only [hlen_lt, ↓reduceDIte, ← getElem!_pos arr idx hlen_lt]
+   ```
+3. The `↓reduceDIte` collapses the dite to the then branch; `← getElem!_pos` rewrites `arr[idx]` back to `arr[idx]!` so the rest of the proof is unchanged.
+
+## Quality metrics
+
+- `Zip/Native/Deflate.lean` `]!` count: **48 → 42** (target ≤42 ✓)
+- `Zip/Native/Inflate.lean` `]!` count: **1 → 0** ✓
+- sorry count: **0 → 0** ✓
+- `lake build` clean, `lake exe test` all passing.
+
+## Out of scope (confirmed)
+
+The 40+ `]!` in `lz77Greedy`, `lz77GreedyIter`, `lz77Lazy`, `lz77LazyIter`
+remain for a follow-up issue.


### PR DESCRIPTION
Closes #1490

Session: `a70022be-c940-472c-a0f7-739c3f402af9`

07bcf30 chore: progress entry for #1490 session
c4d383c chore: tag Huffman.Spec.nextCodes_size @[simp]
5d5dd1e feat: proven-bounds in Inflate.insertLoop
b481eec feat: proven-bounds in canonicalCodes.go
5304e3d feat: proven-bounds in findTableCode.go

🤖 Prepared with Claude Code