### PR TITLE
Refresh stale Priority 5 audit-checklist anchors Zip/Archive.lean:341 → :1024 (readBoundedSpanFromHandle def) and Zip/Tar.lean:169 → :308 (readBoundedEntryData def) — 1-row 2-anchor doc-only sweep on plans/track-e-current-audit-checklist.md lines 184-185, structural drift class matching PR #2178/#2186/#2187 linker-undetected precedent (file not scanned by check-inventory-links.sh); current cites land on unrelated lines (Archive :341 = '| "mtime" =>' PAX timestamp branch / Tar :169 = a comment line); section's item-1 body explicitly names readBoundedSpanFromHandle / readBoundedEntryData as the PR #1608 helpers; sibling Priority 2 anchor refresh at line 82 queued separately as #2205

### DIFF
--- a/plans/track-e-current-audit-checklist.md
+++ b/plans/track-e-current-audit-checklist.md
@@ -181,8 +181,8 @@ Targets:
 
 Targets:
 
-- [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:341)
-- [Zip/Tar.lean](/home/kim/lean-zip/Zip/Tar.lean:169)
+- [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:1024)
+- [Zip/Tar.lean](/home/kim/lean-zip/Zip/Tar.lean:308)
 
 - [x] Introduce proof-friendly helper functions for bounded reads and
   validated spans.

--- a/progress/2026-04-25T23-25-15Z_df7ed4e9.md
+++ b/progress/2026-04-25T23-25-15Z_df7ed4e9.md
@@ -1,0 +1,28 @@
+# Feature session df7ed4e9 — 2026-04-25T23:25Z
+
+Closed issue #2206: Refresh stale Priority 5 audit-checklist anchors.
+
+## Done
+
+- `plans/track-e-current-audit-checklist.md` lines 184-185:
+  - `Zip/Archive.lean:341` → `:1024` (`def readBoundedSpanFromHandle`).
+  - `Zip/Tar.lean:169` → `:308` (`partial def readBoundedEntryData`).
+- 1-row 2-anchor doc-only sweep, no source/test changes.
+
+## Verification
+
+- `awk 'NR==1024' Zip/Archive.lean` prints
+  `def readBoundedSpanFromHandle (h : IO.FS.Handle)`.
+- `awk 'NR==308' Zip/Tar.lean` prints
+  `partial def readBoundedEntryData (input : IO.FS.Stream) (size maxSize : Nat)`.
+- `git diff --stat origin/master..HEAD` =
+  `1 file changed, 2 insertions(+), 2 deletions(-)`.
+- `bash scripts/check-inventory-links.sh` exits 0 with the same 13
+  pre-existing warnings (none on `plans/`).
+- `grep -F ':341' plans/track-e-current-audit-checklist.md` and
+  `grep -F ':169' plans/track-e-current-audit-checklist.md` return
+  no hits.
+
+## Quality metric
+
+- sorry count unchanged (doc-only).


### PR DESCRIPTION
Closes #2206

Session: `df7ed4e9-6f09-47a6-bb07-3be6b0d4d8f9`

d8d98a1 progress: 2026-04-25T23:25Z df7ed4e9 (doc anchor refresh #2206)
74a8a05 doc: re-anchor stale Priority 5 audit-checklist target anchors

🤖 Prepared with Claude Code