### PR TITLE
Refresh stale Zip/Archive.lean self-cites in writeEndRecords + writeCentralHeader writer-site commentary — single-file 7-anchor sweep across five CD-parse explainer paragraphs (:338 → :142→:152, :371 → :150→:154, :517 → :145/:158→:155/:168, :527 → :146-147/:160-161→:156-157/:170-171, :586 → :121→:131); ~+10 line shifts uniform across writeEndRecords body from documentation/comment expansion (no parser-logic changes); linker-undetected drift class matching PR #2178/#2186/#2187/#2197 narrative-paragraph/mixed-form/prose precedent; 1-file 7-anchor sweep extends prior in-row anchor counts (PR #2059 4-anchor / PR #2135 6-anchor) but stays within 1-file scope as a single 'refresh writer-site cite cluster' sweep

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -335,7 +335,7 @@ private def findEndOfCentralDir (data : ByteArray) (baseOffset : Nat := 0)
             -- equal `SizeOfFixedFields + SizeOfVariableData - 12`, i.e.
             -- `44` (56 fixed bytes minus the 12 bytes of signature +
             -- size field).  Writer-side confirmation:
-            -- `Zip/Archive.lean:142` hard-codes `44`.  A non-44 value is
+            -- `Zip/Archive.lean:152` hard-codes `44`.  A non-44 value is
             -- a parser-differential smuggling vector: lean-zip uses the
             -- fixed 56-byte layout, while a stricter parser trusts the
             -- self-declared length and reads past or short of that.
@@ -368,7 +368,7 @@ private def findEndOfCentralDir (data : ByteArray) (baseOffset : Nat := 0)
             -- beyond the defined spec — either attacker-smuggled
             -- beyond-spec metadata or a parser-differential smuggling
             -- vector against strict readers.  Writer-side at
-            -- `Zip/Archive.lean:150` hard-codes `45` (EOCD64 requires
+            -- `Zip/Archive.lean:154` hard-codes `45` (EOCD64 requires
             -- ZIP64 support, §4.4.3.2), so `45 ≤ 63` holds trivially.
             -- Upper-bound sibling of the lower-bound `≥ 45` check
             -- (issue #1758); the two bounds close the EOCD64
@@ -514,7 +514,7 @@ private def parseCentralDir (data : ByteArray)
   -- EOCD disk-number sanity: lean-zip supports single-disk archives only.
   -- Writer-side confirmation: both fields are hard-coded to 0 (see the
   -- "disk number" comments at the ZIP64 and standard EOCD write sites
-  -- around Zip/Archive.lean:145 and :158). The reader rejects nonzero
+  -- around Zip/Archive.lean:155 and :168). The reader rejects nonzero
   -- values here — post-ZIP64-override — to close the cross-disk
   -- smuggling vector. The two fields are checked together and both
   -- values are reported to make attribution deterministic.
@@ -524,8 +524,8 @@ private def parseCentralDir (data : ByteArray)
   -- EOCD entry-count sanity: `numEntriesThisDisk` and `totalEntries` must
   -- agree on single-disk archives (the only shape lean-zip supports).
   -- Writer-side confirmation: both fields receive the same `numEntries`
-  -- at the EOCD/ZIP64 write sites (see Zip/Archive.lean:146-147 and
-  -- :160-161). Treat `declaredEntries` (post-ZIP64-override `totalEntries`)
+  -- at the EOCD/ZIP64 write sites (see Zip/Archive.lean:156-157 and
+  -- :170-171). Treat `declaredEntries` (post-ZIP64-override `totalEntries`)
   -- as authoritative and report `entriesThisDisk` as the disagreement,
   -- matching the direction of the sibling `totalEntries` check below.
   unless entriesThisDisk == declaredEntries do
@@ -583,7 +583,7 @@ private def parseCentralDir (data : ByteArray)
     -- `0`. Writer-side confirmation: the 46-byte CD header is
     -- `Binary.zeros`-initialised and `pos + 34` is never overwritten (see
     -- the "disk number start (34)" comment at the writer site around
-    -- Zip/Archive.lean:121). Reject early — this is a metadata-only
+    -- Zip/Archive.lean:131). Reject early — this is a metadata-only
     -- dimension and a parser-differential smuggling vector. Mirrors the
     -- archive-level EOCD disk-number check above.
     let diskNumberStart := Binary.readUInt16LE data (pos + 34)

--- a/progress/20260426T004325Z_5549a70a.md
+++ b/progress/20260426T004325Z_5549a70a.md
@@ -1,0 +1,51 @@
+# 2026-04-26T00:43Z — Refresh writeEndRecords + writeCentralHeader writer-site cite cluster (issue #2219)
+
+## Session
+- Type: feature
+- Branch: agent/5549a70a
+- Issue: #2219
+
+## Outcome
+
+Refreshed seven stale `Zip/Archive.lean` self-cites in the
+`parseCentralDir` / EOCD-parse explainer paragraphs that point at the
+`writeEndRecords` / `writeCentralHeader` writer body, all shifted by
+roughly +10 lines after a documentation/comment expansion in the writer
+docstring and section headers.
+
+| Cite | Old | New | What's at the new line |
+|------|-----|-----|------------------------|
+| `:338` | `:142` | `:152` | `buf := Binary.writeUInt64LEAt buf 4 44  -- size of remaining EOCD64` |
+| `:371` | `:150` | `:154` | `buf := Binary.writeUInt16LEAt buf 14 45  -- version needed` |
+| `:517` | `:145` | `:155` | `-- disk number (16) and disk with CD (20): 0 from zeros` |
+| `:517` | `:158` | `:168` | `-- disk number (eocdOff+4), disk with CD (eocdOff+6): 0 from zeros` |
+| `:527` | `:146-147` | `:156-157` | EOCD64 `entries on disk` / `total entries` writes |
+| `:527` | `:160-161` | `:170-171` | Standard EOCD `numEntries16` writes |
+| `:586` | `:121` | `:131` | `-- comment length (32), disk number start (34), internal attrs (36): all 0 from zeros` |
+
+Pure comment refresh — no source/test logic changes.
+
+## Verification
+
+- `grep -c 'Zip/Archive\.lean:142\b' Zip/Archive.lean` → 0
+- `grep -c 'Zip/Archive\.lean:150\b' Zip/Archive.lean` → 0
+- `grep -c 'Zip/Archive\.lean:145 ' Zip/Archive.lean` → 0
+- `grep -c 'Zip/Archive\.lean:146-147' Zip/Archive.lean` → 0
+- `grep -c 'Zip/Archive\.lean:160-161' Zip/Archive.lean` → 0
+- `grep -c 'Zip/Archive\.lean:121' Zip/Archive.lean` → 0
+- `grep -c 'Zip/Archive\.lean:158' Zip/Archive.lean` → 0
+- `bash scripts/check-inventory-links.sh` → `errors=0, warnings=13`
+  (unchanged baseline)
+- `lake build` → succeeds (191 jobs)
+- `lake exe test` → All tests passed!
+
+## Sibling
+
+Issue #2225 covers the related `:322` cite of the writer body range
+(`:141-164` claim now needs to extend to cover `:177` after the
+Standard EOCD writes shifted past the cited range). Out of scope for
+this single-cluster sweep.
+
+## Quality metrics
+
+`grep -rc sorry Zip/` — unchanged (comment-only edit).


### PR DESCRIPTION
Closes #2219

Session: `5549a70a-16fb-4459-ac58-0462d4682ab8`

e8026f1 doc: refresh stale Zip/Archive.lean writer-site self-cites in writeEndRecords + writeCentralHeader explainer paragraphs

🤖 Prepared with Claude Code