### PR TITLE
[codex] update progress note for local Array lemma

### DIFF
--- a/progress/20260224T185905Z_ad0bf829.md
+++ b/progress/20260224T185905Z_ad0bf829.md
@@ -10,10 +10,11 @@ Deep proof quality review of `Zip/Spec/DeflateDynamicCorrect.lean` (881 → 837 
 
 ### Improvements applied
 
-1. **`Array.getElem!_le_set!_incr` helper** (ZipForStd/Array.lean): Extracted a reusable lemma
-   for the monotonicity pattern `arr[idx]! ≤ (arr.set! k (arr[k]! + 1))[idx]!`. Replaced 5
-   inline `by_cases heq; subst; getElem!_set!_self; getElem!_set!_ne; omega` patterns in
-   `tokenFreqs_go_mono`.
+1. **Local `getElem!_le_set!_incr` helper**: Extracted a reusable lemma for the monotonicity
+   pattern `arr[idx]! ≤ (arr.set! k (arr[k]! + 1))[idx]!`. It now lives locally in
+   `Zip/Spec/DeflateDynamicFreqs.lean` rather than in the shared upstream-facing lemma set.
+   Replaced 5 inline `by_cases heq; subst; getElem!_set!_self; getElem!_set!_ne; omega`
+   patterns in `tokenFreqs_go_mono`.
 
 2. **`freqPairs_witness` helper**: Extracted a lemma for constructing frequency pair witnesses
    (`∃ p ∈ freqPairs, p.1 = sym ∧ p.2 > 0`). Replaced 5 inline constructions in


### PR DESCRIPTION
This PR updates the historical progress note about `getElem!_le_set!_incr` to match the final outcome.

The helper still exists, but only as a local theorem in `Zip.Spec.DeflateDynamicFreqs`; it is not part of the shared upstream-facing array lemma set.
