### PR TITLE
Review: paired-review entry for PR #1899 — Track E reject duplicate keys in PAX extended headers at parsePaxRecords + pax-duplicate-path.tar fixture (sibling of PR #1866 NUL-byte rejection on the same parsePaxRecords surface; closes both parser-differential dimensions on PAX-record decode pipeline)

### DIFF
--- a/progress/20260425T013022Z_f70026ff-paired-review-1899.md
+++ b/progress/20260425T013022Z_f70026ff-paired-review-1899.md
@@ -1,0 +1,374 @@
+# Paired review: PR #1899 — Track E Tar PAX duplicate-key rejection in `parsePaxRecords`
+
+- Date: 2026-04-25T01:30Z
+- Session: f70026ff
+- Type: review (issue #1910, paired-review for PR #1899)
+
+PR #1899 landed at merge commit `631ea79` on 2026-04-25T00:03:23Z,
+closing issue #1895. Sibling-dimension partner of PR #1866 (PAX
+NUL-byte rejection) on the same `parsePaxRecords` decode pipeline:
+together the two PRs close the parser-differential dimension on
+PAX-record validation (NUL-byte smuggle + duplicate-key smuggle),
+each routed through the same `if let (some key, some value) := …`
+scrutinee inside the `while pos < data.size do` outer loop.
+
+## A. Guard correctness
+
+- **A.1 Placement.** Guard lives in `parsePaxRecords` at
+  [Zip/Tar.lean:147-149](/home/kim/lean-zip/Zip/Tar.lean:147), inside
+  the `if let (some key, some value) := …` UTF-8-decode scrutinee
+  (line 144) and inside the `(keyBytes.findIdx? (· == 0)).isNone &&
+  (valueBytes.findIdx? (· == 0)).isNone` raw-byte NUL guard (lines
+  145-146). Ordering: UTF-8 decode → NUL-in-bytes guard →
+  duplicate-key check → `records.push` (line 150). Both prior gates
+  silently drop the record, so the duplicate guard only ever
+  observes records that *would have* been pushed — i.e. records
+  with valid UTF-8 keys *and* zero-NUL byte content. Garbage
+  cannot smuggle a duplicate past this guard, matching the
+  module docstring's claim at
+  [Zip/Tar.lean:87-89](/home/kim/lean-zip/Zip/Tar.lean:87).
+- **A.2 Predicate correctness.** Guard predicate is
+  `records.any (·.1 == key)` (line 147). Three properties to
+  verify:
+    - (a) `records : Array (String × String)` accumulates only
+      records that **passed** the UTF-8 + NUL gates above; the
+      `records.push (key, value)` at line 150 is the only place
+      `records` is mutated, and the gates run before the push,
+      so the predicate compares well-formed `String` keys against
+      well-formed `String` keys (no decoder-vs-decoder bias).
+    - (b) The predicate is `String.==` (Bool-equality on the
+      decoded `key`), case-sensitive — POSIX SUSv4 §pax keys
+      are case-sensitive, so this is correct.
+    - (c) Duplicate detection runs **before** the push (the
+      `if records.any ...` at line 147 conditionally bypasses
+      the push at line 150 by setting `err` and `break`-ing).
+      The first `path=` record in the fixture is admitted at
+      line 150; the second `path=` record fires line 147 →
+      sets `err` → `break`. Semantics: *first-wins-then-fail*
+      (the issue body's chosen policy, distinct from
+      `applyPaxOverrides`'s default *last-wins-silent*).
+- **A.3 Error-wording uniqueness — confirmed.** The substring
+  `"duplicate"` in `Zip/Tar.lean` appears at four lines per
+  `grep -n duplicate Zip/Tar.lean`: 80, 88, 89 (all inside the
+  `parsePaxRecords` docstring, lines 76-89), and 148 (the new
+  `s!"tar: PAX extended header has duplicate {key.quote} record"`
+  error). The error is the only **executable** occurrence — no
+  other thrown / returned error in `Zip/Tar.lean` carries the
+  word `duplicate`. The `assertThrows … "duplicate"` substring
+  match in
+  [ZipTest/TarFixtures.lean:168](/home/kim/lean-zip/ZipTest/TarFixtures.lean:168)
+  is therefore unambiguous against any current
+  `Zip/Tar.lean`-thrown wording. Style alignment with the
+  rest of the file: `s!"tar: …"` prefix (matches the 13 other
+  `s!"tar:` strings in the file per `grep -n 's!"tar:'
+  Zip/Tar.lean`), lower-case opener, no trailing period, key
+  attribution via `String.quote` (matches the
+  `tar: path too long: {entry.path}` precedent at
+  [Zip/Tar.lean:365](/home/kim/lean-zip/Zip/Tar.lean:365)).
+
+## B. Early-exit mechanics
+
+- **B.1 `err` sentinel + `break`.** The duplicate-detect arm
+  at lines 147-149 sets `err := some msg` then `break`. The
+  `break` is lexically inside the outer `while pos < data.size do`
+  at line 95 — Lean's `break` exits the **immediately enclosing
+  loop**, and the surrounding `if`-blocks (lines 126, 144,
+  145-146, 147) are not loops. Therefore `break` exits the
+  outer `while`, not the inner length-scan `while h : lenEnd <
+  data.size do` at line 101 (which has already terminated by the
+  time line 147 is reached, since the length-scan loop is in the
+  prologue at lines 101-114). After `break`, `pos := recordEnd`
+  on line 151 does not execute — the loop exits and control
+  flows to the tail `match err with` on line 152. No subsequent
+  PAX records are parsed.
+- **B.2 Tail `match err`.** Lines 152-154:
+  `match err with | some msg => return .error msg | none =>
+  return .ok records`. The function returns:
+    - `.error msg` only when `err` was set (i.e. the duplicate
+      guard fired);
+    - `.ok records` with the (possibly partial / possibly empty)
+      accumulated records when no duplicate was found, including
+      when one or more records were silently dropped by the
+      UTF-8 / NUL gates. The partial-records branch is for the
+      `.ok` arm only — the `.error` arm carries no `records`,
+      and the caller throws unconditionally on `.error`, so
+      the partial state is never observed downstream.
+
+## C. Caller integration
+
+- **C.1 `forEntries` PAX-extended branch.** *Issue body cites
+  `Zip/Tar.lean:651`; the actual caller is at line 669.* Per
+  `grep -n parsePaxRecords Zip/Tar.lean`, exactly one production
+  caller exists, at
+  [Zip/Tar.lean:669](/home/kim/lean-zip/Zip/Tar.lean:669)
+  inside the `if entry.typeflag == typePaxExtended` branch of
+  `forEntries`. The pattern-match on the `Except` result reads:
+
+  ```lean
+  match parsePaxRecords paxData with
+  | .ok records => paxOverrides := some records
+  | .error msg => throw (IO.userError msg)
+  ```
+
+  The `.error` arm joins the existing
+  `throw (IO.userError …)` family inside `forEntries`. No silent
+  fallback to `paxOverrides := none` on error — the throw boundary
+  closes the parser-differential vector for any caller (`Tar.list`,
+  `Tar.extract`, the GZipped variants) routing through `forEntries`.
+  The line-number drift (issue body said 651) does not affect
+  correctness — the body warned the worker to verify line numbers
+  via `grep -n`, and the caller's behaviour matches the issue body's
+  description verbatim.
+- **C.2 Test caller migration.** Per
+  `grep -n parsePaxRecords ZipTest/Tar.lean`, exactly one test
+  caller, at
+  [ZipTest/Tar.lean:199](/home/kim/lean-zip/ZipTest/Tar.lean:199):
+  `let records ← IO.ofExcept (Tar.parsePaxRecords paxData)`.
+  The migration from a direct
+  `Array (String × String)` consumer to `IO.ofExcept` lifts the
+  `Except` into the surrounding `IO`-monadic test block; on `.error`
+  the test fails with the parser's own message, on `.ok` the test
+  proceeds to the existing `records[0]! == ("path", "abc")` /
+  `records[1]! == ("uid", "42")` assertions on lines 200-202. The
+  test exercises the parse-success path on a *legitimate* PAX
+  block (`"12 path=abc\n10 uid=42\n"`) — the duplicate-key
+  failure path is exercised by the new fixture-driven
+  `assertThrows` in `ZipTest/TarFixtures.lean` (D below). No
+  other production or test caller of `parsePaxRecords` exists
+  per repo-wide grep.
+
+## D. Fixture mechanics
+
+- **D.1 Determinism.** Re-ran the builder via
+  `lake env -R lean --run scripts/build-pax-malformed-fixtures.lean`
+  (the bare `lake env` invocation failed with *"compiled
+  configuration is invalid; run with '-R' to reconfigure"*, an
+  artefact of the worktree's stale Lake config — the `-R` flag
+  refreshes it). Build output: *"Built 7 malformed PAX fixtures
+  under testdata/tar/malformed/."* Pre/post `cmp` of
+  `testdata/tar/malformed/pax-duplicate-path.tar` against an
+  out-of-tree copy: `BYTE-IDENTICAL`. SHA-256:
+  `0f0e4dfadc65fa76ba981fdad6256ae11f910d852c0be5a408a1a11d82f3b952`
+  (2048 B). The other six pre-existing PAX fixtures
+  (`pax-oversized-length.tar`, `pax-truncated-record.tar`,
+  `pax-invalid-utf8-key.tar`, `pax-invalid-utf8-value.tar`,
+  `pax-inconsistent-length.tar`, `pax-path-nul-in-value.tar`)
+  were also re-emitted; none were touched in the working tree
+  (they remain at the same bytes already in `master`).
+- **D.2 Length arithmetic.** Payload (per
+  [scripts/build-pax-malformed-fixtures.lean:109-110](/home/kim/lean-zip/scripts/build-pax-malformed-fixtures.lean:109)):
+  `"17 path=safe.txt\n22 path=../etc/passwd\n"`.
+    - Record 1 — `"17 path=safe.txt\n"`. Self-counting POSIX
+      length prefix `17` decomposes as
+      `2 + 1 + 4 + 1 + 8 + 1 = 17`:
+      `len("17") + len(" ") + len("path") + len("=") +
+      len("safe.txt") + len("\n")`. Counted character-by-character
+      from the literal: `1, 7, ' ', p, a, t, h, =, s, a, f, e, .,
+      t, x, t, \n` — 17 bytes. ✓
+    - Record 2 — `"22 path=../etc/passwd\n"`. Self-counting
+      length prefix `22` decomposes as
+      `2 + 1 + 4 + 1 + 13 + 1 = 22`:
+      `len("22") + len(" ") + len("path") + len("=") +
+      len("../etc/passwd") + len("\n")`. Counted character-by-character:
+      `2, 2, ' ', p, a, t, h, =, ., ., /, e, t, c, /, p, a, s, s,
+      w, d, \n` — 22 bytes. ✓
+    - Total payload size = `17 + 22 = 39 B`. Matches
+      `paxData.size = 39` consumed by `buildPaxMalformedFixture`.
+- **D.3 Fixture geometry.** `wc -c` = 2048 B. Block layout
+  per `buildPaxMalformedFixture` at
+  [scripts/build-pax-malformed-fixtures.lean:30-49](/home/kim/lean-zip/scripts/build-pax-malformed-fixtures.lean:30):
+    - PAX extended header (block 0): 512 B.
+    - PAX data (39 B) + `Binary.zeros (paddingFor 39)` =
+      `512 - 39 = 473 B` zeros (block 1, 512 B total).
+    - Regular file UStar header (block 2): 512 B.
+    - Regular file payload `"hello\n"` (6 B) +
+      `paddingFor 6 = 506 B` zeros (block 3, 512 B total).
+    - No end-of-archive zero blocks (matches the
+      `malformed-fixture-builder` skill's *End-of-archive
+      policy* at lines 93-98 — `Tar.forEntries` terminates on
+      short read).
+    - Total: 4 × 512 = 2048 B. ✓
+  Geometry matches the existing six-PAX-malformed-fixture
+  family budget (`malformed-fixture-builder` skill table at
+  line 89, *"PAX malformed | 2048 B"*). Sibling family of:
+  `pax-oversized-length.tar`, `pax-truncated-record.tar`,
+  `pax-invalid-utf8-key.tar`, `pax-invalid-utf8-value.tar`,
+  `pax-inconsistent-length.tar`, `pax-path-nul-in-value.tar`,
+  all 2048 B.
+
+## E. Inventory + cross-skill alignment
+
+- **E.1 `SECURITY_INVENTORY.md` row absence — gap to flag.**
+  `grep -n pax-duplicate-path SECURITY_INVENTORY.md` returns
+  zero hits. PR #1899's diff did not touch
+  `SECURITY_INVENTORY.md` per
+  `gh pr view 1899 --json files`. The PAX malformed rows in
+  the *Minimized Reproducer Corpus* table currently span
+  lines 1225-1230 (`pax-inconsistent-length.tar`,
+  `pax-invalid-utf8-key.tar`, `pax-invalid-utf8-value.tar`,
+  `pax-oversized-length.tar`, `pax-path-nul-in-value.tar`,
+  `pax-truncated-record.tar`) with no
+  `pax-duplicate-path.tar` row. Alphabetical placement is
+  **before line 1225** (`d < i` per ASCII; the existing
+  rows are sorted ascending by leaf basename). Recommended
+  row text — class `archive-slip` / `parser-differential`,
+  citing the line 147 guard, with the same prose voice as
+  the `pax-path-nul-in-value.tar` row at line 1229. The row
+  belongs to a follow-up inventory-reconciliation PR (the
+  `inventory-reconciliation` skill bundles these along the
+  one-PR-per-bullet cadence); the paired-review remains
+  read-only against `SECURITY_INVENTORY.md` per the issue
+  body's *Verification* section.
+- **E.2 Recent-wins / Tar Parser bullet — gap to flag.**
+  `grep -n duplicate SECURITY_INVENTORY.md` returns three
+  PR-#1793 ZIP CD/LH duplicate ZIP64 extra-block hits
+  (lines 417-419, 437) but no PAX duplicate-key bullet under
+  the *Tar Parser/Extractor* heading. Adding a bullet of
+  the form *"PAX duplicate-key rejection — PR #1899
+  (`testdata/tar/malformed/pax-duplicate-path.tar`) rejects
+  PAX records that repeat a key (e.g. two `path=` records),
+  closing the parser-differential dimension on
+  `parsePaxRecords` complementary to PR #1866's NUL-byte
+  silent-skip"* would mirror the existing PR-#1793 bullet
+  structure at lines 417-419. Same follow-up scope as E.1.
+- **E.3 `error-wording-catalogue` skill — gap to flag.**
+  Per `grep -n duplicate
+  .claude/skills/error-wording-catalogue/SKILL.md`, the
+  catalogue has rows for *Archive CD ZIP64 duplicate
+  extra-block* (line 48, *"duplicate ZIP64 extra field"*)
+  and *Archive LH ZIP64 duplicate extra-block* (line 50,
+  *"duplicate ZIP64 local extra field"*) but **no row for
+  the new PAX duplicate-key wording** *"PAX extended header
+  has duplicate"* / match-substring `"duplicate"` (which
+  in `Zip/Tar.lean` is uniquely associated with this guard
+  per A.3 above). The recommended catalogue row would slot
+  between line 50 and the *Tar per-entry bomb* row at line
+  51, in the `Zip/Tar.lean` block, with structure:
+
+  | Tar PAX extended-header duplicate-key | `Zip/Tar.lean` (`parsePaxRecords`, after `String.fromUTF8?` decode and after the raw-byte NUL guard, before `records.push`) | `tar: PAX extended header has duplicate <key.quote> record` | `"duplicate"` — uniquely associated in `Zip/Tar.lean` (only `s!"tar:` string containing the word; docstring also mentions the substring at lines 80, 88, 89 but those are not error positions) |
+
+  Per the issue body: *do not* update the skill in this
+  paired-review PR — skill edits are a separate stream.
+  Flag this for a `meditate` issue.
+- **E.4 `malformed-fixture-builder` skill — no drift.**
+  Per `grep -n PAX
+  .claude/skills/malformed-fixture-builder/SKILL.md`, the
+  PAX malformed fixture pattern is documented at line 89
+  (*"PAX malformed | 2048 B | Matches `bad-checksum.tar` /
+  `no-magic.tar` precedent. Two 512-byte entries × 2 blocks
+  of payload."*). The new `pax-duplicate-path.tar` fits
+  that geometry exactly (D.3). The fixture builder's
+  module docstring at
+  [scripts/build-pax-malformed-fixtures.lean:1-23](/home/kim/lean-zip/scripts/build-pax-malformed-fixtures.lean:1)
+  was extended to add the new fixture path — no other
+  builder shape changes. No skill drift to flag.
+
+## F. Wave context + paired-review-cadence diagnostics
+
+- **F.1 Wave membership.** PR #1899 merged at
+  2026-04-25T00:03:23Z, AFTER the prior post-#1869 wave's
+  closing PR #1894 and BEFORE the wave's summarize PR #1904
+  (merged 00:30:23Z, the file
+  [`progress/20260425T002634Z_ffc69171-summarize-post-1869.md`](/home/kim/lean-zip/progress/20260425T002634Z_ffc69171-summarize-post-1869.md)
+  — that summarize covers 10 PRs through #1894 and does not
+  include #1899). PR #1899 is therefore the **first feature
+  PR of the active post-#1894 wave**, which also already
+  contains PR #1903 (cd-bad-lh-signature.zip fixture, merged
+  00:18:36Z) and PRs #1905 / #1908 / #1911 (per-slot ZIP64
+  override fixtures, merged 00:39Z–01:16Z). The next
+  summarize will need a paired-review reference to weave
+  this PR into its narrative; the present progress entry
+  is that reference.
+- **F.2 Sibling cadence.** PR #1866 (PAX NUL-byte) was
+  paired-reviewed by issue #1873 → PR #1882 (file
+  [`progress/20260424T215605Z_96b97029-paired-review-1866.md`](/home/kim/lean-zip/progress/20260424T215605Z_96b97029-paired-review-1866.md)).
+  PR #1899 (PAX duplicate-key) is paired-reviewed by issue
+  #1910 → this PR. Naming convention `paired-review-<PR>.md`
+  preserved. Wording-family alignment: PR #1866 chose silent
+  skip (no thrown error wording — confirmed in the prior
+  paired-review's section A.4); PR #1899 chose hard reject
+  (`tar: PAX extended header has duplicate {key.quote}
+  record`). The two PRs **diverge on policy** (skip vs
+  throw) but **align on style** (`tar:` prefix, lower-case,
+  no trailing period). The policy split is justified
+  in PR #1899's progress entry decision *"Reject (hard error)
+  rather than skip"*: NUL bytes are byte-level corruption
+  (sibling-arms in ZIP CD / GNU long-name also chose
+  rejection but the PAX context already had a tolerance
+  precedent that PR #1866 honoured); duplicate keys are a
+  structural-validity failure where rejection cleanly
+  closes the parser-differential dimension, since silent
+  *first-wins* and silent *last-wins* both leave the smuggle
+  exploitable downstream. Both sibling PRs together close
+  the PAX-record validation surface.
+
+  Minor narrative drift: PR #1899's progress entry decision
+  *"Error message wording"* claims the new wording matches
+  *"the recent PAX error-wording family
+  (`tar: PAX record path value contains NUL byte` from PR
+  #1866)"*. Per A.4 of paired-review #1873 (file
+  `20260424T215605Z_96b97029-paired-review-1866.md`),
+  PR #1866 added **no error wording** — its NUL guard
+  silently skips. The cited string `tar: PAX record path
+  value contains NUL byte` appears nowhere in `Zip/Tar.lean`
+  per `grep -n "PAX.*NUL"`; the worker likely conflated the
+  ZIP CD-side NUL guard wording (`zip: CD entry name
+  contains NUL byte` at `Zip/Archive.lean`) or the
+  UStar-side wording (`tar: UStar name contains NUL byte`).
+  Drift is small (it does not affect correctness of the
+  guard or its tests) but worth flagging — the paired-review
+  is the right forum for catching this kind of after-the-fact
+  narrative-vs-fact drift.
+
+- **F.3 Paired-review latency.**
+    - PR #1899 merged: 2026-04-25T00:03:23Z.
+    - Paired-review issue #1910 created:
+      2026-04-25T01:06Z (per `coordination orient` listing).
+      Latency merge → issue creation: **63 min**.
+    - Paired-review PR (this PR): claim at 2026-04-25T01:25Z
+      (per `coordination claim 1910` ack); progress entry
+      finalised at 2026-04-25T01:30Z. Merge timestamp TBD
+      (recorded by the next summarize).
+  For the post-#1869 wave the summarize-post-#1869 file
+  reports a median in-wave paired-review latency of ~25 min
+  (file lines 149-157, *"three in-wave pairs all landed
+  inside 30 min — the tightest median in the Track E wave
+  series so far"*). PR #1899's 63-min merge → issue latency
+  is above that median, but #1899 also straddles the prior
+  wave's summarize cutoff (00:30Z) — issue #1910 was created
+  at 01:06Z, after the wave-close summarize had landed, so
+  the latency is closer to a *wave-rollover* statistic than
+  an in-wave one. The next summarize should record this as
+  the first post-#1894 wave entry rather than a degraded
+  post-#1869 outlier.
+
+## Verification
+
+- **Build & test.** `lake build` clean (191/191). `lake exe
+  test` — *All tests passed!* Source tree unchanged in this
+  session except for the new progress file. Sorry count: 0
+  before and after (`grep -rc sorry Zip/` returns all zeros).
+- **Inventory-link check.** `bash scripts/check-inventory-links.sh`
+  → `errors=0` (all inventory links resolve). Run as a
+  smoke check; the inventory was not touched in this PR.
+- **Diff scope.** `git diff master..HEAD` (excluding
+  pre-existing dirty CLAUDE.md/skill edits owned by the
+  worktree setup, which are not part of this PR) = exactly
+  one new file under `progress/`. No `Zip/` / `ZipTest/` /
+  `testdata/` / `SECURITY_INVENTORY.md` / `scripts/` edits.
+- **Self-review.** Sections A-F each carry a verifiable
+  claim (line number, sha256, byte-count arithmetic, grep
+  uniqueness, merge timestamp) rather than narrative
+  prose alone. Three drift items flagged for follow-up
+  (E.1, E.2, E.3); one minor narrative-vs-fact drift in
+  PR #1899's own progress entry noted in F.2.
+
+## Quality metric deltas
+
+- Sorry count: 0 → 0.
+- Source files touched: 0.
+- New progress entry: +1.
+- Follow-up issues to file in a future `meditate` /
+  inventory-reconciliation session: E.1 (inventory row),
+  E.2 (recent-wins bullet), E.3 (error-wording catalogue
+  row).


### PR DESCRIPTION
Closes #1910

Session: `f70026ff-0f3d-42c9-b8d5-26a9bfe2fdee`

1dee700 doc: paired-review entry for PR #1899 — Tar PAX duplicate-key rejection in parsePaxRecords (closes #1910)

🤖 Prepared with Claude Code