### PR TITLE
Inventory: re-anchor stale Zip/Tar.lean line citation on SECURITY_INVENTORY.md row 992 narrative paragraph (Recommended policy section, PR #1899 PAX extended-header duplicate-key rejection bullet — :669 → :691 forEntries typePaxExtended branch 'throw (IO.userError msg)' rethrow, +22 shift from PAX/GNU/UStar interior-NUL guard insertion wave); 1-row single-anchor narrative-paragraph sweep matching PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/#2071/#2082/#2091/#2093/#2098/#2099/#2100/#2101/#2104/#2105/#2111/#2114/#2115/#2122 1-row tightening cadence; distinct from in-flight #2119 (row 1402 pax-inconsistent-length.tar parsePaxRecords scan-loop / silent-skip dual-anchor) — this issue targets the caller-side rethrow in forEntries, not the parser-internal scan loop

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -989,7 +989,7 @@ Summary — what this pattern catches and what it does not:
     offending record and continues), PR #1899 hard-rejects — the
     `.error` return is rethrown unconditionally by `forEntries`'s
     `typePaxExtended` branch at
-    [Zip/Tar.lean:669](/home/kim/lean-zip/Zip/Tar.lean:669) via
+    [Zip/Tar.lean:691](/home/kim/lean-zip/Zip/Tar.lean:691) via
     `throw (IO.userError msg)`. Error wording *"tar: PAX extended
     header has duplicate {key.quote} record"* uses `String.quote`
     attribution on the duplicate key. Closes the parser-differential

--- a/progress/2026-04-25T174833Z_3cf1cac1.md
+++ b/progress/2026-04-25T174833Z_3cf1cac1.md
@@ -1,0 +1,58 @@
+# Session 3cf1cac1 — feature
+
+**Date (UTC):** 2026-04-25T17:48:33Z
+**Type:** feature
+**Issue:** #2128
+
+## Accomplished
+
+Re-anchored the single stale `Zip/Tar.lean` line citation on
+`SECURITY_INVENTORY.md:992` (Recommended policy section, PR #1899
+PAX extended-header duplicate-key rejection bullet — trailing prose
+clause attributing the rethrow to `forEntries`'s `typePaxExtended`
+branch).
+
+- `[Zip/Tar.lean:669](/home/kim/lean-zip/Zip/Tar.lean:669)` →
+  `[Zip/Tar.lean:691](/home/kim/lean-zip/Zip/Tar.lean:691)`
+- Verified `:691` is the `| .error msg => throw (IO.userError msg)`
+  rethrow line inside the `typePaxExtended` branch (line 686 is the
+  `if entry.typeflag == typePaxExtended` discriminator). Cite phrasing
+  "via `throw (IO.userError msg)`" pins the anchor at the throw line.
+- `+22` shift from the post-#1866/#1880/#1934/#1937/#1944/#1953/#1957/
+  #1979 PAX/GNU/UStar interior-NUL guard insertion wave.
+
+## Verification
+
+- `git diff SECURITY_INVENTORY.md`: exactly one 1-line edit on line 992
+  (both visible-text and link-target halves of the markdown link).
+- `grep -n 'Zip/Tar.lean:669' SECURITY_INVENTORY.md`: only remaining
+  match is on line 1400 (corpus row for pax-duplicate-path.tar — out of
+  scope for this single-anchor sweep, covered by sibling issue #2136).
+- `bash scripts/check-inventory-links.sh`: no new warnings; the
+  previously-reported warning for `:992 cites :669` is gone.
+
+## Quality metrics
+
+- sorry count unchanged (doc-only edit; no source files touched).
+
+## Decisions / patterns
+
+- 1-row single-anchor narrative-paragraph sweep matching the cadence of
+  PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/
+  #2071/#2082/#2091/#2093/#2098/#2099/#2100/#2101/#2104/#2105/#2111/
+  #2114/#2115/#2122. No deviations.
+- Distinct from in-flight #2119 (parser-internal scan loop / silent-skip
+  in `parsePaxRecords`) and from sibling unclaimed #2136 (corpus-row
+  cite at line 1400). All three sweeps touch disjoint cites.
+- The sibling Zip/Tar.lean cites at lines 986/1007/1009/1016/1023/1025
+  in the same and adjacent bullets remain current on master and are
+  out of scope.
+
+## Worktree note
+
+Branch `agent/3cf1cac1` already existed in this reused worktree with
+stale `.claude/CLAUDE.md` and `.claude/skills/agent-worker-flow/SKILL.md`
+modifications and untracked `.claude/{commands,skills/{acquiring-skills,
+pr-repair-flow,second-opinion}}` directories. No open PR; reset the
+branch to `origin/master` per the agent-worker-flow Step 2 procedure
+before starting fresh.


### PR DESCRIPTION
Closes #2128

Session: `3cf1cac1-0451-4126-96d8-479f0902be1c`

99f2176 docs: re-anchor SECURITY_INVENTORY.md:992 Zip/Tar.lean :669 → :691

🤖 Prepared with Claude Code