### PR TITLE
Feature: Track E P5.1 — Proof-friendly helpers for bounded reads and validated spans

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -379,6 +379,43 @@ partial def readExactStream (s : IO.FS.Stream) (n : Nat) (what : String) : IO By
     buf := buf ++ chunk
   return buf
 
+/-- Validate a read span against `fileSize`, seek to `offset`, and read exactly
+    `length` bytes. The one-shot "validate the span, then read" primitive that
+    `Archive.readEntryData`'s three open-coded `assertSpanInFile` + seek +
+    `readExact` chains implement today.
+
+    Precondition: `offset + length ≤ fileSize`. On violation, throws
+    `IO.userError` with one of two substrings (sourced from `assertSpanInFile`):
+    `"offset (…) exceeds file size (…)"` if `offset > fileSize`, or
+    `"extends past end of file"` if the span runs past the tail. If the span is
+    valid but the underlying handle returns fewer than `length` bytes, throws
+    with substring `"short read for {what}"` (sourced from `readExact`). The
+    addressable-range guard (`"exceeds addressable range"`) also fires here for
+    any `length` whose `Nat` value does not round-trip through `USize`.
+
+    Callers that have already validated the span and only need the read primitive
+    should use `readBoundedExactFromHandle` instead. Cross-reference:
+    `SECURITY_INVENTORY.md` § "Local guard inventory for `Handle.read` and
+    `Stream.read`". -/
+def readBoundedSpanFromHandle (h : IO.FS.Handle)
+    (fileSize offset length : UInt64) (what : String) : IO ByteArray := do
+  assertSpanInFile fileSize offset length what
+  Handle.seek h offset
+  readExact h length.toNat what
+
+/-- Bounded-length `readExact` for callers that have validated their span
+    separately (e.g. after seeking within a span they already confirmed lies
+    inside the file). Asserts `length.toUSize.toNat = length` before any
+    `Handle.read`; on violation throws `IO.userError` with substring
+    `"exceeds addressable range"`. Short reads surface the
+    `"short read for {what}"` substring from `readExact`. This is the "already-
+    validated span" cousin of `readBoundedSpanFromHandle`. Cross-reference:
+    `SECURITY_INVENTORY.md` § "Local guard inventory for `Handle.read` and
+    `Stream.read`". -/
+def readBoundedExactFromHandle (h : IO.FS.Handle)
+    (length : UInt64) (what : String) : IO ByteArray :=
+  readExact h length.toNat what
+
 /-- Read entries from a file handle by seeking to the tail, EOCD, and central directory.
     Memory usage: O(65KB + central directory size). -/
 private def listFromHandle (h : IO.FS.Handle) (maxCentralDirSize : Nat := 67108864) : IO (Array Entry) := do

--- a/Zip/Tar.lean
+++ b/Zip/Tar.lean
@@ -241,6 +241,48 @@ private partial def readEntryData (input : IO.FS.Stream) (size : Nat)
       padRemaining := padRemaining - chunk.size
   return result
 
+/-- Thin bounded-length `readExact`-style helper over `IO.FS.Stream`, adding the
+    `length.toUSize.toNat = length` addressable-range guard that the ZIP
+    `readExact` already applies at `Zip/Archive.lean` but the Tar `readExact`
+    does not. On the addressable-range violation throws `IO.userError` with
+    substring `"tar: {what} size {n} exceeds addressable range"`; on short read
+    throws with the message produced by the caller-handled EOF path (the
+    underlying loop returns a shorter `ByteArray` at true EOF — callers that
+    require strict `length` bytes must check `result.size = length`).
+
+    This wraps the existing private `readExact` for the Tar surface so callers
+    on `Stream` get the same `Nat → USize` roundtrip as the ZIP `Handle` path.
+    Cross-reference: `SECURITY_INVENTORY.md` § "Local guard inventory for
+    `Handle.read` and `Stream.read`". -/
+partial def readBoundedExactFromStream (s : IO.FS.Stream) (length : Nat)
+    (what : String) : IO ByteArray := do
+  unless length.toUSize.toNat == length do
+    throw (IO.userError s!"tar: {what} size {length} exceeds addressable range")
+  readExact s length
+
+/-- General-purpose bounded wrapper around `readEntryData` that enforces a
+    caller-supplied `maxSize` upper bound on the payload before the allocator
+    loop starts. On violation throws `IO.userError` with substring
+    `"exceeds maximum"` (stable phrase kept in sync with the existing
+    `readEntryData` `"exceeds maximum header size"` guard). Otherwise delegates
+    to `readEntryData` — the existing `maxHeaderSize` cap there still applies
+    and uses the same substring anchor, so the two bounds compose.
+
+    Used by callers that have a semantically meaningful per-call maximum
+    (e.g. PAX record size, long-name size) distinct from `defaultMaxHeaderSize`.
+    The existing `readEntryData (maxHeaderSize := ...)` signature is not a
+    substitute for this helper: that parameter is the **global** default cap
+    for any header-buffering caller, whereas `readBoundedEntryData` is the
+    **per-call** cap primitive — typically the stricter of the two. Cross-
+    reference: `SECURITY_INVENTORY.md` § "Local guard inventory for
+    `Handle.read` and `Stream.read`". -/
+partial def readBoundedEntryData (input : IO.FS.Stream) (size maxSize : Nat)
+    (what : String) : IO ByteArray := do
+  if size > maxSize then
+    throw (IO.userError
+      s!"tar: {what} size ({size}) exceeds maximum ({maxSize})")
+  readEntryData input size
+
 /-- Split a path into (prefix, name) for UStar format.
     Returns `none` if the path is too long to encode. -/
 def splitPath (path : String) : Option (String × String) := Id.run do

--- a/ZipTest.lean
+++ b/ZipTest.lean
@@ -20,6 +20,7 @@ import ZipTest.NativeDeflate
 import ZipTest.NativeCompressBench
 import ZipTest.Benchmark
 import ZipTest.FuzzInflate
+import ZipTest.BoundedReadTest
 
 def main : IO Unit := do
   unless ← System.FilePath.pathExists "testdata" do
@@ -45,4 +46,5 @@ def main : IO Unit := do
   ZipTest.NativeCompressBench.tests
   ZipTest.Benchmark.tests
   ZipTest.FuzzInflate.tests
+  ZipTest.BoundedRead.tests
   IO.println "\nAll tests passed!"

--- a/ZipTest/BoundedReadTest.lean
+++ b/ZipTest/BoundedReadTest.lean
@@ -1,0 +1,104 @@
+import ZipTest.Helpers
+
+/-! Smoke tests for Track E P5.1 bounded-read helpers: exercises each of
+    `Archive.readBoundedSpanFromHandle`, `Archive.readBoundedExactFromHandle`,
+    `Tar.readBoundedExactFromStream`, and `Tar.readBoundedEntryData` on a
+    happy path and a representative validation-failure path. -/
+
+namespace ZipTest.BoundedRead
+
+/-- Fixture file containing ASCII "0123456789" (10 bytes). Used by the Archive
+    helpers to exercise `fileSize = 10`. -/
+private def writeDigitsFile : IO System.FilePath := do
+  let path : System.FilePath := "/tmp/lean-zlib-bounded-digits.bin"
+  IO.FS.writeBinFile path "0123456789".toUTF8
+  return path
+
+/-- `Archive.readBoundedSpanFromHandle`: valid span + sufficient data, and
+    offset-past-fileSize failure surfacing the `"exceeds file size"` substring,
+    and overshooting-span failure surfacing `"extends past end of file"`. -/
+private def testReadBoundedSpanFromHandle : IO Unit := do
+  let path ← writeDigitsFile
+  -- Happy path: read 4 bytes from offset 2 (= "2345")
+  IO.FS.withFile path .read fun h => do
+    let buf ← Archive.readBoundedSpanFromHandle h 10 2 4 "digits mid-span"
+    unless buf.data == "2345".toUTF8.data do
+      throw (IO.userError s!"readBoundedSpanFromHandle: expected \"2345\", got {String.fromUTF8! buf}")
+  -- Failure: offset beyond fileSize → "exceeds file size"
+  assertThrows "readBoundedSpanFromHandle offset>fileSize"
+    (IO.FS.withFile path .read fun h => do
+      let _ ← Archive.readBoundedSpanFromHandle h 10 11 1 "digits past eof"
+      pure ())
+    "exceeds file size"
+  -- Failure: span runs past the tail → "extends past end of file"
+  assertThrows "readBoundedSpanFromHandle span>tail"
+    (IO.FS.withFile path .read fun h => do
+      let _ ← Archive.readBoundedSpanFromHandle h 10 8 5 "digits overshoot"
+      pure ())
+    "extends past end of file"
+
+/-- `Archive.readBoundedExactFromHandle`: valid post-seek read, and short-read
+    failure surfacing the `"short read for"` substring sourced from `readExact`. -/
+private def testReadBoundedExactFromHandle : IO Unit := do
+  let path ← writeDigitsFile
+  -- Happy path: caller seeks, then reads exactly 3 bytes (= "234")
+  IO.FS.withFile path .read fun h => do
+    Handle.seek h 2
+    let buf ← Archive.readBoundedExactFromHandle h 3 "digits post-seek"
+    unless buf.data == "234".toUTF8.data do
+      throw (IO.userError s!"readBoundedExactFromHandle: expected \"234\", got {String.fromUTF8! buf}")
+  -- Failure: caller requests more bytes than the handle has remaining
+  assertThrows "readBoundedExactFromHandle short-read"
+    (IO.FS.withFile path .read fun h => do
+      Handle.seek h 8
+      let _ ← Archive.readBoundedExactFromHandle h 5 "digits short"
+      pure ())
+    "short read for"
+
+/-- `Tar.readBoundedExactFromStream`: valid stream read, and addressable-range
+    failure surfacing the `"exceeds addressable range"` substring. -/
+private def testReadBoundedExactFromStream : IO Unit := do
+  let stream ← byteArrayReadStream "abcdef".toUTF8
+  -- Happy path: pull 4 bytes from the stream
+  let buf ← Tar.readBoundedExactFromStream stream 4 "alpha"
+  unless buf.data == "abcd".toUTF8.data do
+    throw (IO.userError s!"readBoundedExactFromStream: expected \"abcd\", got {String.fromUTF8! buf}")
+  -- Failure: length exceeds USize addressable range. On a 64-bit host
+  -- `USize.size = 2^64`, so any `Nat ≥ USize.size` trips the guard. We use
+  -- `USize.size` directly to stay portable to the (currently hypothetical)
+  -- 32-bit build.
+  let stream2 ← byteArrayReadStream "abcdef".toUTF8
+  assertThrows "readBoundedExactFromStream addressable-range"
+    (do
+      let _ ← Tar.readBoundedExactFromStream stream2 USize.size "alpha overflow"
+      pure ())
+    "exceeds addressable range"
+
+/-- `Tar.readBoundedEntryData`: happy path reads a small payload inside the cap,
+    and over-the-cap call surfaces the `"exceeds maximum"` substring. -/
+private def testReadBoundedEntryData : IO Unit := do
+  -- Construct a 16-byte payload followed by enough padding to reach the next
+  -- 512-byte boundary, since `readEntryData` also consumes the tar padding.
+  let payload : ByteArray := (ByteArray.mk (Array.replicate 16 0x41)) ++
+    (ByteArray.mk (Array.replicate (512 - 16) 0))
+  let stream ← byteArrayReadStream payload
+  -- Happy path: 16 ≤ maxSize = 1024, payload buffered into memory.
+  let buf ← Tar.readBoundedEntryData stream 16 1024 "payload"
+  unless buf.size == 16 do
+    throw (IO.userError s!"readBoundedEntryData: expected 16 bytes, got {buf.size}")
+  -- Failure: size exceeds caller-supplied max.
+  let stream2 ← byteArrayReadStream payload
+  assertThrows "readBoundedEntryData exceeds-maximum"
+    (do
+      let _ ← Tar.readBoundedEntryData stream2 16 8 "payload overflow"
+      pure ())
+    "exceeds maximum"
+
+def tests : IO Unit := do
+  testReadBoundedSpanFromHandle
+  testReadBoundedExactFromHandle
+  testReadBoundedExactFromStream
+  testReadBoundedEntryData
+  IO.println "bounded-read helper tests passed"
+
+end ZipTest.BoundedRead

--- a/progress/2026-04-22T05-27-16Z_058e50ac.md
+++ b/progress/2026-04-22T05-27-16Z_058e50ac.md
@@ -1,0 +1,89 @@
+# Track E P5.1 — bounded-read helpers for Handle and Stream
+
+- **Session**: `058e50ac` (feature)
+- **Issue**: #1596 — *Proof-friendly helpers for bounded reads and validated spans*
+- **Branch**: `agent/058e50ac`
+
+## Summary
+
+Landed the P5.1 plumbing step: four bounded-read helpers now live
+alongside the existing open-coded `assertSpanInFile + seek + readExact`
+chains, unreferenced outside their smoke tests. P5.2 (lemmas over the
+helpers) and P5.3 (migrating the existing callers) are deliberate
+follow-ups.
+
+## Deliverables
+
+- `Archive.readBoundedSpanFromHandle` — one-shot "validate span, seek,
+  readExact" primitive over `IO.FS.Handle` + `fileSize`.
+- `Archive.readBoundedExactFromHandle` — `UInt64`-bounded `readExact`
+  cousin for callers who have validated their span separately.
+- `Tar.readBoundedExactFromStream` — `Stream` wrapper around
+  `readExact` adding the `Nat → USize` roundtrip guard the ZIP Handle
+  path already applies.
+- `Tar.readBoundedEntryData` — general per-call `maxSize` wrapper
+  around the existing `readEntryData`, independent of the
+  global `maxHeaderSize` default that #1597 tightened.
+- `ZipTest/BoundedReadTest.lean` — 4 helpers × (1 happy + 1–2
+  failure) assertions, pinned to `"exceeds file size"`, `"extends past
+  end of file"`, `"short read for"`, `"exceeds addressable range"`,
+  `"exceeds maximum"` substrings.
+- `ZipTest.lean` — module registered, test run included in `main`.
+
+## Decisions
+
+- **Not marked `private`.** The issue text asks helpers to "stay
+  private", but also asks for smoke tests outside the defining module.
+  Without `open private` scaffolding in this codebase, a `private`
+  helper cannot be exercised from `ZipTest/`. I followed the same
+  pragmatic split the existing code uses: `readExact` is `private`,
+  `readExactStream` is not (tests exercise it). The new helpers
+  default to namespaced-but-public access (`Archive.readBounded…`,
+  `Tar.readBounded…`), with the same "no external caller yet" scope
+  as before.
+- **`readBoundedExactFromHandle` failure mode tested via short-read,
+  not addressable-range.** The issue spec's
+  `length.toUSize.toNat = length` guard is only reachable for a
+  `Nat ≥ 2^64`; since this helper takes `UInt64`, the check is dead
+  code on 64-bit hosts. The smoke test covers the reachable path
+  (`"short read for"` from the underlying `readExact`). The
+  addressable-range path *is* tested on the `Tar.readBoundedExactFromStream`
+  helper, which takes `Nat` and can legitimately receive `USize.size`.
+- **`readBoundedEntryData` composes with `readEntryData`'s existing
+  `maxHeaderSize` cap.** The wrapper checks `size > maxSize` *before*
+  delegating, so a caller hitting both bounds sees the tighter one
+  reported first. Both error substrings include `"exceeds maximum"`,
+  so test assertions that grep for that substring catch either
+  variant — matches issue intent that `"exceeds maximum"` be the
+  cross-surface anchor.
+
+## Scope discipline
+
+- No caller migrations (P5.3 scope).
+- No proofs (P5.2 scope).
+- No changes to `assertSpanInFile`, `readExact`, or `readEntryData`
+  signatures, error wording, or behaviour.
+- No edits to `PLAN.md`, `.claude/CLAUDE.md`, `SECURITY_INVENTORY.md`,
+  or `c/`.
+- Audit checklist box in `plans/track-e-current-audit-checklist.md`
+  deliberately left unchecked — it belongs to P5.3.
+
+## Quality metrics
+
+- `grep -rc sorry Zip/` — `0` (unchanged).
+- `lake build` — clean.
+- `lake exe test` — passes including the four new smoke tests.
+- Diff: 185 net additions across `Zip/Archive.lean`, `Zip/Tar.lean`,
+  `ZipTest/BoundedReadTest.lean`, `ZipTest.lean` (≤ 200 target met).
+
+## Follow-ups
+
+- P5.2 — prove the "validated span ⇒ requested read length is file-
+  bounded" lemma over `readBoundedSpanFromHandle`. Expected spec: a
+  `successful-read-bounded-by-fileSize` theorem conditioned on the
+  `assertSpanInFile` precondition.
+- P5.3 — migrate the three `readEntryData` callsites in
+  `Zip/Archive.lean` and the four GNU/PAX callsites in `Zip/Tar.lean`
+  to the helpers introduced here. That is also the step that ticks
+  the Priority 5 Item 1 box in
+  `plans/track-e-current-audit-checklist.md`.


### PR DESCRIPTION
Closes #1596

Session: `058e50ac-7909-4825-bc6f-f0ce62cb611b`

318eb1b doc: progress entry for #1596 P5.1 bounded-read helpers
6ccab57 test: Track E P5.1 — smoke tests for bounded-read helpers
bf0f1f2 feat: Track E P5.1 — introduce bounded-read helpers for Handle and Stream

🤖 Prepared with Claude Code