### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citation on SECURITY_INVENTORY.md narrative paragraph for ZIP64 EOCD64 versionMadeBy spec-version upper-bound check (PR #1826 zip64-eocd64-versionmadeby-too-high.zip bullet, Recommended policy section, line 296) — :337 → :363 ('zip: ZIP64 EOCD64 versionMadeBy spec-version byte too high' throw, +26 shift from later-landing throw inside findEndOfCentralDir); 1-row single-anchor narrative-paragraph sweep matching PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/#2071/#2082/#2091/#2093/#2098/#2099/#2100/#2101/#2104/#2105/#2111/#2114/#2115/#2122/#2131/#2132/#2133/#2137/#2146/#2153/#2161 1-row tightening cadence; convention pinned by SECURITY_INVENTORY.md:1356-1364 throw-message s!"…" line precedent; corrected replacement for #2152 (which misattributed line 296 to the adjacent PR #1761 record-size paragraph and proposed the wrong destination :345); writer-side :153 cite at line 303 stays unchanged

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -293,7 +293,7 @@ Summary — what this pattern catches and what it does not:
     rejects archives whose EOCD64 `versionMadeBy` field (APPNOTE
     §4.4.2.1 / §4.4.2.2, at `bufPos + 12`) carries a lower byte greater
     than `63` (spec version 6.3) at `findEndOfCentralDir` time
-    ([Zip/Archive.lean:337](/home/kim/lean-zip/Zip/Archive.lean:337)).
+    ([Zip/Archive.lean:363](/home/kim/lean-zip/Zip/Archive.lean:363)).
     The low byte of `versionMadeBy` is the "version of the ZIP
     specification" in decimal-coded form (APPNOTE-defined values 1.0
     through 6.3, encoded `10`..`63`); any higher value is either a

--- a/progress/20260425T193500Z_fbbf281b.md
+++ b/progress/20260425T193500Z_fbbf281b.md
@@ -1,0 +1,42 @@
+# Session fbbf281b — feature
+
+**UTC**: 2026-04-25T19:35Z
+**Type**: feature (inventory line-anchor sweep)
+**Issue**: #2163
+**Branch**: agent/fbbf281b
+
+## Accomplished
+
+Single-anchor doc-only re-cite on `SECURITY_INVENTORY.md:296`
+(narrative paragraph for the PR #1826 ZIP64 EOCD64 `versionMadeBy`
+spec-version upper-bound check, paragraph spans lines 291-318):
+
+- `:337` → `:363` (the actual `s!"zip: ZIP64 EOCD64 versionMadeBy
+  spec-version byte too high …"` throw payload). +26 shift reflects
+  the later-landing throw inside `findEndOfCentralDir`; line 337 in
+  current master is now an interior comment line inside the EOCD64
+  record-size sanity block.
+
+## Verification
+
+- `bash scripts/check-inventory-links.sh` → errors=0 (warnings=18,
+  none on line 296 — all pre-existing on unrelated rows: 1066,
+  1192-1195, 1304, 1307, 1309-1311, 1402, 1412, 1429, 1447)
+- `git diff origin/master..HEAD --stat` → exactly
+  `1 file changed, 1 insertion(+), 1 deletion(-)` on
+  SECURITY_INVENTORY.md, matching the deliverable
+
+## Notes
+
+- This issue corrected the misattribution from skipped #2152, which
+  proposed `:345` (the record-size throw, in the adjacent PR #1761
+  paragraph at lines 272-290 — wrong paragraph, wrong destination).
+- Writer-side cite at line 303 (`Zip/Archive.lean:153`,
+  `buf := Binary.writeUInt16LEAt buf 12 (3 * 256 + 45)`) stays
+  unchanged — still the correct anchor.
+- 1-row single-anchor narrative-paragraph sweep matching the
+  PR #1985/#1994/.../#2153/#2161 1-row tightening cadence.
+
+## Quality metric
+
+- `grep -rc sorry Zip/` unchanged (doc-only edit).


### PR DESCRIPTION
Closes #2163

Session: `fbbf281b-5233-40da-885c-9fe372ff703f`

3430a61 chore: add progress entry for session fbbf281b (#2163)
bdbd5d0 doc: re-anchor SECURITY_INVENTORY.md:296 EOCD64 versionMadeBy cite to Zip/Archive.lean:363

🤖 Prepared with Claude Code