### PR TITLE
Inventory: re-anchor stale Zip/Tar.lean line citations on Decompression Limit Inventory → Public extraction APIs Tar.extractTarGzNative cluster (rows 1196-1198) — :848 → :945 (partial def extractTarGzNative, rows 1196-1197) / :851 → :948 (maxOutputSize parameter, row 1198), uniform +97 line shift from Tar parser growth wave; closes the table refresh begun by Archive cluster A (rows 1186-1191) and Tar cluster B (rows 1192-1195); 3-row contiguous-block sweep matching PR #2023 / PR #1995 multi-row precedent

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1193,9 +1193,9 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all regular-file entries; directories and symlinks contribute zero. |
 | [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |
 | [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
-| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:848) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. |
-| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:848) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
-| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:851) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | whole-archive tar-buffer cap for the outer native gzip decode. |
+| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:945) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. |
+| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:945) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
+| [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:948) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | whole-archive tar-buffer cap for the outer native gzip decode. |
 
 ### Known inconsistencies
 

--- a/progress/2026-04-25T130348Z_49989739.md
+++ b/progress/2026-04-25T130348Z_49989739.md
@@ -1,0 +1,32 @@
+# Session 49989739 — feature
+
+- Date: 2026-04-25T13:03:48Z
+- Type: feature
+- Issue: #2028
+
+## Accomplished
+
+Re-anchored three stale `Zip/Tar.lean` line citations in the
+*Decompression Limit Inventory → Public decompression / extraction
+APIs* table of `SECURITY_INVENTORY.md`:
+
+- Row 1196 — `Tar.extractTarGzNative` / `maxEntrySize`: `:848` → `:945`
+- Row 1197 — `Tar.extractTarGzNative` / `maxTotalSize`: `:848` → `:945`
+- Row 1198 — `Tar.extractTarGzNative` / `maxOutputSize`: `:851` → `:948`
+
+Uniform +97 line shift, matching cluster B (rows 1192-1195). Closes the
+3-cluster refresh of the *Public decompression / extraction APIs* table
+begun by clusters A (Archive, rows 1186-1191, PR #2034) and B
+(Tar.extract+extractTarGz, rows 1192-1195, PR #2027/#2035).
+
+## Verification
+
+- `grep -n "Zip/Tar.lean:848\|Zip/Tar.lean:851" SECURITY_INVENTORY.md`
+  returns zero matches.
+- `scripts/check-inventory-links.sh 2>&1 | wc -l`: 80 → 77 (drops by 3).
+- Pure documentation change; no source files touched.
+
+## Remaining
+
+None for this issue. Sibling clusters A and B are landed/in-flight per
+issue body.


### PR DESCRIPTION
Closes #2028

Session: `49989739-a733-4d58-9cc3-4193e4023ba3`

1332ed1 chore: progress entry for session 49989739 (#2028)
d87e215 doc: re-anchor SECURITY_INVENTORY.md rows 1196-1198 (Tar.extractTarGzNative cluster)

🤖 Prepared with Claude Code