### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citation on SECURITY_INVENTORY.md narrative paragraph for ZIP64 EOCD64 versionNeededToExtract upper-bound writer-side anchor (PR #1852 zip64-eocd64-versionneeded-too-high.zip bullet, Recommended policy section, line 328) — :150 → :154 (writer-side hard-coded `45` for versionNeededToExtract inside writeEndRecords, +4 shift from comment-block insertion); 1-row single-anchor narrative-paragraph sweep matching PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/#2071/#2082/#2091/#2093/#2098/#2099/#2100/#2101/#2104/#2105/#2111/#2114/#2115/#2122/#2131/#2132/#2133/#2137/#2146/#2153 1-row tightening cadence; convention pinned to actual Binary.writeUInt16LEAt call (analogous to PR #2153 writer-side Checksum.crc32 0 fileData precedent); sibling narrative-paragraph re-anchors at lines 296/347/414 queued separately

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -325,7 +325,7 @@ Summary — what this pattern catches and what it does not:
     to interpret the EOCD64 record; any higher value is either a
     forward-looking extension lean-zip does not support or a crafted
     smuggle against strict readers. Writer-side at
-    [Zip/Archive.lean:150](/home/kim/lean-zip/Zip/Archive.lean:150)
+    [Zip/Archive.lean:154](/home/kim/lean-zip/Zip/Archive.lean:154)
     hard-codes `45` (EOCD64 requires ZIP64 support, §4.4.3.2), so the
     bound `45 ≤ 63` holds trivially for every lean-zip-produced
     archive. Upper-bound sibling of the lower-bound `≥ 45` check

--- a/progress/20260425T191347Z_c611b0a1.md
+++ b/progress/20260425T191347Z_c611b0a1.md
@@ -1,0 +1,24 @@
+# Session 20260425T191347Z (c611b0a1) — feature
+
+## Issue
+#2159 — Inventory: re-anchor stale Zip/Archive.lean line citation on
+SECURITY_INVENTORY.md narrative paragraph for ZIP64 EOCD64
+versionNeededToExtract upper-bound writer-side anchor (PR #1852, line 328).
+
+## What was done
+Single-anchor doc-only edit on `SECURITY_INVENTORY.md:328`:
+
+- `:150` → `:154` (writer-side hard-coded `45` for
+  `versionNeededToExtract` inside `writeEndRecords`, +4 shift from
+  comment-block insertion).
+
+Verified: `Zip/Archive.lean:154` is
+`buf := Binary.writeUInt16LEAt buf 14 45  -- version needed`,
+matching the cited prose substring "hard-codes `45`".
+
+`bash scripts/check-inventory-links.sh` reports `errors=0`; the 18
+warnings are all pre-existing drift warnings on other anchors and
+none touch `SECURITY_INVENTORY.md:328`.
+
+## Quality metrics
+No code or test files modified. No build/test impact.


### PR DESCRIPTION
Closes #2159

Session: `c611b0a1-7b34-4e69-9812-3c58096f041c`

26007c2 chore: add progress entry for #2159
fa3297f docs: re-anchor stale Zip/Archive.lean line citation on SECURITY_INVENTORY.md narrative paragraph for ZIP64 EOCD64 versionNeededToExtract upper-bound writer-side anchor (PR #1852, line 328)

🤖 Prepared with Claude Code