### PR TITLE
Review: CRC32 + Adler-32 _append characterizing properties (PRs #1640 / #1641)

### DIFF
--- a/Zip/Native/Adler32.lean
+++ b/Zip/Native/Adler32.lean
@@ -38,22 +38,17 @@ append — an incremental streaming pipeline over concatenated chunks
 yields the same result as a whole-buffer computation. -/
 theorem adler32_append (init : UInt32) (a b : ByteArray) :
     adler32 init (a ++ b) = adler32 (adler32 init a) b := by
-  simp only [adler32]
-  rw [updateBytes_eq_updateList, updateBytes_eq_updateList, updateBytes_eq_updateList,
-      ByteArray.data_append, Array.toList_append, Spec.updateList_append]
+  simp only [adler32, updateBytes_eq_updateList, ByteArray.data_append,
+    Array.toList_append, Spec.updateList_append]
   -- Goal: pack (updateList (updateList (unpack init) A) B)
   --     = pack (updateList (unpack (pack (updateList (unpack init) A))) B)
   -- Case split on whether A = a.data.toList is empty; Valid applies only in the
   -- cons case. The nil case reduces via `pack_unpack`.
-  generalize ha : a.data.toList = A
+  generalize a.data.toList = A
   match A with
-  | [] =>
-    simp only [Spec.updateList_nil]
-    rw [Spec.pack_unpack]
+  | [] => rw [Spec.updateList_nil, Spec.pack_unpack]
   | x :: xs =>
-    have hvalid : Spec.Valid (Spec.updateList (Spec.unpack init) (x :: xs)) := by
-      rw [Spec.updateList_cons]
-      exact Spec.updateList_valid _ (Spec.updateByte_valid _ _) _
-    rw [Spec.unpack_pack_of_valid _ hvalid]
+    rw [Spec.unpack_pack_of_valid _ (Spec.updateList_cons .. ▸
+      Spec.updateList_valid _ (Spec.updateByte_valid ..) _)]
 
 end Adler32.Native

--- a/Zip/Native/Crc32.lean
+++ b/Zip/Native/Crc32.lean
@@ -94,11 +94,10 @@ theorem crc32_append (init : UInt32) (a b : ByteArray) :
     crc32 init (a ++ b) = crc32 (crc32 init a) b := by
   have raw_eq : ∀ x : UInt32,
       (if x == 0 then (0xFFFFFFFF : UInt32) else x ^^^ 0xFFFFFFFF) = x ^^^ 0xFFFFFFFF := by
-    intro x; bv_decide
-  have xor_twice : ∀ x : UInt32, (x ^^^ 0xFFFFFFFF) ^^^ 0xFFFFFFFF = x := by
-    intro x; bv_decide
+    bv_decide
   simp only [crc32, raw_eq]
-  rw [updateBytes_eq_updateList, updateBytes_eq_updateList, updateBytes_eq_updateList,
-      xor_twice, ByteArray.data_append, Array.toList_append, Spec.updateList_append]
+  simp only [UInt32.xor_assoc, UInt32.xor_self, UInt32.xor_zero,
+    updateBytes_eq_updateList, ByteArray.data_append, Array.toList_append,
+    Spec.updateList_append]
 
 end Crc32.Native

--- a/ZipTest/NativeChecksum.lean
+++ b/ZipTest/NativeChecksum.lean
@@ -4,18 +4,6 @@ import Zip.Native.Crc32
 
 /-! Conformance tests comparing native Adler32 and CRC32 implementations against FFI. -/
 
-/-- Sanity check that the `crc32_append` characterizing property is usable
-as a rewrite target for associativity over `ByteArray` concatenation. -/
-example (a b : ByteArray) :
-    Crc32.Native.crc32 0 (a ++ b) = Crc32.Native.crc32 (Crc32.Native.crc32 0 a) b :=
-  Crc32.Native.crc32_append 0 a b
-
-/-- Sanity check that the `adler32_append` characterizing property is usable
-as a rewrite target for associativity over `ByteArray` concatenation. -/
-example (a b : ByteArray) :
-    Adler32.Native.adler32 1 (a ++ b) = Adler32.Native.adler32 (Adler32.Native.adler32 1 a) b :=
-  Adler32.Native.adler32_append 1 a b
-
 def ZipTest.NativeChecksum.tests : IO Unit := do
   let big ← mkTestData
   let helloBytes := "Hello, world!".toUTF8

--- a/progress/20260422T104752Z_bd26e67c.md
+++ b/progress/20260422T104752Z_bd26e67c.md
@@ -1,0 +1,209 @@
+# Progress — 2026-04-22 (review, bd26e67c)
+
+**Session type**: review
+**Issue**: #1648 — Review: CRC32 + Adler-32 `_append` characterizing
+properties (PRs #1640 / #1641)
+
+## Accomplished
+
+Audited the three deliverables called for by the issue and made one
+code change per deliverable.
+
+### 1. `Crc32.Native.crc32_append` proof minimality
+
+Refactored the proof body. Original: 8 lines, two private `have`
+lemmas (`raw_eq`, `xor_twice`), one `simp only` + one `rw` with three
+repeated `updateBytes_eq_updateList` entries.
+
+New proof body: 7 lines. Changes:
+
+- **Dropped the `xor_twice` helper entirely.** The goal
+  `(x ^^^ 0xFFFFFFFF) ^^^ 0xFFFFFFFF = x` is a composition of three
+  standard-library `@[simp]` lemmas:
+  `UInt32.xor_assoc`, `UInt32.xor_self`, `UInt32.xor_zero`. Adding them
+  to the `simp only` set replaces both the `have` and the `xor_twice`
+  rewrite — reducing two tactic-level lines to zero while making the
+  underlying algebraic cancellation (associate, self-cancel, drop zero)
+  explicit at the call site.
+- **Collapsed the three repeated `updateBytes_eq_updateList` rewrites
+  into a single `simp only` entry.** The original used `rw` (one
+  rewrite per occurrence), necessitating three copies of the lemma
+  name. `simp only` handles all occurrences in one go.
+- **Shortened `intro x; bv_decide` → `bv_decide`.** `bv_decide` accepts
+  the `∀ x : UInt32, ...` goal directly; the `intro x` was unnecessary.
+
+Worth noting that a single-pass `simp only` over the entire rewrite
+chain does **not** work: if `UInt32.xor_assoc` / `xor_self` / `xor_zero`
+fire before `raw_eq`, they simplify the `init ^^^ 0xFFFFFFFF` inside
+the `if` branch to a form that no longer matches `raw_eq`'s
+`x ^^^ 0xFFFFFFFF` pattern. The split into two consecutive `simp only`
+calls (first `crc32` + `raw_eq`, then the cancellation + list-lemma
+set) preserves the intended rewrite order.
+
+`raw_eq` itself cannot be dropped — the `if init == 0 then 0xFF..F
+else init ^^^ 0xFF..F` special-case is a performance optimization in
+the `crc32` definition that reduces to `init ^^^ 0xFF..F` only after a
+`bv_decide`-level case-analysis, not by any standard `@[simp]` rule.
+
+### 2. `Adler32.Native.adler32_append` proof minimality
+
+Refactored the proof body. Original: 16 lines of body plus 4 lines of
+comment, with `simp only [adler32]; rw [updateBytes_eq_updateList × 3,
+ByteArray.data_append, Array.toList_append, Spec.updateList_append]`
+then a `match A with | [] ... | x :: xs ...` where each branch has a
+two-step tactic sequence (and the cons branch introduces a named
+`hvalid`).
+
+New proof body: 12 lines (comment retained). Changes:
+
+- **Fused `simp only [adler32]` with the subsequent `rw` chain into a
+  single `simp only`**, same idea as CRC-32: collapses the three
+  repeated `updateBytes_eq_updateList` occurrences. Order-sensitivity
+  is not an issue here because no later lemma rewrites the intermediate
+  `updateBytes`/`ByteArray.data`/`Array.toList` forms.
+- **Nil branch**: `simp only [updateList_nil]; rw [pack_unpack]` →
+  single `rw [updateList_nil, pack_unpack]` (2 lines → 1).
+- **Cons branch**: inlined the `hvalid` binding. The proof of
+  `Valid (updateList (unpack init) (x :: xs))` is
+  `Spec.updateList_cons .. ▸ updateList_valid _ (updateByte_valid ..) _`
+  (a rewrite via `updateList_cons` of
+  `Valid (updateList (updateByte (unpack init) x) xs)` — produced by
+  `updateList_valid` starting from the always-valid `updateByte`
+  output). Passing that term directly to `unpack_pack_of_valid _`
+  eliminates the standalone `have` block (4 lines → 2).
+
+**The case-split itself cannot be eliminated** for the current theorem
+statement. `unpack init` for an arbitrary `init : UInt32` may not be
+`Valid` — specifically when `init.toNat % 65536 ∈ [MOD_ADLER, 65536)`
+(15 values in that gap). The nil case therefore needs `pack_unpack`
+(`pack ∘ unpack = id`, no Valid required) while the cons case needs
+`unpack_pack_of_valid` (needs Valid, established by the first
+`updateByte`). A unified lemma
+`unpack (pack (updateList (unpack init) A)) = updateList (unpack init) A`
+holds for all `A`, but proving it would require the same case split —
+moving the split elsewhere doesn't save lines. A
+`Spec.unpack_init_valid : Valid (unpack 1)` lemma would collapse the
+cons case only for the specific `init = 1` seed; the theorem quantifies
+over all `UInt32` inits, so such a lemma doesn't apply.
+
+### 3. Test redundancy in `ZipTest/NativeChecksum.lean`
+
+**Removed** both +6-line `example` stanzas added by #1640 and #1641.
+
+Each block was of the shape
+
+```lean
+/-- Sanity check that the `F_append` characterizing property is usable
+as a rewrite target for associativity over `ByteArray` concatenation. -/
+example (a b : ByteArray) :
+    F init (a ++ b) = F (F init a) b :=
+  F_append init a b
+```
+
+with `init = 0` for CRC and `init = 1` for Adler. These are not:
+
+- **conformance tests** (native-vs-FFI): they don't mention FFI at all;
+- **finite spot-checks** on concrete inputs: the arguments `a, b` are
+  universally quantified free variables;
+- **edge-case exercises**: they don't instantiate any specific
+  `ByteArray` value, not even `.empty`.
+
+They are purely a re-statement of the theorem signature at a fixed
+`init`. All information the `example` encodes is already the
+theorem's type, and `Crc32.Native.crc32_append` / `.adler32_append`
+are both already exported public theorems. CLAUDE.md's "Testing in
+Formal Verification" guidance ("Once correctness is proven, remove
+exploratory tests — theorems are stronger than finite test sets")
+applies directly.
+
+**Kept** the pre-existing IO-level tests (runtime `assert!` chains
+starting at lines 33-40 for Adler-32 and 61-71 for CRC-32 in the
+pre-cleanup file). These exercise concerns the theorem does **not**
+subsume:
+
+- **Native-vs-FFI incremental conformance**: `nativeInc2 == ffiInc2`
+  compares two independent implementations of the split-then-combine
+  computation. The theorem relates native to the native *spec*; it
+  doesn't witness FFI agreement. FFI can have different semantics at
+  edge cases (allocation, byte-order on unusual architectures) that
+  only the runtime test can catch.
+- **`ByteArray.extract` + `ByteArray.append` composition**: the
+  `firstHalf ++ secondHalf = big` identity over `ByteArray.extract`
+  pieces is an implicit runtime check. `adler32_append`/`crc32_append`
+  only produces `adler32 1 (firstHalf ++ secondHalf) = adler32 (adler32
+  1 firstHalf) secondHalf` — it does not prove `firstHalf ++
+  secondHalf = big`. The existing assertion `nativeInc2 == nativeWhole`
+  implicitly checks the extract/append composition.
+
+## Decisions / patterns
+
+- **Library simp lemmas over bespoke `bv_decide` helpers where the
+  algebraic structure is visible.** For `(x ^^^ c) ^^^ c = x` with
+  concrete `c`, listing `UInt32.xor_assoc` + `UInt32.xor_self` +
+  `UInt32.xor_zero` in a `simp only` is strictly more informative than
+  a bespoke `bv_decide` helper, because the three-lemma chain names
+  each algebraic step (associativity, self-cancellation, zero
+  identity). The bespoke helper is better only when the identity is
+  genuinely ad-hoc (e.g. the `if init == 0 then 0xFF..F else init ^^^
+  0xFF..F` special case). Pattern worth copying in future
+  `_append`-style characterizing-property proofs for FNV-1a, XxHash,
+  etc.
+- **`simp only` vs. `rw` for collapsing repeated rewrites.** When the
+  same lemma fires at three (or more) occurrences of a subterm,
+  `simp only [lemma]` rewrites all at once; `rw [lemma, lemma,
+  lemma]` (as the author-mode proofs used) is a code smell that
+  signals the `simp only` refactor.
+- **`simp only` ordering is not preserved.** Putting the full rewrite
+  set into a single `simp only` can break if rewrite rules compose
+  non-commutatively (the `xor_twice` / `raw_eq` interaction in
+  `crc32_append` is a concrete instance). Keep multiple `simp only`
+  passes when rule order matters.
+- **`h ▸ term`-style "inline the proof" simplification.** For
+  single-use `have h : Valid (...) := ...; rw [lemma _ h]`, the term
+  `lemma _ (witness-expression)` with `▸` to reshape the witness is
+  often cleaner than the named `have`. Applies whenever the witness
+  is built by a short chain of lemma applications and the only reason
+  to name it was proof-term reuse.
+- **Case-split inevitability test.** Before trying to eliminate a
+  case split, identify whether the two branches need *different*
+  lemmas (e.g. `pack_unpack` vs. `unpack_pack_of_valid`). If they do,
+  the split is structural; only a helper that performs the split
+  internally can remove it from the caller. No-op when the helper is
+  single-use.
+
+## Quality deltas
+
+- `grep -rc sorry Zip/` — 0 (unchanged from issue baseline).
+- `lake build -R` — clean, 191 jobs successful.
+- `lake exe test` — all tests pass, including the retained
+  `NativeChecksum` incremental-conformance assertions.
+- Diff (two commits):
+  - `refactor: shorten crc32_append / adler32_append proofs` — 2 files,
+    +10 / −16 (6-line net reduction across both proof bodies).
+  - `test: remove redundant crc32/adler32_append example stanzas` —
+    1 file, 0 / −12.
+  - Total: 3 files, +10 / −28 (18-line net reduction).
+- No theorem statement was modified. No new lemmas were introduced
+  (no `Spec.checksum_append`-style expansion of scope).
+- No changes to `PLAN.md`, `PROGRESS.md`, `.claude/CLAUDE.md`, or
+  `SECURITY_INVENTORY.md`.
+- `PLAN.md:27-28` cross-reference in the proof docstrings was
+  spot-checked — the paragraph at those line numbers still describes
+  the *Cross-cutting Concerns → Characterizing Properties* gold
+  standard. No flag to the planner is needed.
+
+## Remaining
+
+None. All three deliverables from issue #1648 are addressed.
+
+### Follow-up suggestions (no new issue created, per scope discipline)
+
+- A future audit could consider whether the existing FFI-vs-native
+  *incremental* assertions in `ZipTest/NativeChecksum.lean` should
+  move into a `#guard_msgs`-style or `ByteArray`-value-parameterised
+  golden test — currently they rely on a single `big` buffer. Out of
+  scope for this review (unchanged by the `_append` PR wave).
+- Review template for future `_append`-style proofs: the two-pass
+  `simp only` + single-step `rw` shape used here is small enough to
+  copy wholesale into an FNV-1a or XxHash `_append` proof if those
+  characterizing properties are added. No action needed now.


### PR DESCRIPTION
Closes #1648

Session: `bd26e67c-87d4-40ea-8cea-da4fa3529906`

622e58f chore: progress entry for #1648
cd8b463 test: remove redundant crc32/adler32_append example stanzas
adf8efb refactor: shorten crc32_append / adler32_append proofs

🤖 Prepared with Claude Code