### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citation on SECURITY_INVENTORY.md standalone audit section '### 3. Unlimited decompression knobs' (line 1156) — :783 → :1233 (def line of Archive.extract, the top-level extraction API whose maxEntrySize := 0 / maxTotalSize := 0 defaults are the audit's subject; +450 shift from cumulative Archive late-section growth wave); 1-paragraph single-anchor standalone-audit-section sweep — sibling of planner-queued audit-section refreshes for '### 1. ZIP metadata to Handle.read' (Zip/Archive.lean:491) and '### 2. Tar UTF-8 partial functions' (Zip/Tar.lean:246); convention pinned by Decompression Limit Inventory table cite at SECURITY_INVENTORY.md:1187 which already anchors to Zip/Archive.lean:1233 — cross-link consistency with See: clause at line 1162; sibling Zip/Basic.lean:9 cite untouched

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1151,7 +1151,7 @@ Regression fixtures live under `testdata/tar/security/`:
 
 - Files:
   - [Zip/Basic.lean](/home/kim/lean-zip/Zip/Basic.lean:9)
-  - [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:783)
+  - [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:1233)
 - Concern:
   - `0 = no limit` is convenient but weak as a default for hostile inputs
 - Needed:

--- a/progress/20260425T201801Z_d93e677b.md
+++ b/progress/20260425T201801Z_d93e677b.md
@@ -1,0 +1,44 @@
+# Progress: 2026-04-25T20:18:01Z (session d93e677b)
+
+## Session type
+feature
+
+## Issue
+#2167 — Inventory: re-anchor stale Zip/Archive.lean line citation on
+SECURITY_INVENTORY.md standalone audit section "### 3. Unlimited
+decompression knobs" (`:783 → :1233`).
+
+## Accomplished
+- Single-anchor doc edit on `SECURITY_INVENTORY.md` line 1154
+  (audit section `### 3. Unlimited decompression knobs`, `Files:`
+  slot): `Zip/Archive.lean:783` → `Zip/Archive.lean:1233`.
+- Verified `:1233` is the def line of `Archive.extract`, the
+  top-level extraction API whose `maxEntrySize` / `maxTotalSize`
+  defaults are the audit's subject.
+- Cross-link consistency restored with the *Decompression Limit
+  Inventory* table at `SECURITY_INVENTORY.md:1187-1189` (already
+  anchors to `:1233`); the `See:` clause at line 1160 now points
+  to a table whose first row matches this audit cite.
+
+## Verification
+- `git grep -nE 'Zip/Archive\.lean:783' SECURITY_INVENTORY.md`
+  → no matches after edit.
+- `git grep -nE 'Zip/Archive\.lean:1233' SECURITY_INVENTORY.md`
+  → 4 matches (line 1154 from this PR plus pre-existing rows
+  1187 / 1188 / 1189 in the Decompression Limit Inventory table).
+- `Zip/Archive.lean:1233` reads
+  `def extract (inputPath : System.FilePath) (outDir : System.FilePath)`.
+- Doc-only edit; no Lean source changes, no `lake build` /
+  `lake exe test` required.
+
+## Quality metric deltas
+- sorry count: unchanged (doc-only edit).
+
+## Notes
+- Issue body cited the audit-section line as 1156, file shows
+  1154 (small drift from intervening edits since the issue was
+  created). Content matches exactly; substring-based edit is
+  unaffected by line-number drift.
+- Sibling planner-queued audit-section refreshes for "### 1. ZIP
+  metadata to Handle.read" and "### 2. Tar UTF-8 partial functions"
+  remain to be picked up separately.


### PR DESCRIPTION
Closes #2167

Session: `d93e677b-ddc1-4095-84e0-b29957741764`

14f53e0 chore: progress entry for session d93e677b (#2167)
df46ff6 doc: re-anchor SECURITY_INVENTORY.md audit section '### 3. Unlimited decompression knobs' Archive.lean cite (:783 → :1233)

🤖 Prepared with Claude Code