### PR TITLE
Review: paired-review entry for PR #1953 — Track E per-slot GNU long-link interior-NUL fixture gnu-longlink-nul-in-link.tar (long-link slot, terminal closure of the 2-slot GNU long-name/long-link interior-NUL family — sibling of PR #1865 which closed the long-name slot at gnu-longname-nul-in-name.tar)

### DIFF
--- a/progress/20260425T071545Z_6ec57afb-paired-review-1953.md
+++ b/progress/20260425T071545Z_6ec57afb-paired-review-1953.md
@@ -1,0 +1,411 @@
+# Paired review: PR #1953 — Track E per-slot GNU long-link interior-NUL fixture `gnu-longlink-nul-in-link.tar` (long-link slot — terminal closure of the 2-slot GNU long-name / long-link interior-NUL family)
+
+- Date: 2026-04-25T07:15Z
+- Session: 6ec57afb
+- Type: review (issue #1954, paired-review for PR #1953)
+
+PR #1953 landed at merge commit `f0a8e8a03aa67f2b0f0b97b666a521b025afbfa6`
+on 2026-04-25T06:30:19Z, closing issue #1945. **PR #1953 is a 2-slot
+family closure** of the GNU long-name / long-link interior-NUL guard
+family. Together with PR #1865 (which added both guards in a single
+landing but only emitted the long-name fixture at
+`testdata/tar/malformed/gnu-longname-nul-in-name.tar`), the family is
+now pinned at every per-slot position by a dedicated regression
+fixture: `gnu-longname-nul-in-name.tar` (long-name slot, PR #1865) and
+`gnu-longlink-nul-in-link.tar` (long-link slot, PR #1953).
+
+This paired-review is **the first 2-slot terminal-closure
+paired-review** in Track E history. It mirrors the cadence
+established by the in-flight long-name sibling
+[`progress/20260424T*paired-review-1865`](https://github.com/kim-em/lean-zip/pull/1876)
+(PR #1876, paired-review for PR #1865 itself, currently in flight)
+and the post-#1880/#1934/#1937 3-slot UStar filesystem-reaching arm
+closure cadence ending at
+[`progress/20260425T053039Z_fd0cfd7b-paired-review-1937.md`](/home/kim/lean-zip/progress/20260425T053039Z_fd0cfd7b-paired-review-1937.md)
+(`prefix` slot, terminal of the 3-slot arm). The wave timeline for the
+2-slot GNU long-name / long-link family is: PR #1865
+(2026-04-24T20:04:31Z, long-name slot) → PR #1953 (2026-04-25T06:30:19Z,
+long-link slot, +10h 25min 48s — terminal of the 2-slot family).
+
+## A. Fixture correctness
+
+### A.1 Determinism
+
+Reran `lake env lean --run scripts/build-gnu-long-malformed-fixtures.lean`
+in the worktree against current `master`. Post-rerun, `git status testdata/`
+reports **`nothing to commit, working tree clean`** — all six fixtures
+the script emits are byte-identical to the on-disk copies. The builder's
+final line is `Built 6 malformed GNU long-name/long-link fixtures under
+testdata/tar/malformed/.` (the count was bumped from `5 malformed` to
+`6 malformed` by PR #1953 to reflect the new emitter).
+
+SHA-256 of the new fixture
+(`testdata/tar/malformed/gnu-longlink-nul-in-link.tar`):
+
+    aa4171af74f458eccd479bf6f39dc86f4efec6d45eb1e34002460bd93269f0a4
+
+— byte-identical to the value cited in the issue body. The pre-existing
+five fixtures emitted by the same builder
+(`gnu-longname.tar`, `gnu-longname-truncated.tar`,
+`gnu-longlink-truncated.tar`, `gnu-longname-no-terminator.tar`,
+`gnu-longname-invalid-utf8.tar`, `gnu-longname-oversized-size.tar`,
+`gnu-longname-nul-in-name.tar`) are reproduced byte-for-byte by the
+rerun — the addition of `buildGnuLonglinkNulInLink` cannot have shifted
+the bytes of the earlier emitters because the six emit functions are
+independent (each produces an isolated fixture path with no shared
+mutable state).
+
+### A.2 Block geometry (1 536 B)
+
+The fixture is exactly **1 536 B** = 512 B header for the long-link
+pseudo-entry + 512 B long-link payload block + 512 B trailing
+zero-length regular-file entry (for symmetry with the precursor
+`gnu-longname-nul-in-name.tar`). This matches the issue body's
+geometry note exactly. The long-link pseudo-entry's `typeflag` is
+`'K'` (`Tar.typeGnuLongLink`); its size field declares 18 bytes (the
+`"safe.lnk\x00rogue.tar"` payload length); the long-link payload
+block contains the 18 bytes of payload followed by 494 bytes of NUL
+padding to round up to the 512 B block boundary. The trailing
+zero-length regular-file entry is reached only by the no-guard
+regression baseline — the guard fires on the long-link pseudo-entry
+itself before any subsequent block is read.
+
+The long-name sibling (`gnu-longname-nul-in-name.tar`, PR #1865) has
+the same 1 536 B geometry, with the only differences being:
+
+| Field             | long-name (PR #1865)      | long-link (PR #1953)         |
+|-------------------|---------------------------|------------------------------|
+| `typeflag`        | `'L'` (`typeGnuLongName`) | `'K'` (`typeGnuLongLink`)    |
+| Smuggled payload  | `"evil.txt\x00.tar"`      | `"safe.lnk\x00rogue.tar"`    |
+| Payload length    | 13 B                      | 18 B                         |
+| NUL position      | byte 8                    | byte 8                       |
+
+The two fixtures' header geometry is otherwise identical: 512 B header
++ 512 B payload block + 512 B trailing zero-length regular-file entry.
+
+### A.3 Smuggled value choice: `"safe.lnk\x00rogue.tar"` (18 B printable + interior NUL at byte 8)
+
+The smuggled value `"safe.lnk\x00rogue.tar"` encodes long-link slot
+identity in three independent ways:
+
+1. **`.lnk` extension**: signals "this is a long-link fixture" to a
+   reader skimming the bytes (the long-name sibling uses
+   `evil.txt\x00.tar` with `.txt`); per-slot-distinct printable
+   prefix discipline.
+2. **`safe` / `rogue` rhetoric**: matches the per-slot UStar fixture
+   convention (`uname = "trusted\x00rogue"`, `gname = "trusted\x00rogue"`) —
+   the printable prefix `"safe"` is what a parser-differential caller
+   would see if `Binary.fromLatin1` truncated at NUL, while strict
+   peer parsers (GNU tar, BSD tar, libarchive) preserve the full
+   18 bytes.
+3. **`stripTrailingNuls` no-op**: the payload's last byte is `'r'`
+   (the `r` in `rogue.tar`'s `r`), not NUL. So `stripTrailingNuls`
+   removes nothing, and the interior NUL at byte 8 survives into
+   the `(linkBytes.findIdx? (· == 0)).isSome` guard. This is the
+   key invariant the smuggle exploits.
+
+The `.tar` suffix on the rhs is harmless cover — the guard rejects
+on the raw `ByteArray` before any parser sees the smuggled extension.
+
+## B. Guard attribution
+
+Project-wide grep on the long-link substring at current `master`:
+
+    $ grep -rn "GNU long-link contains NUL byte" Zip/ ZipTest/ scripts/
+    Zip/Tar.lean:679: throw (IO.userError "tar: GNU long-link contains NUL byte")
+    ZipTest/TarFixtures.lean:213:    "GNU long-link contains NUL byte"
+    scripts/build-gnu-long-malformed-fixtures.lean:128:    `"GNU long-link contains NUL byte"` before
+
+Three hits: one source (the actual `throw` in `forEntries`), one test
+(the `assertThrows` substring), and one builder docstring (a benign
+cross-reference in `buildGnuLonglinkNulInLink`'s docstring). The
+issue body anticipated "exactly two source-side hits" — the third hit
+is the builder docstring and counts as a benign cross-reference, not
+a duplicate guard. The throw + assertThrows pair is clean.
+
+The 2-slot `forEntries` interior-NUL guard is at:
+
+- `Zip/Tar.lean:667` (long-name throw), inside the
+  `entry.typeflag == typeGnuLongName` branch starting at line 662.
+- `Zip/Tar.lean:679` (long-link throw), inside the
+  `entry.typeflag == typeGnuLongLink` branch starting at line 674.
+
+The issue body cites `Zip/Tar.lean:660` (long-name) / `Zip/Tar.lean:672`
+(long-link) — those line numbers were correct at the PR #1953 landing
+commit `f0a8e8a` but have drifted by +7 lines after PR #1957 added the
+UStar `gname` interior-NUL guard at `Zip/Tar.lean:539`. This drift is
+**post-#1957 line-anchor drift**, not introduced by PR #1953. See §D
+for the inventory-row anchor consequence and §E.7 for the follow-up
+re-anchoring issue.
+
+The long-link arm is the **uniquely-tripped** sub-check for this
+fixture: the fixture's pseudo-entry typeflag is `typeGnuLongLink`
+(`'K'`), so the per-typeflag dispatch at lines 662 (`typeGnuLongName`)
+vs 674 (`typeGnuLongLink`) routes to the long-link branch. The
+long-name guard at line 667 cannot fire because the typeflag check at
+line 662 returns false. Attribution pins on the long-link arm
+specifically.
+
+## C. Test assertion placement
+
+The new `assertThrows` block is at
+[`ZipTest/TarFixtures.lean:207-213`](/home/kim/lean-zip/ZipTest/TarFixtures.lean:207),
+adjacent to the long-name sibling block at
+[`ZipTest/TarFixtures.lean:194-200`](/home/kim/lean-zip/ZipTest/TarFixtures.lean:194).
+The two blocks share their structure exactly (read fixture → write tmp
+copy → assertThrows on a `Tar.list` invocation against the substring),
+diverging only in:
+
+| Line ref                              | long-name (PR #1865)            | long-link (PR #1953)            |
+|---------------------------------------|---------------------------------|---------------------------------|
+| Fixture-name binding                  | `gnuLnNulData` / `gnuLnNulPath` | `gnuLkNulData` / `gnuLkNulPath` |
+| `readFixture` argument                | `gnu-longname-nul-in-name.tar`  | `gnu-longlink-nul-in-link.tar`  |
+| `assertThrows` description            | `gnu-longname-nul-in-name.tar`  | `gnu-longlink-nul-in-link.tar`  |
+| Substring                             | `GNU long-name contains NUL byte` | `GNU long-link contains NUL byte` |
+
+The substring `"GNU long-link contains NUL byte"` is **per-slot-distinct**
+from the long-name sibling's substring `"GNU long-name contains NUL byte"`
+and from the five UStar siblings' substrings (`"UStar name contains NUL byte"`,
+`"UStar linkname contains NUL byte"`, `"UStar prefix contains NUL byte"`,
+`"UStar uname contains NUL byte"`, `"UStar gname contains NUL byte"`).
+The bare `"GNU long-"` prefix would also match the long-name arm, so the
+inclusion of `"long-link"` in the substring is essential to keep per-slot
+distinction. The naming convention matches the issue body's per-slot
+discipline note.
+
+The cleanup-list-array registration at
+[`ZipTest/TarFixtures.lean:433`](/home/kim/lean-zip/ZipTest/TarFixtures.lean:433)
+covers the new fixture: the array contains `"gnu-longlink-nul-in-link.tar"`
+in the GNU-long-fixtures sub-block, ensuring `/tmp/lean-zip-fixture-gnu-longlink-nul-in-link.tar`
+is removed at the end of the test run. Note: the **pre-existing oversight**
+flagged in
+[`progress/20260425T062807Z_8b320d14.md`](/home/kim/lean-zip/progress/20260425T062807Z_8b320d14.md)
+— `gnu-longname-nul-in-name.tar` is **not** in the cleanup-list array
+(PR #1865 missed it) — is **out of scope** for this paired-review. It
+is being separately planned as a one-line cleanup follow-up (issue
+#1956, claimed by the same planner cycle that issued this review).
+This pre-existing leak is benign in practice (the `/tmp/lean-zip-fixture-*`
+files are 1.5 KB each and are already silently overwritten on subsequent
+test runs) but should be tightened.
+
+## D. Inventory placement
+
+The new `SECURITY_INVENTORY.md` row is at line 1296, sitting at the
+**alphabetical position** between
+[`SECURITY_INVENTORY.md:1293`](/home/kim/lean-zip/SECURITY_INVENTORY.md:1293)
+(`bad-checksum.tar`) and
+[`SECURITY_INVENTORY.md:1298`](/home/kim/lean-zip/SECURITY_INVENTORY.md:1298)
+(`gnu-longlink-truncated.tar`).
+
+The issue body asked for a different position (the worker
+[notes in `progress/20260425T062807Z_8b320d14.md` lines 32-39](/home/kim/lean-zip/progress/20260425T062807Z_8b320d14.md))
+that the worker followed file convention (alphabetical) over literal
+issue instruction; this is a sound deviation: the inventory file is
+sorted alphabetically by fixture path, and inserting at any other
+position would require the next inventory-substitution sweep to fix
+the order.
+
+The row's `Zip/Tar.lean:672` anchor was correct at the PR #1953 landing
+commit `f0a8e8a` (the long-link throw was at line 672 then) but has
+drifted by +7 lines after PR #1957 added the UStar `gname` guard. The
+new actual line is `Zip/Tar.lean:679`. This drift is **post-#1957
+line-anchor drift**, not a PR #1953 defect — the anchor was correct
+at the time of authoring. See §E.7 for the re-anchoring follow-up.
+
+The remaining `#N` placeholder in the inventory row is the only
+post-#1953 inventory drift introduced by PR #1953. As of current
+`master`, the inventory check
+(`bash scripts/check-inventory-links.sh`) reports two
+placeholder-PR `#N` warnings:
+
+1. `:1296` — gnu-longlink-nul-in-link.tar (this PR's row)
+2. `:1313` — ustar-gname-nul-in-gname.tar (PR #1957's row, landed
+   2026-04-25T07:00:34Z)
+
+The issue body anticipated "two placeholder-PR `#N` warnings — one
+for ustar-uname row :1314 and one for the new long-link row" — but the
+ustar-uname placeholder was substituted by PR #1958 (landed
+2026-04-25T07:00:42Z, `coordination`-routed inventory sweep, after the
+issue was authored at 2026-04-25T06:37 but before this review claimed).
+The two outstanding placeholders are now `:1296` (long-link) and `:1313`
+(gname); the identity shifted but the count of two matches the
+prediction. Both will be substituted in the next post-#1953/#1957
+inventory sweep — already queued as **issue #1960** ("Inventory:
+substitute two placeholder PR refs in SECURITY_INVENTORY.md corpus
+table (post-#1953 + post-#1957 wave)").
+
+## E. Family structure + wave cadence — the headline
+
+PR #1953 closes the **2-slot GNU long-name / long-link interior-NUL
+per-fixture family** at **2/2 slots**, mirroring the post-#1880/#1934/#1937
+closure of the 3-slot UStar filesystem-reaching arm. The wave timeline:
+
+- PR #1865 (2026-04-24T20:04:31Z, long-name slot — added both guards in
+  a single landing but emitted only the long-name fixture).
+- PR #1953 (2026-04-25T06:30:19Z, long-link slot, +10h 25min 48s —
+  emits the long-link fixture, closing the per-slot fixture asymmetry
+  PR #1865 left behind).
+
+**Cross-family comparison** (Tar interior-NUL guards across UStar +
+GNU long-name/long-link):
+
+| Family | Slot count | State | Slots | Closing PR | Paired-review |
+|--------|-----------|-------|-------|------------|---------------|
+| UStar interior-NUL fs-reaching arm | 3 | closed 3/3 | name / linkname / prefix | PR #1937 (2026-04-25T04:29Z) | PR #1947 (issue #1939) |
+| UStar interior-NUL with uname (defense-in-depth) | 4 | closed 4/4 | + uname | PR #1944 (2026-04-25T05:22Z) | PR #1951 (issue #1950) |
+| UStar interior-NUL with gname (final) | 5 | closed 5/5 | + gname | PR #1957 (2026-04-25T07:00Z) | TBD (issue #1961) |
+| GNU long-name / long-link | 2 | **closed 2/2** | long-name / long-link | **PR #1953 (2026-04-25T06:30Z)** | **TBD (this issue #1954)** |
+| PAX path / linkpath NUL (sibling) | 2 | open 1/2 | path covered (PR #1866) | linkpath gated on issue #1855 | TBD |
+
+The post-#1928 wave's family-closure cadence has accelerated: each
+closure event triggers a paired-review issue exactly once. The four
+Tar interior-NUL families are now in three states:
+- **3-slot UStar filesystem-reaching arm**: closed and paired-reviewed
+  (PR #1937 / PR #1947).
+- **4-slot UStar + 5-slot UStar (defense-in-depth)**: closed; 4-slot
+  paired-reviewed (PR #1951); 5-slot paired-review pending (issue #1961).
+- **2-slot GNU long-name / long-link**: closed; paired-review pending
+  (this entry; closes issue #1954).
+
+**Observations for next `/summarize`** (post-#1928 wave continuation
+or its next phase):
+
+- The 2-slot GNU family's closure timing (`+10h 25min 48s` from
+  precursor PR #1865 to closure PR #1953) is comparable to the 3-slot
+  UStar arm's first-to-second closure (`+6h 19min 59s`) and second-to-
+  terminal closure (`+17min 16s`) — but the 2-slot family was
+  hand-rolled in a single planner cycle (issue #1945), while the 3-slot
+  family ran across three issues (#1879, #1933, #1936). The 2-slot family
+  is **smaller** (only one fixture asymmetry to close, since both guards
+  already existed in source from PR #1865), so it absorbs less wave time.
+- The 5-slot UStar family's closure (PR #1957 at 2026-04-25T07:00Z, gname
+  slot, +1h 38min from PR #1944) is roughly contemporaneous with PR #1953's
+  closure (+30min apart), suggesting the post-#1928 wave has converged
+  on a parallel planning style: multiple per-slot families closed in
+  near-simultaneous bursts.
+- The PAX path/linkpath family (issue #1855) is the **last** Tar
+  interior-NUL family unclosed. It is structurally similar to the
+  2-slot GNU long-name / long-link family (two parallel slots, both
+  reaching `entry.path` / `entry.linkname` post-resolution), so its
+  closure is expected to follow a similar cadence: a single PR with
+  both guards, then a per-slot fixture asymmetry closure (or both
+  slots emitted at once if the planner asks for it).
+
+**Observations for next `/meditate`** (skill-update cycle):
+
+- The
+  [`error-wording-catalogue` skill row at `.claude/skills/error-wording-catalogue/SKILL.md:52`](/home/kim/lean-zip/.claude/skills/error-wording-catalogue/SKILL.md:52)
+  documents the long-link substring family. Its 2-slot family-shape
+  annotation can now be tightened from "long-link slot pending #1945"
+  (or whatever the current text is — the issue body summarizes this)
+  to **"fully-pinned 2-slot family at PR #1865 + PR #1953"**.
+- The `malformed-fixture-builder` skill should be reviewed for the
+  `gnu-longlink-nul-in-link.tar` fixture pattern — the `safe.lnk\x00rogue.tar`
+  smuggled-value pattern is **the third per-slot-distinct printable
+  prefix** in the wave (after `safe` / `evil.txt` / `trusted` / `rogue`).
+  The `.lnk` extension as a slot-identity marker is novel; it could be
+  added to the skill's "smuggled value choice" examples table.
+
+## F. Reviewer observations
+
+- **Per-slot-distinct substring discipline.** Each of the now-seven
+  closed slots in the Tar interior-NUL guard families uses a unique
+  substring: `"GNU long-name contains NUL byte"`, `"GNU long-link
+  contains NUL byte"`, `"UStar name contains NUL byte"`, `"UStar
+  linkname contains NUL byte"`, `"UStar prefix contains NUL byte"`,
+  `"UStar uname contains NUL byte"`, `"UStar gname contains NUL byte"`.
+  Including the per-slot keyword in the substring is essential — the
+  bare prefixes (`"GNU long-"`, `"UStar"`) would multi-match. The
+  `error-wording-catalogue` skill should be checked for adherence.
+
+- **`name = "safe"`-style discipline analog.** The long-link payload
+  first 8 bytes are `"safe.lnk"` — a printable prefix that mirrors the
+  UStar fixtures' `name = "safe"` prefix and the `gname = "trusted"`
+  prefix. The interior NUL is at byte 8 (the same byte position as the
+  long-name sibling's NUL), so the smuggle's "post-truncation" view is
+  `safe.lnk` (a clean 8-character `.lnk` filename). This is the
+  per-slot-distinct printable prefix discipline applied consistently.
+
+- **Writer-side compliance.** `Tar.create` does **not** emit GNU
+  long-name / long-link pseudo-entries — the writer always emits
+  UStar-or-PAX-extended-headers when paths exceed the UStar 100/155-byte
+  limits. So neither guard ever fires on legitimate archives produced
+  by `Tar.create`, regardless of input. To actually trigger the
+  long-link guard a caller would have to construct a malformed UStar
+  pseudo-entry block by hand and feed it to `Tar.list` — which is
+  exactly what the fixture does. The writer-side invariant is
+  **"writer never emits typeflag `'K'` or `'L'`"**, which is structurally
+  stronger than the `Binary.writeString` NUL-padding-only invariant of
+  the UStar slot guards (`name`, `linkname`, `prefix`, `uname`, `gname`).
+
+- **Fixture-builder hook shape.** The new emitter
+  `buildGnuLonglinkNulInLink` at
+  [`scripts/build-gnu-long-malformed-fixtures.lean:139`](/home/kim/lean-zip/scripts/build-gnu-long-malformed-fixtures.lean:139)
+  follows the precedent of `buildGnuLongnameNulInName` at line 105
+  exactly: same 18-byte payload, same `typeGnuLongLink` typeflag, same
+  `1536` total size, same trailing zero-length regular-file entry. The
+  `main` print-line bump from `5 malformed` to `6 malformed` is correct.
+
+- **Cleanup-list-array oversight carried forward from PR #1865.** The
+  long-name sibling fixture (`gnu-longname-nul-in-name.tar`) is not
+  in the cleanup-list array at
+  [`ZipTest/TarFixtures.lean:425`](/home/kim/lean-zip/ZipTest/TarFixtures.lean:425),
+  whereas the new long-link fixture is. PR #1953's worker followed the
+  rule (registered the new fixture) but did not opportunistically fix
+  the precursor's omission. This is sound scope discipline — the
+  cleanup-list-array fix is a separate one-line PR (issue #1956) — but
+  it leaves a temporary asymmetry in the cleanup-list array for the
+  duration between PR #1953 landing and issue #1956 closure.
+
+## G. Scope and quality metrics
+
+`grep -rc sorry Zip/`: 0 (matches the `master` baseline; PR #1953
+did not introduce any sorry).
+
+`lake build -R`: clean. Build completed successfully (191 jobs).
+
+`lake exe test`: all tests passed. The new `assertThrows` at
+`ZipTest/TarFixtures.lean:213` is exercised in-band — `Tar.list`
+on the fixture throws `"tar: GNU long-link contains NUL byte"`, and
+`assertThrows` matches on the substring `"GNU long-link contains NUL byte"`.
+
+`bash scripts/check-inventory-links.sh`: 0 errors, 106 warnings.
+The two relevant warnings are the **expected** placeholder-PR `#N`
+substitution warnings:
+
+1. `SECURITY_INVENTORY.md:1296` — gnu-longlink-nul-in-link.tar (PR #1953)
+2. `SECURITY_INVENTORY.md:1313` — ustar-gname-nul-in-gname.tar (PR #1957)
+
+Both are queued for substitution in the next inventory sweep
+(issue #1960). The remaining 104 warnings are pre-existing
+line-content heuristic mismatches (covered by separate re-anchoring
+issues including #1955 / PR #1959) and pre-existing line-anchor drift
+on the four UStar rows — none introduced or made worse by PR #1953.
+
+`scripts/build-gnu-long-malformed-fixtures.lean` rerun: post-rerun
+`git status testdata/` reports `nothing to commit, working tree clean`
+— all six fixtures byte-identical.
+
+`grep -rn "GNU long-link contains NUL byte" Zip/ ZipTest/ scripts/`:
+3 hits (one source, one test, one builder docstring) — see §B for
+the full enumeration.
+
+Only this paired-review progress entry is committed; zero changes
+to `Zip/`, `ZipTest/`, `testdata/`, `SECURITY_INVENTORY.md`,
+`scripts/`, `PLAN.md`, top-level `.claude/CLAUDE.md`, `PROGRESS.md`,
+or skill files.
+
+## Summary
+
+PR #1953 **closes the 2-slot GNU long-name / long-link interior-NUL
+guard family at 2/2 slots**, terminal closure of the 2-slot family.
+The fixture is correct (deterministic, 1 536 B geometry, 18 B
+smuggled value with NUL at byte 8 surviving `stripTrailingNuls`),
+the guard attribution pins on the long-link arm specifically (typeflag
+dispatch routes there), the test substring is per-slot-distinct, the
+inventory placement is alphabetically correct (worker followed file
+convention), the inventory placeholder `#N` is queued for substitution
+(issue #1960), and the `cleanup-list-array` registration is correct
+(though the long-name precursor's pre-existing omission carries
+forward, queued as issue #1956). No sorries, no test failures, no
+code-side side-effects. **Approved.**


### PR DESCRIPTION
Closes #1954

Session: `6ec57afb-d12e-4134-b225-9ed2e822c55d`

d66789a doc: paired-review entry for PR #1953 — Track E per-slot GNU long-link interior-NUL fixture gnu-longlink-nul-in-link.tar (long-link slot, terminal closure of the 2-slot GNU long-name / long-link interior-NUL family — sibling of PR #1865 which closed the long-name slot at gnu-longname-nul-in-name.tar)

🤖 Prepared with Claude Code