### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citations on SECURITY_INVENTORY.md narrative paragraph for cd-empty-name.zip (PR #1848 CD-entry empty-filename rejection bullet, Recommended policy section, lines 748-789) — :535 → :578 (s!"empty filename (nameLen=0)" throw, +43 shift from CD-parse-guard wave) / :570 → :614 (entryEnd > cdEnd overrun check, +44 shift); 1-row dual-anchor narrative-paragraph sweep, sibling of recently-merged narrative-paragraph re-anchors at lines 478/529/814/486/491/652/677 (PRs #2131/#2132/#2133/#2137/#2122/#2120/#2121); convention pinned by SECURITY_INVENTORY.md:1356-1364 throw-message s!"…" line precedent; sibling narrative-paragraph re-anchors for cd-empty-entry-crc-nonzero.zip / cd-deflate-zero-compsize.zip / cd-path-unsafe.zip queued separately

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -749,10 +749,10 @@ Summary — what this pattern catches and what it does not:
     (`testdata/zip/malformed/cd-empty-name.zip`) rejects CD entries
     whose `nameLen` field at CD +28 (APPNOTE §4.4.10) is `0` at
     `parseCentralDir` time
-    ([Zip/Archive.lean:535](/home/kim/lean-zip/Zip/Archive.lean:535)),
+    ([Zip/Archive.lean:578](/home/kim/lean-zip/Zip/Archive.lean:578)),
     immediately after the `nameLen` read and before the
     `entryEnd > cdEnd` overrun check at
-    [Zip/Archive.lean:570](/home/kim/lean-zip/Zip/Archive.lean:570)
+    [Zip/Archive.lean:614](/home/kim/lean-zip/Zip/Archive.lean:614)
     and the sibling NUL-byte / path-safety filename guards. Every
     legitimate ZIP entry — file or directory — has at least one byte
     of name, so `nameLen == 0` is structurally pathological and a

--- a/progress/20260425T181234Z_ee429c3d.md
+++ b/progress/20260425T181234Z_ee429c3d.md
@@ -1,0 +1,46 @@
+# 2026-04-25T18:12:34Z — feature session ee429c3d
+
+## Issue claimed
+
+#2140: Re-anchor stale Zip/Archive.lean line citations on
+SECURITY_INVENTORY.md narrative paragraph for cd-empty-name.zip
+(PR #1848 CD-entry empty-filename rejection bullet, Recommended policy
+section, lines 748–789).
+
+## What was done
+
+Doc-only edit in `SECURITY_INVENTORY.md`. Two anchors in the
+cd-empty-name.zip bullet drifted past the post-#1843 CD-parse-guard
+wave and were refreshed to current master:
+
+- Line 752: `Zip/Archive.lean:535` → `:578` (the
+  `s!"zip: CD entry has empty filename (nameLen=0)..."` throw).
+- Line 755: `Zip/Archive.lean:570` → `:614` (the `entryEnd > cdEnd`
+  guard, `if entryEnd > cdEnd then`).
+
+Verified via direct read of `Zip/Archive.lean` lines 575–615 that the
+new anchors land on exactly the substrings cited by the surrounding
+prose, and that no occurrences of `:535` / `:570` referencing
+`Zip/Archive.lean` remain inside the cd-empty-name.zip paragraph
+(`grep -nE 'Zip/Archive\.lean:535|Zip/Archive\.lean:570'` returns
+empty).
+
+The trailing writer-side anchors `:84` and `:110` in this same bullet
+remain current and were explicitly excluded per the issue body.
+
+## Verification
+
+- `git diff master..HEAD` for `SECURITY_INVENTORY.md`: 1 file, 2
+  insertions(+), 2 deletions(-) (matches issue's expected scope).
+- `bash scripts/check-inventory-links.sh` warning count is unchanged
+  (18 warnings before and after; this paragraph was not flagged either
+  way, as the issue body predicted).
+- No source files modified; no `lake build` / `lake exe test` needed
+  (doc-only edit).
+
+## Next
+
+PR opened via `coordination create-pr 2140`. Sibling narrative-paragraph
+re-anchors for cd-empty-entry-crc-nonzero.zip (#2141),
+cd-deflate-zero-compsize.zip (#2142), cd-path-unsafe.zip (#2143)
+remain queued separately for the next worker.


### PR DESCRIPTION
Closes #2140

Session: `ee429c3d-e5f4-472b-99e3-36d90cf461c8`

1af6f9c chore: progress entry for ee429c3d (issue #2140)
a370fbb doc: re-anchor SECURITY_INVENTORY.md cd-empty-name.zip narrative paragraph

🤖 Prepared with Claude Code