### PR TITLE
Feature: Track E P5.3 — migrate Zip/Archive.lean and Zip/Tar.lean callers to P5.1 bounded-read helpers

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -448,9 +448,8 @@ private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
     throw (IO.userError s!"zip: entry '{label}' uncompressed size ({entry.uncompressedSize}) exceeds limit ({maxEntrySize})")
   -- Span-validate every attacker-controlled read against actual file size.
   let fileSize ← Handle.fileSize h
-  assertSpanInFile fileSize entry.localOffset 30 s!"local header for {label}"
-  Handle.seek h entry.localOffset
-  let localHdr ← readExact h 30 s!"local header for {label}"
+  let localHdr ← readBoundedSpanFromHandle h fileSize entry.localOffset 30
+    s!"local header for {label}"
   unless Binary.readUInt32LE localHdr 0 == sigLocal do
     throw (IO.userError s!"zip: bad local header signature for {label}")
   -- Parse the remaining local-header fields for CD/LH consistency checks.
@@ -463,17 +462,19 @@ private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
   let stdLocalUncompSize := Binary.readUInt32LE localHdr 22
   let nameLen := (Binary.readUInt16LE localHdr 26).toNat
   let extraLen := (Binary.readUInt16LE localHdr 28).toNat
-  -- Verify the full local data span (header + name + extra + compressed payload)
-  -- lies within the file before any further `Handle.read` is driven by
-  -- untrusted metadata. `nameLen + extraLen` is bounded by `2 * UInt16.max`,
-  -- so the first addend cannot overflow `UInt64`; the second call bounds
-  -- `entry.compressedSize` against the remaining file tail.
+  -- Verify the compressed-payload span lies within the file before the
+  -- `readBoundedSpanFromHandle` calls below are driven by untrusted metadata.
+  -- `nameLen + extraLen` is bounded by `2 * UInt16.max`, so `headerAndNames`
+  -- cannot overflow `UInt64`; this assertion bounds `entry.compressedSize`
+  -- against the remaining file tail. The `readBoundedSpanFromHandle` for the
+  -- compressed payload re-asserts the same span internally — that redundancy
+  -- is harmless and keeps the helper interface uniform across the three reads.
   let headerAndNames : UInt64 := 30 + nameLen.toUInt64 + extraLen.toUInt64
-  assertSpanInFile fileSize entry.localOffset headerAndNames
-    s!"local name+extra for {label}"
   assertSpanInFile fileSize (entry.localOffset + headerAndNames)
     entry.compressedSize s!"local data span for {label}"
-  let nameAndExtra ← readExact h (nameLen + extraLen) s!"local name+extra for {label}"
+  let nameAndExtra ← readBoundedSpanFromHandle h fileSize
+    (entry.localOffset + 30) (nameLen.toUInt64 + extraLen.toUInt64)
+    s!"local name+extra for {label}"
   -- Resolve the effective local sizes through any ZIP64 local extra block.
   -- Local headers do not carry the file-offset field, so pass `stdOffset = 0`
   -- to `parseZip64Extra` and discard the offset slot it returns.
@@ -506,7 +507,9 @@ private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
     unless localCrc == entry.crc32 do
       throw (IO.userError
         s!"zip: crc32 mismatch between CD and local header for {label} (CD={entry.crc32}, LH={localCrc})")
-  let compData ← readExact h entry.compressedSize.toNat s!"compressed data for {label}"
+  let compData ← readBoundedSpanFromHandle h fileSize
+    (entry.localOffset + headerAndNames) entry.compressedSize
+    s!"compressed data for {label}"
   let fileData ←
     if entry.method == 0 then pure compData
     else if entry.method == 8 then

--- a/Zip/Tar.lean
+++ b/Zip/Tar.lean
@@ -569,7 +569,8 @@ private partial def forEntries (input : IO.FS.Stream)
     | some entry =>
       -- GNU long name: read data as the name for the next entry
       if entry.typeflag == typeGnuLongName then
-        let nameData ← readEntryData input entry.size.toNat maxHeaderSize
+        let nameData ← readBoundedEntryData input entry.size.toNat maxHeaderSize
+          "GNU long name"
         let nameBytes := stripTrailingNuls nameData
         let name := match String.fromUTF8? nameBytes with
           | some s => s
@@ -578,7 +579,8 @@ private partial def forEntries (input : IO.FS.Stream)
         continue
       -- GNU long link: read data as the linkname for the next entry
       if entry.typeflag == typeGnuLongLink then
-        let linkData ← readEntryData input entry.size.toNat maxHeaderSize
+        let linkData ← readBoundedEntryData input entry.size.toNat maxHeaderSize
+          "GNU long link"
         let linkBytes := stripTrailingNuls linkData
         let link := match String.fromUTF8? linkBytes with
           | some s => s
@@ -587,12 +589,14 @@ private partial def forEntries (input : IO.FS.Stream)
         continue
       -- PAX extended header: parse records for the next entry
       if entry.typeflag == typePaxExtended then
-        let paxData ← readEntryData input entry.size.toNat maxHeaderSize
+        let paxData ← readBoundedEntryData input entry.size.toNat maxHeaderSize
+          "PAX extended header"
         paxOverrides := some (parsePaxRecords paxData)
         continue
       -- PAX global header: skip (we don't track global state)
       if entry.typeflag == typePaxGlobal then
-        let _ ← readEntryData input entry.size.toNat maxHeaderSize
+        let _ ← readBoundedEntryData input entry.size.toNat maxHeaderSize
+          "PAX global header"
         continue
       -- Apply GNU/PAX overrides
       let mut e := entry

--- a/ZipTest/TarFixtures.lean
+++ b/ZipTest/TarFixtures.lean
@@ -198,7 +198,7 @@ def ZipTest.TarFixtures.tests : IO Unit := do
     (IO.FS.withFile gnuLnOverPath .read fun h => do
       let _ ← Tar.list (IO.FS.Stream.ofHandle h)
       pure ())
-    "exceeds maximum header size"
+    "exceeds maximum"
 
   let paxExtOverData ← readFixture "tar/malformed/pax-extended-oversized-size.tar"
   let paxExtOverPath ← writeFixtureTmp "pax-extended-oversized-size.tar" paxExtOverData
@@ -206,7 +206,7 @@ def ZipTest.TarFixtures.tests : IO Unit := do
     (IO.FS.withFile paxExtOverPath .read fun h => do
       let _ ← Tar.list (IO.FS.Stream.ofHandle h)
       pure ())
-    "exceeds maximum header size"
+    "exceeds maximum"
 
   -- === TAR security fixtures ===
 

--- a/plans/track-e-current-audit-checklist.md
+++ b/plans/track-e-current-audit-checklist.md
@@ -184,12 +184,21 @@ Targets:
 - [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:341)
 - [Zip/Tar.lean](/home/kim/lean-zip/Zip/Tar.lean:169)
 
-- [ ] Introduce proof-friendly helper functions for bounded reads and
+- [x] Introduce proof-friendly helper functions for bounded reads and
   validated spans.
+  (PR #1608 landed `readBoundedSpanFromHandle`,
+  `readBoundedExactFromHandle`, `readBoundedExactFromStream`, and
+  `readBoundedEntryData` plus smoke coverage in
+  `ZipTest/BoundedReadTest.lean`.)
 - [ ] Prove simple lemmas of the form:
   validated span implies requested read length is file-bounded.
-- [ ] Use those helpers so parser hardening is easier to audit and less
+- [x] Use those helpers so parser hardening is easier to audit and less
   likely to regress than open-coded checks.
+  (This PR migrated the three `Zip/Archive.lean` `readEntryData`
+  `assertSpanInFile` + seek + `readExact` chains to
+  `readBoundedSpanFromHandle`, and the four GNU/PAX
+  `Zip/Tar.lean` `readEntryData` callsites to
+  `readBoundedEntryData`.)
 
 ## Completion Rule
 

--- a/progress/2026-04-22T07-42-03Z_395ec4a0.md
+++ b/progress/2026-04-22T07-42-03Z_395ec4a0.md
@@ -1,0 +1,108 @@
+# Track E P5.3 — migrate Archive/Tar callers to P5.1 bounded-read helpers
+
+**Date (UTC):** 2026-04-22T07:42Z
+**Session type:** feature
+**Issue:** #1614 — Track E P5.3 caller migration
+**Branch:** `agent/395ec4a0`
+**Quality metric:** sorry count `0 → 0`; `lake build` clean; `lake exe test` passes.
+
+## What landed
+
+Migrated the seven open-coded read sites named in the issue to the
+bounded-read helpers introduced by PR #1608:
+
+| File | Site | Helper |
+|------|------|--------|
+| `Zip/Archive.lean` | local-header span (was :450-453) | `readBoundedSpanFromHandle` |
+| `Zip/Archive.lean` | name+extra span (was :471-476) | `readBoundedSpanFromHandle` |
+| `Zip/Archive.lean` | compressed-payload read (was :509) | `readBoundedSpanFromHandle` |
+| `Zip/Tar.lean` | GNU long-name (was :572) | `readBoundedEntryData` |
+| `Zip/Tar.lean` | GNU long-link (was :581) | `readBoundedEntryData` |
+| `Zip/Tar.lean` | PAX extended (was :590) | `readBoundedEntryData` |
+| `Zip/Tar.lean` | PAX global (was :595) | `readBoundedEntryData` |
+
+The standalone `assertSpanInFile` for the *"local data span"* (now
+`Zip/Archive.lean:471-472`) stays — it fires before the compressed
+payload `readBoundedSpanFromHandle` and keeps the existing ZIP
+malformed-fixture assertions (`oversized-compressed-size.zip` and
+`oversized-zip64-compressed-size.zip` in `ZipTest/ZipFixtures.lean`)
+anchored to the canonical `"local data span"` substring.
+
+For the Tar GNU/PAX migrations, the wrapper's
+`"tar: {what} size ({size}) exceeds maximum ({maxSize})"` error fires
+before the underlying `readEntryData`'s
+`"exceeds maximum header size"` check, so the two TAR malformed-fixture
+assertions in `ZipTest/TarFixtures.lean` (`gnu-longname-oversized-size.tar`
+and `pax-extended-oversized-size.tar`) were widened from
+`"exceeds maximum header size"` to `"exceeds maximum"` in the same
+diff. Both messages share the `"exceeds maximum"` anchor, so the
+combined behaviour is preserved regardless of which guard fires
+first.
+
+The Priority 5 Item 1 checklist boxes
+(`plans/track-e-current-audit-checklist.md`) now read:
+
+- `[x] Introduce proof-friendly helper functions ...` — closed by PR #1608.
+- `[ ] Prove simple lemmas of the form: validated span implies ...` —
+  open, P5.2.
+- `[x] Use those helpers so parser hardening is easier to audit ...` —
+  closed by this PR.
+
+## Decisions
+
+- **`readBoundedSpanFromHandle` for the compressed payload, not just
+  the header reads.** The current code routes the compressed payload
+  through a `readExact h entry.compressedSize.toNat` that relied on
+  the file position being correctly advanced by the prior name+extra
+  `readExact`. Migrating to the helper adds an explicit
+  `Handle.seek h (entry.localOffset + headerAndNames)`, which is to
+  the same offset the file is already at — so behaviour is preserved
+  and the helper's internal span re-assertion is harmless redundancy.
+- **Keep the `"local data span"` standalone assertion.** Removing it
+  in favour of the helper's internal assertion would change the
+  user-facing substring on the
+  `oversized-compressed-size.zip` /
+  `oversized-zip64-compressed-size.zip` regression paths from
+  `"local data span"` to `"compressed data"`. The `error-wording-catalogue`
+  skill calls out `"local data span"` as the stable anchor, so the
+  redundancy stays.
+- **Widen the TAR fixture assertions in the same diff.** The wrapper's
+  `"exceeds maximum"` substring is what the migrated path emits; the
+  underlying `readEntryData`'s
+  `"exceeds maximum header size"` is still reachable when only the
+  global cap fires. Widening from `"exceeds maximum header size"` to
+  `"exceeds maximum"` keeps both error paths covered by the same
+  assertion.
+
+## Out of scope (followups)
+
+- **P5.2 — prove the bounded-read lemma.** Not in this PR; the
+  proof box stays `[ ]`.
+- **Tar regular-file payload `input.read` loop**
+  (`Zip/Tar.lean extract` around the regular-file branch). The
+  issue explicitly excludes this — it is a write-to-disk loop, not
+  a header-buffering allocation, and `readBoundedEntryData` is not
+  the right helper for it.
+
+## Verification
+
+- `lake build` — 191 jobs, clean.
+- `lake exe test` — `All tests passed!` (including the four ZIP
+  malformed fixtures, the two TAR malformed fixtures, and
+  `ZipTest/BoundedReadTest.lean`).
+- `grep -rc sorry Zip/` — `0` everywhere.
+- `grep -cn 'readEntryData input entry.size.toNat maxHeaderSize' Zip/Tar.lean` — `0`.
+- `grep -cn 'readBoundedEntryData input entry.size.toNat maxHeaderSize' Zip/Tar.lean` — `4`.
+- `grep -n 'readBoundedSpanFromHandle' Zip/Archive.lean` — three
+  caller lines (`:451`, `:475`, `:510`), one definition (`:400`),
+  three doc/comment cross-references.
+- `grep -n 'assertSpanInFile' Zip/Archive.lean` — five matches:
+  the private definition (`:345`), two docstring mentions (`:384`,
+  `:388`), the call inside `readBoundedSpanFromHandle` (`:402`),
+  and the surviving `"local data span"` standalone call (`:473`).
+  No remaining direct callsites in `readEntryData` outside the
+  one the issue specifies should stay.
+
+## Net diff
+
+`+36 / -20` across four files (well under the 100-line target).


### PR DESCRIPTION
Closes #1614

Session: `395ec4a0-6a5e-474a-a7f2-9d6614325250`

f30dc1d doc: progress entry for #1614 P5.3 caller migration
55cd0b5 refactor: migrate Archive/Tar callers to P5.1 bounded-read helpers (Track E P5.3)

🤖 Prepared with Claude Code