### PR TITLE
Inventory: add SECURITY_INVENTORY.md Recent-wins bullet for the 2-slot PAX value-side override (path/linkpath) NUL-byte silent-skip family closure (PR #1866 path slot + PR #1979 linkpath slot) — third terminal closure of the post-#1928 wave (after PR #1957 5-slot UStar and PR #1953 2-slot GNU long-name-link); shape sibling of PR #1978 (post-#1953 GNU bullet); inserted between the existing PAX duplicate-key bullet and the Symlink/hardlink subsection (around line 998)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -996,6 +996,70 @@ Summary — what this pattern catches and what it does not:
     *duplicate-key* dimension on `parsePaxRecords` complementary to
     PR #1866's NUL-byte silent-skip; together the two close both
     parser-differential dimensions on the PAX-record decode pipeline.
+  - PAX extended-header value-side NUL-byte silent-skip in
+    `parsePaxRecords` — PR #1866 (`path` slot,
+    `testdata/tar/malformed/pax-path-nul-in-value.tar`) +
+    per-slot `linkpath` follow-up
+    (`testdata/tar/malformed/pax-linkpath-nul-in-value.tar`,
+    PR #1979). `parsePaxRecords` runs
+    `findIdx? (· == 0)` on the raw `keyBytes` / `valueBytes`
+    slices at
+    [Zip/Tar.lean:145](/home/kim/lean-zip/Zip/Tar.lean:145)
+    (`keyBytes`) and
+    [Zip/Tar.lean:146](/home/kim/lean-zip/Zip/Tar.lean:146)
+    (`valueBytes`) after `String.fromUTF8?` accepts the bytes
+    (which permits U+0000 as valid UTF-8) and before the
+    duplicate-key check pushes onto the records array. Records
+    that fail this guard are dropped silently, matching the
+    invalid-UTF-8 precedent on the same loop, *not* hard-rejected
+    like PR #1899's duplicate-key guard at
+    [Zip/Tar.lean:147](/home/kim/lean-zip/Zip/Tar.lean:147).
+    Ordering inside `parsePaxRecords` is UTF-8 decode → raw-byte
+    NUL guard → duplicate-key check → push; the silent-skip
+    happens at the raw-byte NUL stage on `keyBytes` / `valueBytes`
+    before `Binary.fromLatin1` would re-decode on the
+    `applyPaxOverrides` side. The companion `applyPaxOverrides`
+    case-arms at
+    [Zip/Tar.lean:161](/home/kim/lean-zip/Zip/Tar.lean:161)
+    (`"path"` → `entry.path`) and
+    [Zip/Tar.lean:162](/home/kim/lean-zip/Zip/Tar.lean:162)
+    (`"linkpath"` → `entry.linkname`) are the smuggle targets
+    the silent-skip prevents from firing — pre-guard, an
+    attacker-controlled record `path=a\x00b/c` would land as
+    `entry.path = "a\x00b/c"` (POSIX `open` truncates at NUL on
+    `Tar.extract` while `Tar.list` callers see the full embedded
+    string), and `linkpath=a\x00b/c` would land as
+    `entry.linkname = "a\x00b/c"` (POSIX `symlink` truncates
+    similarly on the symlink path). The PAX value-side override
+    family is **fully closed 2/2** — `path` slot (PR #1866,
+    `pax-path-nul-in-value.tar`) + `linkpath` slot (PR #1979,
+    `pax-linkpath-nul-in-value.tar`). Terminal closure of the
+    third per-slot Tar interior-NUL family in the post-#1928
+    wave (after the 5-slot UStar family closed at PR #1957 and
+    the 2-slot GNU long-name / long-link family closed at
+    PR #1953); together the three terminal closures complete the
+    "smuggled NUL in any user-supplied string field" attack
+    class across the entire Tar parsing surface (UStar + GNU +
+    PAX). Sibling of PRs #1880 / #1934 / #1937 / #1944 / #1957
+    (UStar interior-NUL family fully closed 5/5), PRs #1865 /
+    #1953 (GNU long-name / long-link family fully closed 2/2),
+    PR #1899 (PAX duplicate-key, complementary
+    parser-differential dimension on the same `parsePaxRecords`
+    loop), and PR #1831 (ZIP CD entry name NUL-byte rejection).
+    lean-zip's tar writer does not emit PAX extended headers
+    (`Tar.create` always emits UStar-or-PAX-extended-header for
+    paths exceeding the UStar 100/155-byte limits, but never the
+    value-side override records that this guard fires on), so
+    neither slot of the guard ever fires on legitimate archives
+    produced by `Tar.create` — the guards exist to reject crafted
+    malformed archives fed to `Tar.list` / `Tar.extract`, and the
+    fixtures are the only way to trigger them. The companion
+    `keyBytes` arm at
+    [Zip/Tar.lean:145](/home/kim/lean-zip/Zip/Tar.lean:145) is
+    defense-in-depth (no known-key string in `applyPaxOverrides`'s
+    case match contains `\x00`, so a NUL-bearing key would
+    already be dropped at the case match) and is left for a
+    future per-arm extension.
 
 #### Symlink/hardlink extraction policy
 

--- a/progress/20260425T000000Z_53aa556e-feature-1983.md
+++ b/progress/20260425T000000Z_53aa556e-feature-1983.md
@@ -1,0 +1,65 @@
+# Feature session — issue #1983 (PAX value-side override Recent-wins bullet)
+
+- **Date/time (UTC)**: 2026-04-25
+- **Session UUID prefix**: 53aa556e
+- **Session type**: feature
+- **Issue**: #1983 — Inventory: add SECURITY_INVENTORY.md Recent-wins
+  bullet for the 2-slot PAX value-side override (path/linkpath) NUL-byte
+  silent-skip family closure (PR #1866 + PR #1979)
+- **Branch**: agent/53aa556e
+
+## What landed
+
+One new top-level *Recent wins* bullet under the `Tar Parser/Extractor`
+section of `SECURITY_INVENTORY.md`, inserted between the existing PAX
+duplicate-key bullet (PR #1899) and the `#### Symlink/hardlink
+extraction policy` heading.
+
+The bullet credits both PRs and both fixtures of the 2-slot PAX
+value-side override interior-NUL family — PR #1866 (`path` slot,
+`pax-path-nul-in-value.tar`) + PR #1979 (`linkpath` slot,
+`pax-linkpath-nul-in-value.tar`) — and rewrites the family-closure
+annotation to terminal-closure form (*"fully closed 2/2"*).
+
+This is the third terminal-closure bullet from the post-#1928 wave,
+completing the cross-family parallelism alongside the existing UStar 5/5
+bullet (lines 919-950) and the GNU long-name/long-link 2/2 bullet
+(lines 951-980, added by PR #1978).
+
+## Decisions
+
+- **Line anchors** re-anchored to current master (per the
+  inventory-reconciliation skill's *Line-anchor drift* section): the
+  guard's `findIdx?` checks at `Zip/Tar.lean:145` (`keyBytes`) and `:146`
+  (`valueBytes`); the duplicate-key contrast at `:147`; the
+  `applyPaxOverrides` smuggle targets at `:161` (`"path"`) and `:162`
+  (`"linkpath"`). The issue body cited `:122` as the guard anchor; that's
+  the `=` separator scan, not the NUL guard, so I substituted the more
+  informative anchors.
+- **Bullet shape** mirrors PR #1978's GNU long-name/long-link bullet
+  (the direct shape sibling) and uses the same per-slot follow-up
+  phrasing ("PR #X (`slot1` slot, `fixture1`) + per-slot `slot2`
+  follow-up (`fixture2`, PR #Y)") as the existing UStar bullet.
+- **Defense-in-depth note** retained per the issue's optional ask —
+  matches the wording at row 1341 (the `pax-linkpath-nul-in-value.tar`
+  corpus row).
+
+## Verification
+
+- `git diff --stat` — exactly one file changed (`SECURITY_INVENTORY.md`,
+  +64 lines).
+- `grep -nA1 '^  - PAX extended-header value-side NUL-byte'
+  SECURITY_INVENTORY.md` finds the new bullet at line 999.
+- `grep -n 'PR #1866.*pax-path-nul-in-value\|PR #1979.*pax-linkpath-nul-in-value'
+  SECURITY_INVENTORY.md` shows both per-slot citations (rows 1396, 1407
+  in the corpus table — already-credited paragraph siblings).
+- `bash scripts/check-inventory-links.sh` exits 0 with warning count
+  unchanged from baseline (errors=0, warnings=104). The four new
+  line-anchors (`:145` / `:146` / `:147` / `:161` / `:162`) all sit
+  within ±2 of cited substrings (`keyBytes` / `valueBytes` /
+  `findIdx?` / `String.fromUTF8?` / `applyPaxOverrides` /
+  `"path"` / `"linkpath"`), so they generate no new heuristic warnings.
+
+## Quality metric delta
+
+- `grep -rc sorry Zip/` — unchanged (this PR does not touch Lean code).


### PR DESCRIPTION
Closes #1983

Session: `53aa556e-8b50-4dd7-8ca7-7b4697a0790e`

bde4fe2 progress: feature session for issue #1983 — PAX value-side override Recent-wins bullet
2a34096 doc: add SECURITY_INVENTORY.md Recent-wins bullet for the 2-slot PAX value-side override interior-NUL family closure (PRs #1866 + #1979) — third terminal closure of the post-#1928 wave

🤖 Prepared with Claude Code