### PR TITLE
Feature: Track E — audit String.fromUTF8! callsites in Zip/Tar.lean

### DIFF
--- a/Zip/Tar.lean
+++ b/Zip/Tar.lean
@@ -164,6 +164,23 @@ def paddingFor (size : UInt64) : Nat :=
   let rem := size.toNat % 512
   if rem == 0 then 0 else 512 - rem
 
+/-- Truncate `s` so that its UTF-8 byte length is at most `maxBytes`,
+    stopping at a codepoint boundary. The result is always valid UTF-8,
+    so callers can avoid the panicking fromUTF8 variant on the output.
+    Used by the tar writer when placing a long path into a fixed-width
+    header field (UStar name is 100 bytes, PAX placeholder is 80 bytes). -/
+def truncateUTF8 (s : String) (maxBytes : Nat) : String :=
+  if s.utf8ByteSize ≤ maxBytes then s
+  else Id.run do
+    let mut result := ""
+    let mut bytes : Nat := 0
+    for c in s.toList do
+      let cBytes := c.utf8Size
+      if bytes + cBytes > maxBytes then break
+      result := result.push c
+      bytes := bytes + cBytes
+    return result
+
 /-- Read exactly `n` bytes from a stream, looping on short reads.
     Returns fewer bytes only at true EOF. -/
 private partial def readExact (input : IO.FS.Stream) (n : Nat) : IO ByteArray := do
@@ -213,6 +230,10 @@ def splitPath (path : String) : Option (String × String) := Id.run do
         bestSplit := some i
   match bestSplit with
   | some i =>
+    -- Safe: `i` is the index of a `'/'` byte (0x2F, ASCII), which is
+    -- always a codepoint boundary. `bytes` comes from `path.toUTF8`,
+    -- so both the prefix `[0, i)` and suffix `(i, size)` are valid
+    -- UTF-8 by construction. No panic path through `fromUTF8!`.
     let pfx := String.fromUTF8! (bytes.extract 0 i)
     let name := String.fromUTF8! (bytes.extract (i + 1) bytes.size)
     return some (pfx, name)
@@ -313,16 +334,12 @@ def needsPaxHeader (entry : Entry) : Option ByteArray := Id.run do
 
 /-- Build a PAX extended header entry (typeflag 'x') for the given PAX data. -/
 def buildPaxEntry (paxData : ByteArray) (entryPath : String) : IO ByteArray := do
-  -- Truncate the entry path to fit in UStar name field
-  let paxName :=
-    let truncated := if entryPath.utf8ByteSize > 80 then
-      -- Take first 80 bytes worth of the path
-      String.fromUTF8! (entryPath.toUTF8.extract 0 80)
-    else entryPath
-    s!"PaxHeader/{truncated}"
+  -- Truncate the entry path to fit in UStar name field; `truncateUTF8`
+  -- respects codepoint boundaries so multibyte paths never produce a
+  -- partial UTF-8 sequence here.
+  let paxName := s!"PaxHeader/{truncateUTF8 entryPath 80}"
   let paxEntry : Entry := {
-    path := (if paxName.utf8ByteSize > 100 then
-      String.fromUTF8! (paxName.toUTF8.extract 0 100) else paxName)
+    path := truncateUTF8 paxName 100
     size := paxData.size.toUInt64
     mode := 0o644
     typeflag := typePaxExtended
@@ -407,8 +424,10 @@ partial def create (output : IO.FS.Stream) (basePath : System.FilePath)
     -- Build UStar header, with truncated path if PAX is handling it
     let pathOvr : Option (String × String) :=
       if splitPath entry.path |>.isNone then
-        -- PAX has the real path; use a truncated placeholder in UStar header
-        some ("", String.fromUTF8! (entry.path.toUTF8.extract 0 (min entry.path.utf8ByteSize 100)))
+        -- PAX has the real path; use a truncated placeholder in UStar header.
+        -- `truncateUTF8` keeps the placeholder valid UTF-8 even for paths
+        -- whose 100th byte lands inside a multibyte sequence.
+        some ("", truncateUTF8 entry.path 100)
       else none
     let header ← buildHeader entry pathOvr
     output.write header

--- a/ZipTest.lean
+++ b/ZipTest.lean
@@ -8,6 +8,7 @@ import ZipTest.Tar
 import ZipTest.Archive
 import ZipTest.ZipFixtures
 import ZipTest.TarFixtures
+import ZipTest.TarPathTruncation
 import ZipTest.CompressFixtures
 import ZipTest.Utf8Fixtures
 import ZipTest.NativeChecksum
@@ -31,6 +32,7 @@ def main : IO Unit := do
   ZipTest.Archive.tests
   ZipTest.ZipFixtures.tests
   ZipTest.TarFixtures.tests
+  ZipTest.TarPathTruncation.tests
   ZipTest.CompressFixtures.tests
   ZipTest.Utf8Fixtures.tests
   ZipTest.NativeChecksum.tests

--- a/ZipTest/TarPathTruncation.lean
+++ b/ZipTest/TarPathTruncation.lean
@@ -1,0 +1,84 @@
+import ZipTest.Helpers
+
+/-! Regression tests for codepoint-boundary truncation of UTF-8 paths in
+    the tar writer (`Tar.truncateUTF8`) and for the end-to-end writer/
+    reader round-trip when a path's 80th or 100th byte lands inside a
+    multibyte sequence (Track E Priority 1, item 1). -/
+
+namespace ZipTest.TarPathTruncation
+
+private def assertEq (label : String) (expected actual : String) : IO Unit := do
+  unless expected == actual do
+    throw (IO.userError s!"{label}: expected {repr expected}, got {repr actual}")
+
+def tests : IO Unit := do
+  -- Unit checks: truncateUTF8 respects codepoint boundaries.
+  assertEq "truncateUTF8 ASCII short"  "hello"  (Tar.truncateUTF8 "hello" 10)
+  assertEq "truncateUTF8 ASCII exact"  "abc"    (Tar.truncateUTF8 "abc" 3)
+  assertEq "truncateUTF8 ASCII cut"    "ab"     (Tar.truncateUTF8 "abc" 2)
+  assertEq "truncateUTF8 zero"         ""       (Tar.truncateUTF8 "café" 0)
+  -- "café" is 5 UTF-8 bytes: c(1) a(1) f(1) é(2). A raw byte cut at 4
+  -- would split 'é'; truncateUTF8 must stop before it.
+  assertEq "truncateUTF8 café/4" "caf"  (Tar.truncateUTF8 "café" 4)
+  assertEq "truncateUTF8 café/3" "caf"  (Tar.truncateUTF8 "café" 3)
+  assertEq "truncateUTF8 café/5" "café" (Tar.truncateUTF8 "café" 5)
+
+  -- Boundary-straddle: place 'é' so its first byte sits at position 79,
+  -- i.e. cutting at 80 bytes would split the sequence.
+  let head79 := String.ofList (List.replicate 79 'a')
+  let straddle80 := head79 ++ "é" ++ String.ofList (List.replicate 40 'b')
+  unless straddle80.utf8ByteSize > 80 do
+    throw (IO.userError "straddle80: unexpected byte size")
+  let t80 := Tar.truncateUTF8 straddle80 80
+  assertEq "truncateUTF8 80-byte straddle" head79 t80
+  unless t80.utf8ByteSize ≤ 80 do
+    throw (IO.userError s!"truncateUTF8: produced {t80.utf8ByteSize} bytes (> 80)")
+  unless (String.fromUTF8? t80.toUTF8).isSome do
+    throw (IO.userError "truncateUTF8: result is not valid UTF-8")
+
+  -- Same straddle at the 100-byte boundary used by the PAX placeholder.
+  let head99 := String.ofList (List.replicate 99 'a')
+  let straddle100 := head99 ++ "é" ++ String.ofList (List.replicate 40 'b')
+  let t100 := Tar.truncateUTF8 straddle100 100
+  assertEq "truncateUTF8 100-byte straddle" head99 t100
+  unless t100.utf8ByteSize ≤ 100 do
+    throw (IO.userError "truncateUTF8: 100-byte straddle exceeded max")
+
+  -- buildPaxEntry: a path whose 80th byte lands inside a multibyte
+  -- sequence. Previously this panicked through `String.fromUTF8!` on
+  -- `paxName`'s UStar placeholder. The header must now emerge intact
+  -- and the UStar name field must parse as valid UTF-8.
+  let longPath := head79 ++ "é" ++ String.ofList (List.replicate 20 'c') ++ ".txt"
+  let block ← Tar.buildPaxEntry ByteArray.empty longPath
+  unless block.size == 512 do
+    throw (IO.userError s!"buildPaxEntry: expected 512-byte block, got {block.size}")
+  let placeholderName := Binary.readString block 0 100
+  unless placeholderName.startsWith "PaxHeader/" do
+    throw (IO.userError s!"buildPaxEntry: UStar name missing PaxHeader/ prefix: {placeholderName}")
+  unless (String.fromUTF8? placeholderName.toUTF8).isSome do
+    throw (IO.userError "buildPaxEntry: placeholder is not valid UTF-8")
+
+  -- End-to-end round-trip via createFromDir + list. Build a file whose
+  -- relative path's 100th byte falls inside a multibyte sequence and
+  -- verify the decoder recovers the exact original path through the
+  -- PAX extended header.
+  let tmpDir : System.FilePath := "/tmp/lean-zip-tar-utf8-truncate"
+  if ← tmpDir.pathExists then
+    let _ ← IO.Process.run { cmd := "rm", args := #["-rf", tmpDir.toString] }
+  IO.FS.createDirAll tmpDir
+  let relName := head99 ++ "é" ++ String.ofList (List.replicate 20 'w') ++ ".txt"
+  IO.FS.writeFile (tmpDir / relName) "content"
+  let tarPath : System.FilePath := "/tmp/lean-zip-tar-utf8-truncate.tar"
+  IO.FS.withFile tarPath .write fun outH =>
+    Tar.createFromDir (IO.FS.Stream.ofHandle outH) tmpDir
+  let entries ← IO.FS.withFile tarPath .read fun h =>
+    Tar.list (IO.FS.Stream.ofHandle h)
+  unless entries.any (·.path == relName) do
+    let paths := entries.map (·.path)
+    throw (IO.userError s!"round-trip: expected path preserved, got {paths}")
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", tmpDir.toString] }
+  let _ ← IO.Process.run { cmd := "rm", args := #["-f", tarPath.toString] }
+
+  IO.println "Tar path truncation tests: OK"
+
+end ZipTest.TarPathTruncation

--- a/plans/track-e-current-audit-checklist.md
+++ b/plans/track-e-current-audit-checklist.md
@@ -33,9 +33,14 @@ Target file: [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:1)
 
 Target file: [Zip/Tar.lean](/home/kim/lean-zip/Zip/Tar.lean:1)
 
-- [ ] Enumerate all `String.fromUTF8!` callsites reachable from untrusted
+- [x] Enumerate all `String.fromUTF8!` callsites reachable from untrusted
   tar bytes and replace them with validated or failure-returning paths
   where needed.
+  (Three panicking raw-byte truncations in `buildPaxEntry` and `create`
+  replaced by `Tar.truncateUTF8` which rounds to the nearest codepoint
+  boundary; the two remaining `fromUTF8!` sites in `splitPath` are
+  documented as safe because the split is at an ASCII `'/'` byte.
+  Regression coverage in `ZipTest/TarPathTruncation.lean`.)
 - [x] Add malformed PAX fixtures:
   invalid UTF-8 keys, invalid UTF-8 values, oversized decimal lengths,
   truncated records, and inconsistent record lengths.

--- a/progress/20260418T232841Z_b9adc440.md
+++ b/progress/20260418T232841Z_b9adc440.md
@@ -1,0 +1,59 @@
+# Session b9adc440 — Track E Priority 1: `String.fromUTF8!` callsite audit
+
+- **Session type**: `feature`
+- **Issue**: #1540 — Track E — audit `String.fromUTF8!` callsites in `Zip/Tar.lean`
+- **Branch**: `agent/b9adc440`
+- **UTC**: 2026-04-18T23:28:41Z
+
+## Summary
+
+Removed the three panicking raw-byte truncations of UTF-8 paths in the
+tar writer and closed the corresponding bullet in the Track E
+current-audit checklist. The two remaining `String.fromUTF8!` hits in
+`Zip/Tar.lean` are on safe callsites (ASCII `'/'` split in
+`splitPath`); both are now flagged with an explanatory comment.
+
+## Deliverables
+
+- `refactor(tar)`: introduce `Tar.truncateUTF8` (codepoint-aware),
+  replace the three unsafe `String.fromUTF8!` callsites in
+  `buildPaxEntry` (2) and `create` (1), annotate the safe `splitPath`
+  callsites. `grep -c 'String.fromUTF8!' Zip/Tar.lean` drops from 5 to 2.
+- `test(tar)`: new `ZipTest/TarPathTruncation.lean` exercising
+  `truncateUTF8` on boundary-straddle inputs, calling `buildPaxEntry`
+  directly, and doing a filesystem round-trip through `createFromDir`
+  + `list`. Previously these paths panicked.
+- `plans/track-e-current-audit-checklist.md`: Priority 1 item 1 moved
+  from `- [ ]` to `- [x]` with a one-line summary of the change.
+
+## Decisions
+
+- `truncateUTF8` iterates `s.toList` rather than manipulating
+  `String.Pos` directly. `s.toList` is O(n), but the inputs are bounded
+  by ~200 bytes (UStar header widths of 80 / 100), so the simpler
+  implementation wins.
+- `truncateUTF8` is `def` (public) rather than `private def` so the
+  regression test in `ZipTest/TarPathTruncation.lean` can call it
+  directly. It lives under `namespace Tar`, which keeps it scoped.
+- Kept callsite 2 (`truncateUTF8 paxName 100`) even though it is
+  currently unreachable: `paxName` is at most 10 + 80 = 90 bytes after
+  the first truncation. Defensive and cheap.
+
+## Quality metrics
+
+- `grep -rc sorry Zip/`: all 0 (unchanged).
+- `grep -c 'String.fromUTF8!' Zip/Tar.lean`: **5 → 2** (both remaining
+  hits inside `splitPath` with safety comment).
+- `lake build` clean; `lake exe test` passes including the new test
+  (`Tar path truncation tests: OK`).
+- Two commits:
+  - `5ad00e3` refactor(tar): codepoint-safe UTF-8 truncation for PAX path placeholder
+  - `402e3d1` test(tar): regression coverage for codepoint-safe path truncation
+
+## Remaining work
+
+No follow-up needed for this issue; Priority 1 item 1 is closed.
+Other Track E items in `plans/track-e-current-audit-checklist.md`
+remain open (symlink/hardlink policy, CD-vs-local consistency audit,
+public decompression limit policy, FFI adversarial validation,
+proof-friendly guard lemmas).


### PR DESCRIPTION
Closes #1540

Session: `b9adc440-c5d9-4b2f-8be7-fbb4e2f125eb`

7499b19 doc: progress entry for Track E UTF-8 callsite audit (b9adc440)
402e3d1 test(tar): regression coverage for codepoint-safe path truncation
5ad00e3 refactor(tar): codepoint-safe UTF-8 truncation for PAX path placeholder

🤖 Prepared with Claude Code