### PR TITLE
Feature: Track E P2.4 — explicit limit-policy docstrings for FFI whole-buffer + streaming decompression

### DIFF
--- a/Zip/Basic.lean
+++ b/Zip/Basic.lean
@@ -7,7 +7,10 @@ namespace Zlib
 opaque compress (data : @& ByteArray) (level : UInt8 := 6) : IO ByteArray
 
 /-- Decompress zlib-compressed data.
-    `maxDecompressedSize` limits output size (0 = no limit). -/
+    `maxDecompressedSize` caps output size; default `0` means unlimited
+    (bomb-unsafe for untrusted input). Overflow raises `IO.userError`
+    containing `"decompressed size exceeds limit"`.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 @[extern "lean_zlib_decompress"]
 opaque decompress (data : @& ByteArray) (maxDecompressedSize : UInt64 := 0) : IO ByteArray
 

--- a/Zip/Gzip.lean
+++ b/Zip/Gzip.lean
@@ -8,7 +8,10 @@ namespace Gzip
 opaque compress (data : @& ByteArray) (level : UInt8 := 6) : IO ByteArray
 
 /-- Decompress gzip data. Also handles concatenated gzip streams and raw zlib data.
-    `maxDecompressedSize` limits output size (0 = no limit). -/
+    `maxDecompressedSize` caps the *total* output across all concatenated members;
+    default `0` means unlimited (bomb-unsafe for untrusted input). Overflow raises
+    `IO.userError` containing `"decompressed size exceeds limit"`.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 @[extern "lean_gzip_decompress"]
 opaque decompress (data : @& ByteArray) (maxDecompressedSize : UInt64 := 0) : IO ByteArray
 
@@ -69,7 +72,10 @@ partial def compressStream (input : IO.FS.Stream) (output : IO.FS.Stream)
   output.flush
 
 /-- Decompress gzip data from input stream to output stream.
-    Handles concatenated gzip streams. Memory usage is bounded. -/
+    Handles concatenated gzip streams. Input memory usage is bounded, but there
+    is no library-level cap on total decompressed output — the caller's sink is
+    the only bound. See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*
+    (recommendation 2) for the proposed `maxDecompressedSize` streaming cap. -/
 partial def decompressStream (input : IO.FS.Stream) (output : IO.FS.Stream) : IO Unit := do
   let state ← InflateState.new
   repeat do
@@ -93,7 +99,10 @@ def compressFile (path : System.FilePath) (level : UInt8 := 6) : IO System.FileP
   return outPath
 
 /-- Decompress a gzip file. Strips `.gz` suffix, or appends `.ungz` as fallback.
-    Optional explicit output path. Streams with bounded memory. -/
+    Optional explicit output path. Streams with bounded input memory; as with
+    `decompressStream`, there is no library-level cap on total decompressed
+    output, so a bomb can fill the output path's disk.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def decompressFile (path : System.FilePath) (outPath : Option System.FilePath := none)
     : IO System.FilePath := do
   let out := match outPath with

--- a/Zip/RawDeflate.lean
+++ b/Zip/RawDeflate.lean
@@ -12,7 +12,10 @@ namespace RawDeflate
 opaque compress (data : @& ByteArray) (level : UInt8 := 6) : IO ByteArray
 
 /-- Decompress raw deflate data.
-    `maxDecompressedSize` limits output size (0 = no limit). -/
+    `maxDecompressedSize` caps output size; default `0` means unlimited
+    (bomb-unsafe for untrusted input). Overflow raises `IO.userError`
+    containing `"decompressed size exceeds limit"`.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 @[extern "lean_raw_deflate_decompress"]
 opaque decompress (data : @& ByteArray) (maxDecompressedSize : UInt64 := 0) : IO ByteArray
 
@@ -41,7 +44,11 @@ partial def compressStream (input : IO.FS.Stream) (output : IO.FS.Stream)
   if final.size > 0 then output.write final
   output.flush
 
-/-- Decompress raw deflate data from input stream to output stream. -/
+/-- Decompress raw deflate data from input stream to output stream.
+    Input memory usage is bounded, but there is no library-level cap on total
+    decompressed output — the caller's sink is the only bound. See
+    `SECURITY_INVENTORY.md` *Decompression Limit Inventory* (recommendation 2)
+    for the proposed `maxDecompressedSize` streaming cap. -/
 partial def decompressStream (input : IO.FS.Stream) (output : IO.FS.Stream) : IO Unit := do
   let state ← InflateState.new
   repeat do

--- a/progress/20260422T004517Z_e36d9897.md
+++ b/progress/20260422T004517Z_e36d9897.md
@@ -1,0 +1,66 @@
+# 2026-04-22 00:45 UTC — feature session e36d9897
+
+Track E P2.4 — explicit limit-policy docstrings for FFI whole-buffer and
+streaming decompression. Issue #1564.
+
+## What was accomplished
+
+Doc-only changes to six FFI decompression entry points, splitting into
+two groups matching the inventory in
+`SECURITY_INVENTORY.md` *Decompression Limit Inventory*:
+
+- **Whole-buffer (`maxDecompressedSize : UInt64 := 0`)** —
+  `Zlib.decompress` (`Zip/Basic.lean`), `Gzip.decompress`
+  (`Zip/Gzip.lean`), `RawDeflate.decompress` (`Zip/RawDeflate.lean`).
+  Each docstring now states: default `0` means unlimited and is
+  bomb-unsafe for untrusted input; overflow raises `IO.userError`
+  containing the exact substring `"decompressed size exceeds limit"`
+  (as emitted by `c/zlib_ffi.c:195`); and cross-references
+  `SECURITY_INVENTORY.md` *Decompression Limit Inventory*.
+  `Gzip.decompress` additionally notes the cap applies to the *total*
+  output across concatenated gzip members.
+- **Streaming (no cap parameter)** — `Gzip.decompressStream`,
+  `Gzip.decompressFile` (`Zip/Gzip.lean`), `RawDeflate.decompressStream`
+  (`Zip/RawDeflate.lean`). Each docstring now states that input memory
+  is bounded but there is no library-level cap on total decompressed
+  output — the caller's sink is the only bound — and cross-references
+  recommendation 2 in the inventory (proposed `maxDecompressedSize`
+  streaming parameter).
+
+Nothing in `SECURITY_INVENTORY.md` was edited; docstrings *point at* the
+inventory rather than duplicating it. No function signatures, default
+values, error wording, or runtime behaviour changed.
+
+## Decisions
+
+- Chose per-function docstrings over file-level header cross-references.
+  Docstrings render in tooltips; file headers don't. The issue
+  explicitly said to pick one and not duplicate, so the
+  module-level headers were left untouched.
+- Described **current** behaviour only. The inventory's recommendation 1
+  (256 MiB finite default) is flagged as a proposal; the docstrings
+  don't prejudge it.
+- Kept each docstring to 3–4 sentences, no Markdown bullets, matching
+  the style of surrounding `compress`/`decompress` pairs.
+
+## Verification
+
+- `lake build -R` clean (187 jobs).
+- `lake exe test` green.
+- `grep -rc sorry Zip/` → 0 across all files.
+- Diff limited to `Zip/Basic.lean`, `Zip/Gzip.lean`, `Zip/RawDeflate.lean`
+  (25 insertions, 6 deletions). No `ZipTest/`, `c/`, or fixture changes.
+- All six modified docstrings contain either `"decompressed size
+  exceeds limit"` (whole-buffer group) or `"no library-level"`
+  (streaming group). Grep confirmed 6 matches across the diff.
+
+## Quality metric deltas
+
+- Sorry count: 0 → 0 (unchanged).
+- `lake build` / `lake exe test` status: clean → clean.
+
+## What remains
+
+Nothing for this issue. Sibling Track E P3 issues (#1565 sanitizer
+script, #1566 FFI repeated-inflateReset regression) are unrelated and
+left for the next worker to claim.


### PR DESCRIPTION
Closes #1564

Session: `e36d9897-5047-47f5-911c-442eb0d63aef`

01e75d8 doc: progress entry for Track E P2.4 (#1564)
fadb743 doc: explicit FFI decompression limit-policy docstrings (Track E P2.4)

🤖 Prepared with Claude Code