### PR TITLE
Inventory: re-anchor stale Zip/Archive.lean line citation on SECURITY_INVENTORY.md narrative paragraph for cd-entry-localoffset-past-cdstart per-entry archive-layout invariant (line 515) — :728 → :771 ('entry local offset overlaps central directory' throw inside parseCentralDir, +43 shift from CD-parse-guard insertion wave); 1-row single-anchor narrative-paragraph sweep matching PR #1985/.../#2161/#2171 1-row tightening cadence; sibling fixture-cell cite at corpus row 1430 already anchors to :771 — this issue restores fixture-cite ↔ narrative-cite agreement for PR #1813

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -512,7 +512,7 @@ Summary — what this pattern catches and what it does not:
     rejects CD entries whose resolved `localOffset` plus the 30-byte
     fixed LH header (APPNOTE §4.3.7) reaches into or past the CD
     region at `parseCentralDir` time
-    ([Zip/Archive.lean:728](/home/kim/lean-zip/Zip/Archive.lean:728)).
+    ([Zip/Archive.lean:771](/home/kim/lean-zip/Zip/Archive.lean:771)).
     APPNOTE §4.3.6 pins the archive layout as `[LH+data]* [CD]
     [EOCD]`, so every entry's LH must be readable strictly before the
     CD start; writer-side at

--- a/progress/2026-04-25T2050_85c03895.md
+++ b/progress/2026-04-25T2050_85c03895.md
@@ -1,0 +1,23 @@
+# Session 85c03895 — feature
+
+UTC: 2026-04-25 ~20:50
+Type: feature
+Issue: #2175
+
+## What was accomplished
+
+Doc-only re-anchor sweep on `SECURITY_INVENTORY.md` line 515
+(narrative paragraph for PR #1813 `cd-entry-localoffset-past-cdstart.zip`):
+
+- `[Zip/Archive.lean:728](...)` → `[Zip/Archive.lean:771](...)` (+43)
+
+Verified `Zip/Archive.lean:771` is the throw arm
+`s!"zip: entry local offset overlaps central directory..."` of the
+`unless localOff ≤ cdFileOff ∧ 30 ≤ cdFileOff - localOff` guard inside
+`parseCentralDir`. Sibling fixture cite at corpus row 1430 already
+anchors to `:771`; this restores narrative-cite ↔ fixture-cite agreement.
+
+## Quality metrics
+
+No code changes — `lake build` and `lake exe test` unaffected. sorry
+count unchanged.


### PR DESCRIPTION
Closes #2175

Session: `85c03895-dfed-4847-8a10-ebfb845b7d93`

c5764cf doc: progress entry for session 85c03895
efe163c doc: re-anchor SECURITY_INVENTORY.md narrative cite for cd-entry-localoffset-past-cdstart per-entry archive-layout invariant

🤖 Prepared with Claude Code