### PR TITLE
Feature: Proven-bounds in tokenFreqs.go (DeflateDynamic cluster B)

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -47,27 +47,54 @@ def tokenFreqs (tokens : Array LZ77Token) : Array Nat × Array Nat :=
   let distFreqs := Array.replicate 30 0
   -- Always count end-of-block
   let litLenFreqs := litLenFreqs.set! 256 1
-  go tokens litLenFreqs distFreqs 0
+  go tokens litLenFreqs distFreqs
+    (by show ((Array.replicate 286 0).set! 256 1).size = 286
+        rw [Array.size_set!, Array.size_replicate])
+    (by show (Array.replicate 30 0).size = 30
+        rw [Array.size_replicate]) 0
 where
   go (tokens : Array LZ77Token) (litLenFreqs distFreqs : Array Nat)
+      (hlit : litLenFreqs.size = 286) (hdist : distFreqs.size = 30)
       (i : Nat) : Array Nat × Array Nat :=
     if h : i < tokens.size then
       match tokens[i] with
       | .literal b =>
         let idx := b.toNat
-        let litLenFreqs := litLenFreqs.set! idx (litLenFreqs[idx]! + 1)
-        go tokens litLenFreqs distFreqs (i + 1)
+        have hidx : idx < litLenFreqs.size := by
+          have := UInt8.toNat_lt b; omega
+        let litLenFreqs' := litLenFreqs.set! idx (litLenFreqs[idx] + 1)
+        go tokens litLenFreqs' distFreqs
+          (by simp [litLenFreqs', hlit]) hdist (i + 1)
       | .reference length distance =>
-        let litLenFreqs := match findLengthCode length with
-          | some (idx, _, _) =>
-            let symIdx := idx + 257
-            litLenFreqs.set! symIdx (litLenFreqs[symIdx]! + 1)
-          | none => litLenFreqs
-        let distFreqs := match findDistCode distance with
+        match hflc : findLengthCode length with
+        | none =>
+          match hfdc : findDistCode distance with
+          | none => go tokens litLenFreqs distFreqs hlit hdist (i + 1)
           | some (dIdx, _, _) =>
-            distFreqs.set! dIdx (distFreqs[dIdx]! + 1)
-          | none => distFreqs
-        go tokens litLenFreqs distFreqs (i + 1)
+            have hd : dIdx < distFreqs.size := by
+              have := nativeFindDistCode_idx_bound _ _ _ _ hfdc; omega
+            let distFreqs' := distFreqs.set! dIdx (distFreqs[dIdx] + 1)
+            go tokens litLenFreqs distFreqs' hlit
+              (by show (distFreqs.set! dIdx (distFreqs[dIdx] + 1)).size = 30
+                  rw [Array.size_set!]; exact hdist)
+              (i + 1)
+        | some (lIdx, _, _) =>
+          have hsym : lIdx + 257 < litLenFreqs.size := by
+            have := nativeFindLengthCode_idx_bound _ _ _ _ hflc; omega
+          let litLenFreqs' := litLenFreqs.set! (lIdx + 257) (litLenFreqs[lIdx + 257] + 1)
+          have hlit' : litLenFreqs'.size = 286 := by
+            show (litLenFreqs.set! (lIdx + 257) (litLenFreqs[lIdx + 257] + 1)).size = 286
+            rw [Array.size_set!]; exact hlit
+          match hfdc : findDistCode distance with
+          | none => go tokens litLenFreqs' distFreqs hlit' hdist (i + 1)
+          | some (dIdx, _, _) =>
+            have hd : dIdx < distFreqs.size := by
+              have := nativeFindDistCode_idx_bound _ _ _ _ hfdc; omega
+            let distFreqs' := distFreqs.set! dIdx (distFreqs[dIdx] + 1)
+            go tokens litLenFreqs' distFreqs' hlit'
+              (by show (distFreqs.set! dIdx (distFreqs[dIdx] + 1)).size = 30
+                  rw [Array.size_set!]; exact hdist)
+              (i + 1)
     else (litLenFreqs, distFreqs)
   termination_by tokens.size - i
 

--- a/Zip/Spec/DeflateDynamicFreqs.lean
+++ b/Zip/Spec/DeflateDynamicFreqs.lean
@@ -21,9 +21,11 @@ used by the dynamic Huffman compressor. These are internal helpers for
 
 namespace Zip.Native.Deflate
 
-/-- Incrementing one counter in a Nat frequency array cannot decrease any entry. -/
+/-- Incrementing one counter in a Nat frequency array (proven-bounds form)
+cannot decrease any entry. -/
 private theorem getElem!_le_set!_incr (arr : Array Nat) (k idx : Nat) (hk : k < arr.size) :
-    arr[idx]! ≤ (arr.set! k (arr[k]! + 1))[idx]! := by
+    arr[idx]! ≤ (arr.set! k (arr[k] + 1))[idx]! := by
+  rw [show arr[k] = arr[k]! from (getElem!_pos arr k hk).symm]
   by_cases heq : k = idx
   · subst heq
     rw [Array.getElem!_set!_self arr _ _ hk]
@@ -31,30 +33,30 @@ private theorem getElem!_le_set!_incr (arr : Array Nat) (k idx : Nat) (hk : k < 
   · rw [Array.getElem!_set!_ne arr _ _ _ heq]
     omega
 
-/-- `tokenFreqs.go` preserves array sizes. -/
+/-- `tokenFreqs.go` preserves array sizes. The size invariants are now
+threaded through `go` itself (via `hlit`, `hdist`), so the output sizes
+are 286 and 30 by construction; this theorem just exposes them. -/
 protected theorem tokenFreqs_go_sizes (tokens : Array LZ77Token)
-    (litFreqs distFreqs : Array Nat) (i : Nat)
-    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30) :
-    (tokenFreqs.go tokens litFreqs distFreqs i).1.size = 286 ∧
-    (tokenFreqs.go tokens litFreqs distFreqs i).2.size = 30 := by
+    (litFreqs distFreqs : Array Nat)
+    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30) (i : Nat) :
+    (tokenFreqs.go tokens litFreqs distFreqs hlit hdist i).1.size = 286 ∧
+    (tokenFreqs.go tokens litFreqs distFreqs hlit hdist i).2.size = 30 := by
   unfold tokenFreqs.go
   split
   · rename_i h
     match htok : tokens[i] with
     | .literal b =>
       simp only []
-      apply Deflate.tokenFreqs_go_sizes
-      · rw [Array.size_set!]; omega
-      · exact hdist
+      exact Deflate.tokenFreqs_go_sizes tokens _ _ _ _ (i + 1)
     | .reference len dist =>
       simp only []
-      apply Deflate.tokenFreqs_go_sizes
-      · cases findLengthCode len with
-        | none => exact hlit
-        | some p => obtain ⟨idx, _, _⟩ := p; rw [Array.size_set!]; omega
-      · cases findDistCode dist with
-        | none => exact hdist
-        | some p => obtain ⟨dIdx, _, _⟩ := p; rw [Array.size_set!]; omega
+      split
+      · split
+        · exact Deflate.tokenFreqs_go_sizes tokens _ _ _ _ (i + 1)
+        · exact Deflate.tokenFreqs_go_sizes tokens _ _ _ _ (i + 1)
+      · split
+        · exact Deflate.tokenFreqs_go_sizes tokens _ _ _ _ (i + 1)
+        · exact Deflate.tokenFreqs_go_sizes tokens _ _ _ _ (i + 1)
   · exact ⟨hlit, hdist⟩
 termination_by tokens.size - i
 
@@ -62,94 +64,73 @@ termination_by tokens.size - i
 protected theorem tokenFreqs_sizes (tokens : Array LZ77Token) :
     (tokenFreqs tokens).1.size = 286 ∧ (tokenFreqs tokens).2.size = 30 := by
   simp only [tokenFreqs]
-  apply Deflate.tokenFreqs_go_sizes
-  · rw [Array.size_set!, Array.size_replicate]
-  · rw [Array.size_replicate]
+  exact Deflate.tokenFreqs_go_sizes tokens _ _ _ _ 0
 
 /-- `tokenFreqs.go` only increases frequency values. -/
 protected theorem tokenFreqs_go_mono (tokens : Array LZ77Token)
-    (litFreqs distFreqs : Array Nat) (i idx : Nat)
-    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30) :
-    (idx < 286 → litFreqs[idx]! ≤ (tokenFreqs.go tokens litFreqs distFreqs i).1[idx]!) ∧
-    (idx < 30 → distFreqs[idx]! ≤ (tokenFreqs.go tokens litFreqs distFreqs i).2[idx]!) := by
+    (litFreqs distFreqs : Array Nat)
+    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30) (i idx : Nat) :
+    (idx < 286 →
+      litFreqs[idx]! ≤ (tokenFreqs.go tokens litFreqs distFreqs hlit hdist i).1[idx]!) ∧
+    (idx < 30 →
+      distFreqs[idx]! ≤ (tokenFreqs.go tokens litFreqs distFreqs hlit hdist i).2[idx]!) := by
   unfold tokenFreqs.go
   split
   · rename_i h
     match htok : tokens[i] with
     | .literal b =>
       simp only []
+      have hb : b.toNat < litFreqs.size := by have := UInt8.toNat_lt b; omega
       have ih := Deflate.tokenFreqs_go_mono tokens
-        (litFreqs.set! b.toNat (litFreqs[b.toNat]! + 1)) distFreqs (i + 1) idx
-        (by rw [Array.size_set!]; omega) hdist
-      constructor
-      · intro hidx
-        exact Nat.le_trans (getElem!_le_set!_incr litFreqs b.toNat idx
-          (by have := UInt8.toNat_lt b; omega)) (ih.1 hidx)
-      · exact ih.2
+        (litFreqs.set! b.toNat (litFreqs[b.toNat]'hb + 1)) distFreqs
+        (by rw [Array.size_set!]; omega) hdist (i + 1) idx
+      refine ⟨fun hidx => ?_, ih.2⟩
+      exact Nat.le_trans
+        (getElem!_le_set!_incr litFreqs b.toNat idx hb) (ih.1 hidx)
     | .reference length distance =>
       simp only []
-      -- Split on findLengthCode and findDistCode
-      constructor
-      · intro hidx
-        cases hflc : findLengthCode length with
-        | none =>
-          cases hfdc : findDistCode distance with
-          | none =>
-            have ih := Deflate.tokenFreqs_go_mono tokens litFreqs distFreqs (i + 1) idx hlit hdist
-            exact ih.1 hidx
-          | some p =>
-            obtain ⟨dIdx, dN, dV⟩ := p
-            have ih := Deflate.tokenFreqs_go_mono tokens litFreqs
-              (distFreqs.set! dIdx (distFreqs[dIdx]! + 1)) (i + 1) idx
-              hlit (by rw [Array.size_set!]; omega)
-            exact ih.1 hidx
-        | some p =>
-          obtain ⟨lIdx, lN, lV⟩ := p
-          cases hfdc : findDistCode distance with
-          | none =>
-            have ih := Deflate.tokenFreqs_go_mono tokens
-              (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]! + 1)) distFreqs (i + 1) idx
-              (by rw [Array.size_set!]; omega) hdist
-            have hlIdx := nativeFindLengthCode_idx_bound _ lIdx lN lV hflc
-            exact Nat.le_trans (getElem!_le_set!_incr litFreqs _ idx (by omega)) (ih.1 hidx)
-          | some q =>
-            obtain ⟨dIdx, dN, dV⟩ := q
-            have hlIdx := nativeFindLengthCode_idx_bound _ lIdx lN lV hflc
-            have ih := Deflate.tokenFreqs_go_mono tokens
-              (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]! + 1))
-              (distFreqs.set! dIdx (distFreqs[dIdx]! + 1)) (i + 1) idx
-              (by rw [Array.size_set!]; omega) (by rw [Array.size_set!]; omega)
-            exact Nat.le_trans (getElem!_le_set!_incr litFreqs _ idx (by omega)) (ih.1 hidx)
-      · intro hidx
-        cases hflc : findLengthCode length with
-        | none =>
-          cases hfdc : findDistCode distance with
-          | none =>
-            have ih := Deflate.tokenFreqs_go_mono tokens litFreqs distFreqs (i + 1) idx hlit hdist
-            exact ih.2 hidx
-          | some p =>
-            obtain ⟨dIdx, dN, dV⟩ := p
-            have hdIdx := nativeFindDistCode_idx_bound _ dIdx dN dV hfdc
-            have ih := Deflate.tokenFreqs_go_mono tokens litFreqs
-              (distFreqs.set! dIdx (distFreqs[dIdx]! + 1)) (i + 1) idx
-              hlit (by rw [Array.size_set!]; omega)
-            exact Nat.le_trans (getElem!_le_set!_incr distFreqs dIdx idx (by omega)) (ih.2 hidx)
-        | some p =>
-          obtain ⟨lIdx, lN, lV⟩ := p
-          cases hfdc : findDistCode distance with
-          | none =>
-            have ih := Deflate.tokenFreqs_go_mono tokens
-              (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]! + 1)) distFreqs (i + 1) idx
-              (by rw [Array.size_set!]; omega) hdist
-            exact ih.2 hidx
-          | some q =>
-            obtain ⟨dIdx, dN, dV⟩ := q
-            have hdIdx := nativeFindDistCode_idx_bound _ dIdx dN dV hfdc
-            have ih := Deflate.tokenFreqs_go_mono tokens
-              (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]! + 1))
-              (distFreqs.set! dIdx (distFreqs[dIdx]! + 1)) (i + 1) idx
-              (by rw [Array.size_set!]; omega) (by rw [Array.size_set!]; omega)
-            exact Nat.le_trans (getElem!_le_set!_incr distFreqs dIdx idx (by omega)) (ih.2 hidx)
+      split
+      · -- findLengthCode = none
+        rename_i hflc
+        split
+        · -- findDistCode = none
+          exact Deflate.tokenFreqs_go_mono tokens litFreqs distFreqs hlit hdist (i + 1) idx
+        · -- findDistCode = some
+          rename_i dIdx _ _ hfdc
+          have hdIdx := nativeFindDistCode_idx_bound _ dIdx _ _ hfdc
+          have hd : dIdx < distFreqs.size := by omega
+          have ih := Deflate.tokenFreqs_go_mono tokens litFreqs
+            (distFreqs.set! dIdx (distFreqs[dIdx]'hd + 1))
+            hlit (by rw [Array.size_set!]; omega) (i + 1) idx
+          refine ⟨ih.1, fun hidx => ?_⟩
+          exact Nat.le_trans
+            (getElem!_le_set!_incr distFreqs dIdx idx hd) (ih.2 hidx)
+      · -- findLengthCode = some
+        rename_i lIdx _ _ hflc
+        have hlIdx := nativeFindLengthCode_idx_bound _ lIdx _ _ hflc
+        have hsym : lIdx + 257 < litFreqs.size := by omega
+        split
+        · -- findDistCode = none
+          have ih := Deflate.tokenFreqs_go_mono tokens
+            (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]'hsym + 1)) distFreqs
+            (by rw [Array.size_set!]; omega) hdist (i + 1) idx
+          refine ⟨fun hidx => ?_, ih.2⟩
+          exact Nat.le_trans
+            (getElem!_le_set!_incr litFreqs _ idx hsym) (ih.1 hidx)
+        · -- findDistCode = some
+          rename_i dIdx _ _ hfdc
+          have hdIdx := nativeFindDistCode_idx_bound _ dIdx _ _ hfdc
+          have hd : dIdx < distFreqs.size := by omega
+          have ih := Deflate.tokenFreqs_go_mono tokens
+            (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]'hsym + 1))
+            (distFreqs.set! dIdx (distFreqs[dIdx]'hd + 1))
+            (by rw [Array.size_set!]; omega) (by rw [Array.size_set!]; omega)
+            (i + 1) idx
+          refine ⟨fun hidx => ?_, fun hidx => ?_⟩
+          · exact Nat.le_trans
+              (getElem!_le_set!_incr litFreqs _ idx hsym) (ih.1 hidx)
+          · exact Nat.le_trans
+              (getElem!_le_set!_incr distFreqs _ idx hd) (ih.2 hidx)
   · exact ⟨fun _ => Nat.le.refl, fun _ => Nat.le.refl⟩
 termination_by tokens.size - i
 
@@ -160,53 +141,73 @@ protected theorem tokenFreqs_eob_pos (tokens : Array LZ77Token) :
   -- Initial lit array has [256]! = 1, so result has [256]! ≥ 1
   have hmono : ((Array.replicate 286 (0 : Nat)).set! 256 1)[256]! ≤
       (tokenFreqs tokens).1[256]! :=
-    (Deflate.tokenFreqs_go_mono tokens _ _ 0 256
+    (Deflate.tokenFreqs_go_mono tokens _ _
       (by rw [Array.size_set!, Array.size_replicate])
-      (by rw [Array.size_replicate])).1 (by omega)
+      (by rw [Array.size_replicate]) 0 256).1 (by omega)
   have h256 : ((Array.replicate 286 (0 : Nat)).set! 256 1)[256]! = 1 :=
     Array.getElem!_set!_self _ _ _ (by rw [Array.size_replicate]; omega)
   omega
 
 /-- `tokenFreqs.go` produces positive lit frequency for literal `b` at position `j ≥ i`. -/
 protected theorem tokenFreqs_go_literal_pos (tokens : Array LZ77Token) (b : UInt8)
-    (litFreqs distFreqs : Array Nat) (i j : Nat)
-    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30)
+    (litFreqs distFreqs : Array Nat)
+    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30) (i j : Nat)
     (hj : j ≥ i) (hjlt : j < tokens.size) (htok : tokens[j] = .literal b) :
-    (tokenFreqs.go tokens litFreqs distFreqs i).1[b.toNat]! ≥ 1 := by
+    (tokenFreqs.go tokens litFreqs distFreqs hlit hdist i).1[b.toNat]! ≥ 1 := by
   unfold tokenFreqs.go
   split
   · rename_i h
     match htoki : tokens[i] with
     | .literal b' =>
       simp only []
+      have hb' : b'.toNat < litFreqs.size := by have := UInt8.toNat_lt b'; omega
       by_cases hij : i = j
       · -- This is the token we're looking for
         subst hij; simp only [htoki] at htok
         have hbeq : b' = b := LZ77Token.literal.inj htok
-        rw [hbeq]
+        rw [hbeq] at hb' ⊢
         -- After set, litFreqs[b.toNat]! ≥ 1
         have hle := (Deflate.tokenFreqs_go_mono tokens
-          (litFreqs.set! b.toNat (litFreqs[b.toNat]! + 1)) distFreqs (i + 1) b.toNat
-          (by rw [Array.size_set!]; omega) hdist).1 (by have := UInt8.toNat_lt b; omega)
-        have hblt := UInt8.toNat_lt b
-        have hset : (litFreqs.set! b.toNat (litFreqs[b.toNat]! + 1))[b.toNat]! ≥ 1 := by
-          rw [Array.getElem!_set!_self litFreqs _ _ (by omega)]; omega
+          (litFreqs.set! b.toNat (litFreqs[b.toNat]'hb' + 1)) distFreqs
+          (by rw [Array.size_set!]; omega) hdist (i + 1) b.toNat).1
+          (by have := UInt8.toNat_lt b; omega)
+        have hset : (litFreqs.set! b.toNat (litFreqs[b.toNat]'hb' + 1))[b.toNat]! ≥ 1 := by
+          rw [Array.getElem!_set!_self litFreqs _ _ hb']; omega
         omega
       · -- Not this token yet, recurse
         exact Deflate.tokenFreqs_go_literal_pos tokens b
-          (litFreqs.set! b'.toNat (litFreqs[b'.toNat]! + 1)) distFreqs (i + 1) j
-          (by rw [Array.size_set!]; omega) hdist (by omega) hjlt htok
+          (litFreqs.set! b'.toNat (litFreqs[b'.toNat]'hb' + 1)) distFreqs
+          (by rw [Array.size_set!]; omega) hdist (i + 1) j (by omega) hjlt htok
     | .reference len' dist' =>
       simp only []
       have hij : i ≠ j := by intro heq; subst heq; rw [htoki] at htok; exact nomatch htok
-      exact Deflate.tokenFreqs_go_literal_pos tokens b _ _ (i + 1) j
-        (by cases findLengthCode len' with
-          | none => exact hlit
-          | some p => obtain ⟨idx, _, _⟩ := p; rw [Array.size_set!]; omega)
-        (by cases findDistCode dist' with
-          | none => exact hdist
-          | some p => obtain ⟨dIdx, _, _⟩ := p; rw [Array.size_set!]; omega)
-        (by omega) hjlt htok
+      split
+      · -- findLengthCode = none
+        split
+        · -- findDistCode = none
+          exact Deflate.tokenFreqs_go_literal_pos tokens b litFreqs distFreqs hlit hdist
+            (i + 1) j (by omega) hjlt htok
+        · rename_i dIdx _ _ hfdc
+          have hdIdx := nativeFindDistCode_idx_bound _ _ _ _ hfdc
+          have hd : dIdx < distFreqs.size := by omega
+          exact Deflate.tokenFreqs_go_literal_pos tokens b litFreqs
+            (distFreqs.set! dIdx (distFreqs[dIdx]'hd + 1))
+            hlit (by rw [Array.size_set!]; omega) (i + 1) j (by omega) hjlt htok
+      · rename_i lIdx _ _ hflc
+        have hlIdx := nativeFindLengthCode_idx_bound _ _ _ _ hflc
+        have hsym : lIdx + 257 < litFreqs.size := by omega
+        split
+        · exact Deflate.tokenFreqs_go_literal_pos tokens b
+            (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]'hsym + 1)) distFreqs
+            (by rw [Array.size_set!]; omega) hdist (i + 1) j (by omega) hjlt htok
+        · rename_i dIdx _ _ hfdc
+          have hdIdx := nativeFindDistCode_idx_bound _ _ _ _ hfdc
+          have hd : dIdx < distFreqs.size := by omega
+          exact Deflate.tokenFreqs_go_literal_pos tokens b
+            (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]'hsym + 1))
+            (distFreqs.set! dIdx (distFreqs[dIdx]'hd + 1))
+            (by rw [Array.size_set!]; omega) (by rw [Array.size_set!]; omega)
+            (i + 1) j (by omega) hjlt htok
   · omega
 termination_by tokens.size - i
 
@@ -218,19 +219,19 @@ protected theorem tokenFreqs_literal_pos (tokens : Array LZ77Token) (b : UInt8)
   simp only [Array.length_toList] at hjlt
   have htok' : tokens[j] = .literal b := by
     simp only [Array.getElem_toList] at htok; exact htok
-  exact Deflate.tokenFreqs_go_literal_pos tokens b _ _ 0 j
+  exact Deflate.tokenFreqs_go_literal_pos tokens b _ _
     (by rw [Array.size_set!, Array.size_replicate])
-    (by rw [Array.size_replicate]) (by omega) hjlt htok'
+    (by rw [Array.size_replicate]) 0 j (by omega) hjlt htok'
 
 /-- `tokenFreqs.go` produces positive lit frequency for length code from ref at position `j ≥ i`. -/
 protected theorem tokenFreqs_go_lengthCode_pos (tokens : Array LZ77Token)
     (len dist : Nat) (idx extraN : Nat) (extraV : UInt32)
-    (litFreqs distFreqs : Array Nat) (i j : Nat)
-    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30)
+    (litFreqs distFreqs : Array Nat)
+    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30) (i j : Nat)
     (hj : j ≥ i) (hjlt : j < tokens.size)
     (htok : tokens[j] = .reference len dist)
     (hflc : findLengthCode len = some (idx, extraN, extraV)) :
-    (tokenFreqs.go tokens litFreqs distFreqs i).1[257 + idx]! ≥ 1 := by
+    (tokenFreqs.go tokens litFreqs distFreqs hlit hdist i).1[257 + idx]! ≥ 1 := by
   unfold tokenFreqs.go
   split
   · rename_i h
@@ -238,41 +239,74 @@ protected theorem tokenFreqs_go_lengthCode_pos (tokens : Array LZ77Token)
     | .literal b' =>
       simp only []
       have hij : i ≠ j := by intro heq; subst heq; rw [htoki] at htok; exact nomatch htok
+      have hb' : b'.toNat < litFreqs.size := by have := UInt8.toNat_lt b'; omega
       exact Deflate.tokenFreqs_go_lengthCode_pos tokens len dist idx extraN extraV
-        (litFreqs.set! b'.toNat (litFreqs[b'.toNat]! + 1)) distFreqs (i + 1) j
-        (by rw [Array.size_set!]; omega) hdist (by omega) hjlt htok hflc
+        (litFreqs.set! b'.toNat (litFreqs[b'.toNat]'hb' + 1)) distFreqs
+        (by rw [Array.size_set!]; omega) hdist (i + 1) j (by omega) hjlt htok hflc
     | .reference len' dist' =>
       simp only []
+      have hidx := nativeFindLengthCode_idx_bound _ idx extraN extraV hflc
       by_cases hij : i = j
       · -- This is the token — i = j
         subst hij
-        have ⟨hlen_eq, hdist_eq⟩ := LZ77Token.reference.inj (htoki.symm.trans htok)
-        simp only [hlen_eq, hdist_eq, hflc]
-        have hidx := nativeFindLengthCode_idx_bound _ idx extraN extraV hflc
-        -- After set, litFreqs[257+idx]! ≥ 1
-        have hle := (Deflate.tokenFreqs_go_mono tokens
-          (litFreqs.set! (idx + 257) (litFreqs[idx + 257]! + 1))
-          (match findDistCode dist with
-           | some (dIdx, _, _) => distFreqs.set! dIdx (distFreqs[dIdx]! + 1)
-           | none => distFreqs) (i + 1) (257 + idx)
-          (by rw [Array.size_set!]; omega)
-          (by cases findDistCode dist with
-            | none => exact hdist
-            | some p => obtain ⟨dIdx, _, _⟩ := p; rw [Array.size_set!]; omega)).1
-          (by omega)
-        have hset : (litFreqs.set! (idx + 257) (litFreqs[idx + 257]! + 1))[257 + idx]! ≥ 1 := by
-          rw [show idx + 257 = 257 + idx from by omega,
-            Array.getElem!_set!_self litFreqs _ _ (by omega)]; omega
-        exact Nat.le_trans hset hle
+        have ⟨hlen_eq, _hdist_eq⟩ := LZ77Token.reference.inj (htoki.symm.trans htok)
+        subst hlen_eq
+        have hsym : idx + 257 < litFreqs.size := by omega
+        -- The body chooses on findDistCode dist'. Either way, the lit array
+        -- becomes `litFreqs.set! (idx + 257) (litFreqs[idx + 257] + 1)` and the
+        -- monotonicity result gives ≥ 1 at position 257 + idx.
+        have hset_ge : ∀ (dF : Array Nat) (hd : dF.size = 30),
+            (Deflate.tokenFreqs.go tokens
+              (litFreqs.set! (idx + 257) (litFreqs[idx + 257]'hsym + 1)) dF
+              (by rw [Array.size_set!]; omega) hd (i + 1)).1[257 + idx]! ≥ 1 := by
+          intro dF hd
+          have hle := (Deflate.tokenFreqs_go_mono tokens
+            (litFreqs.set! (idx + 257) (litFreqs[idx + 257]'hsym + 1)) dF
+            (by rw [Array.size_set!]; omega) hd (i + 1) (257 + idx)).1 (by omega)
+          have hset : (litFreqs.set! (idx + 257)
+              (litFreqs[idx + 257]'hsym + 1))[257 + idx]! ≥ 1 := by
+            rw [show 257 + idx = idx + 257 from by omega,
+              Array.getElem!_set!_self litFreqs _ _ hsym]; omega
+          exact Nat.le_trans hset hle
+        split
+        · rename_i hflc'
+          rw [hflc'] at hflc; nomatch hflc
+        · rename_i lIdx eN eV hflc'
+          have heq : (lIdx, eN, eV) = (idx, extraN, extraV) :=
+            Option.some.inj (hflc'.symm.trans hflc)
+          obtain ⟨rfl, rfl, rfl⟩ := heq
+          split
+          · exact hset_ge distFreqs hdist
+          · rename_i dIdx _ _ hfdc
+            have hdIdx := nativeFindDistCode_idx_bound _ _ _ _ hfdc
+            have hd : dIdx < distFreqs.size := by omega
+            exact hset_ge _ (by rw [Array.size_set!]; omega)
       · -- Not this token, recurse
-        exact Deflate.tokenFreqs_go_lengthCode_pos tokens len dist idx extraN extraV _ _ (i + 1) j
-          (by cases findLengthCode len' with
-            | none => exact hlit
-            | some p => obtain ⟨lIdx, _, _⟩ := p; rw [Array.size_set!]; omega)
-          (by cases findDistCode dist' with
-            | none => exact hdist
-            | some p => obtain ⟨dIdx, _, _⟩ := p; rw [Array.size_set!]; omega)
-          (by omega) hjlt htok hflc
+        split
+        · split
+          · exact Deflate.tokenFreqs_go_lengthCode_pos tokens len dist idx extraN extraV
+              litFreqs distFreqs hlit hdist (i + 1) j (by omega) hjlt htok hflc
+          · rename_i dIdx _ _ hfdc
+            have hdIdx := nativeFindDistCode_idx_bound _ _ _ _ hfdc
+            have hd : dIdx < distFreqs.size := by omega
+            exact Deflate.tokenFreqs_go_lengthCode_pos tokens len dist idx extraN extraV
+              litFreqs (distFreqs.set! dIdx (distFreqs[dIdx]'hd + 1))
+              hlit (by rw [Array.size_set!]; omega) (i + 1) j (by omega) hjlt htok hflc
+        · rename_i lIdx _ _ hflc'
+          have hlIdx := nativeFindLengthCode_idx_bound _ _ _ _ hflc'
+          have hsym' : lIdx + 257 < litFreqs.size := by omega
+          split
+          · exact Deflate.tokenFreqs_go_lengthCode_pos tokens len dist idx extraN extraV
+              (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]'hsym' + 1)) distFreqs
+              (by rw [Array.size_set!]; omega) hdist (i + 1) j (by omega) hjlt htok hflc
+          · rename_i dIdx _ _ hfdc
+            have hdIdx := nativeFindDistCode_idx_bound _ _ _ _ hfdc
+            have hd : dIdx < distFreqs.size := by omega
+            exact Deflate.tokenFreqs_go_lengthCode_pos tokens len dist idx extraN extraV
+              (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]'hsym' + 1))
+              (distFreqs.set! dIdx (distFreqs[dIdx]'hd + 1))
+              (by rw [Array.size_set!]; omega) (by rw [Array.size_set!]; omega)
+              (i + 1) j (by omega) hjlt htok hflc
   · omega
 termination_by tokens.size - i
 
@@ -287,19 +321,19 @@ protected theorem tokenFreqs_lengthCode_pos (tokens : Array LZ77Token)
   simp only [Array.length_toList] at hjlt
   have htok' : tokens[j] = .reference len dist := by
     simp only [Array.getElem_toList] at htok; exact htok
-  exact Deflate.tokenFreqs_go_lengthCode_pos tokens len dist idx extraN extraV _ _ 0 j
+  exact Deflate.tokenFreqs_go_lengthCode_pos tokens len dist idx extraN extraV _ _
     (by rw [Array.size_set!, Array.size_replicate])
-    (by rw [Array.size_replicate]) (by omega) hjlt htok' hflc
+    (by rw [Array.size_replicate]) 0 j (by omega) hjlt htok' hflc
 
 /-- `tokenFreqs.go` produces positive dist frequency for dist code from ref at position `j ≥ i`. -/
 protected theorem tokenFreqs_go_distCode_pos (tokens : Array LZ77Token)
     (len dist : Nat) (dCode dExtraN : Nat) (dExtraV : UInt32)
-    (litFreqs distFreqs : Array Nat) (i j : Nat)
-    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30)
+    (litFreqs distFreqs : Array Nat)
+    (hlit : litFreqs.size = 286) (hdist : distFreqs.size = 30) (i j : Nat)
     (hj : j ≥ i) (hjlt : j < tokens.size)
     (htok : tokens[j] = .reference len dist)
     (hfdc : findDistCode dist = some (dCode, dExtraN, dExtraV)) :
-    (tokenFreqs.go tokens litFreqs distFreqs i).2[dCode]! ≥ 1 := by
+    (tokenFreqs.go tokens litFreqs distFreqs hlit hdist i).2[dCode]! ≥ 1 := by
   unfold tokenFreqs.go
   split
   · rename_i h
@@ -307,40 +341,82 @@ protected theorem tokenFreqs_go_distCode_pos (tokens : Array LZ77Token)
     | .literal b' =>
       simp only []
       have hij : i ≠ j := by intro heq; subst heq; rw [htoki] at htok; exact nomatch htok
+      have hb' : b'.toNat < litFreqs.size := by have := UInt8.toNat_lt b'; omega
       exact Deflate.tokenFreqs_go_distCode_pos tokens len dist dCode dExtraN dExtraV
-        (litFreqs.set! b'.toNat (litFreqs[b'.toNat]! + 1)) distFreqs (i + 1) j
-        (by rw [Array.size_set!]; omega) hdist (by omega) hjlt htok hfdc
+        (litFreqs.set! b'.toNat (litFreqs[b'.toNat]'hb' + 1)) distFreqs
+        (by rw [Array.size_set!]; omega) hdist (i + 1) j (by omega) hjlt htok hfdc
     | .reference len' dist' =>
       simp only []
+      have hdcode := nativeFindDistCode_idx_bound _ dCode dExtraN dExtraV hfdc
       by_cases hij : i = j
       · -- This is the token — i = j
         subst hij
-        have ⟨hlen_eq, hdist_eq⟩ := LZ77Token.reference.inj (htoki.symm.trans htok)
-        simp only [hlen_eq, hdist_eq, hfdc]
-        have hdcode := nativeFindDistCode_idx_bound _ dCode dExtraN dExtraV hfdc
-        -- After set, distFreqs[dCode]! ≥ 1
-        have hle := (Deflate.tokenFreqs_go_mono tokens
-          (match findLengthCode len with
-           | some (lIdx, _, _) => litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]! + 1)
-           | none => litFreqs)
-          (distFreqs.set! dCode (distFreqs[dCode]! + 1)) (i + 1) dCode
-          (by cases findLengthCode len with
-            | none => exact hlit
-            | some p => obtain ⟨lIdx, _, _⟩ := p; rw [Array.size_set!]; omega)
-          (by rw [Array.size_set!]; omega)).2
-          (by omega)
-        have hset : (distFreqs.set! dCode (distFreqs[dCode]! + 1))[dCode]! ≥ 1 := by
-          rw [Array.getElem!_set!_self distFreqs _ _ (by omega)]; omega
-        exact Nat.le_trans hset hle
+        have ⟨_hlen_eq, hdist_eq⟩ := LZ77Token.reference.inj (htoki.symm.trans htok)
+        subst hdist_eq
+        -- The body chooses on findLengthCode len'. Either way, the dist array
+        -- becomes `distFreqs.set! dCode (distFreqs[dCode] + 1)` and the
+        -- monotonicity result gives ≥ 1 at position dCode.
+        have hd : dCode < distFreqs.size := by omega
+        have hset_ge : ∀ (lF : Array Nat) (hl : lF.size = 286),
+            (Deflate.tokenFreqs.go tokens lF
+              (distFreqs.set! dCode (distFreqs[dCode]'hd + 1))
+              hl (by rw [Array.size_set!]; omega) (i + 1)).2[dCode]! ≥ 1 := by
+          intro lF hl
+          have hle := (Deflate.tokenFreqs_go_mono tokens lF
+            (distFreqs.set! dCode (distFreqs[dCode]'hd + 1))
+            hl (by rw [Array.size_set!]; omega) (i + 1) dCode).2 (by omega)
+          have hset : (distFreqs.set! dCode (distFreqs[dCode]'hd + 1))[dCode]! ≥ 1 := by
+            rw [Array.getElem!_set!_self distFreqs _ _ hd]; omega
+          exact Nat.le_trans hset hle
+        -- Open the outer match on findLengthCode len. We end up calling go
+        -- with the relevant lit array and the updated dist array.
+        split
+        · -- findLengthCode = none branch:  go uses (distFreqs.set! dCode ..) directly.
+          split
+          · rename_i hfdc'
+            rw [hfdc'] at hfdc; nomatch hfdc
+          · rename_i dIdx' eN' eV' hfdc'
+            have heq : (dIdx', eN', eV') = (dCode, dExtraN, dExtraV) :=
+              Option.some.inj (hfdc'.symm.trans hfdc)
+            obtain ⟨rfl, rfl, rfl⟩ := heq
+            exact hset_ge litFreqs hlit
+        · rename_i lIdx _ _ hflc
+          have hlIdx := nativeFindLengthCode_idx_bound _ _ _ _ hflc
+          have hsym : lIdx + 257 < litFreqs.size := by omega
+          split
+          · rename_i hfdc'
+            rw [hfdc'] at hfdc; nomatch hfdc
+          · rename_i dIdx' eN' eV' hfdc'
+            have heq : (dIdx', eN', eV') = (dCode, dExtraN, dExtraV) :=
+              Option.some.inj (hfdc'.symm.trans hfdc)
+            obtain ⟨rfl, rfl, rfl⟩ := heq
+            exact hset_ge _ (by rw [Array.size_set!]; omega)
       · -- Not this token, recurse
-        exact Deflate.tokenFreqs_go_distCode_pos tokens len dist dCode dExtraN dExtraV _ _ (i + 1) j
-          (by cases findLengthCode len' with
-            | none => exact hlit
-            | some p => obtain ⟨lIdx, _, _⟩ := p; rw [Array.size_set!]; omega)
-          (by cases findDistCode dist' with
-            | none => exact hdist
-            | some p => obtain ⟨dIdx, _, _⟩ := p; rw [Array.size_set!]; omega)
-          (by omega) hjlt htok hfdc
+        split
+        · split
+          · exact Deflate.tokenFreqs_go_distCode_pos tokens len dist dCode dExtraN dExtraV
+              litFreqs distFreqs hlit hdist (i + 1) j (by omega) hjlt htok hfdc
+          · rename_i dIdx _ _ hfdc'
+            have hdIdx := nativeFindDistCode_idx_bound _ _ _ _ hfdc'
+            have hd : dIdx < distFreqs.size := by omega
+            exact Deflate.tokenFreqs_go_distCode_pos tokens len dist dCode dExtraN dExtraV
+              litFreqs (distFreqs.set! dIdx (distFreqs[dIdx]'hd + 1))
+              hlit (by rw [Array.size_set!]; omega) (i + 1) j (by omega) hjlt htok hfdc
+        · rename_i lIdx _ _ hflc'
+          have hlIdx := nativeFindLengthCode_idx_bound _ _ _ _ hflc'
+          have hsym' : lIdx + 257 < litFreqs.size := by omega
+          split
+          · exact Deflate.tokenFreqs_go_distCode_pos tokens len dist dCode dExtraN dExtraV
+              (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]'hsym' + 1)) distFreqs
+              (by rw [Array.size_set!]; omega) hdist (i + 1) j (by omega) hjlt htok hfdc
+          · rename_i dIdx _ _ hfdc'
+            have hdIdx := nativeFindDistCode_idx_bound _ _ _ _ hfdc'
+            have hd : dIdx < distFreqs.size := by omega
+            exact Deflate.tokenFreqs_go_distCode_pos tokens len dist dCode dExtraN dExtraV
+              (litFreqs.set! (lIdx + 257) (litFreqs[lIdx + 257]'hsym' + 1))
+              (distFreqs.set! dIdx (distFreqs[dIdx]'hd + 1))
+              (by rw [Array.size_set!]; omega) (by rw [Array.size_set!]; omega)
+              (i + 1) j (by omega) hjlt htok hfdc
   · omega
 termination_by tokens.size - i
 
@@ -355,9 +431,9 @@ protected theorem tokenFreqs_distCode_pos (tokens : Array LZ77Token)
   simp only [Array.length_toList] at hjlt
   have htok' : tokens[j] = .reference len dist := by
     simp only [Array.getElem_toList] at htok; exact htok
-  exact Deflate.tokenFreqs_go_distCode_pos tokens len dist dCode dExtraN dExtraV _ _ 0 j
+  exact Deflate.tokenFreqs_go_distCode_pos tokens len dist dCode dExtraN dExtraV _ _
     (by rw [Array.size_set!, Array.size_replicate])
-    (by rw [Array.size_replicate]) (by omega) hjlt htok' hfdc
+    (by rw [Array.size_replicate]) 0 j (by omega) hjlt htok' hfdc
 
 /-- Converting a List Nat with elements ≤ 15 to Array UInt8 preserves bounds. -/
 protected theorem toUInt8Array_le (lens : List Nat) (hbound : ∀ x ∈ lens, x ≤ 15) :

--- a/progress/20260418T101128Z_e1478710.md
+++ b/progress/20260418T101128Z_e1478710.md
@@ -1,0 +1,79 @@
+# Progress: DeflateDynamic cluster B — proven-bounds in tokenFreqs.go
+
+- **Date (UTC)**: 2026-04-18 10:11
+- **Session**: feature
+- **Issue**: #1520
+- **Branch**: `agent/e1478710`
+
+## What was done
+
+Converted three `]!` runtime-bounds reads in
+`Zip/Native/DeflateDynamic.lean`'s `tokenFreqs.go` to proven-bounds form
+by threading two size invariants through the recursion:
+
+- `hlit : litLenFreqs.size = 286`
+- `hdist : distFreqs.size = 30`
+
+Restructured the `.reference` arm into nested top-level matches with
+equation hypotheses (`match hflc : findLengthCode length with` /
+`match hfdc : findDistCode distance with`), giving four explicit
+sub-branches: none/none, none/some, some/none, some/some. This shape
+is what makes the bound proofs (via `nativeFindLengthCode_idx_bound`,
+`nativeFindDistCode_idx_bound`) discoverable at the call site of the
+recursive call.
+
+Repaired `Zip/Spec/DeflateDynamicFreqs.lean` to match the new
+signature and shape. All seven `_go_*` theorems now take `(hlit)`
+and `(hdist)` immediately before `(i)`. The four sub-branch shape
+is mirrored in every `.reference` case, and the size proofs are
+threaded through every recursive call.
+
+The wrapper theorems (`tokenFreqs_eob_pos`,
+`tokenFreqs_literal_pos`, `tokenFreqs_lengthCode_pos`,
+`tokenFreqs_distCode_pos`) supply the size proofs explicitly so
+their public signatures are unchanged — `DeflateDynamicCorrect.lean`
+builds without edits.
+
+## Decisions
+
+- For the `i = j` cases in `_lengthCode_pos` / `_distCode_pos`, used
+  `split` + `rename_i` to extract the equation hypothesis from
+  `match h : ... with` rather than rewriting via `simp only [hflc]`.
+  The match form captures the equation hypothesis, so a direct
+  `simp only [hflc]` makes no progress; `split` + `nomatch` for the
+  contradictory branch and `Option.some.inj` + `obtain ⟨rfl, ...⟩`
+  for the `some` branch is the natural fit.
+- `getElem!_le_set!_incr` bridges between proven-bounds form
+  `arr.set! k (arr[k]'h + 1)` and runtime-checked form via
+  `getElem!_pos arr k hk`. Keeping this lemma in `getElem!` form
+  means consumers don't need to thread size proofs into the helper.
+- The proof for `(litFreqs.set! (idx + 257) ...)[257 + idx]! ≥ 1`
+  rewrites `257 + idx → idx + 257` (not the reverse) to avoid a
+  motive-not-type-correct error: `litFreqs[idx + 257]'hsym`
+  references `idx + 257` in the proof argument, so rewriting
+  `idx + 257 → 257 + idx` would un-typecheck `hsym`.
+
+## Verification
+
+- `lake build` — clean
+- `lake exe test` — all tests pass (including dynamic-Huffman
+  conformance against zlib FFI)
+- `grep -c ']!' Zip/Native/DeflateDynamic.lean` = 3 (was 6;
+  remaining 3 are `.set!` writes, which are intentionally
+  left as-is per the issue spec)
+- `grep -rc sorry Zip/` — 0 across all files
+
+## What remains
+
+- Cluster B in DeflateDynamic is now done. Subsequent clusters in
+  `Zip/Native/DeflateDynamic.lean` (e.g. `writeDynamicHeader`,
+  `emitTokensWithCodes`, `deflateDynamic` itself) still contain
+  `]!` reads that a future planner can sequence.
+- The `.set!` writes in `tokenFreqs.go` remain `set!` — moving them
+  to `Array.set` with a proven bound would be a separate cluster
+  (probably worth a planner pass).
+
+## Quality metric deltas
+
+- `]!` reads in `Zip/Native/DeflateDynamic.lean`: 6 → 3
+- `sorry` count across `Zip/`: 0 → 0


### PR DESCRIPTION
Closes #1520

Session: `e1478710-2df7-436f-9bdd-c822f25d257a`

ff24af5 chore: progress entry for DeflateDynamic cluster B (issue #1520)
ff1e044 feat: repair DeflateDynamicFreqs spec for proven-bounds tokenFreqs.go
0ecddff feat: WIP proven-bounds in tokenFreqs.go reads (DeflateDynamic cluster B)

🤖 Prepared with Claude Code