### PR TITLE
Inventory: add SECURITY_INVENTORY.md Recent-wins bullet for GNU long-name / long-link interior-NUL family closure (PRs #1865 + #1953) under Tar Parser/Extractor + tighten UStar bullet's sibling-of paragraph to credit per-slot long-link slot (PR #1953) — sibling of PR #1928 post-#1899 PAX duplicate-key precedent

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -934,8 +934,10 @@ Summary — what this pattern catches and what it does not:
     *"UStar gname contains NUL byte"* (offset 297, 32 B). Closes
     the UStar layer of the smuggled-NUL attack class — sibling of
     PR #1831 (ZIP CD entry name, *"CD entry name contains NUL byte"*),
-    PR #1865 (GNU long-name / long-link, *"GNU long-name contains NUL
-    byte"* / *"GNU long-link contains NUL byte"*), and PR #1866 (PAX
+    PRs #1865 (long-name slot, `gnu-longname-nul-in-name.tar`) /
+    #1953 (long-link slot, `gnu-longlink-nul-in-link.tar`) (GNU
+    long-name / long-link, *"GNU long-name contains NUL byte"* /
+    *"GNU long-link contains NUL byte"*), and PR #1866 (PAX
     `keyBytes` / `valueBytes` silent-skip in `parsePaxRecords`). The
     UStar interior-NUL family is **fully closed 5/5** — the 3-slot
     filesystem-reaching arm (`name` / `linkname` / `prefix`) plus the
@@ -946,6 +948,36 @@ Summary — what this pattern catches and what it does not:
     `Tar.list` caller routing on `entry.uname` / `entry.gname` for a
     trust decision and seeing only the truncated prefix while peer
     parsers preserve the full bytes.
+  - GNU long-name / long-link interior-NUL rejection in `forEntries`
+    — PR #1865 (both guards in `forEntries`'s `typeGnuLongName` /
+    `typeGnuLongLink` arms; long-name regression fixture
+    `testdata/tar/malformed/gnu-longname-nul-in-name.tar`) +
+    per-slot long-link follow-up
+    (`testdata/tar/malformed/gnu-longlink-nul-in-link.tar`,
+    PR #1953). Two error substrings keep per-slot attribution —
+    *"GNU long-name contains NUL byte"* (typeflag `'L'` arm at
+    [Zip/Tar.lean:667](/home/kim/lean-zip/Zip/Tar.lean:667)) and
+    *"GNU long-link contains NUL byte"* (typeflag `'K'` arm at
+    [Zip/Tar.lean:679](/home/kim/lean-zip/Zip/Tar.lean:679)).
+    `forEntries` runs `findIdx? (· == 0)` on the raw `ByteArray`
+    payload after `stripTrailingNuls` and before
+    `String.fromUTF8?` / `Binary.fromLatin1`, so neither decode
+    branch can re-introduce NUL into the error message. The
+    GNU long-name / long-link interior-NUL family is
+    **fully closed 2/2** — long-name slot (PR #1865,
+    `gnu-longname-nul-in-name.tar`) + long-link slot (PR #1953,
+    `gnu-longlink-nul-in-link.tar`). Sibling of PRs #1880 / #1934
+    / #1937 / #1944 / #1957 (UStar interior-NUL family fully
+    closed 5/5), PR #1831 (ZIP CD entry name NUL-byte rejection),
+    and PR #1866 (PAX `keyBytes` / `valueBytes` silent-skip in
+    `parsePaxRecords`). lean-zip's tar writer does not emit GNU
+    long-name / long-link pseudo-entries (`Tar.create` always
+    emits UStar-or-PAX-extended-header for paths exceeding the
+    UStar 100/155-byte limits), so neither guard ever fires on
+    legitimate archives produced by `Tar.create`. The guards
+    exist to reject crafted malformed archives fed to `Tar.list`
+    / `Tar.extract` — the fixtures are the only way to trigger
+    them.
   - PAX extended-header duplicate-key rejection in `parsePaxRecords` —
     PR #1899
     (`testdata/tar/malformed/pax-duplicate-path.tar`).

--- a/progress/20260425T092322Z_e370dee9.md
+++ b/progress/20260425T092322Z_e370dee9.md
@@ -1,0 +1,121 @@
+# Progress entry — 2026-04-25T09:23Z — feature session — issue #1972
+
+Session UUID: `e370dee9-...`
+Branch: `agent/e370dee9`
+Issue: [#1972](https://github.com/kim-em/lean-zip/issues/1972)
+
+## What was accomplished
+
+Single inventory-only PR landing the post-#1953 *Recent wins* bullet
+for the GNU long-name / long-link interior-NUL guard family closure
+(2-slot family, fully closed 2/2 across PR #1865 long-name slot +
+PR #1953 long-link slot), plus a one-paragraph tightening on the
+sibling UStar bullet to credit both PRs.
+
+Two `SECURITY_INVENTORY.md` hunks:
+
+1. **New top-level *Recent wins* bullet** under
+   `### Tar Parser/Extractor` *Recent wins*, inserted between the
+   UStar bullet (now lines 915-950) and the PAX duplicate-key bullet
+   (now lines 981-998). The new bullet sits at lines 951-980 and
+   follows the post-#1928 PAX-duplicate-key bullet shape:
+
+   - lead line names both PRs (PR #1865 introducing both guards in
+     `forEntries`'s `typeGnuLongName` / `typeGnuLongLink` arms +
+     long-name fixture, PR #1953 per-slot long-link follow-up
+     fixture);
+   - cites two error substrings — *"GNU long-name contains NUL byte"*
+     at typeflag `'L'` arm
+     [Zip/Tar.lean:667](/home/kim/lean-zip/Zip/Tar.lean:667) and
+     *"GNU long-link contains NUL byte"* at typeflag `'K'` arm
+     [Zip/Tar.lean:679](/home/kim/lean-zip/Zip/Tar.lean:679);
+   - guard-order paragraph (`findIdx? (· == 0)` on raw `ByteArray`
+     after `stripTrailingNuls`, before `String.fromUTF8?` /
+     `Binary.fromLatin1`);
+   - family-closure annotation: *"fully closed 2/2 — long-name slot
+     (PR #1865, gnu-longname-nul-in-name.tar) + long-link slot
+     (PR #1953, gnu-longlink-nul-in-link.tar)"*;
+   - sibling cross-references: PRs #1880 / #1934 / #1937 / #1944 /
+     #1957 (UStar 5/5), PR #1831 (ZIP CD entry name), PR #1866 (PAX
+     silent-skip);
+   - writer-side invariant: `Tar.create` never emits GNU
+     long-name / long-link pseudo-entries (always emits
+     UStar-or-PAX-extended-header for paths exceeding the UStar
+     100/155-byte limits), so neither guard ever fires on legitimate
+     archives — guards are reject-only for crafted malformed
+     archives.
+
+2. **Tightened UStar bullet's sibling-of paragraph** at
+   `SECURITY_INVENTORY.md:935-941`. Replaced the single
+   `PR #1865 (GNU long-name / long-link, ...)` citation with a
+   two-PR citation crediting both the long-name slot
+   (PR #1865, `gnu-longname-nul-in-name.tar`) and the long-link slot
+   (PR #1953, `gnu-longlink-nul-in-link.tar`), mirroring the
+   post-#1969 error-wording-catalogue skill phrasing.
+
+## Decisions / patterns
+
+- **Used current-master line citations, not the planned-stale
+  ones.** The issue body referenced `Zip/Tar.lean:576` (long-name
+  guard) and `Zip/Tar.lean:672` (long-link guard) — both are stale
+  pre-#1880 / pre-#1944 line numbers. Current master has the long-name
+  guard at line 667 and the long-link guard at line 679 (verified via
+  `git show origin/master:Zip/Tar.lean | grep -n "GNU long-...
+  contains NUL byte"`). Using the planned numbers would have introduced
+  fresh line-anchor drift contradicting the inventory's purpose; using
+  current-master numbers means both anchors resolve cleanly and the
+  link-checker added 2 line-anchor checks (170 → 172) without adding
+  any new warnings.
+
+- **Single-line "fully closed 2/2"** rather than wrapped across two
+  lines. The verification check
+  `grep -n "fully closed 2/2" SECURITY_INVENTORY.md` requires the
+  string on a single line. Reflowed the surrounding prose so
+  `**fully closed 2/2**` lands on one line at :967.
+
+- **Did not touch any of the off-limits regions** flagged in the
+  issue: corpus row at :1296 (gnu-longlink-nul-in-link.tar — already
+  current per PR #1968), UStar corpus rows at :1311-:1317 (covered by
+  in-flight PR #1959 / issue #1955 line-anchor sweep), and any source
+  tree outside `SECURITY_INVENTORY.md`.
+
+## Verification
+
+- `git diff master..HEAD --stat` → 1 file changed, 34 insertions,
+  2 deletions.
+- `bash scripts/check-inventory-links.sh` → `errors=0, warnings=104`.
+  Baseline before edits: `warnings=104`. **Delta: 0.** Two new line
+  anchors (`Zip/Tar.lean:667` and `:679`) added without new warnings,
+  so the heuristic check window for the two new error substrings
+  resolved cleanly. Line-anchor count rose 170 → 172.
+- `grep -nc "#1953" SECURITY_INVENTORY.md` → 4 hits
+  (:938 in the tightened sibling-of paragraph, :957 + :968 in the
+  new bullet, :1296 in the existing corpus row).
+- `grep -n "fully closed 2/2" SECURITY_INVENTORY.md` → 1 hit
+  (:967).
+- Sorry count: unchanged at 0
+  (`grep -rc sorry Zip/ | grep -v ':0$'` empty).
+- `lake build`: not run (inventory-only change, per issue verification
+  note).
+
+## Quality metric deltas
+
+- `errors=0` baseline maintained.
+- `warnings=104` baseline maintained (zero delta).
+- Sorry count: 0 → 0.
+
+## Remaining work
+
+None on this issue. Sibling work that remains in the queue:
+
+- #1976 — per-slot PAX `linkpath` interior-NUL fixture (terminal
+  closure of the PAX value-side override 2-slot family).
+- #1977 — corpus-row tightening at :1300 for
+  `gnu-longname-nul-in-name.tar` (touches a different line range and
+  a different aspect — the per-row PR-credit / line-anchor cleanup,
+  not the *Recent wins* bullet shape).
+- #1974 — skill/command codification of the post-issue-creation
+  tail-deferral pattern (touches `.claude/commands/summarize.md`,
+  unrelated to inventory).
+
+These are independent and can land in any order.


### PR DESCRIPTION
Closes #1972

Session: `e370dee9-d03a-47fe-9ca2-c793ba176d02`

6c225d6 chore: progress entry for #1972 (GNU long-name / long-link Recent-wins bullet)
0adbdfb doc: add Recent-wins bullet for GNU long-name / long-link interior-NUL family closure (PRs #1865 + #1953)

🤖 Prepared with Claude Code