### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citations on SECURITY_INVENTORY.md narrative paragraph for cd-empty-entry-crc-nonzero.zip (PR #1857 CD-entry empty-entry CRC invariant rejection bullet, Recommended policy section, lines 790-836) — :794 → :820 (s!"CRC must be zero when uncompressedSize is zero" throw, +26 shift from CD-parse-guard wave) / :195 → :189 ×2 (writer-side Checksum.crc32 0 fileData call inside Archive.create, cited at lines 803 and 825); 1-row triple-anchor narrative-paragraph sweep, follow-up to PR #2133 (commit 7600498) which refreshed only the post-extraction :1199 'CRC32 mismatch' cite and explicitly deferred the parse-time-throw and writer-side cites; convention pinned by SECURITY_INVENTORY.md:1356-1364 throw-message s!"…" line precedent; sibling narrative-paragraph re-anchors for cd-empty-name.zip / cd-deflate-zero-compsize.zip / cd-path-unsafe.zip queued separately

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -791,7 +791,7 @@ Summary — what this pattern catches and what it does not:
     (`testdata/zip/malformed/cd-empty-entry-crc-nonzero.zip`) rejects
     CD entries whose `uncompressedSize == 0` with any nonzero `crc32`
     at `parseCentralDir` time
-    ([Zip/Archive.lean:794](/home/kim/lean-zip/Zip/Archive.lean:794)),
+    ([Zip/Archive.lean:820](/home/kim/lean-zip/Zip/Archive.lean:820)),
     post-ZIP64-resolution, after the stored-method size invariant.
     APPNOTE §4.4.7 defines the CRC32 field as the ANSI-CRC-32 of the
     uncompressed payload; the empty byte string has CRC32 `0x00000000`
@@ -800,7 +800,7 @@ Summary — what this pattern catches and what it does not:
     universal mathematical invariant. Every correct writer — Info-ZIP,
     Go `archive/zip`, CPython `zipfile`, 7-Zip, and lean-zip's own
     `create` at
-    [Zip/Archive.lean:195](/home/kim/lean-zip/Zip/Archive.lean:195)
+    [Zip/Archive.lean:189](/home/kim/lean-zip/Zip/Archive.lean:189)
     (which emits `Checksum.crc32 0 fileData` and hence `0` on an empty
     payload) — obeys it. Crafted archives carrying `uncompSize = 0`
     alongside any nonzero CRC are structurally malformed and a
@@ -822,7 +822,7 @@ Summary — what this pattern catches and what it does not:
     share the same invariant — a deflate-encoded empty stream has
     `compSize = 2` (the `03 00` empty-block encoding) but `uncompSize
     = 0`, so the check applies regardless of method. Writer-side at
-    [Zip/Archive.lean:195](/home/kim/lean-zip/Zip/Archive.lean:195) is
+    [Zip/Archive.lean:189](/home/kim/lean-zip/Zip/Archive.lean:189) is
     trivially compliant (`Checksum.crc32 0 ByteArray.empty == 0` by
     the CRC-32 init⊕complement identity); the CD-parse guard is
     read-side only. Sibling of PR #1773 (stored-method size invariant)

--- a/progress/2026-04-25T18-15-53Z_001daa6d.md
+++ b/progress/2026-04-25T18-15-53Z_001daa6d.md
@@ -1,0 +1,67 @@
+# Session 2026-04-25T18:15Z (001daa6d) — feature
+
+## Issue claimed
+
+#2141 — Inventory: re-anchor stale Zip/Archive.lean line citations on
+SECURITY_INVENTORY.md narrative paragraph for cd-empty-entry-crc-nonzero.zip
+(PR #1857 CD-entry empty-entry CRC invariant rejection bullet,
+*Recommended policy* section, lines 790–836).
+
+## Outcome
+
+Doc-only edit landed; full completion. PR opened against master.
+
+Three stale Zip/Archive.lean cites refreshed inside the narrative
+paragraph:
+
+- Line 794 cite `:794 → :820` — `s!"CRC must be zero when
+  uncompressedSize is zero"` throw inside the `parseCentralDir` empty-
+  entry CRC-invariant guard (the throw-message s!"…" line per the
+  convention pinned at SECURITY_INVENTORY.md:1356–1364). +26 shift
+  from the CD-parse-guard wave.
+- Line 803 + line 825 dual cite `:195 → :189` — writer-side
+  `Checksum.crc32 0 fileData` call inside `Archive.create`. −6 shift.
+
+Diff: exactly 1 file changed, 3 insertions(+), 3 deletions(-).
+
+## Verification
+
+- `git diff master..HEAD -- SECURITY_INVENTORY.md` → 3+/3-.
+- `bash scripts/check-inventory-links.sh` → `errors=0, warnings=18`,
+  identical to the pre-edit baseline (18 → 18, no new warning gained
+  or lost). Verified via `git stash` + re-run + `git stash pop`.
+- `:794` cite scope: post-edit, `:794` still occurs once at
+  SECURITY_INVENTORY.md:1426 inside the row-table for
+  `cd-empty-entry-crc-nonzero.zip`. The issue body's verification note
+  ("`:794` cite is unique to this paragraph and should be fully
+  cleared") refers to clearing it from the narrative paragraph; the
+  row-table cite is a separate scope per the standing 1-row-per-PR
+  cadence (sibling row-table re-anchors are queued separately).
+
+## Decisions and patterns
+
+- The narrative-paragraph vs row-table split keeps 1-row-per-PR scope
+  tight: the issue body explicitly bounded scope to lines 790–836, the
+  row-table at line 1426 stays out of scope.
+- Convention used for the throw-site re-anchor: pin to the s!"…" line
+  of the `throw (IO.userError ...)` that emits the user-visible
+  message, not the surrounding `if … unless …` guard structure.
+- Convention used for the writer-side re-anchor: pin to the actual
+  `Checksum.crc32 0 fileData` call line, not the surrounding `for`
+  loop or `let entry` structure.
+
+## Quality metrics
+
+- Doc-only edit. No source files modified, no `lake build` /
+  `lake exe test` impact beyond CI doc-link validation.
+- Sorry count: unchanged (no Lean files touched).
+
+## Remaining / siblings
+
+Sibling narrative-paragraph re-anchors queued separately:
+
+- #2142 — cd-deflate-zero-compsize.zip (lines 836–879), single anchor
+  `:195 → :189`.
+- #2143 — cd-path-unsafe.zip (lines 706–740), 5-anchor sweep.
+- (already merged ahead of this session) #2140 / PR #2146 —
+  cd-empty-name.zip (lines 748–789), dual anchor.


### PR DESCRIPTION
Closes #2141

Session: `001daa6d-909f-450e-8072-77f958aab689`

6d9eda6 progress: session 001daa6d — issue #2141 narrative-paragraph re-anchor for cd-empty-entry-crc-nonzero.zip
5d878d8 docs: re-anchor SECURITY_INVENTORY.md narrative paragraph for cd-empty-entry-crc-nonzero.zip (#2141)

🤖 Prepared with Claude Code