### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citation on SECURITY_INVENTORY.md row 529 narrative paragraph (Recommended policy section, PR #1813 CD-entry localOffset+30 ≤ cdOffset bullet — :970 → :1081 'bad local header signature' throw, +111 shift from Archive late-section wave); 1-row single-anchor narrative-paragraph sweep matching PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/#2071/#2082/#2091/#2093/#2098/#2099/#2100/#2101/#2104/#2105/#2111/#2114/#2115/#2122 1-row tightening cadence; sibling narrative-paragraph re-anchors at lines 478 / 814 queued separately

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -526,7 +526,7 @@ Summary — what this pattern catches and what it does not:
     successfully and `Entry`-routing callers treated the metadata as
     trustworthy; only the extract path's late LH-signature check
     (`"bad local header signature"` at
-    [Zip/Archive.lean:970](/home/kim/lean-zip/Zip/Archive.lean:970))
+    [Zip/Archive.lean:1081](/home/kim/lean-zip/Zip/Archive.lean:1081))
     caught a subset of the construction (and could be defeated by a
     carefully chosen overlap where the CD bytes happened to match
     `sigLocal`). Uses the asymmetric `SpanInFile`-shaped subtraction

--- a/progress/20260425T173141Z_e01f4e2b.md
+++ b/progress/20260425T173141Z_e01f4e2b.md
@@ -1,0 +1,31 @@
+# Progress — agent/e01f4e2b — feature session
+
+UTC: 2026-04-25T17:31:41Z
+
+## Issue
+#2125 — Re-anchor SECURITY_INVENTORY.md row 529 Zip/Archive.lean :970 → :1081
+(PR #1813 CD-entry localOffset+30 ≤ cdOffset bullet, trailing prose
+"bad local header signature" cite).
+
+## Work done
+- Single-anchor edit on SECURITY_INVENTORY.md line 529: `:970 → :1081`
+  (markdown link, both visible-text and link-target halves).
+- Verified: `grep -n 'Zip/Archive.lean:970' SECURITY_INVENTORY.md`
+  returns no matches.
+- Verified: `bash scripts/check-inventory-links.sh` reports 0 errors,
+  20 warnings (all pre-existing, none on row 529).
+
+## Decisions
+- Followed the 1-row narrative-paragraph cadence established by
+  PR #1985/#1994/.../#2122 — single-anchor, single-line edit, no
+  source files touched.
+
+## Quality metrics
+- sorry count unchanged (doc-only edit).
+- check-inventory-links: errors 0 → 0; warnings 20 → 20 (no row-529
+  warning gained or lost — the edited cite was not flagged before
+  because the heuristic uses adjacent fixture filenames).
+
+## Remaining
+- None for this issue. Sibling narrative-paragraph re-anchors at lines
+  478 (#2124, has-pr #2131) and 814 (#2126) handled separately.


### PR DESCRIPTION
Closes #2125

Session: `e01f4e2b-64e5-40e8-8f21-fffb3d339faa`

89060d1 doc: progress entry for #2125 (row 529 :970 → :1081 re-anchor)
acb2ccf doc: re-anchor SECURITY_INVENTORY.md row 529 Zip/Archive.lean :970 → :1081

🤖 Prepared with Claude Code