### PR TITLE
Feature: Track E — extend fuzz harness to streaming decompressStream APIs (PR #1610 F-c)

### DIFF
--- a/ZipTest/FuzzInflate.lean
+++ b/ZipTest/FuzzInflate.lean
@@ -109,6 +109,95 @@ private def tryStreaming (chunks : Array ByteArray) : IO Unit := do
   catch _ =>
     pure ()
 
+/-- `maxDecompressedSize` classes used by the high-level streaming
+    fuzz probes. `0` opts into unlimited mode (the PR #1610
+    pre-default / the opt-in for trusted input), so the "no-cap"
+    code path is still exercised after PR #1631 flipped the default
+    to 1 GiB. The finite entries stress the `IO.Ref UInt64` counter +
+    guard at different "distance to cap" regimes. Bomb detection is
+    out of scope — random bytes rarely decompress, and when they do
+    the output is tiny — the value is cross-chunk counter
+    soundness. See PR #1616 review F-c. -/
+private def maxClasses : Array UInt64 :=
+  #[0, 64, 1024, 65536]
+
+/-- Sink `IO.FS.Stream` that discards every byte written. Used as
+    the output side of the high-level streaming fuzz probes — the
+    fuzz driver cares only about whether the decoder crashes or
+    violates a contract, not about the decompressed bytes. -/
+private def discardSinkStream : IO.FS.Stream := {
+  flush := pure ()
+  read := fun _ => pure ByteArray.empty
+  write := fun _ => pure ()
+  getLine := pure ""
+  putStr := fun _ => pure ()
+  isTty := pure false
+}
+
+/-- Readable `IO.FS.Stream` that yields the given `chunks` in order,
+    one chunk per `read` call (capped to the requested byte count).
+    Skips exhausted / empty chunks so the consumer sees an empty
+    read only after every chunk is drained — critical because
+    `decompressStream` treats the first empty read as EOF. -/
+private def chunksReadStream (chunks : Array ByteArray) : IO IO.FS.Stream := do
+  let idxRef ← IO.mkRef 0
+  let offRef ← IO.mkRef 0
+  return {
+    flush := pure ()
+    read := fun n => do
+      let mut idx ← idxRef.get
+      let mut off ← offRef.get
+      -- Advance past already-drained chunks. At most `chunks.size`
+      -- iterations; bounded `for` keeps this obviously terminating.
+      for _ in [:chunks.size] do
+        if idx ≥ chunks.size then break
+        if off < chunks[idx]!.size then break
+        idx := idx + 1
+        off := 0
+      if idx ≥ chunks.size then
+        idxRef.set idx
+        offRef.set 0
+        return ByteArray.empty
+      let chunk := chunks[idx]!
+      let available := chunk.size - off
+      let toRead := min n.toNat available
+      let result := chunk.extract off (off + toRead)
+      idxRef.set idx
+      offRef.set (off + toRead)
+      return result
+    write := fun _ => throw (IO.userError "chunksReadStream: write not supported")
+    getLine := pure ""
+    putStr := fun _ => pure ()
+    isTty := pure false
+  }
+
+/-- Drive the high-level `Gzip.decompressStream` path with the
+    fuzz-generated `chunks` feeding an in-memory input stream and a
+    PRNG-picked `maxDecompressedSize`. Exercises the Lean-side
+    `IO.Ref UInt64` counter at `Zip/Gzip.lean:89-97` that the
+    low-level `InflateState.push/finish` surface does not see. -/
+private def tryStreamingGzip (chunks : Array ByteArray)
+    (maxCap : UInt64) : IO Unit := do
+  try
+    let inStream ← chunksReadStream chunks
+    Gzip.decompressStream inStream discardSinkStream
+      (maxDecompressedSize := maxCap)
+  catch _ =>
+    pure ()
+
+/-- Drive the high-level `RawDeflate.decompressStream` path with the
+    fuzz-generated `chunks` and a PRNG-picked `maxDecompressedSize`.
+    Same counter pattern as `tryStreamingGzip`, on the raw-deflate
+    wrapper at `Zip/RawDeflate.lean:59-69`. -/
+private def tryStreamingRawDeflate (chunks : Array ByteArray)
+    (maxCap : UInt64) : IO Unit := do
+  try
+    let inStream ← chunksReadStream chunks
+    RawDeflate.decompressStream inStream discardSinkStream
+      (maxDecompressedSize := maxCap)
+  catch _ =>
+    pure ()
+
 /-- One fuzz iteration: generate a random input of some size and
     drive every inflate entry point on it. Updates and returns the
     PRNG state. -/
@@ -130,10 +219,18 @@ private def oneIteration (state : UInt64) : IO UInt64 := do
     (Zip.Native.ZlibDecode.decompress input defaultMaxOutput)
   tryNative "Zip.Native.decompressAuto"
     (Zip.Native.decompressAuto input defaultMaxOutput)
-  -- Streaming FFI path (the only streaming decoder we expose).
+  -- Streaming FFI paths: the low-level `InflateState.push/finish`
+  -- surface and the high-level `decompressStream` wrappers. The
+  -- high-level probes share one PRNG-picked `maxDecompressedSize`
+  -- across the gzip + raw-deflate calls — fewer xorshift advances
+  -- per iteration keeps the PRNG state-space simple.
   let (chunks, s2) := splitIntoChunks input s1
   tryStreaming chunks
-  return s2
+  let s3 := xorshift64 s2
+  let maxCap := pick maxClasses s3
+  tryStreamingGzip chunks maxCap
+  tryStreamingRawDeflate chunks maxCap
+  return s3
 
 /-- Run `iterations` fuzz iterations starting from `seed`. Every
     iteration drives every inflate entry point listed above on a

--- a/progress/20260422T111405Z_a1eff9df.md
+++ b/progress/20260422T111405Z_a1eff9df.md
@@ -1,0 +1,94 @@
+# Track E F-c — fuzz harness extension to high-level streaming APIs
+
+**Session**: `a1eff9df` (feature)
+**Date**: 2026-04-22 (UTC)
+**Issue**: #1644 — "Feature: Track E — extend fuzz harness to
+streaming `decompressStream` APIs (PR #1610 F-c)"
+**Branch**: `agent/a1eff9df`
+
+## What was done
+
+Extended `ZipTest/FuzzInflate.lean` with two new probes —
+`tryStreamingGzip` / `tryStreamingRawDeflate` — that drive the
+high-level `Gzip.decompressStream` and `RawDeflate.decompressStream`
+entry points under randomised input and a PRNG-picked
+`maxDecompressedSize`. The low-level `InflateState.push/finish`
+probe (`tryStreaming`) stays intact; the new probes cover the
+Lean-side `IO.Ref UInt64` counter + `next > maxDecompressedSize`
+guard wrapping the FFI — the path added by PR #1610 and flipped to
+a finite 1 GiB default by PR #1631.
+
+**Deliverables**
+
+1. `maxClasses : Array UInt64 := #[0, 64, 1024, 65536]` — `0` opts
+   into unlimited mode (so the `maxDecompressedSize ≠ 0` branch is
+   still exercised after the 1 GiB flip), the three finite entries
+   stress the counter + guard at different "distance to cap"
+   regimes.
+2. `discardSinkStream : IO.FS.Stream` — pure-pass sink that
+   discards bytes; the fuzz driver only cares about crashes /
+   contract violations, not output content.
+3. `chunksReadStream (chunks : Array ByteArray) : IO IO.FS.Stream`
+   — readable in-memory stream that yields one (possibly
+   fragmented) fuzz chunk per `read` call, **skipping exhausted /
+   empty chunks** so `decompressStream` doesn't see a premature EOF
+   between chunks. Critical subtlety: without the skip, an empty
+   chunk mid-stream would terminate the decoder early because
+   `decompressStream`'s top-level loop treats empty reads as EOF.
+4. `tryStreamingGzip` and `tryStreamingRawDeflate` — both follow
+   the `tryStreaming` blanket-catch shape, calling
+   `decompressStream` on an in-memory chunk stream paired with the
+   discard sink.
+5. `oneIteration` wiring — one extra `xorshift64` step produces the
+   shared `maxCap` for both probes, added right after
+   `tryStreaming`. Returns the new state `s3` instead of `s2`.
+
+## Verification
+
+- `lake build -R` — clean, 191/191 jobs.
+- `lake exe test` — **all tests passed** (seed `0xdeadbeef`,
+  1000 iterations), including the `FuzzInflate tests...` smoke
+  run. No observable wall-clock regression.
+- `grep -rc sorry Zip/` — 0 sorries (unchanged baseline).
+- Regression sanity: two alt-seed `lake exe fuzz_inflate 2` runs
+  (`LEAN_ZIP_FUZZ_SEED=42` → 19 442 iterations, `=99999` →
+  20 298 iterations) both completed in 2 s wall time with no
+  failure. High-level probes do not introduce iteration-specific
+  flakiness.
+- `grep -n "Gzip.decompressStream\|RawDeflate.decompressStream"
+  ZipTest/FuzzInflate.lean` — four matches (two in helper bodies,
+  two in the preceding docstrings).
+- `grep -n "maxClasses" ZipTest/FuzzInflate.lean` — two matches
+  (definition + `pick` call in `oneIteration`).
+
+## Decisions / patterns
+
+- **One chunk per read, with skip-empty.** The cleanest way to
+  preserve the PRNG-split `chunks` semantic inside the high-level
+  API — each `decompressStream` top-level iteration corresponds
+  to one fuzz chunk. This maximises cross-chunk state coverage
+  (counter accumulation across multiple `state.push` calls)
+  without introducing a separate fragmentation knob.
+- **Shared `maxCap` across both probes per iteration.** Follows
+  the issue's PRNG-state-space guidance — one `xorshift64`
+  advance produces both probes.
+- **Blanket `catch _`** matches the existing `tryStreaming` shape.
+  The only `IO.Error` variant in-play is `userError` (zlib FFI and
+  the "exceeds limit" `throw`), but uniformity with the neighbour
+  keeps the driver predictable.
+
+## Quality metrics
+
+- Diff: 99 insertions, 2 deletions, `ZipTest/FuzzInflate.lean`
+  only — no changes to `Zip/**`, `c/**`, `SECURITY_INVENTORY.md`,
+  `plans/`, `PLAN.md`, `.claude/CLAUDE.md`, `ZipFuzzInflate.lean`,
+  or `scripts/fuzz-inflate.sh`.
+- Sorries: 0 → 0.
+- Build: clean (191/191).
+- Tests: pass (1000-iter smoke + 2 × 2 s alt-seed runs).
+
+## What remains
+
+- **F-d** — saturating `UInt64` counter add in the streaming FFI
+  decoders (PR #1610 review) is still open as #1645. Orthogonal
+  production-code hardening; does not overlap this test-only PR.


### PR DESCRIPTION
Closes #1644

Session: `a1eff9df-11e1-4e37-9b6f-f8223a58071f`

2c00211 doc: progress entry for #1644 (F-c fuzz extension)
0b502d9 test: fuzz high-level decompressStream APIs (PR #1616 F-c)

🤖 Prepared with Claude Code