### PR TITLE
Inventory: re-anchor stale Zip/Tar.lean line citations on Decompression Limit Inventory → Public extraction APIs Tar.extract + Tar.extractTarGz cluster (rows 1192-1195) — uniform :651 → :748 (partial def extract, rows 1192-1193 incl. dual-anchor row 1192) / :779 → :876 (partial def extractTarGz, rows 1194-1195), uniform +97 line shift from post-#1866 / post-#1880 / post-#1934 / post-#1937 / post-#1944 / post-#1953 / post-#1957 / post-#1979 / post-#1899 Tar parser growth wave; sibling Archive cluster A (rows 1186-1191, +111 shift) and Tar.extractTarGzNative cluster C (rows 1196-1198) queued separately; 4-row contiguous-block sweep matching PR #2018 4-row precedent

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1189,10 +1189,10 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1122) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all entries; intended as a second line of defence against many-small-entries bombs. |
 | [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1167) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
 | [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1167) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap. |
-| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:651](/home/kim/lean-zip/Zip/Tar.lean:651)). |
-| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all regular-file entries; directories and symlinks contribute zero. |
-| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |
-| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
+| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:748) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:748](/home/kim/lean-zip/Zip/Tar.lean:748)). |
+| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:748) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all regular-file entries; directories and symlinks contribute zero. |
+| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:876) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |
+| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:876) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
 | [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:848) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. |
 | [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:848) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
 | [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:851) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | whole-archive tar-buffer cap for the outer native gzip decode. |

--- a/progress/2026-04-25T13-01-21Z_33ec9f9c.md
+++ b/progress/2026-04-25T13-01-21Z_33ec9f9c.md
@@ -1,0 +1,31 @@
+# 2026-04-25T13:01:21Z — feature session 33ec9f9c
+
+Issue #2027: re-anchor SECURITY_INVENTORY.md rows 1192-1195 (Tar.extract +
+Tar.extractTarGz cluster) — pure documentation change.
+
+## Accomplished
+
+- Updated four `Zip/Tar.lean` line citations in `SECURITY_INVENTORY.md`:
+  - `:651` → `:748` (rows 1192-1193, partial def extract)
+  - `:779` → `:876` (rows 1194-1195, partial def extractTarGz)
+- Row 1192 had two anchors (column link + inline parenthetical
+  reference); both updated.
+- Verified canonical line numbers via
+  `grep -n "^partial def extract\b\|^partial def extractTarGz\b" Zip/Tar.lean`.
+- Verified `scripts/check-inventory-links.sh` warning count dropped from
+  86 → 82 (exactly 4, matching deliverable).
+- Verified `grep -n "Zip/Tar.lean:651\|Zip/Tar.lean:779" SECURITY_INVENTORY.md`
+  returns zero matches.
+
+## Quality metrics
+
+- sorry count: unchanged (pure documentation edit).
+- No source code or tests modified.
+
+## Remaining
+
+Sibling clusters queued separately:
+- #2026 / PR #2034: Archive cluster A (rows 1186-1191, +111 shift) —
+  already has open PR.
+- #2028: Tar.extractTarGzNative cluster C (rows 1196-1198, +97 shift) —
+  unclaimed.


### PR DESCRIPTION
Closes #2027

Session: `33ec9f9c-4021-4248-903e-c27a2c416bd2`

89d90df chore: progress entry for issue #2027 (Tar cluster B re-anchor)
8c39377 doc: re-anchor SECURITY_INVENTORY.md rows 1192-1195 to current Tar.lean line numbers

🤖 Prepared with Claude Code