### PR TITLE
doc: fix PR-number attribution in three ZipFixtures.lean precedence-shift comments (#1770 → #1773)

### DIFF
--- a/ZipTest/ZipFixtures.lean
+++ b/ZipTest/ZipFixtures.lean
@@ -113,7 +113,7 @@ def ZipTest.ZipFixtures.tests : IO Unit := do
   IO.FS.createDirAll oversizedExtractDir
   -- This fixture has method=0 with CD compSize=2 MiB and uncompSize=6 —
   -- a stored-method size-invariant violation that `parseCentralDir` now
-  -- rejects at CD parse time (PR #1770), earlier than the `local data
+  -- rejects at CD parse time (PR #1773), earlier than the `local data
   -- span` check in `readEntryData` that historically caught the fault.
   -- Kept in-corpus for regression coverage at the earlier layer.
   assertThrows "ZIP malformed (oversized-compressed-size.zip)"
@@ -146,7 +146,7 @@ def ZipTest.ZipFixtures.tests : IO Unit := do
   IO.FS.createDirAll oversizedZ64ExtractDir
   -- This fixture has method=0 with ZIP64-resolved compSize=1<<60 and
   -- uncompSize=6 — a stored-method size-invariant violation that
-  -- `parseCentralDir` now rejects at CD parse time (PR #1770, post-
+  -- `parseCentralDir` now rejects at CD parse time (PR #1773, post-
   -- ZIP64-resolution), earlier than the `local data span` check in
   -- `readEntryData` that historically caught the fault.  Kept in-corpus
   -- for regression coverage at the earlier layer.
@@ -184,7 +184,7 @@ def ZipTest.ZipFixtures.tests : IO Unit := do
   -- does not trip "exceeds limit" before the CD-parse stored-method check.
   -- This fixture has method=0 with compSize=6 and ZIP64-resolved
   -- uncompSize=1<<60 — a stored-method size-invariant violation that
-  -- `parseCentralDir` now rejects at CD parse time (PR #1770, post-
+  -- `parseCentralDir` now rejects at CD parse time (PR #1773, post-
   -- ZIP64-resolution), earlier than the `truncated ZIP64 local extra
   -- field` check in `readEntryData` that historically caught the fault.
   -- Kept in-corpus for regression coverage at the earlier layer.

--- a/progress/20260424T110441Z_9e67bb60.md
+++ b/progress/20260424T110441Z_9e67bb60.md
@@ -1,0 +1,49 @@
+# Progress entry — 2026-04-24T11:04:41Z
+
+- **Session UUID**: 9e67bb60-9e61-47ab-a405-98852413bd6c
+- **Session type**: feature
+- **Branch**: agent/9e67bb60
+- **Issue**: #1787 — doc: fix PR-number attribution in three ZipFixtures.lean precedence-shift comments (#1770 → #1773)
+
+## Summary
+
+One-shot correction of attribution drift flagged by paired-review
+#1778 §F.2. Three inline comments in `ZipTest/ZipFixtures.lean`
+attributed the CD-parse-time stored-method size-invariant guard to
+`PR #1770` (the summarize PR merged 24 minutes before), when the
+feature PR that landed the guard is `PR #1773`
+(`Track E: method 0 (stored) compressedSize == uncompressedSize
+consistency check + cd-stored-size-mismatch.zip fixture`,
+mergeCommit `87b2b6a`).
+
+## Changes
+
+- `ZipTest/ZipFixtures.lean` lines 116, 149, 187: substitute
+  `PR #1770` → `PR #1773` in three inline comment blocks. No change
+  to `assertThrows` calls, fixture bytes, Lean source, or tests.
+
+## Verification
+
+- `grep -n 'PR #1770' ZipTest/ZipFixtures.lean` → 0 matches
+  post-edit (was 3 pre-edit).
+- `grep -n 'PR #1773' ZipTest/ZipFixtures.lean` → 3 matches
+  post-edit at lines 116, 149, 187 (was 0 pre-edit).
+- `lake -R build` → `Build completed successfully (191 jobs)`.
+- `lake exe test` → `All tests passed!`.
+- `bash scripts/check-inventory-links.sh` → `errors=0, warnings=0`
+  (invariant preserved; this file is not scanned).
+- `gh pr view 1773 --json mergeCommit,title` confirmed PR #1773 is
+  the feature PR that introduced the stored-method size-invariant
+  guard (mergeCommit `87b2b6a`, merged 2026-04-24T06:47:08Z).
+
+## Quality metric delta
+
+- sorry count: unchanged (comment-only edit).
+- Commit count: +1 (`614b34b`).
+
+## Remaining / follow-ups
+
+None. The parallel placeholder-aware linter rule issue (#1786 —
+`check-inventory-links.sh` placeholder-PR linter rule) is tracked
+separately and handles a different drift class (`#TBD` / `this PR`
+placeholders in `SECURITY_INVENTORY.md`).


### PR DESCRIPTION
Closes #1787

Session: `9e67bb60-9e61-47ab-a405-98852413bd6c`

40fcc19 doc: progress entry for #1787 — PR-number attribution fix in ZipFixtures
614b34b doc: fix PR-number attribution in three ZipFixtures precedence-shift comments (#1770 → #1773)

🤖 Prepared with Claude Code