### PR TITLE
Feature: Track E — finite default maxDecompressedSize on FFI whole-buffer decoders (SECURITY_INVENTORY Rec. 1)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -334,9 +334,9 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 
 | Entry point | Parameter | Default | Semantics of 0 | Notes |
 |---|---|---|---|---|
-| [Zlib.decompress](/home/kim/lean-zip/Zip/Basic.lean:15) (FFI) | `maxDecompressedSize : UInt64` | `0` | no limit | whole-buffer zlib (RFC 1950). Only API with a committed bomb-limit regression test today ([ZipTest/Zlib.lean:14-19](/home/kim/lean-zip/ZipTest/Zlib.lean:14)). |
-| [Gzip.decompress](/home/kim/lean-zip/Zip/Gzip.lean:16) (FFI) | `maxDecompressedSize : UInt64` | `0` | no limit | whole-buffer gzip (RFC 1952) + auto-zlib. No bomb-limit regression test. |
-| [RawDeflate.decompress](/home/kim/lean-zip/Zip/RawDeflate.lean:20) (FFI) | `maxDecompressedSize : UInt64` | `0` | no limit | whole-buffer raw DEFLATE (ZIP method 8). No bomb-limit regression test. |
+| [Zlib.decompress](/home/kim/lean-zip/Zip/Basic.lean:15) (FFI) | `maxDecompressedSize : UInt64` | `1073741824` (1 GiB) | no limit (opt-in) | whole-buffer zlib (RFC 1950). Bomb-limit regression test at [ZipTest/Zlib.lean:17-22](/home/kim/lean-zip/ZipTest/Zlib.lean:17). |
+| [Gzip.decompress](/home/kim/lean-zip/Zip/Gzip.lean:16) (FFI) | `maxDecompressedSize : UInt64` | `1073741824` (1 GiB) | no limit (opt-in) | whole-buffer gzip (RFC 1952) + auto-zlib. Bomb-limit regression test at [ZipTest/Gzip.lean:18-23](/home/kim/lean-zip/ZipTest/Gzip.lean:18). |
+| [RawDeflate.decompress](/home/kim/lean-zip/Zip/RawDeflate.lean:20) (FFI) | `maxDecompressedSize : UInt64` | `1073741824` (1 GiB) | no limit (opt-in) | whole-buffer raw DEFLATE (ZIP method 8). Bomb-limit regression test at [ZipTest/RawDeflate.lean:17-22](/home/kim/lean-zip/ZipTest/RawDeflate.lean:17). |
 | [Gzip.decompressStream](/home/kim/lean-zip/Zip/Gzip.lean:83) (FFI) | `maxDecompressedSize : UInt64` | `0` | no limit | streaming via `IO.Ref UInt64` counter on pushed output; cap check fires before `output.write`, so the already-written prefix is ≤ `maxDecompressedSize` bytes. Landed by PR #1610. |
 | [Gzip.decompressFile](/home/kim/lean-zip/Zip/Gzip.lean:123) (FFI) | `maxDecompressedSize : UInt64` | `0` | no limit | thin wrapper forwarding to `decompressStream`; default still unlimited (bomb-unsafe for untrusted input written to disk). Landed by PR #1610. |
 | [RawDeflate.decompressStream](/home/kim/lean-zip/Zip/RawDeflate.lean:56) (FFI) | `maxDecompressedSize : UInt64` | `0` | no limit | streaming raw DEFLATE; same counter/check structure as `Gzip.decompressStream`. Landed by PR #1610. |
@@ -356,14 +356,6 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 
 ### Known inconsistencies
 
-- **`Tar.extractTarGz.maxOutputSize` vs. low-level defaults.**
-  `Tar.extractTarGzNative` caps the outer gzip decode at 256 MiB,
-  mirroring `Zip.Native.GzipDecode.decompress`. But the lower-level
-  FFI APIs — `Zlib.decompress`, `Gzip.decompress`,
-  `RawDeflate.decompress` — default to **unlimited** for the same
-  kind of whole-buffer decompression. A caller copying the
-  `Tar.extractTarGz`-style pattern with the FFI decoders gets no
-  default protection.
 - **Streaming FFI APIs expose `maxDecompressedSize` but default to
   `0 = no limit`.** `Gzip.decompressStream`, `Gzip.decompressFile`, and
   `RawDeflate.decompressStream` now accept an optional
@@ -386,11 +378,8 @@ issues and the follow-up docstring/default change.
 
 1. **Low-level whole-buffer FFI decoders** — `Zlib.decompress`,
    `Gzip.decompress`, `RawDeflate.decompress`.
-   - Keep `0 = no limit` as the literal encoding, but change the
-     **default** to a finite value (suggested: **256 MiB**, matching
-     the native decoders).
-   - Callers that genuinely need unlimited mode pass `0` explicitly
-     — the intent is visible at the call site.
+   Executed — the three FFI whole-buffer decoders now default to 1 GiB;
+   `0` continues to mean unlimited on the opt-in path. See this PR.
 2. **Streaming FFI decoders** — `Gzip.decompressStream`,
    `Gzip.decompressFile`, `RawDeflate.decompressStream`.
    - Add an optional `maxDecompressedSize : UInt64 := 256 * 1024^2`

--- a/Zip/Basic.lean
+++ b/Zip/Basic.lean
@@ -7,11 +7,12 @@ namespace Zlib
 opaque compress (data : @& ByteArray) (level : UInt8 := 6) : IO ByteArray
 
 /-- Decompress zlib-compressed data.
-    `maxDecompressedSize` caps output size; default `0` means unlimited
-    (bomb-unsafe for untrusted input). Overflow raises `IO.userError`
-    containing `"decompressed size exceeds limit"`.
+    `maxDecompressedSize` caps output size; default 1 GiB; pass `0` to opt
+    into unlimited mode (bomb-unsafe for untrusted input). Overflow raises
+    `IO.userError` containing `"decompressed size exceeds limit"`.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 @[extern "lean_zlib_decompress"]
-opaque decompress (data : @& ByteArray) (maxDecompressedSize : UInt64 := 0) : IO ByteArray
+opaque decompress (data : @& ByteArray)
+    (maxDecompressedSize : UInt64 := 1024 * 1024 * 1024) : IO ByteArray
 
 end Zlib

--- a/Zip/Gzip.lean
+++ b/Zip/Gzip.lean
@@ -9,11 +9,13 @@ opaque compress (data : @& ByteArray) (level : UInt8 := 6) : IO ByteArray
 
 /-- Decompress gzip data. Also handles concatenated gzip streams and raw zlib data.
     `maxDecompressedSize` caps the *total* output across all concatenated members;
-    default `0` means unlimited (bomb-unsafe for untrusted input). Overflow raises
-    `IO.userError` containing `"decompressed size exceeds limit"`.
+    default 1 GiB; pass `0` to opt into unlimited mode (bomb-unsafe for untrusted
+    input). Overflow raises `IO.userError` containing
+    `"decompressed size exceeds limit"`.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 @[extern "lean_gzip_decompress"]
-opaque decompress (data : @& ByteArray) (maxDecompressedSize : UInt64 := 0) : IO ByteArray
+opaque decompress (data : @& ByteArray)
+    (maxDecompressedSize : UInt64 := 1024 * 1024 * 1024) : IO ByteArray
 
 -- Streaming compression
 

--- a/Zip/RawDeflate.lean
+++ b/Zip/RawDeflate.lean
@@ -12,12 +12,13 @@ namespace RawDeflate
 opaque compress (data : @& ByteArray) (level : UInt8 := 6) : IO ByteArray
 
 /-- Decompress raw deflate data.
-    `maxDecompressedSize` caps output size; default `0` means unlimited
-    (bomb-unsafe for untrusted input). Overflow raises `IO.userError`
-    containing `"decompressed size exceeds limit"`.
+    `maxDecompressedSize` caps output size; default 1 GiB; pass `0` to opt
+    into unlimited mode (bomb-unsafe for untrusted input). Overflow raises
+    `IO.userError` containing `"decompressed size exceeds limit"`.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 @[extern "lean_raw_deflate_decompress"]
-opaque decompress (data : @& ByteArray) (maxDecompressedSize : UInt64 := 0) : IO ByteArray
+opaque decompress (data : @& ByteArray)
+    (maxDecompressedSize : UInt64 := 1024 * 1024 * 1024) : IO ByteArray
 
 -- Streaming raw deflate. Reuses Gzip.DeflateState/InflateState types
 -- since the underlying z_stream state is format-agnostic after init.

--- a/ZipTest/Gzip.lean
+++ b/ZipTest/Gzip.lean
@@ -3,6 +3,9 @@ import ZipTest.Helpers
 /-! Tests for gzip compression/decompression: streaming, file I/O, compression levels,
     and concatenated streams. -/
 
+-- Compile-time probe: FFI whole-buffer default is 1 GiB (SECURITY_INVENTORY Rec. 1).
+example (d : ByteArray) : Gzip.decompress d = @Gzip.decompress d (1024 * 1024 * 1024) := rfl
+
 def ZipTest.Gzip.tests : IO Unit := do
   let big ← mkTestData
 

--- a/ZipTest/RawDeflate.lean
+++ b/ZipTest/RawDeflate.lean
@@ -2,6 +2,9 @@ import ZipTest.Helpers
 
 /-! Tests for raw DEFLATE compression/decompression with streaming roundtrip verification. -/
 
+-- Compile-time probe: FFI whole-buffer default is 1 GiB (SECURITY_INVENTORY Rec. 1).
+example (d : ByteArray) : RawDeflate.decompress d = @RawDeflate.decompress d (1024 * 1024 * 1024) := rfl
+
 def ZipTest.RawDeflate.tests : IO Unit := do
   let big ← mkTestData
 

--- a/ZipTest/Zlib.lean
+++ b/ZipTest/Zlib.lean
@@ -2,6 +2,9 @@ import ZipTest.Helpers
 
 /-! Tests for zlib compression/decompression with decompression size limits and roundtrip verification. -/
 
+-- Compile-time probe: FFI whole-buffer default is 1 GiB (SECURITY_INVENTORY Rec. 1).
+example (d : ByteArray) : Zlib.decompress d = @Zlib.decompress d (1024 * 1024 * 1024) := rfl
+
 def ZipTest.Zlib.tests : IO Unit := do
   let big ← mkTestData
 

--- a/progress/2026-04-22T07-10-32_0aefbf8e.md
+++ b/progress/2026-04-22T07-10-32_0aefbf8e.md
@@ -1,0 +1,109 @@
+# Progress: finite default `maxDecompressedSize` on FFI whole-buffer decoders (#1613)
+
+**Session**: `0aefbf8e-437b-4be4-acf0-ba21682ab579` (feature)
+**Date**: 2026-04-22 (UTC)
+**Issue**: #1613 — Track E, SECURITY_INVENTORY Rec. 1
+**Branch**: `agent/0aefbf8e`
+
+## Summary
+
+Raised the `maxDecompressedSize` default on the three FFI whole-buffer
+decoders (`Zlib.decompress`, `Gzip.decompress`, `RawDeflate.decompress`)
+from `0` (unlimited) to `1024 * 1024 * 1024` (1 GiB). Callers that need
+unlimited mode now opt in explicitly with `(maxDecompressedSize := 0)`.
+The "0 = no limit" semantics at the FFI/C boundary are unchanged — the
+change is purely the Lean-level default.
+
+This aligns the three public whole-buffer FFI surfaces with the
+`Zip.Native.*` 1 GiB defaults (landed in PR #1617 for Rec. 5) and the
+`Archive.extract` / `Archive.extractFile` per-entry 1 GiB target
+(#1611 / PR #1618).
+
+## Deliverables
+
+1. ✅ **FFI defaults** — `Zip/Basic.lean:16`, `Zip/Gzip.lean:18`,
+   `Zip/RawDeflate.lean:21` all now default to `1024 * 1024 * 1024`.
+   Docstrings updated to `"default 1 GiB; pass `0` to opt into
+   unlimited mode (bomb-unsafe for untrusted input)"` while preserving
+   the P2.4 docstring template from PR #1573 (RFC cross-reference,
+   `"decompressed size exceeds limit"` substring mention,
+   `SECURITY_INVENTORY.md` link).
+2. ✅ **SECURITY_INVENTORY reconciliation** — three prose edits:
+   - Rows 337–339: `Default = 1073741824 (1 GiB)`,
+     `Semantics of 0 = no limit (opt-in)`. The `Zlib.decompress` row's
+     "Only API with a committed bomb-limit regression test" aside is
+     dropped since `ZipTest/Gzip.lean` and `ZipTest/RawDeflate.lean`
+     now both have bomb-limit tests (PR #1560); all three rows now
+     point at their respective bomb-limit tests.
+   - Removed the `Tar.extractTarGz.maxOutputSize` vs. low-level
+     defaults bullet from *Known inconsistencies* — the inconsistency
+     is resolved now that the FFI whole-buffer decoders agree with the
+     native/archive 1 GiB family.
+   - Recommended policy item 1 marked "Executed" with the past-tense
+     one-liner matching the shape used for PR #1590 / #1585 / #1617.
+3. ✅ **Compile-time signature probes** — added a one-line
+   `example` to each of `ZipTest/{Zlib,Gzip,RawDeflate}.lean` that
+   unifies `Xxx.decompress d` against the explicit
+   `@Xxx.decompress d (1024 * 1024 * 1024)` form via `rfl`. If a future
+   refactor silently flips the default back to `0` (or any other
+   value), the `rfl` elaboration fails at compile time with a clear
+   "Type mismatch" error — I verified this by temporarily reverting the
+   `Zip/Basic.lean` default to `0` and confirming `lake build
+   ZipTest.Zlib` fails. No runtime-near-1-GiB test was added, per the
+   issue's explicit guidance.
+
+## Scope discipline — not touched
+
+- `Gzip.decompressStream`, `Gzip.decompressFile`,
+  `RawDeflate.decompressStream` (streaming FFI, Rec. 2 — separate
+  issue; their `UInt64 := 0` defaults remain).
+- `Zip/Native/**` (Rec. 5, landed in PR #1617).
+- `Archive.extract` / `Archive.extractFile` / `Tar.extract*` per-entry
+  caps (Rec. 3, PR #1618).
+- `maxTotalSize` (Rec. 4, #1621).
+- `c/zlib_ffi.c` — the C-side semantics of `0 = no limit` are reused
+  verbatim.
+- `PLAN.md`, `.claude/CLAUDE.md` (off-limits).
+- Error-substring catalogue — no new substrings introduced.
+
+## Verification
+
+- `lake build` clean (191/191).
+- `lake exe test` passes unchanged — no test fixture exceeds 1 GiB.
+- `grep -rc sorry Zip/` → `0` (unchanged from starting commit
+  `35ac9b7`).
+- `grep -n 'maxDecompressedSize : UInt64 := 0' Zip/Basic.lean
+  Zip/Gzip.lean Zip/RawDeflate.lean` → three streaming matches only
+  (`Zip/Gzip.lean:86`, `:126`, `Zip/RawDeflate.lean:58`).
+- `grep -n 'maxDecompressedSize : UInt64 := 1024 \* 1024 \* 1024'
+  Zip/Basic.lean Zip/Gzip.lean Zip/RawDeflate.lean` → three matches
+  (`Zip/Basic.lean:16`, `Zip/Gzip.lean:18`,
+  `Zip/RawDeflate.lean:21`).
+- `grep -nc 'default 1 GiB' Zip/Basic.lean Zip/Gzip.lean
+  Zip/RawDeflate.lean` → `1 1 1` (one docstring per file).
+- `grep -n 'maxOutputSize. vs. low-level defaults'
+  SECURITY_INVENTORY.md` → no matches.
+- Compile-time probes survive a simulated flip: reverting
+  `Zip/Basic.lean:16` back to `0` causes `lake build ZipTest.Zlib`
+  to fail with a `Type mismatch` error on the `rfl`, confirming the
+  probe's detection property.
+
+## Quality metric deltas
+
+- Sorry count: 0 → 0.
+- Diff size: 29 insertions, 27 deletions across 7 files (56 lines
+  total, under the issue's 60-line target).
+
+## Notes for follow-ups
+
+- The *Missing work* paragraph in `SECURITY_INVENTORY.md` at line ~460
+  still says "No bomb-limit regression test yet exists for any FFI
+  decompression default except `Zlib.decompress`". This is stale —
+  PR #1560 added coverage for `Gzip.decompress` and
+  `RawDeflate.decompress`. Out of scope for this issue (the three
+  prose edits listed in the plan are all I touched), but worth a
+  drift-cleanup pass in a future inventory-maintenance PR.
+- The "Recommended policy" item 2 prose still suggests `256 * 1024^2`
+  for the streaming FFI default. That's Rec. 2's concern; any revisit
+  of the streaming default should reconsider the number in light of
+  the 1 GiB family the whole-buffer path now uses.

--- a/progress/2026-04-22T07-29-43_8e74071c.md
+++ b/progress/2026-04-22T07-29-43_8e74071c.md
@@ -1,0 +1,98 @@
+# 2026-04-22T07-29-43 — session 8e74071c — feature (PR-fix)
+
+Session type: feature / rebase-fix
+Issue: [#1624 — Fix PR #1623 rebase onto master (SECURITY_INVENTORY.md conflict)](https://github.com/kim-em/lean-zip/issues/1624)
+PR target: [#1623 — Track E Rec. 1 FFI whole-buffer 1 GiB default](https://github.com/kim-em/lean-zip/pull/1623)
+
+## Conflict shape
+
+`git rebase origin/master` on `agent/0aefbf8e` reported exactly one
+conflicted file: `SECURITY_INVENTORY.md`. The single hunk spanned the
+*Known inconsistencies* section:
+
+- HEAD (master) side contained the `Tar.extractTarGz.maxOutputSize` vs.
+  low-level defaults bullet — the one this PR's own patch deletes.
+- c102fc1 (PR) side contained two older bullets
+  (`Archive.readEntryData` per-entry cap asymmetry;
+  `maxCentralDirSize` vs. `maxEntrySize` semantics) that PR
+  [#1618](https://github.com/kim-em/lean-zip/pull/1618) had already
+  removed on master.
+
+`Zip/Basic.lean`, `Zip/Gzip.lean`, `Zip/RawDeflate.lean`, and the three
+`ZipTest/` probes applied cleanly — no conflict on the functional payload.
+
+## Resolution shape
+
+- *Public decompression / extraction APIs* (rows 337–339): post-rebase
+  table has the PR's values (1 GiB default, `no limit (opt-in)`, test
+  pointers). Rows 340–355 stay verbatim from master (touched by
+  #1610/#1617/#1618 respectively; this PR doesn't retouch them).
+- *Known inconsistencies*: deleted the whole conflict block.
+  - The `Tar.extractTarGz.maxOutputSize` vs. low-level bullet is
+    removed (the PR's intent — Rec. 1 landing resolves the
+    inconsistency).
+  - The two c102fc1-side bullets (`Archive.readEntryData`,
+    `maxCentralDirSize`) are *not* reintroduced; they were cleaned up
+    by #1618.
+  - The *Streaming FFI APIs expose `maxDecompressedSize`* bullet (added
+    by #1610) stays in place — Rec. 2's default change is still
+    unshipped.
+- *Recommended policy* item 1 was already rewritten as the "Executed —
+  …. See this PR." form by the PR's own patch; the rebase took that
+  hunk cleanly.
+
+## Minor doc touch-up
+
+The three test-pointer citations in rows 337–339 had stale line ranges
+on the original PR branch (`ZipTest/Zlib.lean:14-19`,
+`ZipTest/Gzip.lean:14-20`, `ZipTest/RawDeflate.lean:13-19`). The three
+compile-time signature probes that the PR adds to the top of each test
+file shift the bomb-limit regression test blocks down by three lines.
+Updated to the current line ranges:
+
+- `ZipTest/Zlib.lean:17-22`
+- `ZipTest/Gzip.lean:18-23`
+- `ZipTest/RawDeflate.lean:17-22`
+
+`scripts/check-inventory-links.sh` still emits three warnings on these
+anchors because the heuristic looks for the quoted substrings
+`maxDecompressedSize : UInt64` / `1073741824` — the tests use the
+inferred-type form `(maxDecompressedSize := 10)`. This is a
+pre-existing heuristic mismatch (same warning shape existed for the
+Zlib row on master), not a regression from this PR. The script exits 0.
+
+## Verification
+
+- `lake build -R` clean (fresh worktree needed `-R` per the
+  agent-pr-recovery skill's "Fresh-worktree `lake build` needs `-R`"
+  note).
+- `lake exe test` — all tests pass, including the three compile-time
+  probe `example … := rfl` statements in
+  `ZipTest/{Zlib,Gzip,RawDeflate}.lean`.
+- `scripts/check-inventory-links.sh` exits 0 (59 warnings vs. 57 on
+  master; the +2 delta is the Gzip / RawDeflate test-pointer citations
+  introduced by the PR, same heuristic mismatch as the pre-existing
+  Zlib anchor).
+- `git diff origin/master -- SECURITY_INVENTORY.md` shows exactly the
+  three changes required by the issue:
+  - Rows 337–339 FFI default flip.
+  - One bullet removal (`Tar.extractTarGz.maxOutputSize`).
+  - One paragraph rewrite (Rec. 1 "Executed").
+
+## Quality invariants
+
+- `grep -rc sorry Zip/` — 0 sorries (unchanged).
+- `lake build` clean.
+- `lake exe test` passes.
+
+## Workflow notes
+
+- Amended the line-number touch-up into the rebased `c102fc1`
+  commit rather than creating a second commit. The two edits are
+  both part of the rebase doc-merge — keeping them in one commit
+  preserves the single-commit shape of the PR.
+- Progress entry committed and pushed together with the rebased
+  commit in a single `--force-with-lease` push. This follows the
+  "progress-entry-first" pattern documented in the agent-pr-recovery
+  skill ("Auto-merge race: ride-along progress entries") — both
+  commits land on the branch before auto-merge fires.


### PR DESCRIPTION
Closes #1613

Session: `0aefbf8e-437b-4be4-acf0-ba21682ab579`

c102fc1 feat: default FFI whole-buffer decoders to 1 GiB maxDecompressedSize (#1613)

🤖 Prepared with Claude Code