### PR TITLE
Inventory: re-anchor SECURITY_INVENTORY.md prose paragraph (lines 1290-1295) Local guard inventory intro 5-anchor sweep — Zip/Archive.lean:869 → :980, Zip/Tar.lean:189 → :218, Zip/Archive.lean:883 → :994, Zip/Tar.lean:220 → :249, Zip/Tar.lean:539 → :630; non-uniform +111 / +29 / +111 / +29 / +91 shifts reflecting the Archive CD-parse-guard wave + Tar parser growth wave; in-paragraph multi-anchor sweep matching PR #2059 row-1310 4-anchor in-row precedent; sibling Local guard table rows 1302-1307 queued separately

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1288,11 +1288,11 @@ not untrusted archive bytes, so it falls outside this inventory's
 scope.
 
 Trust-boundary callers reach the actual `.read` primitive via
-`readExact` ([Zip/Archive.lean:869](/home/kim/lean-zip/Zip/Archive.lean:869),
-[Zip/Tar.lean:189](/home/kim/lean-zip/Zip/Tar.lean:189)),
-`readExactStream` ([Zip/Archive.lean:883](/home/kim/lean-zip/Zip/Archive.lean:883)),
-`readEntryData` ([Zip/Tar.lean:220](/home/kim/lean-zip/Zip/Tar.lean:220)),
-`skipEntryData` ([Zip/Tar.lean:539](/home/kim/lean-zip/Zip/Tar.lean:539)),
+`readExact` ([Zip/Archive.lean:980](/home/kim/lean-zip/Zip/Archive.lean:980),
+[Zip/Tar.lean:218](/home/kim/lean-zip/Zip/Tar.lean:218)),
+`readExactStream` ([Zip/Archive.lean:994](/home/kim/lean-zip/Zip/Archive.lean:994)),
+`readEntryData` ([Zip/Tar.lean:249](/home/kim/lean-zip/Zip/Tar.lean:249)),
+`skipEntryData` ([Zip/Tar.lean:630](/home/kim/lean-zip/Zip/Tar.lean:630)),
 or open-coded read loops. Each row below names the call site that
 drives an `n`-byte read; the `readExact`-family helpers themselves
 perform a `Nat → USize` roundtrip check before every `Handle.read`.

--- a/progress/20260425T142534Z_d4b66b2c.md
+++ b/progress/20260425T142534Z_d4b66b2c.md
@@ -1,0 +1,56 @@
+# Progress: 2026-04-25T14:25:34Z — feature session d4b66b2c
+
+## Issue claimed
+
+#2062 — Inventory: re-anchor stale Zip/Archive.lean + Zip/Tar.lean line
+citations on the Local guard inventory introductory prose paragraph
+(SECURITY_INVENTORY.md lines 1291–1295) — 5-anchor sweep across
+`readExact` (Archive + Tar), `readExactStream`, `readEntryData`,
+`skipEntryData`.
+
+## What was accomplished
+
+Updated SECURITY_INVENTORY.md prose paragraph at lines 1290–1295. All
+five anchor citations now point at current source lines:
+
+| Anchor                | Stale | Current |
+|-----------------------|-------|---------|
+| `Zip/Archive.lean`    | :869  | :980    |
+| `Zip/Tar.lean`        | :189  | :218    |
+| `Zip/Archive.lean`    | :883  | :994    |
+| `Zip/Tar.lean`        | :220  | :249    |
+| `Zip/Tar.lean`        | :539  | :630    |
+
+Both link target and visible text updated for each citation. Pure
+documentation change; no source / test edits.
+
+## Verification
+
+- `grep -n 'private partial def readExact ' Zip/Archive.lean` → `:980`
+- `grep -n 'private partial def readExact (input : IO.FS.Stream)' Zip/Tar.lean` → `:218`
+- `grep -n 'partial def readExactStream' Zip/Archive.lean` → `:994`
+- `grep -n 'private partial def readEntryData' Zip/Tar.lean` → `:249`
+- `grep -n 'private partial def skipEntryData' Zip/Tar.lean` → `:630`
+- `bash scripts/check-inventory-links.sh` warning count: **48 → 44**
+  (drops by exactly 4 — the linter-flagged warnings at lines 1291,
+  1293, 1294, 1295 are all cleared with no new warnings introduced).
+  The fifth anchor (`Zip/Tar.lean:189`) wasn't linter-flagged but was
+  refreshed for paragraph coherence.
+
+## Decisions / patterns
+
+Followed the in-paragraph multi-anchor sweep pattern set by PR #2059
+(row 1310 4-anchor in-row sweep), distinct from sibling Local guard
+*table rows* 1302–1307 which are queued under separate issues
+(#2063 / #2064 / #2065 / #2066 / #2067).
+
+## Quality metrics
+
+Pure-documentation PR. No source changes. `lake build` unaffected.
+sorry count unchanged.
+
+## What remains
+
+Sibling Local guard inventory table rows 1302 / 1303 / 1304 /
+1305+1306 / 1307 are queued separately under issues #2063–#2067.
+Once those land, the Local guard table is fully refreshed.


### PR DESCRIPTION
Closes #2062

Session: `d4b66b2c-38ec-4b77-a246-08fd58f902d5`

1e178c2 chore: progress entry for feature session d4b66b2c (#2062 — Local guard inventory intro paragraph 5-anchor re-anchor)
8c823d9 doc: re-anchor SECURITY_INVENTORY.md prose paragraph (lines 1290-1295) to current Local guard inventory introductory citations — 5-anchor sweep across `readExact` Archive/Tar pair / `readExactStream` / `readEntryData` / `skipEntryData` (Zip/Archive.lean:869 → :980, Zip/Tar.lean:189 → :218, Zip/Archive.lean:883 → :994, Zip/Tar.lean:220 → :249, Zip/Tar.lean:539 → :630), reflecting the post-#1813 / post-#1857 / post-#1886 / post-#1903 / post-#1921 Archive CD-parse-guard wave + post-#1866 / post-#1880 / post-#1934 / post-#1937 / post-#1944 / post-#1899 Tar parser growth wave with non-uniform +111 / +29 / +111 / +29 / +91 shifts; in-paragraph multi-anchor sweep matching PR #2059 row-1310 4-anchor in-row precedent (distinct because all 5 anchors live in the same prose paragraph). `bash scripts/check-inventory-links.sh` warning count drops from 48 to 44 (4 prose-paragraph warnings at lines 1291 / 1293 / 1294 / 1295 cleared, no new warnings introduced); the fifth Tar `:189` citation isn't linter-flagged but is refreshed for paragraph coherence.

🤖 Prepared with Claude Code