### PR TITLE
Refresh stale maxEntrySize bomb-rejection regression-test cites — ZipTest/Archive.lean:86 (Zip/Archive.lean:408-410 → :1072-1074, EOCD ZIP64-override mismatch unrelated → maxEntrySize bomb-check guard) and ZipTest/Tar.lean:138 (Zip/Tar.lean:565-566 → :758-759, createDirAll-loop helper unrelated → maxEntrySize tar bomb-check) — 2-file 2-anchor sibling cluster sweep; linker-undetected drift class matching PR #2178/#2186/#2187/#2197 narrative-paragraph/mixed-form/prose precedent (test files not scanned by check-inventory-links.sh); both prose patterns share 'must be rejected before any decompression / payload …' and both source-side targets share the 'if maxEntrySize > 0 && …' guard shape; sibling-cluster across two test files matches the post-#2168 wave's group-1 trio precedent (PRs #2172/#2174/#2177 covering three audit sections)

### DIFF
--- a/ZipTest/Archive.lean
+++ b/ZipTest/Archive.lean
@@ -83,7 +83,7 @@ def ZipTest.Archive.tests : IO Unit := do
       throw (IO.userError s!"zip: CD size limit wrong error: {e}")
 
   -- maxEntrySize bomb regression: an uncompressedSize larger than the limit
-  -- must be rejected before any decompression happens (Zip/Archive.lean:408-410).
+  -- must be rejected before any decompression happens (Zip/Archive.lean:1072-1074).
   let bombSrcDir : System.FilePath := "/tmp/lean-zlib-zip-bomb-src"
   let bombZipPath : System.FilePath := "/tmp/lean-zlib-zip-bomb.zip"
   let bombExtractDir : System.FilePath := "/tmp/lean-zlib-zip-bomb-extract"

--- a/ZipTest/Tar.lean
+++ b/ZipTest/Tar.lean
@@ -135,7 +135,7 @@ def ZipTest.Tar.tests : IO Unit := do
   unless nestedGz == "Nested file content here." do throw (IO.userError s!"tar.gz extract nested: {nestedGz}")
 
   -- maxEntrySize bomb regression: a tar entry whose declared size exceeds
-  -- the limit must be rejected before any payload is read (Zip/Tar.lean:565-566).
+  -- the limit must be rejected before any payload is read (Zip/Tar.lean:758-759).
   let bombSrcDir : System.FilePath := "/tmp/lean-zip-tar-bomb-src"
   let bombTarPath : System.FilePath := "/tmp/lean-zip-tar-bomb.tar"
   let bombExtractDir : System.FilePath := "/tmp/lean-zip-tar-bomb-extract"

--- a/progress/2026-04-26T00-08-06Z_77658f0f.md
+++ b/progress/2026-04-26T00-08-06Z_77658f0f.md
@@ -1,0 +1,50 @@
+# 2026-04-26 — feature session 77658f0f
+
+## Issue claimed
+
+#2215 — Refresh stale maxEntrySize bomb-rejection regression-test cites
+across `ZipTest/Archive.lean:86` and `ZipTest/Tar.lean:138`.
+
+## What landed
+
+2-file 2-anchor doc-only sweep:
+
+- `ZipTest/Archive.lean:86`: `Zip/Archive.lean:408-410` → `:1072-1074`
+  (EOCD ZIP64-override mismatch → readEntryData uncompressedSize guard).
+- `ZipTest/Tar.lean:138`: `Zip/Tar.lean:565-566` → `:758-759`
+  (createDirAll-loop helper → Tar.extract size guard).
+
+Both targets share the public-API `if maxEntrySize > 0 && … > maxEntrySize then`
+guard shape, matching the cited "must be rejected before any decompression /
+payload" semantics.
+
+## Verification
+
+- `grep` checks: stale cites gone, fresh cites present (one each).
+- `awk 'NR==1074' Zip/Archive.lean` →
+  `if maxEntrySize > 0 && entry.uncompressedSize > maxEntrySize then`.
+- `awk 'NR==758' Zip/Tar.lean` →
+  `if maxEntrySize > 0 && e.size > maxEntrySize then`.
+- `bash scripts/check-inventory-links.sh` → `errors=0, warnings=13`
+  (matches issue's expected pre-edit state, unchanged because the linker
+  does not scan `ZipTest/`).
+- `lake build -R` → `Build completed successfully (191 jobs)`.
+
+## Decisions
+
+- Reset agent branch to `origin/master` per the worker-flow reuse
+  procedure: the worktree had uncommitted modifications to off-limits
+  `.claude/CLAUDE.md` plus stray skill-directory edits from a previous
+  session that were not part of this feature.
+- Initial `lake build` failed with "compiled configuration is invalid";
+  re-ran with `-R` to reconfigure. Only build action needed for a
+  comments-only sweep.
+
+## Quality metric delta
+
+`grep -rc sorry Zip/`: unchanged (comments-only).
+
+## What remains
+
+Nothing for this issue. The sibling clusters #2216/#2217/#2218/#2219
+are scoped separately and remain unclaimed.


### PR DESCRIPTION
Closes #2215

Session: `77658f0f-aea9-4df2-bca6-3d7a7aa9c532`

e79d082 chore: progress entry for feature session 77658f0f (#2215)
a60eb11 doc: refresh stale maxEntrySize bomb-rejection regression-test cites — ZipTest/Archive.lean:86 (Zip/Archive.lean:408-410 → :1072-1074) and ZipTest/Tar.lean:138 (Zip/Tar.lean:565-566 → :758-759)

🤖 Prepared with Claude Code