### PR TITLE
Inventory: add pax-duplicate-path.tar corpus row + Tar Parser/Extractor recent-wins bullet to SECURITY_INVENTORY.md (post-PR #1899 bookkeeping follow-up flagged by paired-review #1913 sections E.1 + E.2 — PR #1899 landed without touching SECURITY_INVENTORY.md)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -931,6 +931,24 @@ Summary — what this pattern catches and what it does not:
     `Binary.readString` truncation path as the `name` arm, so they
     are covered by symmetric code review rather than dedicated
     fixtures (matching the PR #1865 long-link policy).
+  - PAX extended-header duplicate-key rejection in `parsePaxRecords` —
+    PR #1899
+    (`testdata/tar/malformed/pax-duplicate-path.tar`).
+    Ordering inside `parsePaxRecords`: UTF-8 decode → raw-byte NUL
+    guard → duplicate-key check → push, so the duplicate-key branch
+    at [Zip/Tar.lean:147](/home/kim/lean-zip/Zip/Tar.lean:147) only
+    fires on records that already passed the UTF-8 and NUL filters.
+    Unlike PR #1866 (PAX NUL-byte silent-skip, which drops the
+    offending record and continues), PR #1899 hard-rejects — the
+    `.error` return is rethrown unconditionally by `forEntries`'s
+    `typePaxExtended` branch at
+    [Zip/Tar.lean:669](/home/kim/lean-zip/Zip/Tar.lean:669) via
+    `throw (IO.userError msg)`. Error wording *"tar: PAX extended
+    header has duplicate {key.quote} record"* uses `String.quote`
+    attribution on the duplicate key. Closes the parser-differential
+    *duplicate-key* dimension on `parsePaxRecords` complementary to
+    PR #1866's NUL-byte silent-skip; together the two close both
+    parser-differential dimensions on the PAX-record decode pipeline.
 
 #### Symlink/hardlink extraction policy
 
@@ -1267,6 +1285,7 @@ to be silently skipped.
 | [testdata/tar/malformed/gnu-longname-oversized-size.tar](/home/kim/lean-zip/testdata/tar/malformed/gnu-longname-oversized-size.tar) | 512 B | `readEntryData` `maxHeaderSize` cap at [Zip/Tar.lean:222](/home/kim/lean-zip/Zip/Tar.lean:222) — *"exceeds maximum header size"* (header `size ≈ 8 GiB`, default cap `8 MiB`) | #1597 | oversized allocation |
 | [testdata/tar/malformed/gnu-longname-truncated.tar](/home/kim/lean-zip/testdata/tar/malformed/gnu-longname-truncated.tar) | 612 B | `readEntryData` short-read at [Zip/Tar.lean:230](/home/kim/lean-zip/Zip/Tar.lean:230) — *"unexpected end of archive reading entry data"* | #1546 | partial-decoder panic |
 | [testdata/tar/malformed/no-magic.tar](/home/kim/lean-zip/testdata/tar/malformed/no-magic.tar) | 2048 B | Tar magic check at [Zip/Tar.lean:448](/home/kim/lean-zip/Zip/Tar.lean:448) — *"unsupported format"* | `481e562` | other (header validation) |
+| [testdata/tar/malformed/pax-duplicate-path.tar](/home/kim/lean-zip/testdata/tar/malformed/pax-duplicate-path.tar) | 2048 B | `parsePaxRecords` duplicate-key guard at [Zip/Tar.lean:147](/home/kim/lean-zip/Zip/Tar.lean:147) — *"tar: PAX extended header has duplicate {key.quote} record"* (ordering inside `parsePaxRecords`: UTF-8 decode → raw-byte NUL guard → duplicate-key check → push, so the duplicate-key branch only fires on records that already passed the UTF-8 and NUL filters. Unlike the sibling PR #1866 PAX NUL-byte silent-skip further below — which drops the offending record and continues — PR #1899 hard-rejects by writing `err := some …` and `break`ing the record loop; the `.error` return is rethrown unconditionally by the sole production caller at [Zip/Tar.lean:669](/home/kim/lean-zip/Zip/Tar.lean:669) inside `forEntries`'s `typePaxExtended` branch via `throw (IO.userError msg)`. `String.quote` on the duplicate key pins attribution in logs without leaking NUL or control bytes. Attack class: PAX records allow duplicate keys syntactically, and `applyPaxOverrides`'s default last-wins-silent policy leaves the smuggle exploitable unless the parser rejects duplicates structurally — a crafted second `path=` record would otherwise override the first, enabling parser-differential attacks where strict peer parsers (which reject or use first-wins) disagree with lean-zip. Closes the parser-differential *duplicate-key* dimension on `parsePaxRecords` complementary to PR #1866's NUL-byte silent-skip; together the two close both parser-differential dimensions on the PAX-record decode pipeline. Writer-side has no invariant to record — lean-zip's tar writer does not emit PAX extended headers) | #1899 | archive-slip |
 | [testdata/tar/malformed/pax-extended-oversized-size.tar](/home/kim/lean-zip/testdata/tar/malformed/pax-extended-oversized-size.tar) | 512 B | `readEntryData` `maxHeaderSize` cap at [Zip/Tar.lean:222](/home/kim/lean-zip/Zip/Tar.lean:222) — *"exceeds maximum header size"* (PAX header `size ≈ 8 GiB`, default cap `8 MiB`) | #1597 | oversized allocation |
 | [testdata/tar/malformed/pax-inconsistent-length.tar](/home/kim/lean-zip/testdata/tar/malformed/pax-inconsistent-length.tar) | 2048 B | `parsePaxRecords` silent-skip when no `=` is found before the declared record end (scan at [Zip/Tar.lean:79](/home/kim/lean-zip/Zip/Tar.lean:79); record dropped at [Zip/Tar.lean:79](/home/kim/lean-zip/Zip/Tar.lean:79)) | #1545 | partial-decoder panic |
 | [testdata/tar/malformed/pax-invalid-utf8-key.tar](/home/kim/lean-zip/testdata/tar/malformed/pax-invalid-utf8-key.tar) | 2048 B | `parsePaxRecords` `String.fromUTF8?` guard on key/value at [Zip/Tar.lean:122](/home/kim/lean-zip/Zip/Tar.lean:122) (record dropped, no panic) | #1545 | partial-decoder panic |

--- a/progress/20260425T032026Z_654aaa2e-inventory-1899.md
+++ b/progress/20260425T032026Z_654aaa2e-inventory-1899.md
@@ -1,0 +1,121 @@
+# Inventory reconciliation for PR #1899 PAX duplicate-key rejection
+
+- **Session UUID**: 654aaa2e-2f3c-4874-8748-da9eaf4fc942
+- **Session type**: feature
+- **UTC**: 2026-04-25T03:20:26Z
+- **Issue**: #1918
+- **Branch**: agent/654aaa2e
+- **Starting commit**: f7d1100
+- **Commit**: f88a603
+
+## What was accomplished
+
+Landed the two-hunk `SECURITY_INVENTORY.md` bookkeeping follow-up
+flagged by paired-review PR #1913 sections E.1 + E.2 that PR #1899
+merged without touching. Both edits cite the `parsePaxRecords`
+duplicate-key guard at [Zip/Tar.lean:147](/home/kim/lean-zip/Zip/Tar.lean:147)
+with the exact thrown wording
+`tar: PAX extended header has duplicate {key.quote} record`, note the
+sole production caller at [Zip/Tar.lean:669](/home/kim/lean-zip/Zip/Tar.lean:669)
+rethrows unconditionally via `throw (IO.userError msg)`, and call out
+complementary parser-differential coverage with PR #1866's PAX
+NUL-byte silent-skip.
+
+### Edit 1 — corpus row (post-PR file lines 1270-1270 in the table)
+
+Inserted a new row before `pax-extended-oversized-size.tar` in the
+*Minimized Reproducer Corpus* table:
+
+- path cell: `testdata/tar/malformed/pax-duplicate-path.tar`
+- size cell: `2048 B`
+- description cell: cites the guard + caller, the attack class (PAX
+  allows duplicate keys syntactically; `applyPaxOverrides` default
+  last-wins-silent leaves the smuggle exploitable unless the parser
+  rejects structurally), and the sibling closure with PR #1866.
+- PR cell: `#1899`
+- class cell: `archive-slip` (matching the sibling `pax-path-nul-in-
+  value.tar` row and the UStar-NUL rows, per the issue's preference
+  for adjacency-consistency over the paired-review's
+  *parser-differential* family language).
+
+### Edit 2 — recent-wins bullet (post-PR file lines 934-951)
+
+Inserted a new bullet after the PR #1880 UStar-NUL bullet under
+*Tar Parser/Extractor* → *Recent wins*. Bullet is 18 lines (slightly
+over the ~10-line target suggested by the issue but within the
+established bullet-length precedent — the PR #1880 bullet is 19 lines,
+the PR #1886 CD-deflate-zero-compsize bullet is 23 lines). Follows
+the conventional structure:
+
+- lead line naming the closure
+- ordering inside `parsePaxRecords` (UTF-8 decode → NUL guard →
+  duplicate-key check → push)
+- contrast with PR #1866's silent-skip (hard-reject vs drop)
+- caller unconditional-rethrow path at `forEntries`'s
+  `typePaxExtended` branch
+- error wording with `String.quote` attribution
+- sibling closure note ("together the two close both
+  parser-differential dimensions on the PAX-record decode pipeline").
+
+### Placement correction
+
+Initial draft placed the corpus row *between* `pax-extended-oversized-
+size.tar` and `pax-inconsistent-length.tar` — wrong, because `'d' <
+'e' < 'i'` per ASCII and the row belongs *before* `pax-extended-
+oversized-size.tar`. Caught during pre-commit diff review and
+corrected before running the link checker.
+
+## Decisions
+
+- **Class = `archive-slip`**: the issue gave the worker discretion
+  between `archive-slip` (matching adjacent PAX / UStar NUL rows) and
+  `parser-differential` (matching the paired-review's family
+  language). Chose `archive-slip` for table-adjacency consistency per
+  the issue's explicit preference.
+- **No prose pare-back under *Recent wins***: the issue flagged the
+  optional third hunk "if the *Recent wins* prose at line 882-887
+  needs to be pared back to avoid duplicating the new bullet's
+  content". On inspection, the PR #1880 bullet's mention of PR #1866
+  is inline (single clause citing the silent-skip behaviour) rather
+  than a trailing "sibling-of" paragraph, and does not overlap with
+  the PR #1899 bullet's framing. Skipped the third hunk.
+- **Line numbers in the issue body are stale**: the issue references
+  line 844 for the Tar Parser/Extractor heading and line 1225 for the
+  corpus insertion point. Current file has the heading at line 890
+  and the insertion point at 1270 (pre-edit). Treated the issue's
+  line numbers as stale anchors and navigated by `grep` + section
+  structure instead, which is the norm after multiple post-issue
+  merges.
+
+## Verification
+
+- `bash scripts/check-inventory-links.sh` → `errors=0, warnings=109`
+  — baseline unchanged, no new warnings introduced by either hunk.
+- `lake build -R` → 191/191 targets passed (smoke check; inventory
+  is a doc file, no Lean changes).
+- `git diff master..HEAD` shows one file changed (`SECURITY_INVENTORY.md`),
+  +19 lines. Two hunks: recent-wins bullet, corpus table row.
+- Alphabetical ordering of `pax-*.tar` rows verified by eye: `pax-
+  duplicate-path` (`d`) < `pax-extended-oversized-size` (`e`) < `pax-
+  inconsistent-length` (`i`) < `pax-invalid-utf8-key` < `pax-invalid-
+  utf8-value` < `pax-oversized-length` < `pax-path-nul-in-value` <
+  `pax-truncated-record`.
+
+## Quality metrics
+
+- sorry count: 0 → 0 (unchanged; doc-only edit)
+- errors: 0 → 0
+- warnings: 109 → 109
+
+## What remains
+
+E.3 from paired-review #1913 ("`error-wording-catalogue` skill entry
+for the new `tar: PAX extended header has duplicate {key.quote}
+record` wording") is flagged by the paired-review as a separate
+`meditate`-stream issue, explicitly not in this PR's scope per the
+issue's deliverable 3.
+
+## Files touched
+
+- `SECURITY_INVENTORY.md` (+19 lines, 2 hunks)
+- `progress/20260425T032026Z_654aaa2e-inventory-1899.md` (new)


### PR DESCRIPTION
Closes #1918

Session: `654aaa2e-2f3c-4874-8748-da9eaf4fc942`

6816828 doc: progress entry for inventory reconciliation PR #1899 (closes #1918)
f88a603 doc: reconcile SECURITY_INVENTORY.md for PR #1899 PAX duplicate-key rejection

🤖 Prepared with Claude Code