### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citation on cd-nul-in-name.zip narrative paragraph (SECURITY_INVENTORY.md:677 — :589 → :632 'CD entry name contains NUL byte' throw, +43 shift from CD-parse-guard wave); 1-anchor narrative-paragraph follow-up to PR #2105 row-1440 row-table update (which deferred this paragraph as 'narrative-paragraph at line 677 left untouched'); doc-only edit, the sibling :633-643 UTF-8 decode-range cite is unchanged; sibling line-652 narrative re-anchor (cd-patched-data-flag.zip, issue #2112) queued separately

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -674,7 +674,7 @@ Summary — what this pattern catches and what it does not:
     (`testdata/zip/malformed/cd-nul-in-name.zip`) rejects CD entries
     whose raw name bytes contain a NUL (`0x00`) byte at
     `parseCentralDir` time
-    ([Zip/Archive.lean:589](/home/kim/lean-zip/Zip/Archive.lean:589)),
+    ([Zip/Archive.lean:632](/home/kim/lean-zip/Zip/Archive.lean:632)),
     before the UTF-8 decode at
     [Zip/Archive.lean:633-643](/home/kim/lean-zip/Zip/Archive.lean:633).
     A NUL byte in the filename is a classic parser-differential /

--- a/progress/20260425T165844Z_1e3968fb.md
+++ b/progress/20260425T165844Z_1e3968fb.md
@@ -1,0 +1,24 @@
+# Feature session 1e3968fb — 2026-04-25
+
+## Issue
+#2113 — Inventory re-anchor of stale Zip/Archive.lean line citation in
+the cd-nul-in-name.zip narrative paragraph (SECURITY_INVENTORY.md:677,
+`:589` → `:632`).
+
+## Outcome
+Single-line doc-only edit. Verified target `Zip/Archive.lean:632` still
+contains `s!"zip: CD entry name contains NUL byte at CD offset {pos}"`
+throw and `:633-643` decode block is unchanged.
+
+`lake build -R` green; `lake exe test` all green.
+
+Commit: `620559a` — `Inventory: re-anchor stale Zip/Archive.lean line
+citation on cd-nul-in-name.zip narrative paragraph ...`.
+
+## Quality metric
+`grep -rc sorry Zip/`: not measured (doc-only change, untouched).
+
+## Next
+Sibling line-652 narrative re-anchor (cd-patched-data-flag.zip,
+issue #2112 / PR #2120) already in flight. Sibling line-491 narrative
+re-anchor queued at issue #2116.


### PR DESCRIPTION
Closes #2113

Session: `1e3968fb-117d-4493-be95-7e7b7334e0f5`

9cf6629 doc: progress entry for #2113
620559a Inventory: re-anchor stale Zip/Archive.lean line citation on cd-nul-in-name.zip narrative paragraph (SECURITY_INVENTORY.md:677 — :589 → :632 'CD entry name contains NUL byte' throw, +43 shift from CD-parse-guard wave); 1-anchor narrative-paragraph follow-up to PR #2105 row-1440 row-table update (which deferred this paragraph as 'narrative-paragraph at line 677 left untouched'); doc-only edit, the sibling :633-643 UTF-8 decode-range cite is unchanged

🤖 Prepared with Claude Code