### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citation on SECURITY_INVENTORY.md row 486 narrative paragraph (Recommended policy section, PR #1801 CD-entry compression-method allowlist bullet — :668 → :713 'unsupported compression method' throw, +45 shift from CD-parse-guard wave); 1-row single-anchor narrative-paragraph sweep matching PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/#2071/#2082/#2091/#2093/#2098/#2099/#2100/#2101/#2104/#2105/#2111/#2114/#2115/#2122 1-row tightening cadence; matching prose-paragraph follow-up to PR #2053 row-1424 row-table update (commit c673dd9, same :668 → :713 convention); after this edit and PR #2122's :1083 → :1194 trailing cite both anchors in this bullet are internally consistent

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -483,7 +483,7 @@ Summary — what this pattern catches and what it does not:
     (`testdata/zip/malformed/cd-bad-method-early.zip`) rejects CD
     entries whose `method` field is outside lean-zip's `{0, 8}`
     allowlist (`0` = stored, `8` = deflate) at `parseCentralDir` time
-    ([Zip/Archive.lean:668](/home/kim/lean-zip/Zip/Archive.lean:668)),
+    ([Zip/Archive.lean:713](/home/kim/lean-zip/Zip/Archive.lean:713)),
     before the ZIP64 extra resolution. The check is safe to run
     pre-ZIP64-resolution because `method` is a plain `UInt16` field
     with no sentinel-gating (APPNOTE §4.4.5). Pre-PR, only

--- a/progress/20260425T174556Z_ba606bec.md
+++ b/progress/20260425T174556Z_ba606bec.md
@@ -1,0 +1,44 @@
+# Progress entry: ba606bec — feature session
+
+**UTC:** 2026-04-25T17:45:56Z
+**Session type:** feature
+**Issue:** #2127
+**Branch:** `agent/ba606bec`
+
+## What was accomplished
+
+Re-anchored the stale `Zip/Archive.lean:668` line citation on
+`SECURITY_INVENTORY.md:486` (PR #1801 *CD-entry compression-method
+allowlist check* bullet in the *Recommended policy* section) to its
+current location at line 713.
+
+- Single anchor change (visible-text and link-target halves of one
+  markdown link).
+- Convention `:668 → :713` (+45) pinned by PR #2053 (commit c673dd9)
+  which refreshed the matching row-1424 cell for the same fixture.
+- After this edit, no `Zip/Archive.lean:668` citations remain in
+  `SECURITY_INVENTORY.md`.
+- `check-inventory-links.sh` reports 20 warnings (0 errors); the
+  pre-existing warnings on rows 1304 / 1307 / 1310 / 1311 / 1402 / 1412 /
+  1429 / 1447 are all tracked by other in-flight inventory issues
+  (#2134, #2055/PR #2060, #2073, #2081, etc.). No new warning was
+  introduced by this edit (the :713 cite resolves cleanly).
+
+## Decisions
+
+- Edit was minimal and exactly as scoped by the issue body: one anchor
+  change on the bullet's primary citation. No prose touched. No source
+  files modified.
+
+## Quality metric deltas
+
+- `sorry` count: unchanged (doc-only edit).
+- `check-inventory-links.sh` warnings: unchanged from pre-edit baseline
+  (this issue clears the last `:668` citation; remaining warnings cover
+  unrelated stale anchors tracked elsewhere).
+
+## What remains
+
+Nothing for this issue. Sibling narrative-paragraph re-anchors for
+PRs #1773 and #1813 in the same Recommended policy section already
+landed earlier today (PRs/commits 7abd550 row-478 and 050f37a row-529).


### PR DESCRIPTION
Closes #2127

Session: `ba606bec-11cf-4a4f-8467-7474bb6ac5cf`

c5d8dd8 chore: progress entry for feature session ba606bec (issue #2127)
2bd41e7 doc: re-anchor SECURITY_INVENTORY.md row 486 (PR #1801 CD-entry compression-method allowlist) from Zip/Archive.lean:668 to :713

🤖 Prepared with Claude Code