### PR TITLE
Refresh stale Priority 2 audit-checklist SECURITY_INVENTORY.md cross-link anchors :151 → :1162 (Decompression Limit Inventory section header) and :151 → :1205 (Recommended policy subsection header) — 1-row 2-anchor doc-only sweep on plans/track-e-current-audit-checklist.md lines 86 and 90, structural drift class matching merged sibling PR #2205 (Priority 2 source-file anchor on line 82) and unclaimed sibling #2206 (Priority 5 source-file anchors lines 184-185); current cite :151 lands inside the Allocation site audit table (an unrelated c/zlib_ffi.c:435 row) — strictly wrong vs the prose which names the Decompression Limit Inventory section and Recommended policy subsection by title; same linker-undetected drift class as PR #2178/#2186/#2187 (file not scanned by check-inventory-links.sh)

### DIFF
--- a/plans/track-e-current-audit-checklist.md
+++ b/plans/track-e-current-audit-checklist.md
@@ -83,11 +83,11 @@ Targets:
 
 - [x] Inventory every public API where `0 = no limit`.
   (See *"Decompression Limit Inventory"* in
-  [SECURITY_INVENTORY.md](/home/kim/lean-zip/SECURITY_INVENTORY.md:151).)
+  [SECURITY_INVENTORY.md](/home/kim/lean-zip/SECURITY_INVENTORY.md:1162).)
 - [x] Decide which APIs should keep that behavior and which should expose
   safer extraction defaults.
   (Proposed direction in the *"Recommended policy"* subsection of
-  [SECURITY_INVENTORY.md](/home/kim/lean-zip/SECURITY_INVENTORY.md:151);
+  [SECURITY_INVENTORY.md](/home/kim/lean-zip/SECURITY_INVENTORY.md:1205);
   final numbers and signature changes are deferred to follow-up issues
   so this inventory stays doc-only.)
 - [x] Add decompression-bomb tests for:

--- a/progress/2026-04-26T000107Z_e2f6cb18.md
+++ b/progress/2026-04-26T000107Z_e2f6cb18.md
@@ -1,0 +1,41 @@
+# Session 2026-04-26T00:01Z — feature — issue #2211
+
+## Accomplished
+
+Refreshed the two stale `SECURITY_INVENTORY.md` cross-link anchors in
+`plans/track-e-current-audit-checklist.md` Priority 2 section
+(*Public decompression limit policy*):
+
+- Line 86: `SECURITY_INVENTORY.md:151` → `:1162`
+  (`## Decompression Limit Inventory` section header).
+- Line 90: `SECURITY_INVENTORY.md:151` → `:1205`
+  (`### Recommended policy` subsection header).
+
+Both target line numbers verified pre-edit via
+`grep -n '^## Decompression Limit Inventory\|^### Recommended policy'
+SECURITY_INVENTORY.md`.
+
+Diff: 1 file changed, 2 insertions(+), 2 deletions(-). The Priority 2
+anchor set is fully fresh after this lands (sibling source-file anchor
+on line 82 was refreshed by merged PR #2205; sibling Priority 5 anchors
+on lines 184-185 were refreshed by merged PR #2212).
+
+## Decisions / patterns
+
+- Same linker-undetected drift class as PR #2178 / #2186 / #2187 —
+  `scripts/check-inventory-links.sh` does not scan `plans/`, so anchor
+  drift accumulates silently and is detected/refreshed by manual
+  inspection rather than CI.
+- Doc-only edit; no `lake build` / `lake exe test` impact.
+- Visible-text label (`SECURITY_INVENTORY.md`) does not embed the line
+  number, so only the link-target half changed per link.
+
+## Quality metric
+
+`grep -rc sorry Zip/ || true` — unchanged (doc-only edit).
+
+## Remains
+
+Sibling unclaimed feature issues to refresh other parts of the
+linker-undetected drift surface (#2213, #2215, #2216, #2217, #2218,
+#2219).


### PR DESCRIPTION
Closes #2211

Session: `e2f6cb18-532f-4bb6-953c-8d67433f283f`

b561b60 doc: refresh Priority 2 audit-checklist SECURITY_INVENTORY.md cross-link anchors :151 → :1162 (Decompression Limit Inventory section header) and :151 → :1205 (Recommended policy subsection header)

🤖 Prepared with Claude Code