### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citations on SECURITY_INVENTORY.md narrative paragraph for duplicate ZIP64 (headerId 0x0001) extra-block rejection (PR #1793 cd-zip64-extra-duplicate.zip / lh-zip64-extra-duplicate.zip bullet, Recommended policy section, lines 419-446) — :406 → :449 (hasDuplicateZip64Extra helper def, +43 shift from CD-parse-guard wave) / :693 → :742 (CD-side caller in parseCentralDir, +49 shift) / :983 → :1123 (LH-side caller in readEntryData, +140 shift from Archive late-section wave) triple-anchor sweep with non-uniform shifts; 1-paragraph triple-anchor narrative-paragraph sweep matching PR #2147 cadence; writer-side :73-80 / :66-71 cites at lines 444-445 stay unchanged

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -429,12 +429,12 @@ Summary — what this pattern catches and what it does not:
     `headerId == 0x0001` match — a "first-wins" policy that lets a
     "last-wins" parser disagree on identical bytes. The new
     `hasDuplicateZip64Extra` helper at
-    [Zip/Archive.lean:406](/home/kim/lean-zip/Zip/Archive.lean:406)
+    [Zip/Archive.lean:449](/home/kim/lean-zip/Zip/Archive.lean:449)
     walks the TLV structure once and is invoked by both the CD-side
     caller in `parseCentralDir`
-    ([Zip/Archive.lean:693](/home/kim/lean-zip/Zip/Archive.lean:693))
+    ([Zip/Archive.lean:742](/home/kim/lean-zip/Zip/Archive.lean:742))
     and the LH-side caller in `readEntryData`
-    ([Zip/Archive.lean:983](/home/kim/lean-zip/Zip/Archive.lean:983))
+    ([Zip/Archive.lean:1123](/home/kim/lean-zip/Zip/Archive.lean:1123))
     before `parseZip64Extra` is called. The two error wordings
     (`"duplicate ZIP64 extra field"` vs `"duplicate ZIP64 local extra
     field"`) keep attribution distinct between layers. Sibling of the

--- a/progress/2026-04-25T18-42-59Z_7b86f204.md
+++ b/progress/2026-04-25T18-42-59Z_7b86f204.md
@@ -1,0 +1,47 @@
+# 2026-04-25T18:42 UTC — feature session 7b86f204
+
+## Issue
+#2150 — Inventory re-anchor: SECURITY_INVENTORY.md narrative paragraph
+for duplicate ZIP64 (headerId 0x0001) extra-block rejection (PR #1793,
+lines 419-446 in Recommended policy section).
+
+## What landed
+Triple-anchor narrative-paragraph sweep on
+`SECURITY_INVENTORY.md`, three edits inside lines 432-437:
+
+- :406 → :449 (line 432) — `hasDuplicateZip64Extra` helper def
+- :693 → :742 (line 435) — CD-side caller in `parseCentralDir`
+- :983 → :1123 (line 437) — LH-side caller in `readEntryData`
+
+Non-uniform shifts (+43 / +49 / +140) reflect the chronological
+order of distinct edit waves: the CD-parse-guard wave shifted the
+helper def +43 and the CD caller +49, while the Archive
+late-section `readBoundedSpanFromHandle` refactor wave (PRs #2065 /
+#2067) shifted the LH caller +140. Each updated cite was verified to
+resolve to the expected source line in current master.
+
+Writer-side cites at lines 444-445 (`:73-80` / `:66-71`) remain
+unchanged per issue spec.
+
+## Verification
+- Diff is exactly the three planned anchor edits, nothing else
+  (`git diff master..HEAD SECURITY_INVENTORY.md`)
+- Doc-only change; `lake build` / `lake exe test` unaffected (skipped
+  per project convention for inventory-only sweeps)
+- Source lines re-checked:
+  - `Zip/Archive.lean:449` — `private def hasDuplicateZip64Extra
+    (extraData : ByteArray) : Bool := Id.run do`
+  - `Zip/Archive.lean:742` — `if hasDuplicateZip64Extra extraData
+    then` (CD-side)
+  - `Zip/Archive.lean:1123` — `if hasDuplicateZip64Extra localExtra
+    then` (LH-side)
+
+## Sorry count
+Unchanged (doc-only edit).
+
+## Pattern notes
+Continues the narrative-paragraph re-anchor cadence (PRs #2131 /
+#2132 / #2133 / #2137 / #2122 / #2120 / #2121 / #2146 single-anchor;
+PR #2147 / #2154 multi-anchor). Non-uniform-shift triple-anchor cite
+sweep within a single bullet — sibling shape to PR #2147
+(cd-empty-entry-crc-nonzero.zip, three anchors with mixed shifts).


### PR DESCRIPTION
Closes #2150

Session: `7b86f204-2912-41c4-beda-648f024880fb`

3768983 chore: progress entry for #2150 (re-anchor duplicate-ZIP64 narrative paragraph)
8643ab5 doc: re-anchor SECURITY_INVENTORY.md duplicate-ZIP64 narrative paragraph (lines 432/435/437) — :406→:449 / :693→:742 / :983→:1123 (#2150)

🤖 Prepared with Claude Code