### PR TITLE
Feature: streaming FFI decoders — add maxDecompressedSize parameter (closes SECURITY_INVENTORY gap)

### DIFF
--- a/.claude/skills/error-wording-catalogue/SKILL.md
+++ b/.claude/skills/error-wording-catalogue/SKILL.md
@@ -17,6 +17,8 @@ one makes the test brittle to message rewrites.
 | Subsystem | Emits from | Full message (approx.) | Recommended match substring |
 |-----------|------------|------------------------|-----------------------------|
 | FFI whole-buffer decoders | `c/zlib_ffi.c:195` | `ZLib: decompressed data exceeds limit (…)` | `"exceeds limit"` |
+| FFI streaming decoders (gzip) | `Zip/Gzip.lean` (`decompressStream`, `decompressFile`) | `gzip: decompressed stream exceeds limit (<N> bytes)` | `"exceeds limit"` |
+| FFI streaming decoders (raw deflate) | `Zip/RawDeflate.lean` (`decompressStream`) | `raw deflate: decompressed stream exceeds limit (<N> bytes)` | `"exceeds limit"` |
 | Archive per-entry bomb | `Zip/Archive.lean:408-410` | `Archive: entry <name> exceeds limit (…)` | `"exceeds limit"` |
 | Archive ZIP64 span check | `Zip/Archive.lean:428-429` | `Archive: local data span for <name> (…)` | `"local data span"` |
 | Archive CD/LH consistency | `Zip/Archive.lean` | `mismatch between CD and local header (<field>)` | `"mismatch between CD and local header"` |

--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -386,12 +386,18 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
   misread — a caller who sees "limits default to sensible values" on
   the CD side might reasonably assume the entry side is also
   bounded.
-- **Streaming FFI APIs have no output cap at all.**
-  `Gzip.decompressStream`, `Gzip.decompressFile`, and
-  `RawDeflate.decompressStream` take no output-size parameter — they
-  are bounded only by the caller's sink (`output.write`). Any tool
-  built on top that writes to disk is a potential bomb target with
-  no library-level guard.
+- **Streaming FFI APIs expose `maxDecompressedSize` but default to
+  `0 = no limit`.** `Gzip.decompressStream`, `Gzip.decompressFile`, and
+  `RawDeflate.decompressStream` now accept an optional
+  `maxDecompressedSize : UInt64 := 0` parameter (matching the
+  whole-buffer FFI decoders). Overflow raises `IO.userError`
+  containing `"exceeds limit"` (same substring as the whole-buffer
+  path) and aborts before writing the overflowing chunk. See the
+  function docstrings for the exact error wording. Callers that want
+  bomb protection for disk-backed flows must pass a finite value —
+  the default `0` preserves today's unlimited behaviour for back-compat.
+  Changing the **default** to a finite value is still open; see
+  *Recommended policy* item 2 below.
 
 ### Recommended policy
 

--- a/Zip/Gzip.lean
+++ b/Zip/Gzip.lean
@@ -72,19 +72,34 @@ partial def compressStream (input : IO.FS.Stream) (output : IO.FS.Stream)
   output.flush
 
 /-- Decompress gzip data from input stream to output stream.
-    Handles concatenated gzip streams. Input memory usage is bounded, but there
-    is no library-level cap on total decompressed output — the caller's sink is
-    the only bound. See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*
-    (recommendation 2) for the proposed `maxDecompressedSize` streaming cap. -/
-partial def decompressStream (input : IO.FS.Stream) (output : IO.FS.Stream) : IO Unit := do
+    Handles concatenated gzip streams. Input memory usage is bounded.
+    `maxDecompressedSize` caps the *total* output bytes written to `output`;
+    default `0` means unlimited (bomb-unsafe for untrusted input). Overflow
+    raises `IO.userError` containing `"exceeds limit"` (full message:
+    `"gzip: decompressed stream exceeds limit (<N> bytes)"`) and aborts
+    before writing the overflowing chunk, so the already-written prefix is
+    at most `maxDecompressedSize` bytes.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
+partial def decompressStream (input : IO.FS.Stream) (output : IO.FS.Stream)
+    (maxDecompressedSize : UInt64 := 0) : IO Unit := do
   let state ← InflateState.new
+  let totalRef ← IO.mkRef (0 : UInt64)
+  let checkAndWrite (chunk : ByteArray) : IO Unit := do
+    if chunk.size > 0 then
+      let total ← totalRef.get
+      let next := total + chunk.size.toUInt64
+      if maxDecompressedSize ≠ 0 && next > maxDecompressedSize then
+        throw (IO.userError
+          s!"gzip: decompressed stream exceeds limit ({maxDecompressedSize} bytes)")
+      totalRef.set next
+      output.write chunk
   repeat do
     let chunk ← input.read 65536
     if chunk.isEmpty then break
     let decompressed ← state.push chunk
-    if decompressed.size > 0 then output.write decompressed
+    checkAndWrite decompressed
   let final ← state.finish
-  if final.size > 0 then output.write final
+  checkAndWrite final
   output.flush
 
 -- File helpers
@@ -99,12 +114,14 @@ def compressFile (path : System.FilePath) (level : UInt8 := 6) : IO System.FileP
   return outPath
 
 /-- Decompress a gzip file. Strips `.gz` suffix, or appends `.ungz` as fallback.
-    Optional explicit output path. Streams with bounded input memory; as with
-    `decompressStream`, there is no library-level cap on total decompressed
-    output, so a bomb can fill the output path's disk.
+    Optional explicit output path. Streams with bounded input memory.
+    `maxDecompressedSize` is forwarded to `decompressStream`; default `0`
+    means unlimited (bomb-unsafe for untrusted input, since a bomb can
+    fill the output path's disk). Overflow raises `IO.userError` containing
+    `"exceeds limit"`.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def decompressFile (path : System.FilePath) (outPath : Option System.FilePath := none)
-    : IO System.FilePath := do
+    (maxDecompressedSize : UInt64 := 0) : IO System.FilePath := do
   let out := match outPath with
     | some p => p
     | none =>
@@ -113,6 +130,7 @@ def decompressFile (path : System.FilePath) (outPath : Option System.FilePath :=
   IO.FS.withFile path .read fun inH =>
     IO.FS.withFile out .write fun outH =>
       decompressStream (IO.FS.Stream.ofHandle inH) (IO.FS.Stream.ofHandle outH)
+        (maxDecompressedSize := maxDecompressedSize)
   return out
 
 end Gzip

--- a/Zip/RawDeflate.lean
+++ b/Zip/RawDeflate.lean
@@ -45,19 +45,34 @@ partial def compressStream (input : IO.FS.Stream) (output : IO.FS.Stream)
   output.flush
 
 /-- Decompress raw deflate data from input stream to output stream.
-    Input memory usage is bounded, but there is no library-level cap on total
-    decompressed output — the caller's sink is the only bound. See
-    `SECURITY_INVENTORY.md` *Decompression Limit Inventory* (recommendation 2)
-    for the proposed `maxDecompressedSize` streaming cap. -/
-partial def decompressStream (input : IO.FS.Stream) (output : IO.FS.Stream) : IO Unit := do
+    Input memory usage is bounded. `maxDecompressedSize` caps the *total*
+    output bytes written to `output`; default `0` means unlimited
+    (bomb-unsafe for untrusted input). Overflow raises `IO.userError`
+    containing `"exceeds limit"` (full message:
+    `"raw deflate: decompressed stream exceeds limit (<N> bytes)"`) and
+    aborts before writing the overflowing chunk, so the already-written
+    prefix is at most `maxDecompressedSize` bytes.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
+partial def decompressStream (input : IO.FS.Stream) (output : IO.FS.Stream)
+    (maxDecompressedSize : UInt64 := 0) : IO Unit := do
   let state ← InflateState.new
+  let totalRef ← IO.mkRef (0 : UInt64)
+  let checkAndWrite (chunk : ByteArray) : IO Unit := do
+    if chunk.size > 0 then
+      let total ← totalRef.get
+      let next := total + chunk.size.toUInt64
+      if maxDecompressedSize ≠ 0 && next > maxDecompressedSize then
+        throw (IO.userError
+          s!"raw deflate: decompressed stream exceeds limit ({maxDecompressedSize} bytes)")
+      totalRef.set next
+      output.write chunk
   repeat do
     let chunk ← input.read 65536
     if chunk.isEmpty then break
     let decompressed ← state.push chunk
-    if decompressed.size > 0 then output.write decompressed
+    checkAndWrite decompressed
   let final ← state.finish
-  if final.size > 0 then output.write final
+  checkAndWrite final
   output.flush
 
 end RawDeflate

--- a/ZipTest/Gzip.lean
+++ b/ZipTest/Gzip.lean
@@ -150,6 +150,52 @@ def ZipTest.Gzip.tests : IO Unit := do
   let roundtripped2 ← IO.FS.readBinFile customOut
   assert! roundtripped2.beq big
 
+  -- Streaming decompress with a non-zero limit that is larger than the
+  -- decompressed size: happy path, full output reconstructed.
+  let mkWriteStream : IO (IO.Ref ByteArray × IO.FS.Stream) := do
+    let ref ← IO.mkRef ByteArray.empty
+    let stream : IO.FS.Stream := {
+      flush := pure (), read := fun _ => pure ByteArray.empty
+      write := fun c => ref.modify (· ++ c)
+      getLine := pure "", putStr := fun _ => pure (), isTty := pure false
+    }
+    return (ref, stream)
+  let smallInput := "hello, streaming world!".toUTF8
+  let gzSmall ← Gzip.compress smallInput
+  let inStreamOk ← byteArrayReadStream gzSmall
+  let (outRefOk, outStreamOk) ← mkWriteStream
+  Gzip.decompressStream inStreamOk outStreamOk (maxDecompressedSize := 1024)
+  let outOk ← outRefOk.get
+  assert! outOk.beq smallInput
+
+  -- Streaming decompress with a limit smaller than the decompressed size:
+  -- must abort mid-stream with the shared `"exceeds limit"` substring, and
+  -- the partial output must be at most `maxDecompressedSize` bytes.
+  let bombInput ← mkTestData  -- 6200 bytes of redundant text
+  let gzBomb ← Gzip.compress bombInput
+  let inStreamBomb ← byteArrayReadStream gzBomb
+  let (outRefBomb, outStreamBomb) ← mkWriteStream
+  let streamLimit : UInt64 := 10
+  match ← (Gzip.decompressStream inStreamBomb outStreamBomb
+      (maxDecompressedSize := streamLimit)).toBaseIO with
+  | .ok _ => throw (IO.userError "gzip decompressStream limit should have been rejected")
+  | .error e =>
+    unless (toString e).contains "exceeds limit" do
+      throw (IO.userError s!"gzip decompressStream limit wrong error: {e}")
+  let partial_ ← outRefBomb.get
+  assert! partial_.size.toUInt64 ≤ streamLimit
+
+  -- decompressFile with a generous non-zero limit: happy path.
+  let fileLimitTmp : System.FilePath := "/tmp/lean-zlib-test-filelimit.bin"
+  IO.FS.writeBinFile fileLimitTmp big
+  let fileLimitGz ← Gzip.compressFile fileLimitTmp
+  let fileLimitOut ← Gzip.decompressFile fileLimitGz
+    (maxDecompressedSize := (big.size * 2).toUInt64)
+  let fileLimitRoundtripped ← IO.FS.readBinFile fileLimitOut
+  assert! fileLimitRoundtripped.beq big
+  for f in #["/tmp/lean-zlib-test-filelimit.bin", "/tmp/lean-zlib-test-filelimit.bin.gz"] do
+    let _ ← IO.Process.run { cmd := "rm", args := #["-f", f] }
+
   -- Large data via streaming
   let large ← mkLargeData
   let largeTmp : System.FilePath := "/tmp/lean-zlib-test-large.bin"

--- a/ZipTest/RawDeflate.lean
+++ b/ZipTest/RawDeflate.lean
@@ -60,4 +60,38 @@ def ZipTest.RawDeflate.tests : IO Unit := do
   match ← (RawDeflate.decompress compTrunc).toBaseIO with
   | .ok _ => throw (IO.userError "raw deflate should reject truncated compressed stream")
   | .error _ => pure ()
+
+  -- Streaming decompress with a non-zero limit larger than the decompressed
+  -- size: happy path, output matches input.
+  let mkWriteStream : IO (IO.Ref ByteArray × IO.FS.Stream) := do
+    let ref ← IO.mkRef ByteArray.empty
+    let stream : IO.FS.Stream := {
+      flush := pure (), read := fun _ => pure ByteArray.empty
+      write := fun c => ref.modify (· ++ c)
+      getLine := pure "", putStr := fun _ => pure (), isTty := pure false
+    }
+    return (ref, stream)
+  let smallInput := "raw deflate streaming happy path".toUTF8
+  let rdSmall ← RawDeflate.compress smallInput
+  let rdInOk ← byteArrayReadStream rdSmall
+  let (rdOutRefOk, rdOutOk) ← mkWriteStream
+  RawDeflate.decompressStream rdInOk rdOutOk (maxDecompressedSize := 1024)
+  let rdOkBytes ← rdOutRefOk.get
+  assert! rdOkBytes.beq smallInput
+
+  -- Streaming decompress with a limit smaller than the decompressed size:
+  -- must abort mid-stream with `"exceeds limit"`, and the partial output
+  -- must be at most `maxDecompressedSize` bytes.
+  let rdInBomb ← byteArrayReadStream rawCompressed
+  let (rdOutRefBomb, rdOutBomb) ← mkWriteStream
+  let rdStreamLimit : UInt64 := 10
+  match ← (RawDeflate.decompressStream rdInBomb rdOutBomb
+      (maxDecompressedSize := rdStreamLimit)).toBaseIO with
+  | .ok _ =>
+    throw (IO.userError "raw deflate decompressStream limit should have been rejected")
+  | .error e =>
+    unless (toString e).contains "exceeds limit" do
+      throw (IO.userError s!"raw deflate decompressStream limit wrong error: {e}")
+  let rdPartial ← rdOutRefBomb.get
+  assert! rdPartial.size.toUInt64 ≤ rdStreamLimit
   IO.println "RawDeflate tests: OK"

--- a/progress/2026-04-22T05-42-42Z_da8fb649.md
+++ b/progress/2026-04-22T05-42-42Z_da8fb649.md
@@ -1,0 +1,81 @@
+# Progress — 2026-04-22 05:42 UTC — feature session da8fb649
+
+## Issue
+
+- #1603 Feature: streaming FFI decoders — add `maxDecompressedSize`
+  parameter (closes `SECURITY_INVENTORY.md` gap at line 373).
+
+## Work done
+
+- **`Zip/Gzip.lean`**: extended `decompressStream` and `decompressFile`
+  with an optional `maxDecompressedSize : UInt64 := 0` parameter.
+  Default `0` preserves existing unlimited-output behaviour. Enforcement
+  is Lean-side (no C FFI changes): a `totalRef : IO.Ref UInt64` is
+  incremented after each `push`/`finish` chunk, and the cap check is
+  performed **before** `output.write`, so the already-written prefix is
+  at most `maxDecompressedSize` bytes on overflow. Error message:
+  `gzip: decompressed stream exceeds limit (<N> bytes)` —
+  substring `"exceeds limit"` matches the existing FFI whole-buffer
+  error-wording catalogue row.
+- **`Zip/RawDeflate.lean`**: same change to `decompressStream`. Error
+  prefix `raw deflate:` for log-level distinguishability, same
+  `"exceeds limit"` anchor.
+- **Docstrings**: follow the P2.4 template from PRs #1573/#1586/#1594 —
+  name the parameter, state `0 = no limit` (bomb-unsafe for untrusted
+  input), quote the exact substring, cross-reference
+  `SECURITY_INVENTORY.md` *Decompression Limit Inventory*.
+- **`ZipTest/Gzip.lean`**: added happy-path + bomb-path + `decompressFile`
+  happy-path tests. The bomb-path test asserts the partial output is at
+  most `maxDecompressedSize` bytes (i.e. the cap really aborts before
+  the overflowing write).
+- **`ZipTest/RawDeflate.lean`**: added matching happy-path + bomb-path
+  streaming tests with the same partial-output invariant.
+- **`SECURITY_INVENTORY.md`**: replaced the *"Streaming FFI APIs have
+  no output cap at all"* bullet with a note that the parameter now
+  exists but defaults to `0`. Left the *"Recommended policy"* item 2
+  intact — the default-change decision is a separate policy call.
+- **`.claude/skills/error-wording-catalogue/SKILL.md`**: added two
+  rows for the streaming FFI decoders (gzip + raw deflate) with the
+  exact new message text.
+
+## Decisions
+
+- Used `IO.mkRef` for the running total rather than `let mut`, to avoid
+  any concerns about `let mut` interacting with `repeat do` inside a
+  `partial def`. Consistent with the existing `IO.mkRef` idiom in
+  `Zip/Tar.lean`.
+- Inlined a small `mkWriteStream` helper in each test file rather than
+  adding it to `ZipTest/Helpers.lean`, to stay within the issue's
+  "diff limited to" file list.
+- Kept the error-substring choice at `"exceeds limit"` (same as the
+  whole-buffer FFI path) so tests grepping for `"exceeds limit"`
+  catch both whole-buffer and streaming overflows without an OR.
+
+## Verification
+
+- `lake build` clean.
+- `lake exe test` passes; `Gzip tests: OK`, `RawDeflate tests: OK`,
+  `All tests passed!`.
+- `grep -rc sorry Zip/` → 0 (unchanged from start).
+- Diff footprint: 6 files, +145/-24 lines (net +121, well under the
+  200-line budget stated in the issue).
+- All "Verification" bullets from issue #1603 hold:
+  - `maxDecompressedSize` present on the five required functions.
+  - `"exceeds limit"` asserted four times across the two test files
+    (two new per file, matching the required two per file).
+  - `"Streaming FFI APIs have no output cap"` no longer present in
+    `SECURITY_INVENTORY.md`.
+  - `"exceeds limit"` streaming-row entries present in
+    `error-wording-catalogue/SKILL.md`.
+
+## Quality metrics
+
+- Sorry count: 0 (unchanged).
+
+## Follow-ups
+
+- `SECURITY_INVENTORY.md` *Recommended policy* item 2 still stands: a
+  future issue may want to change the **default** of
+  `maxDecompressedSize` from `0` to a finite value (suggested 256 MiB).
+  That is explicitly out of scope for this issue per the *Scope
+  discipline — do NOT* list.


### PR DESCRIPTION
Closes #1603

Session: `da8fb649-798f-47be-982c-f8e6b451bdcf`

b5b9485 feat: streaming FFI decoders — add maxDecompressedSize parameter (#1603)

🤖 Prepared with Claude Code