### PR TITLE
Feature: Track E — normalise Zip.Native.* default caps (SECURITY_INVENTORY Rec. 5)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -341,9 +341,9 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Gzip.decompressFile](/home/kim/lean-zip/Zip/Gzip.lean:106) (FFI) | — | — | — | writes direct to disk via `decompressStream`; no cap. |
 | [RawDeflate.decompressStream](/home/kim/lean-zip/Zip/RawDeflate.lean:52) (FFI) | — | — | — | streaming; no per-call output cap. |
 | [Zip.Native.Inflate.inflate](/home/kim/lean-zip/Zip/Native/Inflate.lean:384) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 1 GiB. |
-| [Zip.Native.GzipDecode.decompress](/home/kim/lean-zip/Zip/Native/Gzip.lean:40) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 256 MiB. |
-| [Zip.Native.ZlibDecode.decompress](/home/kim/lean-zip/Zip/Native/Gzip.lean:140) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 256 MiB. |
-| [Zip.Native.decompressAuto](/home/kim/lean-zip/Zip/Native/Gzip.lean:240) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | format-auto dispatch over the three natives above. |
+| [Zip.Native.GzipDecode.decompress](/home/kim/lean-zip/Zip/Native/Gzip.lean:40) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 1 GiB (unified with `Inflate.inflate` per Rec. 5). |
+| [Zip.Native.ZlibDecode.decompress](/home/kim/lean-zip/Zip/Native/Gzip.lean:140) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 1 GiB (unified with `Inflate.inflate` per Rec. 5). |
+| [Zip.Native.decompressAuto](/home/kim/lean-zip/Zip/Native/Gzip.lean:240) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | format-auto dispatch over the three natives above. |
 | [Archive.list](/home/kim/lean-zip/Zip/Archive.lean:497) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | metadata-only; caps CD allocation, not decompressed payload. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:515) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:515) | `maxEntrySize : UInt64` | `0` | **asymmetric** — FFI: no limit; native: silently upgraded to 256 MiB inside `readEntryData` (see [Zip/Archive.lean:477](/home/kim/lean-zip/Zip/Archive.lean:477)) | per-entry cap on the decompressed payload. |
@@ -372,13 +372,6 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
   kind of whole-buffer decompression. A caller copying the
   `Tar.extractTarGz`-style pattern with the FFI decoders gets no
   default protection.
-- **Native decompression defaults disagree with each other.**
-  `Zip.Native.Inflate.inflate` defaults to **1 GiB**;
-  `Zip.Native.GzipDecode.decompress`,
-  `Zip.Native.ZlibDecode.decompress`, and
-  `Zip.Native.decompressAuto` default to **256 MiB**. Picking a
-  format auto-dispatch vs. raw DEFLATE directly changes the default
-  cap by a factor of 4.
 - **`maxCentralDirSize` vs. `maxEntrySize` semantics.** In
   `Archive.list` / `Archive.extract` / `Archive.extractFile`, the CD
   cap defaults to a finite 64 MiB (good), while the per-entry cap
@@ -437,12 +430,11 @@ issues and the follow-up docstring/default change.
      `maxEntrySize` (recommendation 3) already bounds the common
      case; the total cap is a second line of defence against
      many-small-entries bombs.
-5. **Native-side uniformity**.
-   - Normalise the native decoder defaults to match one value
-     (suggested: **1 GiB**, matching `Zip.Native.Inflate.inflate`).
-     Whichever value is chosen, all four — `Inflate.inflate`,
-     `GzipDecode.decompress`, `ZlibDecode.decompress`,
-     `decompressAuto` — should agree.
+5. **Native-side uniformity**. Executed (issue #1609) — all four
+   native decoders (`Inflate.inflate`, `GzipDecode.decompress`,
+   `ZlibDecode.decompress`, `decompressAuto`) now default to **1 GiB**,
+   matching `Zip.Native.Inflate.inflate`. The factor-of-4 asymmetry
+   between raw-DEFLATE and format-auto-dispatch is gone.
 6. **Docstrings and error messages**.
    - Every decompression API should state its default, the
      meaning of `0`, and the exact error thrown on cap overflow.

--- a/Zip/Native/Gzip.lean
+++ b/Zip/Native/Gzip.lean
@@ -28,7 +28,7 @@ termination_by data.size - pos
 /-- Decompress a gzip stream (RFC 1952). Supports concatenated members.
     Returns the decompressed data.
 
-    `maxOutputSize` (default 256 MiB) caps the *total* output across all
+    `maxOutputSize` (default 1 GiB) caps the *total* output across all
     concatenated members as a zip-bomb guard. Unlike the FFI path, where
     `maxDecompressedSize := 0` means unlimited, here `0` rejects any
     non-empty output (the inner inflate guards compare
@@ -37,7 +37,7 @@ termination_by data.size - pos
     the inner per-member `Inflate.inflateRaw` call also enforces the bound
     and may surface `"Inflate: output exceeds maximum size"` first.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
-def decompress (data : ByteArray) (maxOutputSize : Nat := 256 * 1024 * 1024) :
+def decompress (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
     Except String ByteArray := do
   if data.size < 10 then throw "Gzip: input too short for gzip header"
   let mut pos : Nat := 0
@@ -130,14 +130,14 @@ namespace ZlibDecode
 /-- Decompress a zlib stream (RFC 1950).
     Returns the decompressed data.
 
-    `maxOutputSize` (default 256 MiB) is forwarded to the inner
+    `maxOutputSize` (default 1 GiB) is forwarded to the inner
     `Inflate.inflateRaw`; this layer adds no separate guard. Unlike the
     FFI path, where `maxDecompressedSize := 0` means unlimited, here `0`
     rejects any non-empty output (the inflate guards compare
     `output.size + len > maxOutputSize`). Overflow raises an `Except`
     error containing `"Inflate: output exceeds maximum size"`.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
-def decompress (data : ByteArray) (maxOutputSize : Nat := 256 * 1024 * 1024) :
+def decompress (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
     Except String ByteArray := do
   if hSz : data.size < 6 then throw "Zlib: input too short"
   else
@@ -228,7 +228,7 @@ def detectFormat (data : ByteArray) : CompressFormat :=
 
 /-- Decompress data by auto-detecting the format (gzip, zlib, or raw deflate).
 
-    `maxOutputSize` (default 256 MiB) is forwarded to whichever of
+    `maxOutputSize` (default 1 GiB) is forwarded to whichever of
     `GzipDecode.decompress`, `ZlibDecode.decompress`, or `Inflate.inflate`
     the dispatch picks based on `detectFormat`. The surfaced error
     substring depends on the dispatch: `"Gzip: total output exceeds
@@ -237,7 +237,7 @@ def detectFormat (data : ByteArray) : CompressFormat :=
     Unlike the FFI path, where `maxDecompressedSize := 0` means unlimited,
     here `0` rejects any non-empty output.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
-def decompressAuto (data : ByteArray) (maxOutputSize : Nat := 256 * 1024 * 1024) :
+def decompressAuto (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
     Except String ByteArray :=
   match detectFormat data with
   | .gzip => GzipDecode.decompress data maxOutputSize

--- a/ZipTest/NativeGzip.lean
+++ b/ZipTest/NativeGzip.lean
@@ -6,6 +6,20 @@ import Zip.Spec.ZlibCorrect
 /-! Tests for native gzip/zlib decompression and compression against FFI,
     across compression levels and data patterns. -/
 
+/-- Regression probe for SECURITY_INVENTORY.md Rec. 5: all three native
+    decoders default to 1 GiB. If a future refactor silently flips the
+    default back to 256 MiB (or any other value), `rfl` fails and these
+    examples stop type-checking. -/
+example (data : ByteArray) :
+    Zip.Native.GzipDecode.decompress data
+      = Zip.Native.GzipDecode.decompress data (1024 * 1024 * 1024) := rfl
+example (data : ByteArray) :
+    Zip.Native.ZlibDecode.decompress data
+      = Zip.Native.ZlibDecode.decompress data (1024 * 1024 * 1024) := rfl
+example (data : ByteArray) :
+    Zip.Native.decompressAuto data
+      = Zip.Native.decompressAuto data (1024 * 1024 * 1024) := rfl
+
 def ZipTest.NativeGzip.tests : IO Unit := do
   IO.println "  NativeGzip tests..."
   let big ← mkTestData

--- a/progress/20260422T062909Z_3bbf32e0.md
+++ b/progress/20260422T062909Z_3bbf32e0.md
@@ -1,0 +1,97 @@
+# 2026-04-22 06:29 UTC — Track E Rec. 5: unify Zip.Native.* default caps
+
+**Session type:** feature
+**Issue:** #1609
+**Branch:** agent/3bbf32e0
+
+## Accomplished
+
+Resolved `SECURITY_INVENTORY.md` *Recommended policy* item 5: all four
+native decompression entry points now default to 1 GiB. The factor-of-4
+asymmetry between raw-DEFLATE (`Zip.Native.Inflate.inflate`, already
+1 GiB) and the format wrappers (`GzipDecode.decompress`,
+`ZlibDecode.decompress`, `decompressAuto`, all previously 256 MiB) is
+gone.
+
+### Edits
+
+1. `Zip/Native/Gzip.lean` — three signatures (lines 40, 140, 240)
+   changed from `256 * 1024 * 1024` to `1024 * 1024 * 1024`. The
+   matching docstrings at lines 31, 133, and 231 changed `default
+   256 MiB` → `default 1 GiB`. No other wording touched — the
+   `SECURITY_INVENTORY.md` cross-reference, `0`-semantics note, and
+   error-substring phrases stay verbatim so the P2.4 docstring
+   template from PR #1594 is preserved.
+
+2. `SECURITY_INVENTORY.md`:
+   - *Decompression Limit Inventory* table rows for the three
+     decoders (lines 344–346) updated from `256 * 1024^2 (256 MiB)`
+     to `1 * 1024^3 (1 GiB)`. Required to satisfy the issue's
+     verification grep `'Zip.Native.GzipDecode.decompress.*256'`
+     → no matches, otherwise the table would self-contradict the
+     code.
+   - *Known inconsistencies* bullet "Native decompression defaults
+     disagree with each other" deleted in full.
+   - *Recommended policy* item 5 converted to a past-tense one-liner
+     citing issue #1609.
+
+3. `ZipTest/NativeGzip.lean` — three `example` regression probes
+   (one per decoder) using `rfl` to assert the default literal is
+   `1024 * 1024 * 1024`. If a future refactor silently flips the
+   default back to 256 MiB the test stops type-checking. Cheap —
+   no decompression actually runs.
+
+## Decisions
+
+- **Direction up to 1 GiB, not down to 256 MiB.** The issue
+  prescribed this; the rationale is that `Inflate.inflate`'s 1 GiB
+  default is the most-stable API and lowering it would be a
+  user-visible regression on existing direct callers, while raising
+  the three wrappers is invisible to today's tests (every bomb test
+  passes an explicit small cap).
+
+- **Smoke test as `example` rather than runtime assertion.** The
+  issue allowed either `#check` or `#eval`. A bare `#check` only
+  type-checks the signature, not the default value. A `#eval` would
+  print on every test build. An `example ... := rfl` definitionally
+  equates the no-default form with the explicit-1-GiB form — `rfl`
+  fails iff the default literal changes, exactly the regression we
+  want to catch, and produces no runtime output.
+
+## Out-of-scope, intentionally untouched
+
+- `Zip/Native/Inflate.lean` — already 1 GiB, the unification target.
+- `Zip/Archive.lean:477` (`Archive.readEntryData` silent
+  `0 → 256 MiB` upgrade) — Rec. 3, separate issue.
+- `Zip/Tar.lean:769` (`Tar.extractTarGzNative.maxOutputSize := 256 *
+  1024 * 1024`) — tar-extractor cap, not a native-decoder cap, and
+  the caller passes it explicitly. Issue #1611 territory.
+- FFI defaults in `Zip/Basic.lean`, `Zip/Gzip.lean`,
+  `Zip/RawDeflate.lean` — Rec. 1, separate issue (#1613 in queue).
+- `c/zlib_ffi.c` — no FFI changes.
+- `PLAN.md`, `.claude/CLAUDE.md` — off-limits to agents.
+
+## Verification
+
+- `lake build` — clean (191/191).
+- `lake exe test` — all tests passed.
+- `grep -rc sorry Zip/` total — 0 (unchanged).
+- `grep -c '256 \* 1024 \* 1024' Zip/Native/Gzip.lean` — 0.
+- `grep -c '1024 \* 1024 \* 1024' Zip/Native/Gzip.lean` — 3.
+- `grep -nc 'default 1 GiB' Zip/Native/Gzip.lean` — 3.
+- `grep -n 'Native decompression defaults disagree' SECURITY_INVENTORY.md`
+  — no matches.
+- `grep -nE 'Zip.Native.GzipDecode.decompress.*256' SECURITY_INVENTORY.md`
+  — no matches.
+- `bash scripts/check-inventory-links.sh` — `errors=0`, 55
+  pre-existing warnings (all on Tar.lean / Archive.lean line
+  references, unrelated to my edits at lines 344–346 / 433–434).
+
+## Diff size
+
+3 files, 28 insertions, 22 deletions — well under the 40-line target
+in the issue.
+
+## Quality metric delta
+
+- Sorries: 0 → 0 (unchanged).


### PR DESCRIPTION
Closes #1609

Session: `3bbf32e0-f0d8-4d40-b9de-5edc22ab4554`

6d5a6e0 feat: unify Zip.Native.* default caps at 1 GiB (SECURITY_INVENTORY Rec. 5)

🤖 Prepared with Claude Code