### PR TITLE
Refresh stale Zip/Archive.lean self-cites in Archive.extract guard cluster (CRC32-mismatch + Binary.isPathSafe + trailing-slash) — :655 cites :1070 (EOCD ZIP64-override unrelated) → :1244 and :1074 (maxEntrySize bomb-check unrelated) → :1248 (Binary.isPathSafe call sites in Archive.extract); :659 cites :1068 (path := archiveName, create-side helper unrelated) → :1242 (entry.path.endsWith trailing-slash carve-out); :805 cites :1088 (Binary.readUInt16LE localHdr 8 unrelated) → :1199 (CRC32 mismatch for {label} post-extraction throw); single-file 4-anchor sweep across three CD-parse explainer comments, +111 to +174 shifts from post-#2110 / post-#2168 archive-layout guard waves; linker-undetected drift class matching PR #2178/#2186/#2187/#2197 narrative-paragraph/mixed-form/prose precedent; sibling ZipTest/ZipFixtures.lean cluster (:606 / :672, same target lines) queued separately as #2216; 1-file 4-anchor sweep matches PR #2059 (1-row 4-anchor non-uniform in-row) precedent

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -652,11 +652,11 @@ private def parseCentralDir (data : ByteArray)
     -- the unsafe `path` verbatim — exposing the full smuggled form
     -- to callers who route on `entry.path` before any filesystem
     -- I/O. The extract-time `Binary.isPathSafe` calls in
-    -- `Archive.extract` (around Zip/Archive.lean:1070 and :1074)
+    -- `Archive.extract` (around Zip/Archive.lean:1244 and :1248)
     -- remain in place as defense-in-depth — unreachable for
     -- CD-parseable archives via the public API, but kept for the
     -- precedence-shift story. Mirror the trailing-slash carve-out
-    -- at Zip/Archive.lean:1068: directory entries end with `"/"`
+    -- at Zip/Archive.lean:1242: directory entries end with `"/"`
     -- and `isPathSafe` is checked on the slash-stripped form, so
     -- legitimate directory entries (including the empty-component
     -- case produced by stripping `"/"`) are not tripped. Run on the
@@ -802,7 +802,7 @@ private def parseCentralDir (data : ByteArray)
     -- parsers or CRC-cross-checking callers reject. Pre-PR,
     -- `Archive.extract` caught the mismatch only post-extraction
     -- via the `"CRC32 mismatch"` guard at
-    -- [Zip/Archive.lean:1088](/home/kim/lean-zip/Zip/Archive.lean:1088),
+    -- [Zip/Archive.lean:1199](/home/kim/lean-zip/Zip/Archive.lean:1199),
     -- after any I/O work had been performed; `Archive.list` had no
     -- gate at all. Placed after the stored-method size invariant
     -- so `uncompSize : UInt64` is the resolved value (post-ZIP64)

--- a/progress/20260426T001736Z_a3220ac9.md
+++ b/progress/20260426T001736Z_a3220ac9.md
@@ -1,0 +1,43 @@
+# Progress: 2026-04-26T00:17:36Z — feature session a3220ac9
+
+## Issue claimed
+
+#2217 — Refresh stale `Zip/Archive.lean` self-cites in `Archive.extract`
+guard cluster (CRC32-mismatch + `Binary.isPathSafe` + trailing-slash).
+
+## What was done
+
+Single-file 4-anchor sweep on `Zip/Archive.lean` across three CD-parse
+fixture-explainer comments:
+
+- `:655` — `Binary.isPathSafe` calls: `:1070 → :1244`, `:1074 → :1248`
+  (mixed prefixed-and-bare form; the `:1248` half follows the existing
+  `Zip/Archive.lean:1244 and :1248` style, which the issue verification
+  command's `grep -c 'Zip/Archive\.lean:1248'` would not match — the
+  actual reference is the bare suffix `:1248` after the prefixed `:1244`).
+- `:659` — trailing-slash carve-out: `:1068 → :1242`.
+- `:805` — markdown-link "CRC32 mismatch" post-extraction throw:
+  `:1088 → :1199`.
+
+Comment-only refresh; no source / test logic changes.
+
+## Verification
+
+- `grep -nE 'Zip/Archive\.lean:(1068|1070|1074|1088)' Zip/Archive.lean`
+  → no output (all four stale anchors gone).
+- `awk 'NR==1199 || NR==1242 || NR==1244 || NR==1248' Zip/Archive.lean`
+  → matches expected content
+  (`throw … "zip: CRC32 mismatch …"`, `let checkPath := …`, two
+  `unless Binary.isPathSafe checkPath do` lines).
+- `bash scripts/check-inventory-links.sh` →
+  `errors=0, warnings=13` (unchanged).
+- `lake -R build` → `Build completed successfully (191 jobs)`.
+
+## Quality metric delta
+
+`grep -rc sorry Zip/` unchanged (comment-only edit).
+
+## What remains
+
+Sibling `ZipTest/ZipFixtures.lean` cluster (#2216, same target shifts
+:1088→:1199, :1070→:1244, :1074→:1248) is queued for a separate sweep.


### PR DESCRIPTION
Closes #2217

Session: `a3220ac9-5a34-46c9-83b2-1600eec42601`

e33e9a5 chore: progress entry for #2217
714b64c doc: refresh stale Zip/Archive.lean self-cites in Archive.extract guard cluster

🤖 Prepared with Claude Code