### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md Local-guard-inventory introductory-narrative paragraph dual-anchor cluster (lines 1331/1333) — Zip/Archive.lean:980 → :1005 (readExact def) and :994 → :1019 (readExactStream def), uniform +25 shift across both anchors from post-#2110 / post-#2168 archive-layout guard wave; 1-paragraph dual-anchor doc-only sweep matching PR #2065/#2073 in-row multi-anchor cadence; linker-undetected drift class; sibling audit-section #1 single-anchor refresh at line 1167 (same readExact :980 → :1005 anchor in Known Immediate Audit Targets section) queued separately

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1328,9 +1328,9 @@ not untrusted archive bytes, so it falls outside this inventory's
 scope.
 
 Trust-boundary callers reach the actual `.read` primitive via
-`readExact` ([Zip/Archive.lean:980](/home/kim/lean-zip/Zip/Archive.lean:980),
+`readExact` ([Zip/Archive.lean:1005](/home/kim/lean-zip/Zip/Archive.lean:1005),
 [Zip/Tar.lean:218](/home/kim/lean-zip/Zip/Tar.lean:218)),
-`readExactStream` ([Zip/Archive.lean:994](/home/kim/lean-zip/Zip/Archive.lean:994)),
+`readExactStream` ([Zip/Archive.lean:1019](/home/kim/lean-zip/Zip/Archive.lean:1019)),
 `readEntryData` ([Zip/Tar.lean:249](/home/kim/lean-zip/Zip/Tar.lean:249)),
 `skipEntryData` ([Zip/Tar.lean:630](/home/kim/lean-zip/Zip/Tar.lean:630)),
 or open-coded read loops. Each row below names the call site that

--- a/progress/20260426T024425Z_6f8a0e65.md
+++ b/progress/20260426T024425Z_6f8a0e65.md
@@ -1,0 +1,47 @@
+# Feature session 6f8a0e65 — issue #2242
+
+## Date
+2026-04-26 UTC
+
+## Type
+feature (inventory re-anchor)
+
+## Issue
+#2242 — Inventory: re-anchor stale SECURITY_INVENTORY.md Local-guard-inventory
+introductory-narrative paragraph dual-anchor cluster (lines 1331/1333).
+
+## Accomplished
+Re-anchored two stale Zip/Archive.lean cites in the *Local guard inventory
+for `Handle.read` and `Stream.read`* introductory narrative paragraph:
+
+- Line 1331: `:980` → `:1005` (`readExact` def)
+- Line 1333: `:994` → `:1019` (`readExactStream` def)
+
+Both are uniform +25 shifts from the post-#2110 / post-#2168 archive-layout
+guard waves. Convention pinned to the `(partial )def <name>` declaration
+line — matches the sibling Tar cites in the same paragraph.
+
+## Verification
+- `awk 'NR==1005' Zip/Archive.lean` → `private partial def readExact ...` ✓
+- `awk 'NR==1019' Zip/Archive.lean` → `partial def readExactStream ...` ✓
+- `bash scripts/check-inventory-links.sh` → errors=0; warnings=43 (all
+  pre-existing on other lines, not on the changed lines 1331/1333).
+- `lake build -R` → clean (191/191 jobs).
+- `git diff` → exactly the two intended anchor edits, no other changes.
+
+## Decisions / patterns
+- Sibling lines 1167 (Known Immediate Audit Targets section, same
+  `readExact :980 → :1005` anchor) and 1342 (table row `readExactStream`
+  helper) are explicitly out of scope per the issue body — left untouched.
+- Single-paragraph dual-anchor sweep matches PR #2065/#2073 in-row
+  multi-anchor cadence.
+- Linker-undetected drift class — both `[…](…)` forms pass
+  `check-inventory-links.sh`'s URL existence check, so the drift was
+  caught only by the line-content heuristic.
+
+## Quality metric delta
+None applicable — doc-only inventory refresh, no Lean source touched, no
+new sorries, no test changes.
+
+## Remaining
+None for this issue. Sibling issues (line 1167) are queued separately.


### PR DESCRIPTION
Closes #2242

Session: `6f8a0e65-5446-47bb-9a51-6239ce3377ea`

d3efbc9 chore: progress entry for #2242 (Local-guard-inventory paragraph dual-anchor refresh)
26b3ccd doc: re-anchor stale Local-guard-inventory paragraph cites at SECURITY_INVENTORY.md:1331/1333 — Zip/Archive.lean:980 → :1005 (readExact def) and :994 → :1019 (readExactStream def)

🤖 Prepared with Claude Code