### PR TITLE
Refresh stale ZipTest/ZipFixtures.lean cites in Archive.extract guard cluster (CRC32-mismatch + Binary.isPathSafe) — :606 cites Zip/Archive.lean:1088 (now Binary.readUInt16LE localHdr 8, unrelated) → :1199 (CRC32 mismatch for {label} throw, +111 shift) and :672 cites Zip/Archive.lean:1070 / :1074 (EOCD ZIP64-override mismatch / maxEntrySize bomb-check, unrelated) → :1244 / :1248 (Binary.isPathSafe in Archive.extract); single-file 3-anchor sweep; linker-undetected drift class matching PR #2178/#2186/#2187/#2197 narrative-paragraph/mixed-form/prose precedent (ZipTest/ not scanned by check-inventory-links.sh); sibling Zip/Archive.lean self-cite cluster on the same Archive.extract guards (CRC32-mismatch + isPathSafe + trailing-slash) queued separately; 1-file 3-anchor sweep matches PR #2065 (1-row triple-anchor) precedent on in-row multi-anchor cadence

### DIFF
--- a/ZipTest/ZipFixtures.lean
+++ b/ZipTest/ZipFixtures.lean
@@ -603,7 +603,7 @@ def ZipTest.ZipFixtures.tests : IO Unit := do
   -- `Entry.crc32` verbatim — callers routing on `entry.crc32` saw the
   -- smuggled value) and `Archive.extract` (pre-PR caught the mismatch
   -- only post-extraction via the `"CRC32 mismatch"` guard at
-  -- Zip/Archive.lean:1088, after any I/O work had been performed)
+  -- Zip/Archive.lean:1199, after any I/O work had been performed)
   -- dimensions simultaneously.  Sibling of PR #1773 (stored-method
   -- size invariant) at the CD-parse mathematical-invariant family:
   -- #1773 closes the `compSize == uncompSize` column; this fixture
@@ -669,7 +669,7 @@ def ZipTest.ZipFixtures.tests : IO Unit := do
   -- with the unsafe `path = "../evil.txt"` verbatim (exposing the
   -- full smuggled form to callers that route on `entry.path` before
   -- any filesystem I/O).  The extract-time `Binary.isPathSafe` calls
-  -- at Zip/Archive.lean:1070 / :1074 remain in place as defense-in-
+  -- at Zip/Archive.lean:1244 / :1248 remain in place as defense-in-
   -- depth but are now unreachable for CD-parseable archives via the
   -- public API.  LH and CD name bytes match byte-for-byte, keeping
   -- the CD/LH name-bytes consistency invariant (issue #1722) intact.

--- a/progress/20260426T001253Z_de2521dc.md
+++ b/progress/20260426T001253Z_de2521dc.md
@@ -1,0 +1,47 @@
+# Session de2521dc — feature
+
+**Date (UTC):** 2026-04-26T00:12:53Z
+**Issue:** #2216 — Refresh stale ZipTest/ZipFixtures.lean cites in Archive.extract guard cluster
+
+## Accomplished
+
+Single-file 3-anchor doc-only sweep on `ZipTest/ZipFixtures.lean`:
+
+- `:606` `Zip/Archive.lean:1088` → `:1199` (CRC32 mismatch for {label} throw site, +111 shift)
+- `:672` `Zip/Archive.lean:1070 / :1074` → `:1244 / :1248` (the two
+  `Binary.isPathSafe checkPath` call sites in `Archive.extract`, +174 shift)
+
+All three were stale post-#2110 / post-#2168 archive-layout guard waves;
+old anchors landed on unrelated CD/LH consistency-check helpers
+(`Binary.readUInt16LE localHdr 8` at :1088, EOCD ZIP64-override mismatch
+at :1070, `maxEntrySize` bomb-check at :1074). Linker-undetected drift
+class — `ZipTest/` is not scanned by `scripts/check-inventory-links.sh`.
+
+## Verification
+
+- `lake -R build` succeeds (191 jobs)
+- `bash scripts/check-inventory-links.sh` → `errors=0, warnings=13`
+  (unchanged baseline)
+- Target line content confirmed via `awk`:
+  - `:1199` → `throw (IO.userError s!"zip: CRC32 mismatch for {label}: …")`
+  - `:1244` and `:1248` → both `unless Binary.isPathSafe checkPath do`
+
+## Decisions / Patterns
+
+The issue's verification grep pattern `Zip/Archive\.lean:1248\b` matches
+zero occurrences because the citation is in the form
+`Zip/Archive.lean:1244 / :1248` — the `:1248` part is separated from the
+file-path prefix by ` / `. The same was true for the original `:1074`
+under that pattern. The substantive edit is correct; the grep-count check
+is just a coarse sanity probe and doesn't reflect the in-line `/ :NNNN`
+cadence used in this comment.
+
+## Quality metrics
+
+No code changes; sorry count and test counts unchanged.
+
+## Remaining
+
+Sibling cluster `#2217` (Zip/Archive.lean self-cite cluster on the same
+Archive.extract guards — CRC32-mismatch + isPathSafe + trailing-slash) is
+queued separately and not in scope here.


### PR DESCRIPTION
Closes #2216

Session: `de2521dc-c62f-46b2-82ff-e378a8d6b61e`

9b18752 doc: progress entry for #2216 (ZipFixtures Archive.extract cite refresh)
8786d54 doc: refresh stale ZipTest/ZipFixtures.lean Archive.extract guard cites — :606 → :1199 (CRC32 mismatch throw, +111 shift) and :672 → :1244 / :1248 (Binary.isPathSafe call sites in Archive.extract, +174 shift)

🤖 Prepared with Claude Code