### PR TITLE
Inventory: re-anchor stale Zip/Tar.lean line citation on SECURITY_INVENTORY.md standalone audit section '### 2. Tar UTF-8 partial functions' (line 1140) — :246 → :317 (def line of splitPath, the function holding both remaining fromUTF8! callsites at lines 335-336 that the Status: text documents as safe; +71 shift from post-#1899 / post-#1944 / post-#1957 / post-#1979 Tar parser growth wave plus hasInteriorNul helper insertion); 1-paragraph single-anchor standalone-audit-section sweep — sibling of planner-queued audit-section refreshes for '### 1. ZIP metadata to Handle.read' (Zip/Archive.lean:491) and '### 3. Unlimited decompression knobs' (Zip/Archive.lean:783); convention pinned by sibling readExact-def precedent in sibling issue '### 1.'

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1137,7 +1137,7 @@ Regression fixtures live under `testdata/tar/security/`:
 
 ### 2. Tar UTF-8 partial functions
 
-- File: [Zip/Tar.lean](/home/kim/lean-zip/Zip/Tar.lean:246)
+- File: [Zip/Tar.lean](/home/kim/lean-zip/Zip/Tar.lean:317)
 - Concern:
   - `String.fromUTF8!` is partial and should not be reachable from
     attacker-controlled invalid bytes without prior validation

--- a/progress/2026-04-25T195134Z_19fd70fc.md
+++ b/progress/2026-04-25T195134Z_19fd70fc.md
@@ -1,0 +1,47 @@
+# Session 19fd70fc — feature
+
+- Date: 2026-04-25T19:51:34Z
+- Type: feature (single-anchor doc-only inventory re-anchor)
+- Issue: #2166
+
+## Accomplished
+
+Re-anchored stale `Zip/Tar.lean:246` cite at
+`SECURITY_INVENTORY.md:1140` (audit section "### 2. Tar UTF-8 partial
+functions" `File:` slot) to `Zip/Tar.lean:317` (def line of
+`splitPath`, which holds both remaining `String.fromUTF8!` callsites
+at lines 335-336 that the `Status:` text documents safe).
+
++71 shift from post-#1899 / post-#1944 / post-#1957 / post-#1979 Tar
+parser growth wave plus `hasInteriorNul` helper insertion.
+
+## Verification
+
+- `git grep -nE 'Zip/Tar\.lean:246' SECURITY_INVENTORY.md` → no
+  matches (was 1140)
+- `git grep -nE 'Zip/Tar\.lean:317' SECURITY_INVENTORY.md` → exactly
+  one match at line 1140
+- `Zip/Tar.lean:317` reads
+  `def splitPath (path : String) : Option (String × String) := Id.run do`
+- `grep -n 'String\.fromUTF8!' Zip/Tar.lean` → exactly two hits at
+  lines 335 and 336, both inside `splitPath`
+- `lake build` / `lake exe test` not run — doc-only edit, no Lean
+  source changes
+
+## Quality metric
+
+sorry count unchanged (no Lean source touched).
+
+## Decisions / patterns
+
+Convention pinned by sibling readExact-def precedent at PR #2172
+(`Zip/Archive.lean:980` for audit section "### 1."). Each audit
+section's `File:` cite is independently maintained, distinct from the
+*Recommended policy* / *Minimized Reproducer Corpus* / *Local guard
+inventory* tables further down the document.
+
+## Remains
+
+Sibling audit-section refresh `#2167` ("### 3. Unlimited
+decompression knobs", `Zip/Archive.lean:783 → :1233`) still
+unclaimed.


### PR DESCRIPTION
Closes #2166

Session: `19fd70fc-3ef3-4fcd-a700-3fa08c1e0fc9`

2562480 chore: progress entry for #2166
b48fb9e doc: re-anchor SECURITY_INVENTORY.md '### 2. Tar UTF-8 partial functions' File cite — Zip/Tar.lean:246 → :317

🤖 Prepared with Claude Code