### PR TITLE
Feature: Track E — whole-archive maxTotalSize cap on Archive/Tar extractors (SECURITY_INVENTORY Rec. 4)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -347,11 +347,15 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Archive.list](/home/kim/lean-zip/Zip/Archive.lean:497) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | metadata-only; caps CD allocation, not decompressed payload. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:515) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:515) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap on the decompressed payload. |
+| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:515) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all entries; intended as a second line of defence against many-small-entries bombs. |
 | [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:551) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
 | [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:551) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap. |
-| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:602) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:610](/home/kim/lean-zip/Zip/Tar.lean:610)). No whole-archive cap. |
+| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:602) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:610](/home/kim/lean-zip/Zip/Tar.lean:610)). |
+| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:602) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all regular-file entries; directories and symlinks contribute zero. |
 | [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:714) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |
+| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:714) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
 | [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:768) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. |
+| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:768) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
 | [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:768) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | whole-archive tar-buffer cap for the outer native gzip decode. |
 
 ### Known inconsistencies
@@ -393,13 +397,11 @@ issues and the follow-up docstring/default change.
    (pass `0` to opt into unlimited mode on the FFI backend), and the
    silent `0 → 256 MiB` upgrade in `Archive.readEntryData` has been
    removed. See this PR.
-4. **Archive extraction — whole-archive cap**.
-   - Add a new `maxTotalSize : UInt64 := 0` (sum of decompressed
-     entries) to `Archive.extract` and the tar extractors. Default
-     `0 = no limit` is acceptable here as a starting point because
-     `maxEntrySize` (recommendation 3) already bounds the common
-     case; the total cap is a second line of defence against
-     many-small-entries bombs.
+4. **Archive extraction — whole-archive cap**. Executed —
+   `Archive.extract`, `Tar.extract`, `Tar.extractTarGz`, and
+   `Tar.extractTarGzNative` now accept an optional
+   `maxTotalSize : UInt64 := 0` parameter; default `0` is unlimited
+   and callers opt into a finite cap. See this PR.
 5. **Native-side uniformity**. Executed (issue #1609) — all four
    native decoders (`Inflate.inflate`, `GzipDecode.decompress`,
    `ZlibDecode.decompress`, `decompressAuto`) now default to **1 GiB**,
@@ -439,9 +441,6 @@ Known caller impact if recommendations 1–5 land:
   is still open. Until a caller passes a finite value, a crafted
   input that inflates to terabytes will still write terabytes to
   the caller's sink.
-- There is no public API for "whole-archive" decompressed-size cap
-  on ZIP or tar extraction — see recommendation 4.
-
 ### Local guard inventory for `Handle.read` and `Stream.read`
 
 Per-callsite audit of every `Handle.read`, `Stream.read`, and

--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -552,13 +552,22 @@ def list (inputPath : System.FilePath) (maxCentralDirSize : Nat := 67108864) : I
     Overflow raises `IO.userError` containing
     `"zip: entry '…' uncompressed size (…) exceeds limit (…)"`.
 
+    `maxTotalSize` (when non-zero) caps the sum of decompressed bytes across
+    all entries written by this extraction. Default `0` means no whole-archive
+    cap; rely on `maxEntrySize` for per-entry bounding. Overflow raises
+    `IO.userError` containing
+    `"zip: total extracted size (…) exceeds whole-archive limit (…)"`.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*.
+
     When `useNative` is true, uses pure Lean decompression (no C FFI).
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def extract (inputPath : System.FilePath) (outDir : System.FilePath)
     (maxCentralDirSize : Nat := 67108864) (maxEntrySize : UInt64 := 1024 * 1024 * 1024)
+    (maxTotalSize : UInt64 := 0)
     (useNative : Bool := false) : IO Unit := do
   IO.FS.withFile inputPath .read fun h => do
     let entries ← listFromHandle h maxCentralDirSize
+    let totalRef ← IO.mkRef (0 : UInt64)
     for entry in entries do
       -- Strip trailing slash for path safety check (directories end with "/")
       let checkPath := if entry.path.endsWith "/" then entry.path.dropEnd 1 |>.toString else entry.path
@@ -569,11 +578,19 @@ def extract (inputPath : System.FilePath) (outDir : System.FilePath)
         continue
       unless Binary.isPathSafe checkPath do
         throw (IO.userError s!"zip: unsafe path: {entry.path}")
+      -- Whole-archive running-total check: fires before any payload bytes are
+      -- written for this entry. The invariant `running ≤ maxTotalSize` keeps
+      -- `maxTotalSize - running` well-defined in UInt64 arithmetic.
+      if maxTotalSize > 0 then
+        let running ← totalRef.get
+        if maxTotalSize - running < entry.uncompressedSize then
+          throw (IO.userError s!"zip: total extracted size ({entry.uncompressedSize.toNat + running.toNat}) exceeds whole-archive limit ({maxTotalSize})")
       let outPath := outDir / entry.path
       if let some parent := outPath.parent then
         IO.FS.createDirAll parent
       let fileData ← readEntryData h entry entry.path maxEntrySize useNative
       IO.FS.writeBinFile outPath fileData
+      totalRef.modify (· + entry.uncompressedSize)
 
 /-- Extract a single file from a ZIP archive by name.
     Memory: O(65KB + central directory + target file).

--- a/Zip/Tar.lean
+++ b/Zip/Tar.lean
@@ -618,11 +618,14 @@ private partial def forEntries (input : IO.FS.Stream)
     tar header's `e.size` before any payload bytes are read. Default `1 GiB`
     per entry; pass `0` to opt out into unlimited mode. Overflow raises
     `IO.userError` containing
-    `"tar: entry '…' size (…) exceeds limit (…)"`. There is no
-    library-level cap on total extracted bytes across an archive — many
-    small entries can still exhaust disk. See `SECURITY_INVENTORY.md`
-    *Decompression Limit Inventory* (recommendation 3 calls out the
-    total-bytes gap).
+    `"tar: entry '…' size (…) exceeds limit (…)"`.
+
+    `maxTotalSize` (when non-zero) caps the sum of decompressed bytes across
+    all entries written by this extraction. Default `0` means no whole-archive
+    cap; rely on `maxEntrySize` for per-entry bounding. Overflow raises
+    `IO.userError` containing
+    `"tar: total extracted size (…) exceeds whole-archive limit (…)"`.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*.
 
     `maxHeaderSize` (default `defaultMaxHeaderSize` = 8 MiB) bounds the
     buffered payload of every GNU long-name, GNU long-link, and PAX
@@ -647,7 +650,9 @@ private partial def forEntries (input : IO.FS.Stream)
       escape `outDir`. -/
 partial def extract (input : IO.FS.Stream) (outDir : System.FilePath)
     (maxEntrySize : UInt64 := 1024 * 1024 * 1024)
+    (maxTotalSize : UInt64 := 0)
     (maxHeaderSize : Nat := defaultMaxHeaderSize) : IO Unit := do
+  let totalRef ← IO.mkRef (0 : UInt64)
   forEntries (maxHeaderSize := maxHeaderSize) input fun e => do
     -- Strip trailing slash for path safety check (directories end with "/")
     let checkPath := if e.path.endsWith "/" then e.path.dropEnd 1 |>.toString else e.path
@@ -664,6 +669,12 @@ partial def extract (input : IO.FS.Stream) (outDir : System.FilePath)
         IO.Prim.setAccessRights outPath mode
       skipEntryData input e.size
     else if e.typeflag == typeRegular then
+      -- Whole-archive running-total check: fires before any payload bytes are
+      -- written for this entry. Only regular-file payloads contribute.
+      if maxTotalSize > 0 then
+        let running ← totalRef.get
+        if maxTotalSize - running < e.size then
+          throw (IO.userError s!"tar: total extracted size ({e.size.toNat + running.toNat}) exceeds whole-archive limit ({maxTotalSize})")
       if let some parent := outPath.parent then
         IO.FS.createDirAll parent
       IO.FS.withFile outPath .write fun h => do
@@ -684,6 +695,7 @@ partial def extract (input : IO.FS.Stream) (outDir : System.FilePath)
           let chunk ← input.read (min padRemaining 512).toUSize
           if chunk.isEmpty then break
           padRemaining := padRemaining - chunk.size
+      totalRef.modify (· + e.size)
     else if e.typeflag == typeSymlink then
       -- Component-level validation: reject absolute, backslash, and `..` traversal
       if e.linkname.startsWith "/" || e.linkname.any (· == '\\') then
@@ -753,12 +765,20 @@ partial def createTarGz (outputPath : System.FilePath) (dir : System.FilePath)
     `maxOutputSize` parameter today (the known gap tracked by
     `SECURITY_INVENTORY.md` *Decompression Limit Inventory*, recommendation 2).
 
+    `maxTotalSize` (when non-zero) caps the sum of decompressed bytes across
+    all entries written by this extraction. Default `0` means no whole-archive
+    cap; rely on `maxEntrySize` for per-entry bounding. Overflow raises
+    `IO.userError` containing
+    `"tar: total extracted size (…) exceeds whole-archive limit (…)"`.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*.
+
     `maxHeaderSize` (default `defaultMaxHeaderSize` = 8 MiB) bounds the
     buffered payload of every GNU long-name, GNU long-link, and PAX
     pseudo-entry. Overflow raises `IO.userError` containing the
     substring `"exceeds maximum header size"`. -/
 partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath)
     (maxEntrySize : UInt64 := 1024 * 1024 * 1024)
+    (maxTotalSize : UInt64 := 0)
     (maxHeaderSize : Nat := defaultMaxHeaderSize) : IO Unit := do
   IO.FS.withFile inputPath .read fun inH => do
     let inStream := IO.FS.Stream.ofHandle inH
@@ -787,7 +807,7 @@ partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath
       putStr := fun _ => pure ()
       isTty := pure false
     }
-    extract tarStream outDir maxEntrySize maxHeaderSize
+    extract tarStream outDir maxEntrySize maxTotalSize maxHeaderSize
 
 /-- Extract a .tar.gz archive using pure Lean decompression (no C FFI).
     Unlike `extractTarGz`, this reads the entire file into memory before
@@ -798,6 +818,13 @@ partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath
     bytes are read. Default `1 GiB` per entry; pass `0` to opt out into
     unlimited mode. Overflow raises `IO.userError`
     containing `"tar: entry '…' size (…) exceeds limit (…)"`.
+
+    `maxTotalSize` (when non-zero) caps the sum of decompressed bytes across
+    all entries written by this extraction. Default `0` means no whole-archive
+    cap; rely on `maxEntrySize` for per-entry bounding. Overflow raises
+    `IO.userError` containing
+    `"tar: total extracted size (…) exceeds whole-archive limit (…)"`.
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*.
 
     `maxOutputSize` (default 256 MiB) caps the decompressed tar buffer
     produced by the outer native gzip decode. The native variant exposes this
@@ -812,7 +839,9 @@ partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath
     pseudo-entry. Overflow raises `IO.userError` containing the
     substring `"exceeds maximum header size"`. -/
 partial def extractTarGzNative (inputPath : System.FilePath) (outDir : System.FilePath)
-    (maxEntrySize : UInt64 := 1024 * 1024 * 1024) (maxOutputSize : Nat := 256 * 1024 * 1024)
+    (maxEntrySize : UInt64 := 1024 * 1024 * 1024)
+    (maxTotalSize : UInt64 := 0)
+    (maxOutputSize : Nat := 256 * 1024 * 1024)
     (maxHeaderSize : Nat := defaultMaxHeaderSize) : IO Unit := do
   let gzData ← IO.FS.readBinFile inputPath
   let tarData ← match Zip.Native.GzipDecode.decompress gzData maxOutputSize with
@@ -835,6 +864,6 @@ partial def extractTarGzNative (inputPath : System.FilePath) (outDir : System.Fi
     putStr := fun _ => pure ()
     isTty := pure false
   }
-  extract tarStream outDir maxEntrySize maxHeaderSize
+  extract tarStream outDir maxEntrySize maxTotalSize maxHeaderSize
 
 end Tar

--- a/ZipTest/Archive.lean
+++ b/ZipTest/Archive.lean
@@ -114,6 +114,44 @@ def ZipTest.Archive.tests : IO Unit := do
   let _ ← IO.Process.run { cmd := "rm", args := #["-rf", bombExtractDir.toString] }
   let _ ← IO.Process.run { cmd := "rm", args := #["-f", bombZipPath.toString] }
 
+  -- maxTotalSize whole-archive bomb regression (SECURITY_INVENTORY Rec. 4):
+  -- a three-entry zip whose per-entry sizes pass the `maxEntrySize` check
+  -- individually must still be rejected by the running-sum check when the
+  -- cumulative uncompressed bytes exceed `maxTotalSize`. The per-entry
+  -- payloads are each 100 bytes (total 300); the exact-fit run at 300 must
+  -- succeed, while `300 - 1 = 299` must trip the whole-archive cap.
+  let totSrcDir : System.FilePath := "/tmp/lean-zip-zip-total-src"
+  let totZipPath : System.FilePath := "/tmp/lean-zip-zip-total.zip"
+  let totExtractDir : System.FilePath := "/tmp/lean-zip-zip-total-extract"
+  if ← totSrcDir.pathExists then
+    let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totSrcDir.toString] }
+  IO.FS.createDirAll totSrcDir
+  let totPayload : ByteArray := ByteArray.mk (Array.replicate 100 (0x41 : UInt8))
+  IO.FS.writeBinFile (totSrcDir / "a.txt") totPayload
+  IO.FS.writeBinFile (totSrcDir / "b.txt") totPayload
+  IO.FS.writeBinFile (totSrcDir / "c.txt") totPayload
+  Archive.create totZipPath #[
+    ("a.txt", totSrcDir / "a.txt"),
+    ("b.txt", totSrcDir / "b.txt"),
+    ("c.txt", totSrcDir / "c.txt")]
+  if ← totExtractDir.pathExists then
+    let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  IO.FS.createDirAll totExtractDir
+  let totOverResult ←
+    (Archive.extract totZipPath totExtractDir (maxTotalSize := 299)).toBaseIO
+  match totOverResult with
+  | .ok _ => throw (IO.userError "zip: maxTotalSize bomb should have been rejected by extract")
+  | .error e =>
+    unless (toString e).contains "exceeds whole-archive limit" do
+      throw (IO.userError s!"zip: maxTotalSize bomb wrong error from extract: {e}")
+  -- Clean any partial output from the previous attempt before the exact-fit run.
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  IO.FS.createDirAll totExtractDir
+  Archive.extract totZipPath totExtractDir (maxTotalSize := 300)
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totSrcDir.toString] }
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  let _ ← IO.Process.run { cmd := "rm", args := #["-f", totZipPath.toString] }
+
   -- readExactStream with fragmenting stream (Bug #1: short read robustness)
   let testPayload := "Hello, World! This is test data for readExactStream.".toUTF8
   let fragStream := fragmentingStream (← byteArrayReadStream testPayload) 3

--- a/ZipTest/Tar.lean
+++ b/ZipTest/Tar.lean
@@ -2,6 +2,79 @@ import ZipTest.Helpers
 
 /-! Tests for tar archive creation, listing, extraction, tar.gz roundtrips, and PAX record parsing. -/
 
+/-- maxTotalSize whole-archive bomb regression (SECURITY_INVENTORY Rec. 4):
+    a three-entry tar whose per-entry sizes pass the `maxEntrySize` check
+    individually must still be rejected by the running-sum check when the
+    cumulative uncompressed bytes exceed `maxTotalSize`. Per-entry payloads
+    are 100 bytes each (total 300); at `maxTotalSize := 299` the cap trips
+    on the third entry; at `maxTotalSize := 300` all three entries fit
+    exactly. Both the streaming .tar.gz and the native .tar.gz extractors
+    forward the cap to `Tar.extract`. Extracted as a top-level helper to
+    keep `ZipTest.Tar.tests`'s single `do` block under the elaborator's
+    recursion limit. -/
+private def runMaxTotalSizeBombTest : IO Unit := do
+  let totSrcDir : System.FilePath := "/tmp/lean-zip-tar-total-src"
+  let totTarPath : System.FilePath := "/tmp/lean-zip-tar-total.tar"
+  let totTarGzPath : System.FilePath := "/tmp/lean-zip-tar-total.tar.gz"
+  let totExtractDir : System.FilePath := "/tmp/lean-zip-tar-total-extract"
+  if ← totSrcDir.pathExists then
+    let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totSrcDir.toString] }
+  IO.FS.createDirAll totSrcDir
+  let totPayload : ByteArray := ByteArray.mk (Array.replicate 100 (0x41 : UInt8))
+  IO.FS.writeBinFile (totSrcDir / "a.txt") totPayload
+  IO.FS.writeBinFile (totSrcDir / "b.txt") totPayload
+  IO.FS.writeBinFile (totSrcDir / "c.txt") totPayload
+  IO.FS.withFile totTarPath .write fun h =>
+    Tar.create (IO.FS.Stream.ofHandle h) totSrcDir
+      #[totSrcDir / "a.txt", totSrcDir / "b.txt", totSrcDir / "c.txt"]
+  Tar.createTarGz totTarGzPath totSrcDir
+  -- Tar.extract: cap trips on third entry.
+  if ← totExtractDir.pathExists then
+    let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  IO.FS.createDirAll totExtractDir
+  let totOverResult ← (IO.FS.withFile totTarPath .read fun h =>
+    Tar.extract (IO.FS.Stream.ofHandle h) totExtractDir (maxTotalSize := 299)).toBaseIO
+  match totOverResult with
+  | .ok _ => throw (IO.userError "tar: maxTotalSize bomb should have been rejected by extract")
+  | .error e =>
+    unless (toString e).contains "exceeds whole-archive limit" do
+      throw (IO.userError s!"tar: maxTotalSize bomb wrong error from extract: {e}")
+  -- Tar.extract: exact-fit succeeds.
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  IO.FS.createDirAll totExtractDir
+  IO.FS.withFile totTarPath .read fun h =>
+    Tar.extract (IO.FS.Stream.ofHandle h) totExtractDir (maxTotalSize := 300)
+  -- Tar.extractTarGz: streaming .tar.gz, same bomb.
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  IO.FS.createDirAll totExtractDir
+  let totGzOverResult ←
+    (Tar.extractTarGz totTarGzPath totExtractDir (maxTotalSize := 299)).toBaseIO
+  match totGzOverResult with
+  | .ok _ => throw (IO.userError "tar.gz: maxTotalSize bomb should have been rejected by extractTarGz")
+  | .error e =>
+    unless (toString e).contains "exceeds whole-archive limit" do
+      throw (IO.userError s!"tar.gz: maxTotalSize bomb wrong error from extractTarGz: {e}")
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  IO.FS.createDirAll totExtractDir
+  Tar.extractTarGz totTarGzPath totExtractDir (maxTotalSize := 300)
+  -- Tar.extractTarGzNative: whole-buffer .tar.gz, same bomb.
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  IO.FS.createDirAll totExtractDir
+  let totGzNatOverResult ←
+    (Tar.extractTarGzNative totTarGzPath totExtractDir (maxTotalSize := 299)).toBaseIO
+  match totGzNatOverResult with
+  | .ok _ => throw (IO.userError "tar.gz native: maxTotalSize bomb should have been rejected by extractTarGzNative")
+  | .error e =>
+    unless (toString e).contains "exceeds whole-archive limit" do
+      throw (IO.userError s!"tar.gz native: maxTotalSize bomb wrong error from extractTarGzNative: {e}")
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  IO.FS.createDirAll totExtractDir
+  Tar.extractTarGzNative totTarGzPath totExtractDir (maxTotalSize := 300)
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totSrcDir.toString] }
+  let _ ← IO.Process.run { cmd := "rm", args := #["-rf", totExtractDir.toString] }
+  let _ ← IO.Process.run { cmd := "rm", args := #["-f", totTarPath.toString] }
+  let _ ← IO.Process.run { cmd := "rm", args := #["-f", totTarGzPath.toString] }
+
 def ZipTest.Tar.tests : IO Unit := do
   -- Create a temp directory with test files
   let tarTestDir : System.FilePath := "/tmp/lean-zlib-tar-test"
@@ -104,6 +177,8 @@ def ZipTest.Tar.tests : IO Unit := do
   let _ ← IO.Process.run { cmd := "rm", args := #["-rf", bombExtractDir.toString] }
   let _ ← IO.Process.run { cmd := "rm", args := #["-f", bombTarPath.toString] }
   let _ ← IO.Process.run { cmd := "rm", args := #["-f", bombGzPath.toString] }
+
+  runMaxTotalSizeBombTest
 
   -- Test splitPath
   let some (pfx1, name1) := Tar.splitPath "short.txt" | throw (IO.userError "splitPath short")

--- a/progress/20260422T080402Z_bebc249a.md
+++ b/progress/20260422T080402Z_bebc249a.md
@@ -1,0 +1,96 @@
+# Session bebc249a — Feature: whole-archive `maxTotalSize` on Archive/Tar extractors (#1621)
+
+- **UTC**: 2026-04-22T08:04Z
+- **Session type**: feature
+- **Issue**: #1621 — Track E, SECURITY_INVENTORY Rec. 4
+- **Branch**: `agent/bebc249a`
+- **Starting commit**: `5997c5e`
+- **Quality metrics**: `grep -rc sorry Zip/` = 0 both before and after.
+
+## What landed
+
+Threaded a new optional `maxTotalSize : UInt64 := 0` parameter through the
+four public extractors that the inventory called out:
+
+- `Archive.extract` — checks `running + entry.uncompressedSize` against
+  the cap before `readEntryData` on each non-directory entry, then
+  bumps the running counter after the payload is written.
+- `Tar.extract` — running-counter gated on `typeRegular` branch only;
+  directories and symlinks contribute zero to the total.
+- `Tar.extractTarGz` and `Tar.extractTarGzNative` — forward the new
+  parameter through to the inner `Tar.extract` call.
+
+Default `0` means no whole-archive cap, matching the inventory's
+"second line of defence" framing — `maxEntrySize` (default 1 GiB)
+still bounds the common case.
+
+Error wording is `"<zip|tar>: total extracted size (…) exceeds
+whole-archive limit (…)"`, which slots into the existing
+`"exceeds"` substring families from the error-wording catalogue.
+Counter arithmetic uses UInt64 with the `cap - running < size`
+guard pattern; the displayed total casts to `Nat` to avoid overflow
+formatting artefacts.
+
+## SECURITY_INVENTORY.md reconciliation
+
+- Added four `maxTotalSize` rows to the *Decompression Limit Inventory*
+  table (one per extractor). Kept the existing rows for
+  `maxEntrySize` and `maxOutputSize` verbatim and re-used the stale
+  line anchors already in use for each function (drift tracked
+  separately by `scripts/check-inventory-links.sh`).
+- Rewrote *Recommended policy* item 4 as a one-line "Executed"
+  entry matching the shape used for items 3 and 5.
+- Dropped the "no public API for whole-archive decompressed-size cap"
+  bullet from *Missing work*.
+
+## Tests
+
+Four bomb-limit regression tests, one per entry point. Each test
+writes a three-entry archive with 100-byte payloads (total 300
+bytes), then calls the extractor twice:
+
+- `maxTotalSize := 299` → `assertThrows ... "exceeds whole-archive limit"`
+- `maxTotalSize := 300` → succeeds (exact fit)
+
+`Archive.extract` test lives inline in `ZipTest/Archive.lean`. The
+three tar-related tests live in a top-level `runMaxTotalSizeBombTest`
+helper in `ZipTest/Tar.lean` — the single `do` block of
+`ZipTest.Tar.tests` was already close to the elaborator's
+`maxRecDepth` ceiling, and inlining all three new tests blew past
+it. Extracting to a separate function sidestepped the depth issue
+without tweaking the `maxRecDepth` option.
+
+## Verification
+
+- `lake build` clean.
+- `lake exe test` passes including the four new bomb-limit tests.
+- `scripts/check-inventory-links.sh` reports `errors=0, warnings=60`
+  — all warnings are pre-existing line-number drift for anchors my PR
+  did not introduce.
+- Issue verification greps: all 7 grep invariants from the issue's
+  *Verification* checklist match as specified.
+
+## Diff scope
+
+`SECURITY_INVENTORY.md`, `Zip/Archive.lean`, `Zip/Tar.lean`,
+`ZipTest/Archive.lean`, `ZipTest/Tar.lean`. No changes to
+`Zip/Native/**`, `c/**`, `PLAN.md`, `.claude/CLAUDE.md`, or
+`Archive.extractFile` (out-of-scope per issue).
+
+## Minor docstring edit outside the listed sites
+
+I removed one stale sentence from `Tar.extract`'s docstring that
+said "There is no library-level cap on total extracted bytes
+across an archive … (recommendation 3 calls out the total-bytes
+gap)" — it is now factually false (the cap exists, and the cited
+recommendation number refers to per-entry, not total, in any case).
+The issue asked to keep the other paragraphs verbatim; I judged
+retaining a sentence contradicted by the new paragraph three lines
+below it a worse choice than editing it. No other prose moved.
+
+## Follow-ups
+
+None from this issue. A future tightening of `maxTotalSize`'s
+default to a finite value can be a separate PR once real-world
+archive sizes are measured — the inventory's framing already
+anticipates this.


### PR DESCRIPTION
Closes #1621

Session: `bebc249a-0fb8-4c46-9041-b697243c72b4`

ae087c8 feat: whole-archive maxTotalSize cap on Archive/Tar extractors

🤖 Prepared with Claude Code