### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md narrative-paragraph cite for ZIP64 EOCD64 record-size check (PR #1761 zip64-eocd64-bad-recsize.zip bullet, Recommended policy section, line 279) — :142 → :152 (writer-side hard-coded `44` Binary.writeUInt64LEAt buf 4 inside writeEndRecords, +10 shift from documentation/comment expansion); 1-row single-anchor narrative-paragraph sweep matching PR #2158/#2164 narrative-paragraph precedent and the post-#2228 writeEndRecords body shift wave; convention pinned to actual Binary.writeUInt64LEAt call (analogous to PR #2153/#2164 writer-side anchor precedent); sibling narrative-paragraph re-anchors at lines 357 (range :148-164 → :148-176) and 652 (CD bit-5 :725 → :728) queued separately

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -276,7 +276,7 @@ Summary — what this pattern catches and what it does not:
     offsets from a hard-coded 56-byte layout; a stricter parser that
     trusts the self-declared length would read past or short of that,
     yielding a parser-differential smuggling vector (writer-side at
-    [Zip/Archive.lean:142](/home/kim/lean-zip/Zip/Archive.lean:142)
+    [Zip/Archive.lean:152](/home/kim/lean-zip/Zip/Archive.lean:152)
     hard-codes `44`). Additional regression coverage from PR #1889
     (`testdata/zip/malformed/zip64-eocd64-v2-record.zip`) pins the
     rejection behaviour against the APPNOTE §4.3.14.2 v2 shape: an

--- a/progress/20260426T011557Z_e491b62e-feature-2229.md
+++ b/progress/20260426T011557Z_e491b62e-feature-2229.md
@@ -1,0 +1,39 @@
+# Feature session: refresh SECURITY_INVENTORY.md:279 cite (issue #2229)
+
+- **Date**: 2026-04-26 01:15 UTC
+- **Session UUID prefix**: e491b62e
+- **Type**: feature
+- **Issue**: #2229
+- **Branch**: agent/e491b62e
+
+## What was done
+
+Refreshed one stale narrative-paragraph cite in `SECURITY_INVENTORY.md:279`:
+
+- `[Zip/Archive.lean:142](/home/kim/lean-zip/Zip/Archive.lean:142)` →
+  `[Zip/Archive.lean:152](/home/kim/lean-zip/Zip/Archive.lean:152)`
+
+The cite anchors PR #1761's "ZIP64 EOCD64 self-declared record-size
+check" bullet to the writer-side hard-coded `44`. After the
+post-#2168 / post-#2228 documentation expansion in `writeEndRecords`,
+`:142` now lands on the def header rather than the
+`Binary.writeUInt64LEAt buf 4 44  -- size of remaining EOCD64` write
+site, which is now at `:152` (+10 lines).
+
+## Verification
+
+- `git diff master..HEAD` shows exactly one file (SECURITY_INVENTORY.md),
+  1 insertion / 1 deletion on line 279 — matches the issue's expected
+  scope.
+- `grep -n 'Zip/Archive.lean:142.*hard-codes' SECURITY_INVENTORY.md` →
+  no matches.
+- `grep -n 'Zip/Archive.lean:152' SECURITY_INVENTORY.md` returns the
+  refreshed cite at line 279.
+- `bash scripts/check-inventory-links.sh` reports `errors=0,
+  warnings=13` — baseline unchanged.
+
+## Remaining work
+
+Two sibling re-anchors are queued separately as #2230 (line 357 range
+:148-164 → :148-176) and #2231 (line 652 :725 → :728). Out of scope
+for this PR per the issue body's one-bullet-per-PR cadence.


### PR DESCRIPTION
Closes #2229

Session: `e491b62e-371d-4380-b470-e066fc138a79`

ebec7af chore: progress entry for issue #2229
a778b54 doc: refresh stale SECURITY_INVENTORY.md narrative-paragraph cite for ZIP64 EOCD64 record-size check (line 279)

🤖 Prepared with Claude Code