### PR TITLE
Feature: CRC32 checksum_pair closed form (two table lookups, analog of Adler-32 checksum_pair)

### DIFF
--- a/Zip/Native/Crc32.lean
+++ b/Zip/Native/Crc32.lean
@@ -109,6 +109,24 @@ theorem crc32_singleton (b : UInt8) :
     updateBytes_eq_updateList, hdata]
   exact Spec.checksum_singleton b
 
+/-- Closed form for the CRC-32 of a two-byte input starting from the
+default `init = 0`. Matches `Spec.checksum_pair` via
+`updateBytes_eq_updateList`. -/
+theorem crc32_pair (b₁ b₂ : UInt8) :
+    crc32 0 (ByteArray.mk #[b₁, b₂]) =
+      (let s₁ : UInt32 :=
+        0x00FFFFFF ^^^ Spec.mkTable[0xFF ^^^ b₁.toNat]'
+          (by exact Spec.xor_ff_byte_lt_mkTable_size b₁)
+       (s₁ >>> 8) ^^^
+         Spec.mkTable[((s₁ ^^^ UInt32.ofNat b₂.toNat) &&& 0xFF).toNat]'(by
+           rw [Spec.mkTable_size]; exact and_0xFF_toNat_lt _) ^^^ 0xFFFFFFFF) := by
+  have hdata : (ByteArray.mk #[b₁, b₂]).data.toList = [b₁, b₂] := rfl
+  simp only [crc32]
+  show _ ^^^ (0xFFFFFFFF : UInt32) = _
+  rw [show ((0 : UInt32) == 0) = true from rfl, if_pos rfl,
+    updateBytes_eq_updateList, hdata]
+  exact Spec.checksum_pair b₁ b₂
+
 /-- Compositionality of incremental CRC-32 computation (native level,
 see `PLAN.md:27-28`). Associativity of `crc32` over `ByteArray` append
 — an incremental streaming pipeline over concatenated chunks yields

--- a/Zip/Spec/Crc32.lean
+++ b/Zip/Spec/Crc32.lean
@@ -182,4 +182,48 @@ theorem checksum_singleton (b : UInt8) :
   generalize mkTable[0xFF ^^^ b.toNat]'(hidx ▸ hlt) = t
   bv_decide
 
+/-- The CRC-32 checksum of a two-byte input `[b₁, b₂]` has a closed
+form as two `mkTable` lookups. The running state `s₁` after byte `b₁`
+is `0x00FFFFFF ^^^ mkTable[0xFF ^^^ b₁.toNat]` (the `0x00FFFFFF` comes
+from `0xFFFFFFFF >>> 8`); then the second table lookup is indexed by
+the low byte of `s₁ ^^^ b₂`. The trailing `^^^ 0xFFFFFFFF` is the
+final complement. -/
+theorem checksum_pair (b₁ b₂ : UInt8) :
+    checksum [b₁, b₂] =
+      (let s₁ : UInt32 :=
+        0x00FFFFFF ^^^ mkTable[0xFF ^^^ b₁.toNat]'
+          (by exact xor_ff_byte_lt_mkTable_size b₁)
+       (s₁ >>> 8) ^^^
+         mkTable[((s₁ ^^^ UInt32.ofNat b₂.toNat) &&& 0xFF).toNat]'(by
+           rw [mkTable_size]; exact and_0xFF_toNat_lt _) ^^^ 0xFFFFFFFF) := by
+  -- Bridge the inner `crcByte` through the table.
+  show crcByte (crcByte 0xFFFFFFFF b₁) b₂ ^^^ 0xFFFFFFFF = _
+  rw [← crcByteTable_mkTable_eq_crcByte 0xFFFFFFFF b₁]
+  simp only [crcByteTable]
+  have hb1 : b₁.toNat < UInt32.size := Nat.lt_trans b₁.toNat_lt (by decide)
+  have hlt₁ : ((((0xFFFFFFFF : UInt32) ^^^ UInt32.ofNat b₁.toNat) &&& 0xFF).toNat) <
+      mkTable.size := by rw [mkTable_size]; exact and_0xFF_toNat_lt _
+  rw [dif_pos hlt₁]
+  -- Simplify the inner index to `0xFF ^^^ b₁.toNat`.
+  have hidx₁ :
+      (((0xFFFFFFFF : UInt32) ^^^ UInt32.ofNat b₁.toNat) &&& 0xFF).toNat =
+      0xFF ^^^ b₁.toNat := by
+    rw [UInt32.toNat_and, UInt32.toNat_xor, UInt32.toNat_ofNat_of_lt' hb1,
+      show ((0xFFFFFFFF : UInt32).toNat) = 0xFFFFFFFF from rfl,
+      show ((0xFF : UInt32).toNat) = 0xFF from rfl,
+      Nat.and_xor_distrib_right,
+      show (0xFFFFFFFF : Nat) &&& 0xFF = 0xFF from rfl,
+      Nat.and_two_pow_sub_one_of_lt_two_pow (n := 8) b₁.toNat_lt]
+  rw [getElem_congr_idx (c := mkTable) hidx₁]
+  -- `0xFFFFFFFF >>> 8 = 0x00FFFFFF`, so the running state matches `s₁`.
+  rw [show ((0xFFFFFFFF : UInt32) >>> 8) = 0x00FFFFFF from rfl]
+  -- Bridge the outer `crcByte` through the table.
+  rw [← crcByteTable_mkTable_eq_crcByte _ b₂]
+  simp only [crcByteTable]
+  have hlt₂ : ((((0x00FFFFFF : UInt32) ^^^
+      mkTable[0xFF ^^^ b₁.toNat]'(by exact xor_ff_byte_lt_mkTable_size b₁) ^^^
+      UInt32.ofNat b₂.toNat) &&& 0xFF).toNat) < mkTable.size := by
+    rw [mkTable_size]; exact and_0xFF_toNat_lt _
+  rw [dif_pos hlt₂]
+
 end Crc32.Spec

--- a/progress/2026-04-22T20-42-37Z_81f2b9a4.md
+++ b/progress/2026-04-22T20-42-37Z_81f2b9a4.md
@@ -1,0 +1,86 @@
+# Feature session 81f2b9a4 — CRC32 `checksum_pair` / `crc32_pair`
+
+- **Date (UTC):** 2026-04-22T20:42Z
+- **Session type:** feature
+- **Issue:** #1694 (Feature: CRC32 checksum_pair closed form, two table lookups)
+- **Branch:** `agent/81f2b9a4`
+
+## What was accomplished
+
+Added the two-byte rung of the CRC-32 closed-form ladder, mirroring
+the Adler-32 `_pair` precedent (`Spec.checksum_pair` /
+`Native.adler32_pair`):
+
+- `Zip/Spec/Crc32.lean` (+44 LOC): `checksum_pair` — closed form for
+  `checksum [b₁, b₂]` as a let-bound running state `s₁` after byte
+  `b₁` (`0x00FFFFFF ^^^ mkTable[0xFF ^^^ b₁.toNat]`), then a second
+  `mkTable` lookup indexed by `((s₁ ^^^ b₂_ext) &&& 0xFF).toNat`,
+  XOR'd with `0xFFFFFFFF` (the final complement composed with the
+  high-bit residue from `s₁ >>> 8`).
+- `Zip/Native/Crc32.lean` (+18 LOC): `crc32_pair` — three-line
+  translation-validation wrapper following the `crc32_singleton`
+  template (data-as-list rewrite, `updateBytes_eq_updateList`,
+  defer to `Spec.checksum_pair`).
+
+## Proof structure
+
+Spec proof (one tactic per logical step, ~25 lines):
+1. `show crcByte (crcByte 0xFFFFFFFF b₁) b₂ ^^^ 0xFFFFFFFF = _`
+2. `rw [← crcByteTable_mkTable_eq_crcByte 0xFFFFFFFF b₁]` — bridge
+   inner `crcByte` through the public table-bridge from #1692.
+3. Unfold `crcByteTable`, discharge `dif_pos hlt₁` via
+   `mkTable_size` + `and_0xFF_toNat_lt`.
+4. `hidx₁` simplifies the inner index to `0xFF ^^^ b₁.toNat`
+   (identical Nat-level XOR/AND derivation as in
+   `checksum_singleton`).
+5. `getElem_congr_idx` rewrites the inner `mkTable` access to use
+   the simplified index.
+6. `rfl`-style rewrite reduces `0xFFFFFFFF >>> 8` to `0x00FFFFFF`.
+7. Bridge the outer `crcByte` (`← crcByteTable_mkTable_eq_crcByte _ b₂`),
+   unfold, discharge `dif_pos hlt₂`. After let-zeta the goal closes
+   by definitional equality (no `bv_decide` needed at the tail —
+   the LHS literally matches the RHS once both bridges fire).
+
+## Decisions / patterns
+
+- **Statement shape**: chose `let s₁ : UInt32 := ...` over inlining
+  `mkTable[0xFF ^^^ b₁.toNat]` twice in the RHS. Both shapes
+  hit a `maximum recursion depth` elaboration error unless the
+  proof obligation `(xor_ff_byte_lt_mkTable_size b₁)` is wrapped
+  in `(by exact ...)`. With the `by exact` wrapper, the let-bound
+  form elaborates cleanly and reads better. This `(by exact …)`
+  pattern matches the existing
+  `Spec.mkTable[…]'(by exact Spec.xor_ff_byte_lt_mkTable_size b)`
+  in `Native.crc32_singleton`.
+- **No new helper lemmas**: the visibility-ratchet rule keeps
+  helpers `private` until 3 in-file call sites appear. The
+  `((0xFFFFFFFF ^^^ b_ext) &&& 0xFF).toNat = 0xFF ^^^ b.toNat`
+  derivation now appears twice in `Zip/Spec/Crc32.lean`
+  (`checksum_singleton`, `checksum_pair`); kept inline for now,
+  next caller would justify extraction. Same for the `< 256` /
+  `mkTable.size` index bound — already a public helper
+  (`mkTable_size`) plus a private `and_0xFF_toNat_lt`.
+- **No `bv_decide` tail**: unlike `checksum_singleton` (where a
+  trailing `bv_decide` closes a `0xFF000000 ^^^ T = T ^^^ 0xFF000000`
+  re-association), the pair theorem's RHS is *literally* what the
+  iterative algorithm computes, so the proof closes by
+  definitional equality after the two bridges + index
+  simplification.
+
+## Quality metrics
+
+- `grep -rc sorry Zip/`: 0 (unchanged).
+- `lake build`: ✓ clean (191/191 jobs).
+- `lake exe test`: ✓ all tests pass.
+- `git diff --stat origin/master..HEAD`: exactly two Lean files
+  (`Zip/Spec/Crc32.lean` +44, `Zip/Native/Crc32.lean` +18) plus
+  this progress entry.
+
+## What remains
+
+The CRC-32 ladder now has `checksum_empty`, `checksum_append`,
+`checksum_singleton`, `checksum_pair`. Next rungs would be
+analogous to the Adler-32 ladder:
+`checksum_replicate_zero`, `checksum_replicate`,
+`checksum_combine` — these are separate planner-scoped issues and
+not in scope for #1694.


### PR DESCRIPTION
Closes #1694

Session: `81f2b9a4-771a-4b89-9e85-d8d684e50f13`

b8a4bbc doc: progress entry for #1694 (CRC32 checksum_pair / crc32_pair)
219d1e1 feat: CRC32 checksum_pair / crc32_pair (two table lookups, closes #1694)

🤖 Prepared with Claude Code