### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citation on SECURITY_INVENTORY.md narrative paragraph for ZIP64 per-entry extra-field dataSize exactness check (PR #1785 zip64-extra-oversized-datasize.zip bullet, Recommended policy section, line 414) — :428 → :495 (parseZip64Extra fpos != fieldEnd exactness check, +67 shift from CD-parse-guard insertion wave); 1-row single-anchor narrative-paragraph sweep matching PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/#2071/#2082/#2091/#2093/#2098/#2099/#2100/#2101/#2104/#2105/#2111/#2114/#2115/#2122/#2131/#2132/#2133/#2137/#2146 1-row tightening cadence; convention pinned by SECURITY_INVENTORY.md:1356-1364 referent-line precedent (anchor lands on the if fpos != fieldEnd then return none guard line); also adopts markdown-link form to match surrounding paragraph cite style

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -411,7 +411,7 @@ Summary — what this pattern catches and what it does not:
     (the pre-PR lean-zip) silently discards the slack after the first
     `N * 8` bytes, while a strict parser rejects the archive.
     `parseZip64Extra` now asserts `fpos == fieldEnd` after the three
-    conditional reads (Zip/Archive.lean:428). Sibling of the outer
+    conditional reads ([Zip/Archive.lean:495](/home/kim/lean-zip/Zip/Archive.lean:495)). Sibling of the outer
     `zip64-eocd64-bad-recsize.zip` record-size check (same
     parser-differential attack class, different layer); writer-side at
     [Zip/Archive.lean:73-80](/home/kim/lean-zip/Zip/Archive.lean:73)

--- a/progress/2026-04-25T1910Z_7ccd49dd.md
+++ b/progress/2026-04-25T1910Z_7ccd49dd.md
@@ -1,0 +1,20 @@
+# 2026-04-25T19:10Z — Feature session 7ccd49dd
+
+## Issue
+#2151 — Inventory re-anchor: SECURITY_INVENTORY.md line 414 narrative
+paragraph for PR #1785 (zip64-extra-oversized-datasize.zip),
+ZIP64 per-entry extra-field `dataSize` exactness check.
+
+## What was done
+- Single edit to `SECURITY_INVENTORY.md` line 414:
+  `(Zip/Archive.lean:428)` →
+  `([Zip/Archive.lean:495](/home/kim/lean-zip/Zip/Archive.lean:495))`
+- Verified line 495 is `if fpos != fieldEnd then return none` inside
+  `parseZip64Extra`.
+- Adopts markdown-link form matching surrounding paragraph cite style.
+
+## Verification
+- Doc-only edit; `lake build` and `lake exe test` unaffected.
+
+## Quality metric delta
+- Sorry count unchanged (no source code touched).


### PR DESCRIPTION
Closes #2151

Session: `7ccd49dd-1c12-4b6f-9bd2-1d9be8913d7b`

f72508a chore: add progress entry for issue #2151 (session 7ccd49dd)
241be9f doc: re-anchor SECURITY_INVENTORY.md narrative cite for ZIP64 dataSize exactness check

🤖 Prepared with Claude Code