### PR TITLE
Feature: Track E P2.4 — Archive + Tar public-API limit-policy docstrings

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -490,13 +490,28 @@ private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
   return fileData
 
 /-- List entries in a ZIP archive. Memory: O(65KB + central directory metadata).
-    `maxCentralDirSize` limits the central directory allocation (default 64MB, 0 = no limit). -/
+    `maxCentralDirSize` limits the central directory allocation; default 64 MiB,
+    `0` means unlimited (bomb-unsafe for untrusted input). Overflow raises
+    `IO.userError` containing `"zip: central directory too large"`.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def list (inputPath : System.FilePath) (maxCentralDirSize : Nat := 67108864) : IO (Array Entry) :=
   IO.FS.withFile inputPath .read (listFromHandle · maxCentralDirSize)
 
 /-- Extract a ZIP archive to an output directory.
     Memory: O(65KB + central directory + largest single file).
-    When `useNative` is true, uses pure Lean decompression (no C FFI). -/
+
+    `maxCentralDirSize` limits the central directory allocation; default 64 MiB,
+    `0` means unlimited. Overflow raises `IO.userError` containing
+    `"zip: central directory too large"`.
+
+    `maxEntrySize` limits each entry's decompressed size. Default `0` means
+    no limit on the FFI backend (bomb-unsafe for untrusted input); the native
+    backend silently caps at 256 MiB when `maxEntrySize = 0` as a zip-bomb
+    guard. Overflow raises `IO.userError` containing
+    `"zip: entry '…' uncompressed size (…) exceeds limit (…)"`.
+
+    When `useNative` is true, uses pure Lean decompression (no C FFI).
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def extract (inputPath : System.FilePath) (outDir : System.FilePath)
     (maxCentralDirSize : Nat := 67108864) (maxEntrySize : UInt64 := 0)
     (useNative : Bool := false) : IO Unit := do
@@ -520,7 +535,19 @@ def extract (inputPath : System.FilePath) (outDir : System.FilePath)
 
 /-- Extract a single file from a ZIP archive by name.
     Memory: O(65KB + central directory + target file).
-    When `useNative` is true, uses pure Lean decompression (no C FFI). -/
+
+    `maxCentralDirSize` limits the central directory allocation; default 64 MiB,
+    `0` means unlimited. Overflow raises `IO.userError` containing
+    `"zip: central directory too large"`.
+
+    `maxEntrySize` limits the decompressed entry size. Default `0` means
+    no limit on the FFI backend (bomb-unsafe for untrusted input); the native
+    backend silently caps at 256 MiB when `maxEntrySize = 0` as a zip-bomb
+    guard. Overflow raises `IO.userError` containing
+    `"zip: entry '…' uncompressed size (…) exceeds limit (…)"`.
+
+    When `useNative` is true, uses pure Lean decompression (no C FFI).
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def extractFile (inputPath : System.FilePath) (filename : String)
     (maxCentralDirSize : Nat := 67108864) (maxEntrySize : UInt64 := 0)
     (useNative : Bool := false) : IO ByteArray := do

--- a/Zip/Tar.lean
+++ b/Zip/Tar.lean
@@ -537,6 +537,16 @@ private partial def forEntries (input : IO.FS.Stream)
 /-- Extract a tar archive from input stream to output directory.
     Handles UStar, GNU long name/link, and PAX extended headers.
 
+    `maxEntrySize` (when non-zero) bounds each entry's declared size — checked
+    against the tar header's `e.size` before any payload bytes are read.
+    Default `0` means no per-entry bound (bomb-unsafe without an external
+    total-extracted cap). Overflow raises `IO.userError` containing
+    `"tar: entry '…' size (…) exceeds limit (…)"`. There is no
+    library-level cap on total extracted bytes across an archive — many
+    small entries can still exhaust disk. See `SECURITY_INVENTORY.md`
+    *Decompression Limit Inventory* (recommendation 3 calls out the
+    total-bytes gap).
+
     Per-typeflag policy:
 
     * `typeRegular` ('0'): write the payload to `outDir/path` after
@@ -551,10 +561,7 @@ private partial def forEntries (input : IO.FS.Stream)
       nodes): the payload is silently consumed and no filesystem entry
       is created. Hard links are never materialised; an attacker who
       crafts `typeflag == '1'` with a malicious `linkname` cannot
-      escape `outDir`.
-
-    `maxEntrySize` (when non-zero) bounds each entry's declared size
-    before any data is read. -/
+      escape `outDir`. -/
 partial def extract (input : IO.FS.Stream) (outDir : System.FilePath)
     (maxEntrySize : UInt64 := 0) : IO Unit := do
   forEntries input fun e => do
@@ -646,7 +653,15 @@ partial def createTarGz (outputPath : System.FilePath) (dir : System.FilePath)
     outStream.flush
 
 /-- Extract a .tar.gz archive.
-    True streaming — bounded memory regardless of archive size. -/
+    True streaming — bounded memory regardless of archive size.
+
+    `maxEntrySize` (when non-zero) bounds each entry's declared size before any
+    payload bytes are read; default `0` means no per-entry bound (bomb-unsafe
+    without an external total-extracted cap). Overflow raises `IO.userError`
+    containing `"tar: entry '…' size (…) exceeds limit (…)"`. There is no
+    outer gzip-stream cap on this variant: streaming FFI gzip has no
+    `maxOutputSize` parameter today (the known gap tracked by
+    `SECURITY_INVENTORY.md` *Decompression Limit Inventory*, recommendation 2). -/
 partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath)
     (maxEntrySize : UInt64 := 0) : IO Unit := do
   IO.FS.withFile inputPath .read fun inH => do
@@ -681,7 +696,20 @@ partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath
 /-- Extract a .tar.gz archive using pure Lean decompression (no C FFI).
     Unlike `extractTarGz`, this reads the entire file into memory before
     decompressing, so memory usage is O(file_size). Use this when C
-    libraries are unavailable. -/
+    libraries are unavailable.
+
+    `maxEntrySize` (when non-zero) bounds each entry's declared size before any
+    payload bytes are read; default `0` means no per-entry bound (bomb-unsafe
+    without an external total-extracted cap). Overflow raises `IO.userError`
+    containing `"tar: entry '…' size (…) exceeds limit (…)"`.
+
+    `maxOutputSize` (default 256 MiB) caps the decompressed tar buffer
+    produced by the outer native gzip decode. The native variant exposes this
+    parameter because the pure Lean `Zip.Native.GzipDecode.decompress` API
+    requires a bound up front; the streaming `extractTarGz` variant does not
+    need one because it drains the outer compressed stream chunk-by-chunk
+    into the tar parser.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 partial def extractTarGzNative (inputPath : System.FilePath) (outDir : System.FilePath)
     (maxEntrySize : UInt64 := 0) (maxOutputSize : Nat := 256 * 1024 * 1024) : IO Unit := do
   let gzData ← IO.FS.readBinFile inputPath

--- a/progress/20260422T022538Z_062e8a92.md
+++ b/progress/20260422T022538Z_062e8a92.md
@@ -1,0 +1,67 @@
+# Track E P2.4 — Archive + Tar limit-policy docstrings
+
+- **Date (UTC):** 2026-04-22 02:25
+- **Session:** 062e8a92
+- **Type:** feature
+- **Issue:** #1578
+- **Branch:** agent/062e8a92
+
+## Summary
+
+Doc-only PR. Expanded the limit-policy docstrings on the six public
+extraction APIs called out in the issue, following the PR #1573
+template (parameter + default + behaviour at `0` + quoted error
+substring + cross-reference to `SECURITY_INVENTORY.md`).
+
+## Changes
+
+- `Zip/Archive.lean`
+  - `Archive.list`: now states the 64 MiB default, what `0` means,
+    quotes `"zip: central directory too large"`, and cross-refs the
+    inventory.
+  - `Archive.extract`: documents both `maxCentralDirSize` and
+    `maxEntrySize`, including the asymmetric FFI/native behaviour at
+    `maxEntrySize = 0` (FFI: unlimited, native: silently 256 MiB cap).
+    Quotes `"zip: entry '…' uncompressed size (…) exceeds limit (…)"`.
+  - `Archive.extractFile`: same expansion as `extract`.
+
+- `Zip/Tar.lean`
+  - `Tar.extract`: prepended a paragraph covering `maxEntrySize` (when
+    `0` means no per-entry bound, error substring quote, and the
+    total-extracted-bytes gap pointing at recommendation 3). Kept the
+    typeflag bullet list and symlink/hardlink policy block intact;
+    removed the now-redundant trailing one-liner.
+  - `extractTarGz`: documents `maxEntrySize` and notes the absence of
+    an outer gzip-stream cap (recommendation 2 gap).
+  - `extractTarGzNative`: documents both `maxEntrySize` and
+    `maxOutputSize`, explaining why the native variant exposes
+    `maxOutputSize` (the Lean `GzipDecode.decompress` API requires a
+    bound) while the streaming variant doesn't (it drains the outer
+    stream chunk-by-chunk).
+
+## Checklist not ticked
+
+`plans/track-e-current-audit-checklist.md` Priority 2 item 4 is left
+unchecked. Reason: the Zip.Native decompression APIs
+(`Zip.Native.Inflate.inflate`, `Zip.Native.GzipDecode.decompress`,
+`Zip.Native.ZlibDecode.decompress`, `Zip.Native.decompressAuto`)
+mention `maxOutputSize` and the default but don't quote the error
+substring (`"Inflate: output exceeds maximum size"`) or cross-reference
+`SECURITY_INVENTORY.md`. They were not in this issue's scope. A
+follow-up issue should bring them up to PR #1573 style for full
+coverage.
+
+## Verification
+
+- `lake build` clean.
+- `lake exe test` — all tests pass.
+- `grep -rc sorry Zip/` — all zero.
+- `grep -c "Decompression Limit Inventory" Zip/Archive.lean Zip/Tar.lean`
+  → 3 each (one per public API touched).
+- Diff limited to `Zip/Archive.lean` and `Zip/Tar.lean`. No
+  `SECURITY_INVENTORY.md`, no `ZipTest/`, no `c/`, no fixtures, no
+  signature/behaviour changes.
+
+## Quality metrics
+
+- `sorry` count: 0 → 0 (unchanged).


### PR DESCRIPTION
Closes #1578

Session: `062e8a92-b011-4eb3-a3fa-94d5cbec82a6`

## What changed

Doc-only. Expanded the limit-policy docstrings on the six public extraction APIs called out in the issue, following the PR #1573 template (parameter + default + behaviour at `0` + quoted error substring + cross-reference to `SECURITY_INVENTORY.md`):

- `Archive.list` — `maxCentralDirSize` policy + `"zip: central directory too large"`.
- `Archive.extract` / `Archive.extractFile` — both `maxCentralDirSize` and `maxEntrySize`, including the asymmetric FFI/native behaviour at `maxEntrySize = 0` (FFI: unlimited; native: silently 256 MiB cap as a zip-bomb guard) — promoted from the private `readEntryData` comment.
- `Tar.extract` — prepended a paragraph on `maxEntrySize` and the total-extracted-bytes gap (recommendation 3); kept the typeflag bullet list and symlink/hardlink policy block intact.
- `Tar.extractTarGz` — `maxEntrySize` + the absence of an outer gzip-stream cap (recommendation 2 gap).
- `Tar.extractTarGzNative` — both `maxEntrySize` and `maxOutputSize`, explaining why the native variant exposes `maxOutputSize` while the streaming `extractTarGz` doesn't.

No signature, default, error wording, or behaviour changes.

## Checklist not ticked — gap to flag

`plans/track-e-current-audit-checklist.md` Priority 2 item 4 is **left unchecked**. The Zip.Native decompression APIs (`Zip.Native.Inflate.inflate`, `Zip.Native.GzipDecode.decompress`, `Zip.Native.ZlibDecode.decompress`, `Zip.Native.decompressAuto`) currently mention `maxOutputSize` and the default but don't quote the error substring (`"Inflate: output exceeds maximum size"`) or cross-reference `SECURITY_INVENTORY.md`. They were not in this issue's scope. A follow-up issue should bring them up to PR #1573 style; once done, the checkbox can be ticked.

## Verification

- `lake build` clean.
- `lake exe test` — all tests pass.
- `grep -rc sorry Zip/` — all zero.
- `grep -c "Decompression Limit Inventory" Zip/Archive.lean Zip/Tar.lean` → 3 each (one per public API touched).
- Diff limited to `Zip/Archive.lean`, `Zip/Tar.lean`, and the progress entry. No `SECURITY_INVENTORY.md`, no `ZipTest/`, no `c/`, no fixtures.

🤖 Prepared with Claude Code