### PR TITLE
Refresh stale Zip/Archive.lean self-cite of writeEndRecords body range — :322 cites :141-164 (now extends through :177; current range covers EOCD64+Locator only, leaving Standard EOCD writes at :167-:176 outside the cited range — stale 'three records contiguously' claim covers only two)

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -319,7 +319,7 @@ private def findEndOfCentralDir (data : ByteArray) (baseOffset : Nat := 0)
             -- at line 304 only bounds the record against `data.size`
             -- and therefore remains in place as defense-in-depth but is
             -- strictly weaker than this layout invariant.  Writer-side
-            -- at `Zip/Archive.lean:141-164` emits the three records
+            -- at `Zip/Archive.lean:141-177` emits the three records
             -- contiguously in APPNOTE order, so the invariant holds
             -- trivially for every lean-zip-produced archive.
             -- Archive-level macro sibling: `cdOffset + cdSize ≤ eocdPos`

--- a/progress/20260426T011344Z_bcaeded6.md
+++ b/progress/20260426T011344Z_bcaeded6.md
@@ -1,0 +1,34 @@
+# 2026-04-26T01:13:44Z — feature session
+
+Session UUID: bcaeded6-0a55-48ba-ae3e-7b80091d528e
+Branch: agent/bcaeded6
+
+## Issue
+
+#2225 — Refresh stale Zip/Archive.lean self-cite of writeEndRecords body
+range (:322 cited :141-164, body now extends to :177).
+
+## What was done
+
+`Zip/Archive.lean:322`: `Zip/Archive.lean:141-164` → `Zip/Archive.lean:141-177`.
+
+The cite lives in the EOCD64 archive-layout invariant explainer
+paragraph inside `parseEndOfCentralDir`'s `bufPos + 56 ≤ pos - 20`
+overlap check. The end-anchor :164 only covered EOCD64+Locator
+(:150-:159 + :160-:164), leaving the Standard EOCD writes (:167-:176)
+outside the "three records contiguously" claim. New end-anchor :177
+(`return buf`) covers the full writer body.
+
+Single-file 1-anchor sweep, comment-only edit.
+
+## Verification
+
+- `grep 'Zip/Archive.lean:141-164' Zip/Archive.lean` → no matches (was 1).
+- `grep 'Zip/Archive.lean:141-177' Zip/Archive.lean` → 1 match at :322.
+- `lake build` — clean.
+- `lake exe test` — all tests pass.
+
+## Quality metric deltas
+
+None. Comment-only refresh — no source/test logic, no new sorry, no
+proof changes.


### PR DESCRIPTION
Closes #2225

Session: `bcaeded6-0a55-48ba-ae3e-7b80091d528e`

5c16eff chore: progress entry for #2225
96a93e2 doc: refresh stale Zip/Archive.lean self-cite of writeEndRecords body range

🤖 Prepared with Claude Code