### PR TITLE
Refresh stale Priority 2 audit-checklist Zip/Archive.lean anchor :432 → :1233 (Archive.extract def line) — 1-row single-anchor doc-only sweep on plans/track-e-current-audit-checklist.md line 82, structural drift class matching PR #2178/#2186/#2187 linker-undetected precedent (file not scanned by check-inventory-links.sh); current cite lands on private def validateExtraFieldStructure unrelated to Priority 2's public-decompression-limit subject; convention pinned by SECURITY_INVENTORY.md:1187 which already anchors Archive.extract entry-point cite to :1233; sibling Priority 5 anchor refreshes at lines 184-185 queued separately

### DIFF
--- a/plans/track-e-current-audit-checklist.md
+++ b/plans/track-e-current-audit-checklist.md
@@ -79,7 +79,7 @@ Targets:
 - [Zip/Basic.lean](/home/kim/lean-zip/Zip/Basic.lean:1)
 - [Zip/Gzip.lean](/home/kim/lean-zip/Zip/Gzip.lean:1)
 - [Zip/RawDeflate.lean](/home/kim/lean-zip/Zip/RawDeflate.lean:1)
-- [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:432)
+- [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:1233)
 
 - [x] Inventory every public API where `0 = no limit`.
   (See *"Decompression Limit Inventory"* in

--- a/progress/2026-04-25T23-11-38Z_48b6240f.md
+++ b/progress/2026-04-25T23-11-38Z_48b6240f.md
@@ -1,0 +1,39 @@
+# Session 48b6240f — feature
+
+- **When**: 2026-04-25T23:11:38Z
+- **Type**: feature
+- **Issue**: #2205
+
+## Accomplished
+
+Refreshed stale Priority 2 audit-checklist anchor in
+`plans/track-e-current-audit-checklist.md` line 82:
+`Zip/Archive.lean:432` → `:1233`. The previous cite landed on
+`private def validateExtraFieldStructure` (an unrelated CD-extra-field
+validator); the new cite lands on `def extract`, the public extraction
+API that Priority 2 ("Public decompression limit policy") audits.
+This matches the `SECURITY_INVENTORY.md:1187` convention for the
+`Archive.extract` entry-point cite.
+
+## Verification
+
+- `awk 'NR==1233' Zip/Archive.lean` prints
+  `def extract (inputPath : System.FilePath) (outDir : System.FilePath)` ✅
+- `git diff --stat origin/master..HEAD` shows
+  `1 file changed, 1 insertion(+), 1 deletion(-)` on the audit checklist ✅
+- `bash scripts/check-inventory-links.sh` exits 0 with the same 13
+  pre-existing warnings (none on the audit-checklist file — `plans/`
+  is not scanned) ✅
+- `grep -F ':1233'` returns the changed line; `grep -F ':432'` returns
+  no hits ✅
+
+## Decisions / patterns
+
+- Doc-only sweep on `plans/` — linker-undetected drift class, matches
+  PR #2178/#2186/#2187 precedent.
+- Sibling Priority 5 anchor refresh (#2206) is queued separately as a
+  distinct atomic issue.
+
+## Quality metrics
+
+- No source changes; sorry count unchanged.


### PR DESCRIPTION
Closes #2205

Session: `48b6240f-7a66-4ea9-973b-e48102ed295a`

c75d609 doc: progress entry for #2205 (audit-checklist Priority 2 Archive anchor refresh)
1c0d449 doc: refresh stale audit-checklist Priority 2 Archive anchor :432 → :1233

🤖 Prepared with Claude Code