### PR TITLE
Feature: Track E P5.2 — prove validated-span / bounded-read lemmas over P5.1 helpers

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -351,6 +351,99 @@ private def assertSpanInFile (fileSize offset length : UInt64) (what : String) :
     throw (IO.userError
       s!"zip: {what} extends past end of file (offset={offset}, length={length}, fileSize={fileSize})")
 
+/-- `SpanInFile fileSize offset length` states that the half-open byte range
+    `[offset, offset + length)` lies inside a file of size `fileSize`, with
+    overflow-safe arithmetic on `UInt64`.
+
+    Mirrors the two-check shape of `assertSpanInFile`: `offset ≤ fileSize`
+    first, then `length ≤ fileSize - offset`, where the subtraction is the
+    saturating remainder (well-defined once `offset ≤ fileSize`). Do NOT
+    restate this as `offset + length ≤ fileSize` — `UInt64` addition wraps
+    silently on overflow, which the asymmetric form exists to avoid. -/
+def SpanInFile (fileSize offset length : UInt64) : Prop :=
+  offset ≤ fileSize ∧ length ≤ fileSize - offset
+
+instance (fileSize offset length : UInt64) :
+    Decidable (SpanInFile fileSize offset length) :=
+  inferInstanceAs (Decidable (_ ∧ _))
+
+@[simp] theorem SpanInFile_iff {fileSize offset length : UInt64} :
+    SpanInFile fileSize offset length ↔
+      offset ≤ fileSize ∧ length ≤ fileSize - offset := Iff.rfl
+
+/-- Forward reduction: if the span is valid then `assertSpanInFile` is
+    `pure ()`. Both `if` guards fall through to the `else` branch and the
+    residual `pure PUnit.unit >>= fun _ => pure PUnit.unit` reduces to
+    `pure ()` definitionally. -/
+private theorem assertSpanInFile_eq_pure_of_spanInFile
+    {fileSize offset length : UInt64} {what : String}
+    (h : SpanInFile fileSize offset length) :
+    assertSpanInFile fileSize offset length what = pure () := by
+  obtain ⟨h1, h2⟩ := h
+  unfold assertSpanInFile
+  rw [if_neg (UInt64.not_lt.mpr h1), if_neg (UInt64.not_lt.mpr h2)]
+  rfl
+
+/-- Backward reduction: success of `assertSpanInFile` implies the pure
+    predicate `SpanInFile` holds. For each guard, contraposition gives
+    `assertSpanInFile = throw ...`, which evaluated at any `Void IO.RealWorld`
+    state forces `EST.Out.error = EST.Out.ok`, a constructor contradiction. -/
+private theorem spanInFile_of_assertSpanInFile_succeeds
+    {fileSize offset length : UInt64} {what : String}
+    (h : assertSpanInFile fileSize offset length what = pure ()) :
+    SpanInFile fileSize offset length := by
+  refine ⟨?_, ?_⟩
+  · refine Decidable.by_contra fun h1 => ?_
+    have h1' : fileSize < offset := UInt64.not_le.mp h1
+    unfold assertSpanInFile at h
+    rw [if_pos h1'] at h
+    have ⟨s⟩ : Nonempty (Void IO.RealWorld) := Void.instNonempty
+    have happ : EST.Out.error (σ := IO.RealWorld) (α := Unit) _ s = EST.Out.ok () s :=
+      congrFun h s
+    cases happ
+  · refine Decidable.by_contra fun h2 => ?_
+    have h1 : offset ≤ fileSize := by
+      refine Decidable.by_contra fun h1 => ?_
+      have h1' : fileSize < offset := UInt64.not_le.mp h1
+      unfold assertSpanInFile at h
+      rw [if_pos h1'] at h
+      have ⟨s⟩ : Nonempty (Void IO.RealWorld) := Void.instNonempty
+      have happ : EST.Out.error (σ := IO.RealWorld) (α := Unit) _ s = EST.Out.ok () s :=
+        congrFun h s
+      cases happ
+    have h2' : fileSize - offset < length := UInt64.not_le.mp h2
+    unfold assertSpanInFile at h
+    rw [if_neg (UInt64.not_lt.mpr h1), if_pos h2'] at h
+    have ⟨s⟩ : Nonempty (Void IO.RealWorld) := Void.instNonempty
+    have happ : EST.Out.error (σ := IO.RealWorld) (α := Unit) _ s = EST.Out.ok () s :=
+      congrFun h s
+    cases happ
+
+/-- `Nat`-level consequence of `SpanInFile`: the end-offset of the span is
+    file-bounded. Caller-facing arithmetic lemma — future bounded-read
+    reasoning cites this without re-deriving the `UInt64` arithmetic. -/
+theorem SpanInFile.toNat_add_le
+    {fileSize offset length : UInt64}
+    (h : SpanInFile fileSize offset length) :
+    offset.toNat + length.toNat ≤ fileSize.toNat := by
+  obtain ⟨h1, h2⟩ := h
+  have h1n : offset.toNat ≤ fileSize.toNat := UInt64.le_iff_toNat_le.mp h1
+  have h2n : length.toNat ≤ (fileSize - offset).toNat := UInt64.le_iff_toNat_le.mp h2
+  rw [UInt64.toNat_sub_of_le _ _ h1] at h2n
+  omega
+
+/-- `Nat`-level consequence of `SpanInFile`: the span length is bounded by the
+    remaining file size past the span's start offset. Caller-facing
+    arithmetic lemma — future bounded-read reasoning cites this without
+    re-deriving the `UInt64` saturating subtraction. -/
+theorem SpanInFile.toNat_length_le_remaining
+    {fileSize offset length : UInt64}
+    (h : SpanInFile fileSize offset length) :
+    length.toNat ≤ fileSize.toNat - offset.toNat := by
+  obtain ⟨h1, h2⟩ := h
+  have h2n : length.toNat ≤ (fileSize - offset).toNat := UInt64.le_iff_toNat_le.mp h2
+  rwa [UInt64.toNat_sub_of_le _ _ h1] at h2n
+
 /-- Read exactly `n` bytes from a handle, throwing on short read.
     Loops to handle short reads from pipes/network streams. -/
 private partial def readExact (h : IO.FS.Handle) (n : Nat) (what : String) : IO ByteArray := do

--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -371,6 +371,19 @@ instance (fileSize offset length : UInt64) :
     SpanInFile fileSize offset length ↔
       offset ≤ fileSize ∧ length ≤ fileSize - offset := Iff.rfl
 
+/-- Helper: an `IO Unit` action that evaluates to `EST.Out.error _ _` at
+    some `Void IO.RealWorld` state cannot equal `pure ()`. Used to discharge
+    the `assertSpanInFile = pure ()` hypothesis once a guard has been shown
+    to fire, by evaluating both sides at an arbitrary state. -/
+private theorem io_ne_pure_of_state_error
+    {x : IO Unit} {e : IO.Error}
+    (hx : ∀ s : Void IO.RealWorld, x s = EST.Out.error e s) :
+    x ≠ pure () := fun h => by
+  have ⟨s⟩ : Nonempty (Void IO.RealWorld) := Void.instNonempty
+  have happ : EST.Out.error (σ := IO.RealWorld) (α := Unit) e s = EST.Out.ok () s := by
+    rw [← hx s]; exact congrFun h s
+  cases happ
+
 /-- Forward reduction: if the span is valid then `assertSpanInFile` is
     `pure ()`. Both `if` guards fall through to the `else` branch and the
     residual `pure PUnit.unit >>= fun _ => pure PUnit.unit` reduces to
@@ -385,39 +398,27 @@ private theorem assertSpanInFile_eq_pure_of_spanInFile
   rfl
 
 /-- Backward reduction: success of `assertSpanInFile` implies the pure
-    predicate `SpanInFile` holds. For each guard, contraposition gives
-    `assertSpanInFile = throw ...`, which evaluated at any `Void IO.RealWorld`
-    state forces `EST.Out.error = EST.Out.ok`, a constructor contradiction. -/
+    predicate `SpanInFile` holds. For each guard, contraposition reduces
+    `assertSpanInFile` to an action whose state-level value is
+    `EST.Out.error`, which `io_ne_pure_of_state_error` rules out. -/
 private theorem spanInFile_of_assertSpanInFile_succeeds
     {fileSize offset length : UInt64} {what : String}
     (h : assertSpanInFile fileSize offset length what = pure ()) :
     SpanInFile fileSize offset length := by
   refine ⟨?_, ?_⟩
   · refine Decidable.by_contra fun h1 => ?_
-    have h1' : fileSize < offset := UInt64.not_le.mp h1
     unfold assertSpanInFile at h
-    rw [if_pos h1'] at h
-    have ⟨s⟩ : Nonempty (Void IO.RealWorld) := Void.instNonempty
-    have happ : EST.Out.error (σ := IO.RealWorld) (α := Unit) _ s = EST.Out.ok () s :=
-      congrFun h s
-    cases happ
+    rw [if_pos (UInt64.not_le.mp h1)] at h
+    exact io_ne_pure_of_state_error (e := _) (fun _ => rfl) h
   · refine Decidable.by_contra fun h2 => ?_
     have h1 : offset ≤ fileSize := by
       refine Decidable.by_contra fun h1 => ?_
-      have h1' : fileSize < offset := UInt64.not_le.mp h1
       unfold assertSpanInFile at h
-      rw [if_pos h1'] at h
-      have ⟨s⟩ : Nonempty (Void IO.RealWorld) := Void.instNonempty
-      have happ : EST.Out.error (σ := IO.RealWorld) (α := Unit) _ s = EST.Out.ok () s :=
-        congrFun h s
-      cases happ
-    have h2' : fileSize - offset < length := UInt64.not_le.mp h2
+      rw [if_pos (UInt64.not_le.mp h1)] at h
+      exact io_ne_pure_of_state_error (e := _) (fun _ => rfl) h
     unfold assertSpanInFile at h
-    rw [if_neg (UInt64.not_lt.mpr h1), if_pos h2'] at h
-    have ⟨s⟩ : Nonempty (Void IO.RealWorld) := Void.instNonempty
-    have happ : EST.Out.error (σ := IO.RealWorld) (α := Unit) _ s = EST.Out.ok () s :=
-      congrFun h s
-    cases happ
+    rw [if_neg (UInt64.not_lt.mpr h1), if_pos (UInt64.not_le.mp h2)] at h
+    exact io_ne_pure_of_state_error (e := _) (fun _ => rfl) h
 
 /-- `Nat`-level consequence of `SpanInFile`: the end-offset of the span is
     file-bounded. Caller-facing arithmetic lemma — future bounded-read

--- a/ZipTest/BoundedReadTest.lean
+++ b/ZipTest/BoundedReadTest.lean
@@ -94,6 +94,14 @@ private def testReadBoundedEntryData : IO Unit := do
       pure ())
     "exceeds maximum"
 
+/-- Sanity checks for the P5.2 pure `Archive.SpanInFile` predicate. Concrete
+    `UInt64` triples kernel-evaluate via `decide`. -/
+example : Archive.SpanInFile 100 10 20 := by decide
+example : ¬ Archive.SpanInFile 100 90 20 := by decide
+example : ¬ Archive.SpanInFile 100 200 0 := by decide
+example : Archive.SpanInFile 100 0 0 := by decide
+example : Archive.SpanInFile 100 100 0 := by decide
+
 def tests : IO Unit := do
   testReadBoundedSpanFromHandle
   testReadBoundedExactFromHandle

--- a/plans/track-e-current-audit-checklist.md
+++ b/plans/track-e-current-audit-checklist.md
@@ -190,8 +190,14 @@ Targets:
   `readBoundedExactFromHandle`, `readBoundedExactFromStream`, and
   `readBoundedEntryData` plus smoke coverage in
   `ZipTest/BoundedReadTest.lean`.)
-- [ ] Prove simple lemmas of the form:
+- [x] Prove simple lemmas of the form:
   validated span implies requested read length is file-bounded.
+  (This PR introduced the pure `Archive.SpanInFile` predicate alongside
+  `assertSpanInFile`, the two `IO` reduction theorems
+  `assertSpanInFile_eq_pure_of_spanInFile` /
+  `spanInFile_of_assertSpanInFile_succeeds`, and the `Nat`-level
+  arithmetic corollaries `SpanInFile.toNat_add_le` /
+  `SpanInFile.toNat_length_le_remaining`.)
 - [x] Use those helpers so parser hardening is easier to audit and less
   likely to regress than open-coded checks.
   (This PR migrated the three `Zip/Archive.lean` `readEntryData`

--- a/progress/2026-04-22T09-11-13Z_5c97dd11.md
+++ b/progress/2026-04-22T09-11-13Z_5c97dd11.md
@@ -1,0 +1,93 @@
+# Progress — 2026-04-22T09:11Z — Session 5c97dd11
+
+- **Type**: feature
+- **Issue**: #1628 — Track E P5.2 — prove validated-span / bounded-read lemmas over P5.1 helpers
+- **Branch**: agent/5c97dd11
+
+## Summary
+
+Landed the pure predicate `Archive.SpanInFile` alongside
+`assertSpanInFile` in `Zip/Archive.lean`, plus the four lemma-layer
+theorems the P5.2 checklist box called for:
+
+- **Pure predicate**: `SpanInFile fileSize offset length := offset ≤ fileSize ∧ length ≤ fileSize - offset`
+  — mirrors the two-check shape of `assertSpanInFile` (overflow-safe
+  saturating-subtraction comparison, NOT `offset + length ≤ fileSize`).
+  Non-private, `Decidable` instance, `@[simp] SpanInFile_iff`
+  unfolder.
+- **IO reduction (forward)**: `assertSpanInFile_eq_pure_of_spanInFile`
+  — `SpanInFile → assertSpanInFile = pure ()`. `unfold` + two
+  `rw [if_neg ...]` (via `UInt64.not_lt.mpr`) + `rfl`.
+- **IO reduction (backward)**: `spanInFile_of_assertSpanInFile_succeeds`
+  — `assertSpanInFile = pure () → SpanInFile`. Per guard,
+  `Decidable.by_contra` contradicts the hypothesis by reducing
+  assertSpanInFile to a `throw`ing action and evaluating at a
+  `Void IO.RealWorld` state.
+- **`Nat` corollary 1**: `SpanInFile.toNat_add_le`
+  — `offset.toNat + length.toNat ≤ fileSize.toNat`.
+  `UInt64.le_iff_toNat_le` + `UInt64.toNat_sub_of_le` + `omega`.
+- **`Nat` corollary 2**: `SpanInFile.toNat_length_le_remaining`
+  — `length.toNat ≤ fileSize.toNat - offset.toNat`.
+  Same tactic plus `rwa`.
+
+Both IO reduction theorems are `private` since they reference the
+`private assertSpanInFile`; the `SpanInFile` predicate and the two
+`Nat` corollaries are non-private for future bounded-read reasoning
+to cite.
+
+## Decisions / patterns
+
+- **State-level error contradiction helper.** The three guard-fires
+  branches in the backward direction used to repeat a five-line
+  `Void IO.RealWorld` + `congrFun` + typed `cases` triple. Factored
+  into `io_ne_pure_of_state_error` keyed on "my action reduces to
+  `EST.Out.error _` at any state"; each call site is now one line
+  (`io_ne_pure_of_state_error (fun _ => rfl) h`).
+- **`IO` in v4.29.1 is `EIO Error = EST Error IO.RealWorld`**, with
+  state `Void IO.RealWorld` (opaque wrapper, `Nonempty` via
+  `Void.instNonempty`). Not `IO.RealWorld` directly — matters for
+  `congrFun`-based state-level reasoning. Initial attempt used
+  `EStateM.Result.noConfusion`, which wanted `Eq.{2}` but our
+  equation is `Eq.{1}`; falling back to typed `have ... : ...` +
+  `cases happ` side-steps the universe mismatch.
+- **`by_contra` is not a core tactic**, only `Decidable.by_contra` is.
+  Refactored all three refute-the-guard sub-proofs to use
+  `Decidable.by_contra fun h => ...` — works fine because `UInt64.≤`
+  is decidable.
+- **Kept `assertSpanInFile` private**; did not widen its visibility
+  just to state file-external theorems. The reduction theorems live
+  in the same file.
+
+## Deliverables vs issue
+
+- (1) pure predicate + Decidable + simp lemma — **done**
+- (2) two IO-reduction theorems — **done**
+- (3) two `Nat` arithmetic corollaries — **done**
+- (4) P5.2 checklist box ticked with cite-this-PR parenthetical — **done**
+- (5) optional tests — **done** (five `by decide` examples appended
+      to `ZipTest/BoundedReadTest.lean`: happy path, offset-overshoot,
+      span-overshoot, empty-head, tail-boundary `fileSize = offset, length = 0`).
+
+## Quality metrics
+
+- Before: 0 sorries across `Zip/`.
+- After: 0 sorries across `Zip/`.
+- `lake build` clean.
+- `lake exe test` passes (including `bounded-read helper tests`).
+
+## Scope discipline
+
+- Did NOT touch `readBoundedSpanFromHandle`, `readBoundedExactFromHandle`,
+  `readBoundedExactFromStream`, `readBoundedEntryData` — left as
+  #1608 / #1626 landed them.
+- Did NOT modify `SECURITY_INVENTORY.md`, `PLAN.md`, or
+  `.claude/CLAUDE.md`.
+- Did NOT rewrite any `assertSpanInFile` error strings.
+- Did NOT migrate callers — P5.3 (#1626) already handled those.
+
+## Follow-ups
+
+None required. The P5 priority block is now fully ticked.
+If future callers want to thread `SpanInFile` through
+`readBoundedSpanFromHandle` (e.g. as a precondition parameter),
+that is a separate refactor PR.


### PR DESCRIPTION
Closes #1628

Session: `5c97dd11-0888-42c9-934e-d399925f2459`

2bb71cf doc: progress entry for session 5c97dd11 (P5.2 SpanInFile)
80531b8 refactor: Track E P5.2 — factor the state-level error contradiction into a helper
8e0ea1c test: Track E P5.2 — SpanInFile decide sanity checks + tick P5.2 box
151867d feat: Track E P5.2 — expose SpanInFile predicate + IO reduction + Nat corollaries

🤖 Prepared with Claude Code