### PR TITLE
doc: SECURITY_INVENTORY.md drift refresh — Tar.extract maxEntrySize default (1 GiB, not 0)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -487,7 +487,7 @@ perform a `Nat → USize` roundtrip check before every `Handle.read`.
 | [Zip/Tar.lean:565](/home/kim/lean-zip/Zip/Tar.lean:565) `readExact input 512` in `forEntries` | fixed `512` (one tar header block) | fixed constant | N/A — fixed 512-byte read |
 | [Zip/Tar.lean:572](/home/kim/lean-zip/Zip/Tar.lean:572), [:582](/home/kim/lean-zip/Zip/Tar.lean:582), [:592](/home/kim/lean-zip/Zip/Tar.lean:592), [:598](/home/kim/lean-zip/Zip/Tar.lean:598) `readEntryData input entry.size.toNat maxHeaderSize` (GNU long-name, GNU long-link, PAX extended header, PAX global header) | `entry.size` from tar header (attacker-controlled `UInt64`) | `maxHeaderSize` cap inside `readEntryData` at [Zip/Tar.lean:222](/home/kim/lean-zip/Zip/Tar.lean:222) (default `defaultMaxHeaderSize = 8 MiB` at [Zip/Tar.lean:212](/home/kim/lean-zip/Zip/Tar.lean:212)) — rejects `entry.size > maxHeaderSize` before any allocation with `IO.userError` containing `"exceeds maximum header size"`. Per-chunk reads are also capped at 64 KiB ([Zip/Tar.lean:229](/home/kim/lean-zip/Zip/Tar.lean:229)) and padding at 512 bytes per chunk ([Zip/Tar.lean:238](/home/kim/lean-zip/Zip/Tar.lean:238)). The cap is independent of the caller's `maxEntrySize`, which only bounds payload-bearing entries. Regression fixtures: `testdata/tar/malformed/gnu-longname-oversized-size.tar`, `pax-extended-oversized-size.tar` | with the cap raised, `readEntryData` would accumulate `entry.size` bytes into memory on a crafted GNU long-name or PAX header claiming multi-GB size — depends on runtime allocation to reject |
 | [Zip/Tar.lean:619](/home/kim/lean-zip/Zip/Tar.lean:619), [:650](/home/kim/lean-zip/Zip/Tar.lean:650), [:657](/home/kim/lean-zip/Zip/Tar.lean:657), [:671](/home/kim/lean-zip/Zip/Tar.lean:671) `skipEntryData input e.size` (directory-entry payload skip, symlink-entry payload skip, unsupported-typeflag payload skip, `Tar.list`) | `e.size + paddingFor e.size` (attacker-controlled `UInt64`) | 64 KiB per-chunk cap at [Zip/Tar.lean:539](/home/kim/lean-zip/Zip/Tar.lean:539); discarded bytes are not buffered (peak allocation = 64 KiB per iteration) | no memory amplification, but a malicious stream can force an unbounded number of 64 KiB reads. `Tar.extract` applies `maxEntrySize` at [Zip/Tar.lean:661](/home/kim/lean-zip/Zip/Tar.lean:661) for payload-bearing entries before the skip; `Tar.list` applies no cap |
-| [Zip/Tar.lean:627](/home/kim/lean-zip/Zip/Tar.lean:627) `input.read toRead.toUSize` in `Tar.extract` regular-file loop | `min remaining 65536` where `remaining ≤ e.size.toNat` (attacker-controlled `UInt64` from tar header) | `maxEntrySize` check at [Zip/Tar.lean:661](/home/kim/lean-zip/Zip/Tar.lean:661) (effective only when `maxEntrySize > 0`); 64 KiB per-chunk cap; data is written through to disk, not buffered | with `maxEntrySize = 0` (the current default), `Tar.extract` writes an attacker-controlled `e.size` bytes to disk. The per-read allocation is bounded at 64 KiB regardless. Documented as the "per-entry cap" row in *Decompression Limit Inventory* |
+| [Zip/Tar.lean:627](/home/kim/lean-zip/Zip/Tar.lean:627) `input.read toRead.toUSize` in `Tar.extract` regular-file loop | `min remaining 65536` where `remaining ≤ e.size.toNat` (attacker-controlled `UInt64` from tar header) | `maxEntrySize` check at [Zip/Tar.lean:661](/home/kim/lean-zip/Zip/Tar.lean:661) (effective only when `maxEntrySize > 0`); 64 KiB per-chunk cap; data is written through to disk, not buffered | with the default 1 GiB cap, `Tar.extract` writes up to 1 GiB to disk per regular-file entry; with `maxEntrySize = 0` (opt-in unlimited), the read is bounded only by `e.size` (attacker-controlled `UInt64`). The per-read allocation is bounded at 64 KiB regardless. Documented as the "per-entry cap" row in *Decompression Limit Inventory* |
 | [Zip/Tar.lean:695](/home/kim/lean-zip/Zip/Tar.lean:695) `input.read (min padRemaining 512).toUSize` in `Tar.extract` padding loop | `min padRemaining 512`; `padRemaining ≤ 511` by tar framing (`paddingFor size < 512`) | fixed 512-byte per-chunk cap; `pad < 512` by tar block alignment | N/A — ≤ 512 bytes per read, bounded by tar block alignment |
 | [Zip/Tar.lean:793](/home/kim/lean-zip/Zip/Tar.lean:793) `inStream.read 65536` in `extractTarGz` tarStream wrapper | fixed `65536` | fixed chunk constant regardless of input | N/A — fixed 64 KiB read |
 
@@ -501,9 +501,14 @@ Summary — what the inventory catches and what it does not:
   or 512 bytes) and discarded, so they cannot amplify memory.
 - **Does NOT catch** — one residual gap that would benefit from a
   follow-up issue:
-  1. `Tar.extract` at row 10 relies on a caller-supplied
-     `maxEntrySize` that defaults to `0` (no limit). The read is
-     bounded by the caller's disk, not by a library-level cap.
+  1. `Tar.extract` row 10 relies on a per-entry `maxEntrySize` cap
+     of 1 GiB by default; an attacker who crafts many entries can
+     still drive disk usage past this cap because the
+     whole-archive `maxTotalSize` parameter on `Tar.extract` /
+     `Tar.extractTarGz` / `Tar.extractTarGzNative` defaults to
+     `0` (no limit) per Recommended Policy item 4. Callers
+     concerned about multi-entry exhaustion must opt into a
+     finite `maxTotalSize`.
 
   The previously-listed `Tar.readEntryData` gap at the four GNU
   long-name / long-link / PAX callsites is now closed by the

--- a/progress/20260422T222049Z_bbd91495.md
+++ b/progress/20260422T222049Z_bbd91495.md
@@ -1,0 +1,114 @@
+# 20260422T222049Z — Feature session bbd91495
+
+Closes issue #1713: refresh `SECURITY_INVENTORY.md` drift on
+`Tar.extract`'s `maxEntrySize` default (1 GiB, not 0).
+
+## Accomplished
+
+Two prose-only edits to `SECURITY_INVENTORY.md` to bring two
+stale "Failure mode" / "Does NOT catch" mentions back in sync
+with the post-Recommended-Policy-item-3 state of the codebase:
+
+- **`SECURITY_INVENTORY.md:490`** — *Local guard inventory*
+  row 10 (`Tar.extract` regular-file `input.read`). The "Failure
+  mode" column previously stated "with `maxEntrySize = 0` (the
+  current default), `Tar.extract` writes an attacker-controlled
+  `e.size` bytes to disk." That default was flipped to 1 GiB by
+  Recommended Policy item 3; the row now reads "with the default
+  1 GiB cap, `Tar.extract` writes up to 1 GiB to disk per
+  regular-file entry; with `maxEntrySize = 0` (opt-in unlimited),
+  the read is bounded only by `e.size` (attacker-controlled
+  `UInt64`)." The "(effective only when `maxEntrySize > 0`)"
+  qualifier in the *Local guard* column is left as-is — it
+  remains a correct description of the source-level `if`
+  predicate at `Zip/Tar.lean:661`.
+
+- **`SECURITY_INVENTORY.md:504–511`** — *Summary — Does NOT
+  catch* bullet. The bullet previously characterised the
+  residual gap as the per-entry cap defaulting to `0`; that's no
+  longer the gap. Re-pointed it at the genuine residual: the
+  whole-archive `maxTotalSize` parameter (on `Tar.extract` /
+  `Tar.extractTarGz` / `Tar.extractTarGzNative`) does default to
+  `0` (no limit) per Recommended Policy item 4, so a
+  many-small-entries bomb can still drive disk past the
+  per-entry 1 GiB cap. The cross-reference to Recommended
+  Policy item 4 keeps the bullet consistent with the policy
+  table (line 405–410), which already states this default is
+  by design and callers must opt in.
+
+## Decisions
+
+- **Re-pointed rather than removed.** The "Does NOT catch"
+  bullet was an honest residual gap before item 3 landed. After
+  item 3, the per-entry gap is gone but the multi-entry gap
+  (`maxTotalSize` default `0`) remains and is documented in the
+  same `Decompression Limit Inventory` table as the per-entry
+  cap. Re-pointing keeps the *Summary — Does NOT catch* section
+  non-empty and useful, rather than leaving a misleadingly
+  optimistic summary that says everything is caught.
+
+- **Did not touch the `Decompression Limit Inventory` table
+  (lines 351–377)** — already correct (line 371 shows
+  `1 * 1024^3 (1 GiB)` for the `Tar.extract` `maxEntrySize`
+  default, line 372 shows `0 / no whole-archive cap` for
+  `maxTotalSize`). The drift was localised to the
+  *Local guard inventory* and *Summary* prose below.
+
+- **Did not modify `Zip/Tar.lean`.** The defaults at
+  `Zip/Tar.lean:652` (`maxEntrySize : UInt64 := 1024 * 1024 * 1024`)
+  and `Zip/Tar.lean:780` (same on `extractTarGz`) are correct;
+  only the inventory was out of sync. No Lean source touched.
+
+## Files touched
+
+- `SECURITY_INVENTORY.md` (+10 / −5 LOC across two adjacent
+  prose edits at lines 490 and 504–511)
+- `progress/20260422T222049Z_bbd91495.md` (this entry)
+
+## Quality metrics
+
+- `grep -rc sorry Zip/` → 0 (unchanged; no Lean source touched).
+- `bash scripts/check-inventory-links.sh` → `errors=0,
+  warnings=0` (unchanged). The drift was in free-text "Failure
+  mode" / "Does NOT catch" prose, not in line-anchor citations
+  — so the existing detector wouldn't have caught it. Both runs
+  before and after the edits report the same `91 unique line
+  anchors, 31 unique fixture paths, 95 line-content heuristics`
+  baseline.
+- `lake build` / `lake exe test` not run — no Lean source
+  touched.
+
+## Verification at write time
+
+| Citation | Verified |
+|---|---|
+| `Zip/Tar.lean:652` `maxEntrySize : UInt64 := 1024 * 1024 * 1024` (1 GiB default on `Tar.extract`) | ✓ (read directly) |
+| `Zip/Tar.lean:780` same default on `Tar.extractTarGz` | ✓ (read directly) |
+| `Zip/Tar.lean:661` `if maxEntrySize > 0 && e.size > maxEntrySize then` (the source-level guard the *Local guard* column describes) | ✓ (read directly) |
+| `SECURITY_INVENTORY.md:371` already shows `1 GiB` for `Tar.extract` `maxEntrySize` (no change) | ✓ |
+| `SECURITY_INVENTORY.md:372` already shows `0` / `no whole-archive cap` for `Tar.extract` `maxTotalSize` (no change) | ✓ |
+| Recommended Policy item 3 at lines 397–404 ("Executed — the per-entry default … is now `1 GiB`") | ✓ |
+| Recommended Policy item 4 at lines 405–410 (`maxTotalSize := 0` is unlimited by design) | ✓ |
+
+## Diff scope
+
+`git diff --stat origin/master...HEAD` lists exactly two files:
+`SECURITY_INVENTORY.md` and this progress entry. No `Zip/`,
+`ZipTest/`, `PLAN.md`, `.claude/`, or skill changes.
+
+## Other claim activity this session
+
+Issue #1711 was claimed first but `coordination skip`ped as a
+stale plan: it asks for an additive note to
+`.claude/skills/acquiring-skills/SKILL.md`, which is a
+pod-bundled template (copied into worktrees from
+`~/.local/share/uv/tools/dev-pod/lib/python3.13/site-packages/pod/data/agent-config/claude/skills/acquiring-skills/SKILL.md`
+and managed via `.claude/.pod-checksums`), not a tracked
+project skill. Commit `a9ca4ec` (Feb 26 2026) moved that
+infrastructure out of the project tree. The plan's verification
+("`git diff --stat origin/master...HEAD` shows +~25 LOC to
+that file") cannot hold because the file is not on master.
+The proper fix for the sensitive-path-guard friction belongs
+upstream in dev-pod, which the plan's own non-goals already
+say not to do. Recommended re-planning as a dev-pod upstream
+contribution.


### PR DESCRIPTION
Closes #1713

Session: `bbd91495-b1cb-4ac2-9406-130304b6afaf`

41024a9 doc: SECURITY_INVENTORY drift refresh — Tar.extract maxEntrySize 1 GiB default (#1713)

🤖 Prepared with Claude Code