### PR TITLE
Test: Adler-32 _combine fixture extensions (empty-xs boundary + large-random split, deterministic)

### DIFF
--- a/ZipTest/NativeChecksum.lean
+++ b/ZipTest/NativeChecksum.lean
@@ -42,15 +42,22 @@ def ZipTest.NativeChecksum.tests : IO Unit := do
   let nativeSingle := Adler32.Native.adler32 1 singleByte
   assert! ffiSingle == nativeSingle
 
-  -- adler32_combine on three (xs, ys) pairs of distinct lengths: empty, 1 byte, 10 bytes.
+  -- adler32_combine on six (xs, ys) pairs: empty-ys, single-byte ys, moderate ys,
+  -- moderate-on-both, empty-xs boundary, and a deterministic 1000-byte split-at-500.
   let combineEmpty : ByteArray := ByteArray.empty
   let combineOne : ByteArray := ByteArray.mk #[7]
   let combineTen : ByteArray := ByteArray.mk #[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  let emptyXsYs : ByteArray := ByteArray.mk #[0x42, 0x07, 0xFF, 0x00, 0x80]
+  let largeData : ByteArray :=
+    ByteArray.mk ((List.range 1000).map (fun i => (i * 31 + 17).toUInt8)).toArray
+  let largeXs := largeData.extract 0 500
+  let largeYs := largeData.extract 500 1000
   let prefix₁ := ByteArray.mk #[100, 101, 102]
   let prefix₂ := helloBytes
   let cases : List (ByteArray × ByteArray) :=
     [(prefix₁, combineEmpty), (prefix₂, combineOne),
-     (combineOne, combineTen), (prefix₂, combineTen)]
+     (combineOne, combineTen), (prefix₂, combineTen),
+     (combineEmpty, emptyXsYs), (largeXs, largeYs)]
   for (xs, ys) in cases do
     let ax := Adler32.Native.adler32 1 xs
     let ay := Adler32.Native.adler32 1 ys

--- a/progress/20260422T220348Z_c6638840.md
+++ b/progress/20260422T220348Z_c6638840.md
@@ -1,0 +1,85 @@
+# Feature session: Adler-32 `_combine` fixture extensions
+
+- **UTC:** 2026-04-22T22:03Z
+- **Session UUID prefix:** `c6638840`
+- **Issue:** #1706 — Test: Adler-32 `_combine` fixture extensions
+  (empty-`xs` boundary + large-random split, deterministic)
+- **Agent type:** feature (implementation)
+
+## Summary
+
+Extended the runtime conformance fixture for
+`Adler32.Native.adler32_combine` in `ZipTest/NativeChecksum.lean` from
+four `(xs, ys)` pairs to six, closing the two gaps flagged in PR #1700's
+review (`progress/20260422T202056Z_559099ab.md` §F): the **empty-`xs`
+boundary** and a **deterministic 1000-byte split-at-500**. Test-only
+change; no theorem, spec, or native implementation touched.
+
+## Post-extension fixture table
+
+| row | xs length | ys length | notes                                          |
+|-----|-----------|-----------|------------------------------------------------|
+| 1   |   3       |   0       | empty-`ys` boundary (pre-existing)             |
+| 2   |  13       |   1       | single-byte `ys` (pre-existing)                |
+| 3   |   1       |  10       | moderate `ys`, tiny `xs` (pre-existing)        |
+| 4   |  13       |  10       | moderate on both sides (pre-existing)          |
+| 5   |   0       |   5       | **empty-`xs` boundary (new)**                  |
+| 6   | 500       | 500       | **deterministic 1000-byte split-at-500 (new)** |
+
+Row 5 uses `ys = #[0x42, 0x07, 0xFF, 0x00, 0x80]` — five bytes chosen
+to exercise both halves of the running Adler-32 state (high bit, low
+byte, zero, and mid-range values). When `xs = []`,
+`adler32 1 xs = 1 = pack (1, 0)`, so the formula's `+ MOD_ADLER - 1`
+shift cancels `a1 = 1` trivially — this row makes that reduction
+empirical, not just symbolic.
+
+Row 6 uses `largeData = ByteArray.mk ((List.range 1000).map
+(fun i => (i * 31 + 17).toUInt8)).toArray`, then
+`largeXs := largeData.extract 0 500` and
+`largeYs := largeData.extract 500 1000`. Determinism: no `IO.rand`;
+the byte sequence is a pure function of `(i * 31 + 17) mod 256`.
+Because `gcd(31, 256) = 1`, the map is a bijection over every 256
+consecutive `i`, so all 256 distinct `UInt8` values occur at least
+three times each in the 1000-byte payload (well above the
+issue's "≥ 200 distinct values" bar). The 500/500 split adds
+differential coverage against silent overflow on the Native side
+(`adler32_combine` threads a 32-bit accumulator; at 500 bytes of
+arbitrary-looking data, `a2` grows well past any naive 16-bit
+wraparound threshold).
+
+## What's intentionally not in this PR
+
+- **No property-based / random fuzz harness.** This is a
+  deterministic-fixture extension, per the issue's non-goals.
+- **No `_replicate`, `_replicate_zero`, or `_pair` test additions**,
+  even though those share the closed-form ladder shape — scope is
+  strictly `_combine`, per the review's flagged gaps.
+- **No CRC32 combine tests** — CRC32 `_combine` is gated by GF(2)[x]
+  and out of scope.
+- **No theorem or proof changes.** `adler32_combine_eq_concat`
+  already covers all `ByteArray` pairs symbolically; these fixtures
+  are differential-coverage backstops, not verification.
+
+## Verification
+
+- `lake build`: clean (test-only file edit).
+- `lake exe test`: all tests pass; `Native checksum tests: OK`
+  observed in log.
+- `grep -rc sorry Zip/`: unchanged (all files at 0; no spec touched).
+- `bash scripts/check-inventory-links.sh`: `errors=0, warnings=0`.
+- `git diff --stat origin/master...HEAD`: single file touched,
+  `ZipTest/NativeChecksum.lean` (+9 / -2).
+
+## Quality metric deltas
+
+- `sorry` count: **0 → 0** (no change).
+- Fixture rows for `adler32_combine`: **4 → 6**.
+- Lines added in `ZipTest/NativeChecksum.lean`: **9**
+  (well under the 15-LOC sizing target).
+
+## Follow-ups
+
+None identified. The issue scope was narrow and is fully addressed.
+The review's two flagged gaps (empty-`xs`, large-random split) are
+now closed as deterministic fixtures; no further runtime-test
+extensions for `_combine` are on the roadmap.


### PR DESCRIPTION
Closes #1706

Session: `c6638840-ac11-412d-8da5-dd34d0942f4f`

d41b775 test: extend Adler-32 _combine fixture with empty-xs boundary and 1000-byte split

🤖 Prepared with Claude Code