### PR TITLE
doc: Track E item 6 — close docstrings & error-messages bullet (#1705)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -372,9 +372,9 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all regular-file entries; directories and symlinks contribute zero. |
 | [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |
 | [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
-| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:842) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. |
-| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:842) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
-| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:842) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | whole-archive tar-buffer cap for the outer native gzip decode. |
+| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:848) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. |
+| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:848) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
+| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:851) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | whole-archive tar-buffer cap for the outer native gzip decode. |
 
 ### Known inconsistencies
 
@@ -412,11 +412,15 @@ issues and the follow-up docstring/default change.
    `ZlibDecode.decompress`, `decompressAuto`) now default to **1 GiB**,
    matching `Zip.Native.Inflate.inflate`. The factor-of-4 asymmetry
    between raw-DEFLATE and format-auto-dispatch is gone.
-6. **Docstrings and error messages**.
-   - Every decompression API should state its default, the
-     meaning of `0`, and the exact error thrown on cap overflow.
-     This is Priority 2 item 4 on the audit checklist and is a
-     separate issue.
+6. **Docstrings and error messages**. Executed — every public
+   decompression / extraction API now states its default cap, the
+   meaning of `0` (unlimited on the FFI path; rejects any non-empty
+   output on the native path), and the exact `IO.userError` /
+   `Except` substring thrown on cap overflow. The closing audit
+   covered all twelve decompression / extraction surfaces plus the
+   `Archive.list` central-directory cap; the only outstanding gap
+   (the `maxOutputSize` paragraph on `Tar.extractTarGzNative`) was
+   filled inline in this PR. See this PR.
 
 Known caller impact if recommendations 1–5 land:
 

--- a/Zip/Tar.lean
+++ b/Zip/Tar.lean
@@ -827,11 +827,18 @@ partial def extractTarGz (inputPath : System.FilePath) (outDir : System.FilePath
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*.
 
     `maxOutputSize` (default 256 MiB) caps the decompressed tar buffer
-    produced by the outer native gzip decode. The native variant exposes this
-    parameter because the pure Lean `Zip.Native.GzipDecode.decompress` API
-    requires a bound up front; the streaming `extractTarGz` variant does not
-    need one because it drains the outer compressed stream chunk-by-chunk
-    into the tar parser.
+    produced by the outer native gzip decode. Unlike the FFI path, where
+    `0` means unlimited, here `0` rejects any non-empty output (the
+    underlying native `GzipDecode.decompress` compares
+    `output.size + len > maxOutputSize`, so even a single produced byte
+    exceeds the bound). Overflow raises `IO.userError` containing
+    `"exceeds maximum size"`, wrapped as
+    `"tar.gz: native gzip decompression failed: …"`.
+    The native variant exposes this parameter because the pure Lean
+    `Zip.Native.GzipDecode.decompress` API requires a bound up front;
+    the streaming `extractTarGz` variant does not need one because it
+    drains the outer compressed stream chunk-by-chunk into the tar
+    parser.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*.
 
     `maxHeaderSize` (default `defaultMaxHeaderSize` = 8 MiB) bounds the

--- a/progress/20260422T215200Z_fa8f64fb.md
+++ b/progress/20260422T215200Z_fa8f64fb.md
@@ -1,0 +1,97 @@
+# 2026-04-22T21:52:00Z — feature session — Track E item 6 (docstrings & error messages)
+
+**Session UUID prefix**: `fa8f64fb`
+**Issue**: #1705
+**Branch**: `agent/fa8f64fb`
+**Starting commit**: `ae861127`
+
+## What was accomplished
+
+Closed *Recommended policy* item 6 ("Docstrings and error messages")
+in `SECURITY_INVENTORY.md`. Audited the twelve public decompression /
+extraction APIs (plus the `Archive.list` central-directory cap) for
+docstring coverage of the three required facts:
+
+1. the default cap value,
+2. the meaning of `0`, and
+3. the exact error substring thrown on cap overflow.
+
+Twelve surfaces were already complete from prior cleanup waves; one
+surface — the `maxOutputSize` paragraph on
+`Zip.Tar.extractTarGzNative` — was missing facts (2) and (3). Fixed
+inline (3 sentences) per the issue's verification clause that
+explicitly contemplates inline gap-fixes. Marked item 6 *Executed*
+with the standard past-tense one-liner per the
+`inventory-reconciliation` skill.
+
+## Audit table
+
+| API | File:line | Outcome | Notes |
+|---|---|---|---|
+| `Zip.Gzip.decompressStream` | `Zip/Gzip.lean:86` | complete | default 1 GiB; `0` = unlimited (bomb-unsafe); error substring `"exceeds limit"` |
+| `Zip.Gzip.decompressFile` | `Zip/Gzip.lean:129` | complete | forwards to `decompressStream`; same triple |
+| `Zip.RawDeflate.decompressStream` | `Zip/RawDeflate.lean:57` | complete | default 1 GiB; `0` = unlimited (bomb-unsafe); error substring `"exceeds limit"` |
+| `Zip.Native.GzipDecode.decompress` | `Zip/Native/Gzip.lean:40` | complete | default 1 GiB; `0` rejects any non-empty output; error substrings `"Gzip: total output exceeds maximum size"` and `"Inflate: output exceeds maximum size"` |
+| `Zip.Native.ZlibDecode.decompress` | `Zip/Native/Gzip.lean:140` | complete | default 1 GiB; `0` rejects any non-empty output; error substring `"Inflate: output exceeds maximum size"` |
+| `Zip.Native.decompressAuto` | `Zip/Native/Gzip.lean:240` | complete | default 1 GiB; `0` rejects any non-empty output; error substrings depend on dispatch |
+| `Zip.Native.Inflate.inflate` | `Zip/Native/Inflate.lean:384` | complete | default 1 GiB; `0` rejects any non-empty output; error substring `"Inflate: output exceeds maximum size"` |
+| `Zip.Archive.list` | `Zip/Archive.lean:630` | complete | `maxCentralDirSize` default 64 MiB; `0` = unlimited; error substring `"zip: central directory too large"` |
+| `Zip.Archive.extract` | `Zip/Archive.lean:654` | complete | three params (`maxCentralDirSize`, `maxEntrySize`, `maxTotalSize`) each documented with default + `0`-meaning + error substring |
+| `Zip.Archive.extractFile` | `Zip/Archive.lean:699` | complete | `maxCentralDirSize` + `maxEntrySize` documented |
+| `Zip.Tar.extract` | `Zip/Tar.lean:651` | complete | `maxEntrySize`, `maxTotalSize`, `maxHeaderSize` each documented |
+| `Zip.Tar.extractTarGz` | `Zip/Tar.lean:779` | complete | same three params; correctly notes the streaming variant has no outer `maxOutputSize` knob |
+| `Zip.Tar.extractTarGzNative` | `Zip/Tar.lean:848` (def) / `:851` (`maxOutputSize`) | **gap → fixed inline** | `maxOutputSize` paragraph was missing the `0`-meaning and the error substring; added 3-sentence clarification per the underlying native APIs |
+
+## Decision
+
+Inline fix + close item 6 in this PR, rather than file-then-PR-then-close.
+The verification clause in the issue explicitly allows this case
+(*"nothing else unless docstring gaps surfaced and were fixed inline as a
+sub-task"*), and the disproportion between a 3-sentence docstring
+fix and a separate claim/branch/PR cycle made inline the cheaper path
+without violating the "one PR per bullet" cadence (the docstring fix
+is the implementation of item 6's last surface).
+
+## Side-effect: line-anchor drift
+
+The 3-sentence docstring expansion shifted `extractTarGzNative` from
+line 842 to 848 — pushing `maxOutputSize` (the 4th parameter) from
+line 845 to 851 (3 below the def line, outside the drift detector's
+±2 window). Updated the three table rows in the inventory to point
+at the new lines (`:848` for the first two parameters within ±2 of
+the def, `:851` for `maxOutputSize` which sits exactly on its
+parameter line). `check-inventory-links.sh` returned to baseline
+`errors=0, warnings=0`.
+
+## Verification
+
+- `bash scripts/check-inventory-links.sh` → `errors=0, warnings=0` ✓
+- `lake build -R` clean ✓
+- `lake exe test` → "All tests passed!" ✓
+- `grep -rc sorry Zip/` → unchanged (still 0) ✓
+- `git diff --name-only origin/master...HEAD` → `SECURITY_INVENTORY.md`,
+  `Zip/Tar.lean`, plus this progress entry. No off-limits files touched ✓
+
+## Quality metric deltas
+
+- sorry count: 0 → 0 (no change)
+- inventory link warnings: 0 → 0 (no change)
+
+## What remains
+
+Nothing on item 6 — *Recommended policy* now reads 1, 2, 3, 4, 5, 6
+all *Executed*. The next planner can reference this PR's number
+once the squash-merge lands, if they want to back-fill the
+"See this PR" placeholder with the literal PR number.
+
+## Notes for future planners
+
+- The `extractTarGz` docstring still mentions *"the known gap tracked by
+  …recommendation 2"* (around `Zip/Tar.lean:765`). Recommendation 2 has
+  been *Executed* for the streaming FFI decoders — the gap that note
+  is referring to is actually that `extractTarGz` uses
+  `Gzip.InflateState` directly and bypasses the cap added by Rec. 2.
+  The note's wording is slightly stale but technically still accurate
+  about the absence of an outer cap on this specific path. Out of
+  scope for this issue (no missing fact about *this* function's
+  parameters), but a planner might choose to file a polish-issue.


### PR DESCRIPTION
Closes #1705

Session: `fa8f64fb-b4ce-4099-bb06-1de1ed888bf8`

3340e6c doc: progress entry for Track E item 6 (issue #1705)
30799df doc: Track E item 6 — close *Recommended policy* item 6 (docstrings & error messages)

🤖 Prepared with Claude Code