### PR TITLE
Test cleanup: register gnu-longname-nul-in-name.tar in ZipTest/TarFixtures.lean cleanup-list array (one-line follow-up to PR #1865's missing cleanup-list registration; flagged in progress/20260425T062807Z_8b320d14.md as out-of-scope follow-up to PR #1953)

### DIFF
--- a/ZipTest/TarFixtures.lean
+++ b/ZipTest/TarFixtures.lean
@@ -430,7 +430,7 @@ def ZipTest.TarFixtures.tests : IO Unit := do
              "pax-duplicate-path.tar",
              "gnu-longname-truncated.tar", "gnu-longlink-truncated.tar",
              "gnu-longname-no-terminator.tar", "gnu-longname-invalid-utf8.tar",
-             "gnu-longlink-nul-in-link.tar",
+             "gnu-longname-nul-in-name.tar", "gnu-longlink-nul-in-link.tar",
              "ustar-name-nul-in-name.tar",
              "ustar-linkname-nul-in-name.tar",
              "ustar-prefix-nul-in-name.tar",

--- a/progress/20260425T074346Z_0908f32a.md
+++ b/progress/20260425T074346Z_0908f32a.md
@@ -1,0 +1,62 @@
+# Progress entry — 2026-04-25T07:43:46Z
+
+Session: feature
+Session UUID prefix: 0908f32a
+Issue: #1956
+PR: (filed via `coordination create-pr 1956`)
+
+## Summary
+
+One-line cleanup-list bookkeeping fix flagged by the PR #1953 worker.
+Registered the `gnu-longname-nul-in-name.tar` fixture basename
+(introduced by PR #1865) in the `for f in #[...] do rm -f` cleanup-list
+array of `ZipTest/TarFixtures.lean` so the stale
+`/tmp/lean-zip-fixture-gnu-longname-nul-in-name.tar` file is removed
+at end of test suite, matching the discipline of every other recent
+NUL/oversized fixture (PRs #1880, #1934, #1937, #1944, #1953).
+
+## What was accomplished
+
+- Added basename `"gnu-longname-nul-in-name.tar"` adjacent to its
+  long-link sibling `"gnu-longlink-nul-in-link.tar"` in the cleanup-list,
+  forming the pair `"gnu-longname-nul-in-name.tar", "gnu-longlink-nul-in-link.tar",`
+  on a single line — mirroring the established
+  `"gnu-longname-truncated.tar", "gnu-longlink-truncated.tar",` pairing
+  on the line above.
+- Verified `lake build -R` clean, `lake exe test` reports
+  `All tests passed!`, and after the test run
+  `/tmp/lean-zip-fixture-gnu-longname-nul-in-name.tar` no longer exists
+  (pre-fix, the file was confirmed present in `/tmp` from prior runs).
+- `git diff` is exactly one line changed in `ZipTest/TarFixtures.lean`,
+  no other files touched. Strictly within the issue's scope clause.
+
+## Decisions
+
+- **Single-line pair vs. own line.** The issue allowed either; chose the
+  single-line pair `"gnu-longname-...", "gnu-longlink-...",` because it
+  visually mirrors the parallel `"gnu-longname-truncated.tar",
+  "gnu-longlink-truncated.tar",` pair on the line directly above. Net
+  diff is +1/-1 and column width remains within the surrounding block's
+  convention.
+- **Issue line-number drift.** The issue cites lines 402-418 for the
+  cleanup-list block; current master has it at lines 425-442 because of
+  earlier additions. The drift is purely cosmetic — the block content
+  matches exactly (same neighbours, same `gnu-longlink-nul-in-link.tar`
+  on its own line). Did not need to skip / replan.
+
+## Quality metric delta
+
+- `sorry` count: unchanged (this PR adds no proofs).
+- File touched: `ZipTest/TarFixtures.lean` only (+1/-1).
+
+## What remains
+
+Nothing for this issue. The terminal cleanup-list registration of the
+2-slot GNU long-name / long-link interior-NUL family is now complete:
+
+  - gnu-longname-nul-in-name.tar (this PR)
+  - gnu-longlink-nul-in-link.tar (registered by PR #1953)
+
+Both siblings sit adjacent in the cleanup-list, matching their adjacency
+in the assertion block at `ZipTest/TarFixtures.lean:194-196` /
+`:207-209`.


### PR DESCRIPTION
Closes #1956

Session: `0908f32a-933b-4a95-b8be-bcd4cb9e33b1`

c4d3ba6 doc: progress entry for #1956 cleanup-list registration of gnu-longname-nul-in-name.tar
09e36d8 test: register gnu-longname-nul-in-name.tar in TarFixtures cleanup-list

🤖 Prepared with Claude Code