### PR TITLE
Feature: Track E — finite default maxEntrySize for archive extractors (SECURITY_INVENTORY Rec. 3)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -346,24 +346,16 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Zip.Native.decompressAuto](/home/kim/lean-zip/Zip/Native/Gzip.lean:240) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | format-auto dispatch over the three natives above. |
 | [Archive.list](/home/kim/lean-zip/Zip/Archive.lean:497) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | metadata-only; caps CD allocation, not decompressed payload. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:515) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
-| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:515) | `maxEntrySize : UInt64` | `0` | **asymmetric** — FFI: no limit; native: silently upgraded to 256 MiB inside `readEntryData` (see [Zip/Archive.lean:477](/home/kim/lean-zip/Zip/Archive.lean:477)) | per-entry cap on the decompressed payload. |
+| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:515) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap on the decompressed payload. |
 | [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:551) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
-| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:551) | `maxEntrySize : UInt64` | `0` | same asymmetry as `Archive.extract` | per-entry cap. |
-| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:602) | `maxEntrySize : UInt64` | `0` | no limit | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:610](/home/kim/lean-zip/Zip/Tar.lean:610)). No whole-archive cap. |
-| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:714) | `maxEntrySize : UInt64` | `0` | no limit | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |
-| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:768) | `maxEntrySize : UInt64` | `0` | no limit | per-entry cap. |
+| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:551) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap. |
+| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:602) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:610](/home/kim/lean-zip/Zip/Tar.lean:610)). No whole-archive cap. |
+| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:714) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |
+| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:768) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. |
 | [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:768) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | whole-archive tar-buffer cap for the outer native gzip decode. |
 
 ### Known inconsistencies
 
-- **`Archive.readEntryData` per-entry cap asymmetry.** When
-  `maxEntrySize = 0`, the FFI path (`RawDeflate.decompress`) runs
-  unlimited, but the native path (`Zip.Native.Inflate.inflate`)
-  silently upgrades to a hard 256 MiB cap — see the
-  `nativeMax := if maxEntrySize == 0 then 256 * 1024 * 1024 else ...`
-  branch at [Zip/Archive.lean:477](/home/kim/lean-zip/Zip/Archive.lean:477).
-  The same caller argument therefore produces different bomb-rejection
-  behaviour depending on `useNative`.
 - **`Tar.extractTarGz.maxOutputSize` vs. low-level defaults.**
   `Tar.extractTarGzNative` caps the outer gzip decode at 256 MiB,
   mirroring `Zip.Native.GzipDecode.decompress`. But the lower-level
@@ -372,13 +364,6 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
   kind of whole-buffer decompression. A caller copying the
   `Tar.extractTarGz`-style pattern with the FFI decoders gets no
   default protection.
-- **`maxCentralDirSize` vs. `maxEntrySize` semantics.** In
-  `Archive.list` / `Archive.extract` / `Archive.extractFile`, the CD
-  cap defaults to a finite 64 MiB (good), while the per-entry cap
-  defaults to `0 = unlimited` (weak). The mixed semantics are easy to
-  misread — a caller who sees "limits default to sensible values" on
-  the CD side might reasonably assume the entry side is also
-  bounded.
 - **Streaming FFI APIs expose `maxDecompressedSize` but default to
   `0 = no limit`.** `Gzip.decompressStream`, `Gzip.decompressFile`, and
   `RawDeflate.decompressStream` now accept an optional
@@ -413,16 +398,12 @@ issues and the follow-up docstring/default change.
    - The streaming case is the one with no current guard; adding
      the parameter is the only way to expose a cap without
      reading into memory.
-3. **Archive extraction — per-entry cap** —
-   `Archive.extract.maxEntrySize`, `Archive.extractFile.maxEntrySize`,
-   `Tar.extract.maxEntrySize`, `Tar.extractTarGz.maxEntrySize`,
-   `Tar.extractTarGzNative.maxEntrySize`.
-   - Change default from `0` to a finite per-entry cap
-     (suggested: **1 GiB** per entry). `0` continues to mean
-     "no per-entry limit" for callers that opt in.
-   - Remove the silent `0 → 256 MiB` upgrade in
-     `Archive.readEntryData` for the native backend; once the
-     default is finite, the two backends behave identically.
+3. **Archive extraction — per-entry cap** — Executed. The per-entry
+   default on `Archive.extract`, `Archive.extractFile`, `Tar.extract`,
+   `Tar.extractTarGz`, and `Tar.extractTarGzNative` is now `1 GiB`
+   (pass `0` to opt into unlimited mode on the FFI backend), and the
+   silent `0 → 256 MiB` upgrade in `Archive.readEntryData` has been
+   removed. See this PR.
 4. **Archive extraction — whole-archive cap**.
    - Add a new `maxTotalSize : UInt64 := 0` (sum of decompressed
      entries) to `Archive.extract` and the tar extractors. Default

--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -438,11 +438,12 @@ private def listFromHandle (h : IO.FS.Handle) (maxCentralDirSize : Nat := 671088
   parseCentralDir cdBuf 0 cdSize
 
 /-- Read an entry's decompressed data from a file handle by seeking to its local header.
-    `maxEntrySize` limits decompressed entry size (0 = no limit for FFI; the native
-    backend caps at 256 MiB when `maxEntrySize = 0` as a zip-bomb guard).
+    `maxEntrySize` limits decompressed entry size; `0` means no limit on the FFI
+    backend. Both public extractors default `maxEntrySize` to `1 GiB` and
+    always pass the value through explicitly, so this helper has no default.
     When `useNative` is true, uses the pure Lean DEFLATE decompressor and CRC-32. -/
 private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
-    (maxEntrySize : UInt64 := 0) (useNative : Bool := false) : IO ByteArray := do
+    (maxEntrySize : UInt64) (useNative : Bool := false) : IO ByteArray := do
   if maxEntrySize > 0 && entry.uncompressedSize > maxEntrySize then
     throw (IO.userError s!"zip: entry '{label}' uncompressed size ({entry.uncompressedSize}) exceeds limit ({maxEntrySize})")
   -- Span-validate every attacker-controlled read against actual file size.
@@ -510,9 +511,11 @@ private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
     if entry.method == 0 then pure compData
     else if entry.method == 8 then
       if useNative then
-        -- maxEntrySize 0 means "no limit" in FFI; native inflate needs an actual bound
-        let nativeMax := if maxEntrySize == 0 then 256 * 1024 * 1024 else maxEntrySize.toNat
-        match Zip.Native.Inflate.inflate compData nativeMax with
+        -- `Zip.Native.Inflate.inflate` treats `0` as "reject any non-empty
+        -- output", unlike the FFI path where `0` means unlimited. Callers
+        -- that opt into `maxEntrySize := 0` for unlimited FFI decompression
+        -- therefore get an immediate rejection on the native backend.
+        match Zip.Native.Inflate.inflate compData maxEntrySize.toNat with
         | .ok data => pure data
         | .error msg => throw (IO.userError s!"zip: native inflate failed for {label}: {msg}")
       else RawDeflate.decompress compData maxEntrySize
@@ -541,16 +544,15 @@ def list (inputPath : System.FilePath) (maxCentralDirSize : Nat := 67108864) : I
     `0` means unlimited. Overflow raises `IO.userError` containing
     `"zip: central directory too large"`.
 
-    `maxEntrySize` limits each entry's decompressed size. Default `0` means
-    no limit on the FFI backend (bomb-unsafe for untrusted input); the native
-    backend silently caps at 256 MiB when `maxEntrySize = 0` as a zip-bomb
-    guard. Overflow raises `IO.userError` containing
+    `maxEntrySize` limits each entry's decompressed size. Default `1 GiB`
+    per entry; pass `0` to opt out into unlimited mode on the FFI backend.
+    Overflow raises `IO.userError` containing
     `"zip: entry '…' uncompressed size (…) exceeds limit (…)"`.
 
     When `useNative` is true, uses pure Lean decompression (no C FFI).
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def extract (inputPath : System.FilePath) (outDir : System.FilePath)
-    (maxCentralDirSize : Nat := 67108864) (maxEntrySize : UInt64 := 0)
+    (maxCentralDirSize : Nat := 67108864) (maxEntrySize : UInt64 := 1024 * 1024 * 1024)
     (useNative : Bool := false) : IO Unit := do
   IO.FS.withFile inputPath .read fun h => do
     let entries ← listFromHandle h maxCentralDirSize
@@ -577,16 +579,15 @@ def extract (inputPath : System.FilePath) (outDir : System.FilePath)
     `0` means unlimited. Overflow raises `IO.userError` containing
     `"zip: central directory too large"`.
 
-    `maxEntrySize` limits the decompressed entry size. Default `0` means
-    no limit on the FFI backend (bomb-unsafe for untrusted input); the native
-    backend silently caps at 256 MiB when `maxEntrySize = 0` as a zip-bomb
-    guard. Overflow raises `IO.userError` containing
+    `maxEntrySize` limits the decompressed entry size. Default `1 GiB`
+    per entry; pass `0` to opt out into unlimited mode on the FFI backend.
+    Overflow raises `IO.userError` containing
     `"zip: entry '…' uncompressed size (…) exceeds limit (…)"`.
 
     When `useNative` is true, uses pure Lean decompression (no C FFI).
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def extractFile (inputPath : System.FilePath) (filename : String)
-    (maxCentralDirSize : Nat := 67108864) (maxEntrySize : UInt64 := 0)
+    (maxCentralDirSize : Nat := 67108864) (maxEntrySize : UInt64 := 1024 * 1024 * 1024)
     (useNative : Bool := false) : IO ByteArray := do
   IO.FS.withFile inputPath .read fun h => do
     let entries ← listFromHandle h maxCentralDirSize

--- a/Zip/Tar.lean
+++ b/Zip/Tar.lean
@@ -610,10 +610,10 @@ private partial def forEntries (input : IO.FS.Stream)
 /-- Extract a tar archive from input stream to output directory.
     Handles UStar, GNU long name/link, and PAX extended headers.
 
-    `maxEntrySize` (when non-zero) bounds each entry's declared size — checked
-    against the tar header's `e.size` before any payload bytes are read.
-    Default `0` means no per-entry bound (bomb-unsafe without an external
-    total-extracted cap). Overflow raises `IO.userError` containing
+    `maxEntrySize` bounds each entry's declared size — checked against the
+    tar header's `e.size` before any payload bytes are read. Default `1 GiB`
+    per entry; pass `0` to opt out into unlimited mode. Overflow raises
+    `IO.userError` containing
     `"tar: entry '…' size (…) exceeds limit (…)"`. There is no
     library-level cap on total extracted bytes across an archive — many
     small entries can still exhaust disk. See `SECURITY_INVENTORY.md`
@@ -642,7 +642,7 @@ private partial def forEntries (input : IO.FS.Stream)
       crafts `typeflag == '1'` with a malicious `linkname` cannot
       escape `outDir`. -/
 partial def extract (input : IO.FS.Stream) (outDir : System.FilePath)
-    (maxEntrySize : UInt64 := 0)
+    (maxEntrySize : UInt64 := 1024 * 1024 * 1024)
     (maxHeaderSize : Nat := defaultMaxHeaderSize) : IO Unit := do
   forEntries (maxHeaderSize := maxHeaderSize) input fun e => do
     -- Strip trailing slash for path safety check (directories end with "/")
@@ -741,10 +741,10 @@ partial def createTarGz (outputPath : System.FilePath) (dir : System.FilePath)
 /-- Extract a .tar.gz archive.
     True streaming — bounded memory regardless of archive size.
 
-    `maxEntrySize` (when non-zero) bounds each entry's declared size before any
-    payload bytes are read; default `0` means no per-entry bound (bomb-unsafe
-    without an external total-extracted cap). Overflow raises `IO.userError`
-    containing `"tar: entry '…' size (…) exceeds limit (…)"`. There is no
+    `maxEntrySize` bounds each entry's declared size before any payload
+    bytes are read. Default `1 GiB` per entry; pass `0` to opt out into
+    unlimited mode. Overflow raises `IO.userError` containing
+    `"tar: entry '…' size (…) exceeds limit (…)"`. There is no
     outer gzip-stream cap on this variant: streaming FFI gzip has no
     `maxOutputSize` parameter today (the known gap tracked by
     `SECURITY_INVENTORY.md` *Decompression Limit Inventory*, recommendation 2).
@@ -754,7 +754,7 @@ partial def createTarGz (outputPath : System.FilePath) (dir : System.FilePath)
     pseudo-entry. Overflow raises `IO.userError` containing the
     substring `"exceeds maximum header size"`. -/
 partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath)
-    (maxEntrySize : UInt64 := 0)
+    (maxEntrySize : UInt64 := 1024 * 1024 * 1024)
     (maxHeaderSize : Nat := defaultMaxHeaderSize) : IO Unit := do
   IO.FS.withFile inputPath .read fun inH => do
     let inStream := IO.FS.Stream.ofHandle inH
@@ -790,9 +790,9 @@ partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath
     decompressing, so memory usage is O(file_size). Use this when C
     libraries are unavailable.
 
-    `maxEntrySize` (when non-zero) bounds each entry's declared size before any
-    payload bytes are read; default `0` means no per-entry bound (bomb-unsafe
-    without an external total-extracted cap). Overflow raises `IO.userError`
+    `maxEntrySize` bounds each entry's declared size before any payload
+    bytes are read. Default `1 GiB` per entry; pass `0` to opt out into
+    unlimited mode. Overflow raises `IO.userError`
     containing `"tar: entry '…' size (…) exceeds limit (…)"`.
 
     `maxOutputSize` (default 256 MiB) caps the decompressed tar buffer
@@ -808,7 +808,7 @@ partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath
     pseudo-entry. Overflow raises `IO.userError` containing the
     substring `"exceeds maximum header size"`. -/
 partial def extractTarGzNative (inputPath : System.FilePath) (outDir : System.FilePath)
-    (maxEntrySize : UInt64 := 0) (maxOutputSize : Nat := 256 * 1024 * 1024)
+    (maxEntrySize : UInt64 := 1024 * 1024 * 1024) (maxOutputSize : Nat := 256 * 1024 * 1024)
     (maxHeaderSize : Nat := defaultMaxHeaderSize) : IO Unit := do
   let gzData ← IO.FS.readBinFile inputPath
   let tarData ← match Zip.Native.GzipDecode.decompress gzData maxOutputSize with

--- a/ZipTest/ZipFixtures.lean
+++ b/ZipTest/ZipFixtures.lean
@@ -167,8 +167,11 @@ def ZipTest.ZipFixtures.tests : IO Unit := do
   let oversizedZ64UExtractDir : System.FilePath :=
     "/tmp/lean-zip-fixture-oversized-zip64-uncompressed-size-extract"
   IO.FS.createDirAll oversizedZ64UExtractDir
+  -- Opt out of the per-entry cap (default 1 GiB) so the 1-EiB uncompressedSize
+  -- does not trip "exceeds limit" before the LH ZIP64 parse — this fixture
+  -- specifically exercises the `truncated ZIP64 local extra field` path.
   assertThrows "ZIP malformed (oversized-zip64-uncompressed-size.zip)"
-    (Archive.extract oversizedZ64UPath oversizedZ64UExtractDir)
+    (Archive.extract oversizedZ64UPath oversizedZ64UExtractDir (maxEntrySize := 0))
     "truncated ZIP64 local extra field"
 
   -- cd-lh-method-mismatch.zip: 122-byte stored ZIP whose CD advertises

--- a/progress/2026-04-22T064210Z_d536c981.md
+++ b/progress/2026-04-22T064210Z_d536c981.md
@@ -1,0 +1,114 @@
+# Track E — finite default maxEntrySize for archive extractors (Rec. 3)
+
+- Date/time: 2026-04-22T06:42 UTC
+- Session: `d536c981-1ba4-4e8d-a35a-972fb95a5757` (feature)
+- Issue: #1611
+
+## Accomplished
+
+- Raised the default `maxEntrySize` on all five archive extractors
+  from `0` (unlimited) to `1 * 1024^3` (1 GiB): `Archive.extract`,
+  `Archive.extractFile`, `Tar.extract`, `Tar.extractTarGz`,
+  `Tar.extractTarGzNative`. `0` still opts into unlimited mode on the
+  FFI backend.
+- Removed the silent `0 → 256 MiB` upgrade in
+  `Archive.readEntryData`'s native branch. Both FFI and native paths
+  now pass the caller's `maxEntrySize` through directly, eliminating
+  the bomb-asymmetry between the two backends.
+- Documented the remaining asymmetry at the native-inflate call site:
+  `Zip.Native.Inflate.inflate` treats `0` as "reject any non-empty
+  output", so an opt-in `maxEntrySize := 0` unlimited caller on the
+  native backend will see an immediate rejection. This is deliberate
+  and captured in both the source comment and the inventory's Default
+  column.
+- Dropped the private `readEntryData` helper's unused `:= 0` default;
+  both call sites in the module always pass `maxEntrySize` through
+  explicitly, so the grep invariant
+  `grep -n 'maxEntrySize : UInt64 := 0' Zip/*.lean` now matches zero
+  lines.
+- Updated docstrings on all five public extractors to the new
+  "Default `1 GiB` per entry; pass `0` to opt out into unlimited
+  mode on the FFI backend" wording. The P2.4 template (error
+  substring, `SECURITY_INVENTORY.md` cross-reference, ZIP64/PAX
+  notes) is preserved verbatim at each site.
+
+## Inventory reconciliation
+
+- `SECURITY_INVENTORY.md` § Known inconsistencies — removed both the
+  "`Archive.readEntryData` per-entry cap asymmetry" bullet and the
+  "`maxCentralDirSize` vs. `maxEntrySize` semantics" bullet. Both
+  concerns are resolved once the per-entry default is finite.
+- § Recommended policy item 3 — rewritten as the "Executed" past-tense
+  one-liner matching the shape hinted in the issue body.
+- Decompression Limit Inventory table (§ Decompression limits,
+  `Archive.extract` / `Archive.extractFile` / `Tar.extract` /
+  `Tar.extractTarGz` / `Tar.extractTarGzNative` rows) — updated
+  Default and Unlimited columns to `1 * 1024^3` (1 GiB) / "pass `0`
+  for unlimited", and removed the asymmetry notes. Beyond the three
+  prose edits the issue listed, but necessary for inventory
+  coherence: leaving the table entries at `0` would contradict the
+  new reality directly.
+- § Missing work contained no sub-bullet cross-referencing the silent
+  upgrade or per-entry default, so no changes there.
+
+## Test adjustment
+
+- `ZipTest/ZipFixtures.lean`: the
+  `oversized-zip64-uncompressed-size.zip` malformed-archive fixture
+  sets the CD-parsed `uncompressedSize` to `0x1000000000000000` (≈ 1
+  EiB) specifically to exercise the LH ZIP64 parse path, which rejects
+  with `"truncated ZIP64 local extra field"`. With the new finite
+  default, the 1 GiB per-entry cap fires first (`"exceeds limit"`),
+  masking the LH parse check the fixture targets. Fixed by passing
+  `maxEntrySize := 0` explicitly at the test call site so the test
+  continues to exercise the intended parser path. Added a two-line
+  comment at the call site explaining why.
+
+## Decisions
+
+- **Pre-existing line drift in the inventory table.** Lines like
+  `Zip/Archive.lean:515` in the Decompression Limit Inventory rows
+  are already stale before this change
+  (`scripts/check-inventory-links.sh` flags a number of them). I did
+  not touch those line numbers in this PR — re-numbering the inventory
+  is separate maintenance work and would have inflated the diff. The
+  table still reads correctly as a current-state summary; only the
+  clickable file-line links are stale.
+- **No compile-time smoke probe.** The issue made this optional. The
+  grep invariants listed in the issue's verification block
+  (`grep -nc 'maxEntrySize : UInt64 := 1024' Zip/Archive.lean → 2`
+  etc.) already catch the "silently flipped back to 0" regression,
+  and a naive `#check` does not actually assert the default value at
+  the type level because `optParam` reduces away. Skipping avoids a
+  ceremonial probe whose load-bearing content is the grep script.
+
+## Verification
+
+- `lake build -R` clean (191/191 jobs).
+- `lake exe test` passes (all suites green, including the adjusted
+  `ZipFixtures` test).
+- `grep -rc sorry Zip/` → `0` (all modules).
+- `grep -n 'maxEntrySize : UInt64 := 0' Zip/*.lean` → no matches.
+- `grep -nc 'maxEntrySize : UInt64 := 1024' Zip/Archive.lean` → `2`.
+- `grep -nc 'maxEntrySize : UInt64 := 1024' Zip/Tar.lean` → `3`.
+- `grep -n 'nativeMax := if maxEntrySize == 0' Zip/Archive.lean` →
+  no matches (silent upgrade removed).
+- `grep -n 'native backend caps at 256 MiB' Zip/Archive.lean` →
+  no matches (docstrings reconciled).
+- `grep -n 'per-entry cap asymmetry' SECURITY_INVENTORY.md` →
+  no matches (inconsistency bullet deleted).
+
+## Diff scope
+
+`Zip/Archive.lean`, `Zip/Tar.lean`, `SECURITY_INVENTORY.md`,
+`ZipTest/ZipFixtures.lean` (one test call-site fix), plus this
+progress entry. No changes to `Zip/Native/**`, `Zip/Basic.lean`,
+`Zip/Gzip.lean`, `Zip/RawDeflate.lean`, `c/**`, `PLAN.md`, or
+`.claude/CLAUDE.md`.
+
+## Quality metric deltas
+
+- `sorry` count in `Zip/`: 0 → 0 (unchanged).
+- Test suite: green → green.
+- Bomb-asymmetry backends (`useNative` toggle changing bomb-rejection
+  behaviour): present → removed.


### PR DESCRIPTION
Closes #1611

Session: `d536c981-1ba4-4e8d-a35a-972fb95a5757`

fd4a43c feat: archive extractors — finite 1 GiB default maxEntrySize

🤖 Prepared with Claude Code