### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citations on Decompression Limit Inventory → Public extraction APIs Archive cluster (rows 1186-1191) — uniform :1098 → :1209 (def list) / :1122 → :1233 (def extract) / :1167 → :1278 (def extractFile), uniform +111 line shift from post-#1813 / post-#1857 / post-#1886 / post-#1903 / post-#1921 CD-parse-guard wave; sibling Tar clusters B (rows 1192-1195) and C (rows 1196-1198) queued separately; 6-row contiguous-block sweep on the Recommended policy table (distinct from Minimized Reproducer Corpus sweeps), matching PR #2018 4-row precedent scaled up for shared shift family

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1183,12 +1183,12 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Zip.Native.GzipDecode.decompress](/home/kim/lean-zip/Zip/Native/Gzip.lean:40) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 1 GiB (unified with `Inflate.inflate` per Rec. 5). |
 | [Zip.Native.ZlibDecode.decompress](/home/kim/lean-zip/Zip/Native/Gzip.lean:140) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 1 GiB (unified with `Inflate.inflate` per Rec. 5). |
 | [Zip.Native.decompressAuto](/home/kim/lean-zip/Zip/Native/Gzip.lean:240) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | format-auto dispatch over the three natives above. |
-| [Archive.list](/home/kim/lean-zip/Zip/Archive.lean:1098) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | metadata-only; caps CD allocation, not decompressed payload. |
-| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1122) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
-| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1122) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap on the decompressed payload. |
-| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1122) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all entries; intended as a second line of defence against many-small-entries bombs. |
-| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1167) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
-| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1167) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap. |
+| [Archive.list](/home/kim/lean-zip/Zip/Archive.lean:1209) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | metadata-only; caps CD allocation, not decompressed payload. |
+| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
+| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap on the decompressed payload. |
+| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all entries; intended as a second line of defence against many-small-entries bombs. |
+| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1278) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
+| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1278) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap. |
 | [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:651](/home/kim/lean-zip/Zip/Tar.lean:651)). |
 | [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all regular-file entries; directories and symlinks contribute zero. |
 | [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |

--- a/progress/20260425T125843Z_34b88500.md
+++ b/progress/20260425T125843Z_34b88500.md
@@ -1,0 +1,40 @@
+# Session 34b88500 — feature
+
+Date: 2026-04-25T12:58:43Z
+Type: feature (inventory reconciliation)
+Issue: #2026
+
+## What was accomplished
+
+Re-anchored six stale `Zip/Archive.lean` line citations in
+`SECURITY_INVENTORY.md` rows 1186-1191 (Public decompression /
+extraction APIs Archive cluster):
+
+- `:1098` → `:1209` (`def list`, +111)
+- `:1122` → `:1233` (`def extract`, +111)
+- `:1167` → `:1278` (`def extractFile`, +111)
+
+Uniform +111 line shift from the post-#1813 / post-#1857 / post-#1886
+/ post-#1903 / post-#1921 CD-parse-guard insertion wave.
+
+## Verification
+
+- `grep -n "^def list\|^def extract\|^def extractFile" Zip/Archive.lean`
+  confirms canonical sites at `:1209`, `:1233`, `:1278`.
+- `scripts/check-inventory-links.sh` warning count: 85 → 79 (exactly 6
+  warnings cleared, no new warnings).
+- `grep -n "Zip/Archive.lean:1098\|Zip/Archive.lean:1122\|Zip/Archive.lean:1167"
+  SECURITY_INVENTORY.md` returns only row 1436 (CD/LH consistency
+  check, distinct from this issue's scope).
+
+No source files touched; pure documentation edit.
+
+## Quality metrics
+
+- Sorry count: not measured (doc-only change)
+- Build/test: not run (no source changes)
+
+## What remains
+
+Sibling Tar clusters B (rows 1192-1195) and C (rows 1196-1198) queued
+as #2027 and #2028 respectively.


### PR DESCRIPTION
Closes #2026

Session: `34b88500-145a-4155-ad6f-6ac4c8857d05`

a48b313 progress: session 34b88500 inventory re-anchor rows 1186-1191
984674a Inventory: re-anchor stale Zip/Archive.lean line citations on Public extraction APIs Archive cluster (rows 1186-1191)

🤖 Prepared with Claude Code