### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citations on SECURITY_INVENTORY.md narrative paragraph for cd-path-unsafe.zip (PR #1840 bullet, lines 706-740) — 5-anchor sweep :631→:676 (path-unsafe throw) / :651→:696 (versionNeeded throw) / :1133→:1244 / :1107→:1248 (extract-time isPathSafe call sites) / :1131→:1242 (trailing-slash carve-out); matches PR #2059 4-anchor / #2135 6-anchor in-row precedent; writer-side :84/:110 anchors still current, excluded

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -707,11 +707,11 @@ Summary — what this pattern catches and what it does not:
     (`testdata/zip/malformed/cd-path-unsafe.zip`) rejects CD entries
     whose decoded `name` is path-unsafe per `Binary.isPathSafe` at
     `parseCentralDir` time
-    ([Zip/Archive.lean:631](/home/kim/lean-zip/Zip/Archive.lean:631)),
+    ([Zip/Archive.lean:676](/home/kim/lean-zip/Zip/Archive.lean:676)),
     immediately after the UTF-8 / Latin-1 decode block at
     [Zip/Archive.lean:633-643](/home/kim/lean-zip/Zip/Archive.lean:633)
     and before the `versionNeeded` upper-bound at
-    [Zip/Archive.lean:651](/home/kim/lean-zip/Zip/Archive.lean:651).
+    [Zip/Archive.lean:696](/home/kim/lean-zip/Zip/Archive.lean:696).
     `Binary.isPathSafe` (canonical lean-zip-common path-safety filter,
     shared with the Tar extract path) rejects absolute paths (`/`
     prefix), `\` anywhere, `..`/`.` components, empty components (from
@@ -721,11 +721,11 @@ Summary — what this pattern catches and what it does not:
     unsafe `path` verbatim — exposing the full smuggled form to
     callers who route on `entry.path` before any filesystem I/O. The
     extract-time `Binary.isPathSafe` calls at
-    [Zip/Archive.lean:1133](/home/kim/lean-zip/Zip/Archive.lean:1133)
-    and :1107 remain in place as defense-in-depth but are now
+    [Zip/Archive.lean:1244](/home/kim/lean-zip/Zip/Archive.lean:1244)
+    and :1248 remain in place as defense-in-depth but are now
     unreachable for CD-parseable archives via the public API. Mirrors
     the trailing-slash carve-out at
-    [Zip/Archive.lean:1131](/home/kim/lean-zip/Zip/Archive.lean:1131)
+    [Zip/Archive.lean:1242](/home/kim/lean-zip/Zip/Archive.lean:1242)
     (directory entries end with `"/"`, checked on the slash-stripped
     form) so legitimate directory entries are not tripped. Quotes the
     name via `String.quote` so control bytes from the smuggled name

--- a/progress/2026-04-25T18-34-44Z_ee448772.md
+++ b/progress/2026-04-25T18-34-44Z_ee448772.md
@@ -1,0 +1,45 @@
+# 2026-04-25T18:34:44Z — feature ee448772
+
+Closed issue #2143: re-anchor stale `Zip/Archive.lean` line citations on
+the `cd-path-unsafe.zip` Recommended-policy narrative paragraph
+(`SECURITY_INVENTORY.md` lines 706–740, PR #1840 bullet).
+
+## What landed
+
+Single-file doc edit, 5 insertions / 5 deletions, scoped to one bullet:
+
+- Line 710: `:631` → `:676` (path-unsafe throw-message line, both halves of the markdown link).
+- Line 714: `:651` → `:696` (`unsupported versionNeededToExtract` throw-message line).
+- Line 724: `:1133` → `:1244` (extract-time `Binary.isPathSafe` call inside the `endsWith "/"` branch).
+- Line 725: bare `:1107` → `:1248` (extract-time `Binary.isPathSafe` call on the regular-file branch).
+- Line 728: `:1131` → `:1242` (trailing-slash carve-out `let checkPath := ...`).
+
+Writer-side anchors `:84` / `:110` (line 733/734) were left unchanged
+per the issue scope.
+
+## Verification
+
+- Lake build / test not required (doc-only edit).
+- `grep -n 'Zip/Archive\.lean:631\|...\\|:1131' SECURITY_INVENTORY.md`
+  reports zero remaining stale anchors anywhere in the file.
+- `bash scripts/check-inventory-links.sh` reports `errors=0, warnings=18`.
+  All 18 warnings reference unrelated rows (1066, 1192-1195, 1304-1311,
+  1402, 1412, 1429, 1447) — none on the 706–740 paragraph. Net delta
+  vs. baseline: 0 new warnings, 0 fewer.
+- `git diff origin/master..HEAD --stat` reports exactly
+  `1 file changed, 5 insertions(+), 5 deletions(-)`, matching the
+  issue's expected change footprint.
+
+## Notes / decisions
+
+- All five anchor migrations confirmed against current master
+  (`ae7474a`):
+  - `:676` is the `s!"zip: CD entry has unsafe path …"` throw inside `parseCentralDir`.
+  - `:696` is the `s!"zip: unsupported versionNeededToExtract …"` throw.
+  - `:1242`–`:1248` are the three extract-time path-safety sites in
+    the `for entry in entries` loop body.
+- Convention applied per `SECURITY_INVENTORY.md:1356-1364`: throw-cite
+  anchors land on the `s!"…"` payload line, not the bare `throw`.
+- Cadence: 1-row 5-anchor narrative-paragraph sweep, matching the
+  PR #2118 trailing-clause / PR #2059 row-1310 / PR #2135 row-1412
+  multi-anchor-in-row precedents.


### PR DESCRIPTION
Closes #2143

Session: `ee448772-9c9c-4cd1-adb7-3371418c0182`

fea65b0 progress: feature session ee448772 — closes #2143
e473827 docs: re-anchor cd-path-unsafe.zip narrative paragraph (5-anchor sweep, closes #2143)

🤖 Prepared with Claude Code