### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citation on SECURITY_INVENTORY.md narrative paragraph for ZIP64 EOCD64 record archive-layout invariant (PR #1856 zip64-eocd64-overlap-locator.zip bullet, Recommended policy section, line 347) — :306 → :331 ('zip: ZIP64 EOCD64 record overlaps locator' throw, +25 shift from rationale-comment block insertion); 1-row single-anchor narrative-paragraph sweep matching PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/#2071/#2082/#2091/#2093/#2098/#2099/#2100/#2101/#2104/#2105/#2111/#2114/#2115/#2122/#2131/#2132/#2133/#2137/#2146/#2153 1-row tightening cadence; convention pinned by SECURITY_INVENTORY.md:1356-1364 throw-message s!"…" line precedent; sibling narrative-paragraph re-anchors at lines 296/328/414 queued separately

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -344,7 +344,7 @@ Summary — what this pattern catches and what it does not:
     rejects archives whose Locator-declared `eocd64Offset` plus the
     56-byte v1 EOCD64 record reaches into or past the Locator at
     `findEndOfCentralDir` time
-    ([Zip/Archive.lean:306](/home/kim/lean-zip/Zip/Archive.lean:306)).
+    ([Zip/Archive.lean:331](/home/kim/lean-zip/Zip/Archive.lean:331)).
     APPNOTE §4.3.6 pins the ZIP64 trailer layout as `[CD] [EOCD64]
     [Locator] [EOCD]`, so a legitimate archive satisfies
     `eocd64Offset + 56 ≤ locatorPos = eocdPos - 20` — the EOCD64

--- a/progress/20260425T190556Z_0fc987a7.md
+++ b/progress/20260425T190556Z_0fc987a7.md
@@ -1,0 +1,35 @@
+# Feature session 0fc987a7 — 2026-04-25T19:05Z
+
+## Outcome
+
+- Skipped issue #2152 (replan): the issue body confused two adjacent
+  inventory paragraphs. It claimed line 296 belonged to the PR #1761
+  record-size paragraph (271-290) and asked to re-anchor `:337` →
+  `:345`, but line 296 is actually inside the PR #1826 versionMadeBy
+  paragraph (291-318), whose surrounding text reads "rejects archives
+  whose EOCD64 versionMadeBy field … at findEndOfCentralDir time".
+  Following the directive literally would push the cite into the
+  record-size throw (`:345`) inside a versionMadeBy-check paragraph —
+  strictly worse than the current state. Correct re-anchor target for
+  that paragraph is `:363` (versionMadeBy throw line).
+- Landed issue #2158: re-anchored
+  `SECURITY_INVENTORY.md:347` `:306` → `:331` for the PR #1856
+  EOCD64-overlap-locator narrative paragraph. Verified `Zip/Archive.lean:331`
+  is the `throw … s!"zip: ZIP64 EOCD64 record overlaps locator …"`
+  line, matching the throw-line convention pinned at
+  `SECURITY_INVENTORY.md:1356-1364`.
+
+## Verification
+
+- Doc-only edit; `lake build` / `lake exe test` unaffected and not
+  re-run.
+- `git diff` confirms a single-line change inside the PR #1856
+  paragraph, no other rows or paragraphs touched.
+
+## Notes
+
+- Sibling re-anchors at lines 296 / 328 / 414 are queued separately
+  (#2152 needs replan, #2159 / #2151 still distinct).
+- The skip on #2152 surfaces a planning bug worth flagging to the
+  next planner — when issuing line-296 again, attribute the cite to
+  the PR #1826 versionMadeBy paragraph and target `:363`.


### PR DESCRIPTION
Closes #2158

Session: `0fc987a7-6a5d-4958-9a7a-8ac75ae75590`

05d84d7 doc: progress entry for session 0fc987a7
97ed548 doc: re-anchor SECURITY_INVENTORY.md:347 EOCD64 overlap-locator narrative cite :306 → :331

🤖 Prepared with Claude Code