### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md Decompression Limit Inventory row 1226 (Archive.list cite) — Zip/Archive.lean:1209 → :1234 (def list, +25 shift from post-#2110 / post-#2168 archive-layout guard waves); 1-row single-anchor doc-only sweep matching PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/#2071/#2082/#2243 1-row tightening cadence; sibling rows 1227-1229 (Archive.extract :1233 → :1258) and 1230-1231 (Archive.extractFile :1278 → :1303) queued separately; linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1223,7 +1223,7 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Zip.Native.GzipDecode.decompress](/home/kim/lean-zip/Zip/Native/Gzip.lean:40) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 1 GiB (unified with `Inflate.inflate` per Rec. 5). |
 | [Zip.Native.ZlibDecode.decompress](/home/kim/lean-zip/Zip/Native/Gzip.lean:140) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 1 GiB (unified with `Inflate.inflate` per Rec. 5). |
 | [Zip.Native.decompressAuto](/home/kim/lean-zip/Zip/Native/Gzip.lean:240) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | format-auto dispatch over the three natives above. |
-| [Archive.list](/home/kim/lean-zip/Zip/Archive.lean:1209) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | metadata-only; caps CD allocation, not decompressed payload. |
+| [Archive.list](/home/kim/lean-zip/Zip/Archive.lean:1234) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | metadata-only; caps CD allocation, not decompressed payload. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap on the decompressed payload. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all entries; intended as a second line of defence against many-small-entries bombs. |

--- a/progress/20260426T024842Z_b658379d.md
+++ b/progress/20260426T024842Z_b658379d.md
@@ -1,0 +1,33 @@
+# 2026-04-26T02:48Z — feature session b658379d
+
+## Issue claimed
+- #2246: Inventory re-anchor — `SECURITY_INVENTORY.md:1226` *Decompression
+  Limit Inventory* `Archive.list` cite, `Zip/Archive.lean:1209 → :1234`.
+
+## Work performed
+- Verified `Zip/Archive.lean:1234` is the current `def list (inputPath :
+  System.FilePath) (maxCentralDirSize : Nat := 67108864) : IO (Array
+  Entry) :=` declaration (matches the *Decompression Limit Inventory*
+  convention of citing each public API at its `(partial )def <name>` line).
+- Confirmed `:1209` lands inside an unrelated `if entry.method == 8`
+  branch in `readEntryData`.
+- Updated the markdown link target on `SECURITY_INVENTORY.md:1226` from
+  `Zip/Archive.lean:1209` to `Zip/Archive.lean:1234`.
+- Verified `grep -n "Zip/Archive.lean:1209" SECURITY_INVENTORY.md`
+  returns no hits.
+- Verified `bash scripts/check-inventory-links.sh` no longer warns at
+  line 1226 (other warnings are sibling queued issues).
+- Verified `lake -R build` succeeds (191/191).
+
+## Decisions
+- One-row, single-anchor, doc-only sweep — matches the cadence cited in
+  the issue body.
+- Sibling rows 1227-1229 (`Archive.extract` `:1233 → :1258`) and
+  1230-1231 (`Archive.extractFile` `:1278 → :1303`) are queued as
+  separate issues (#2247, #2248) — not touched here.
+
+## Quality metric
+- `grep -rc sorry Zip/` unchanged (doc-only edit).
+
+## Outcome
+- Single commit on `agent/b658379d`. PR to follow.


### PR DESCRIPTION
Closes #2246

Session: `b658379d-8feb-4dc4-b3fc-948c8708c8a0`

9568312 chore: add progress entry for #2246
e3e2b18 Inventory: re-anchor stale SECURITY_INVENTORY.md Decompression Limit Inventory row 1226 (Archive.list cite) — Zip/Archive.lean:1209 → :1234 (def list, +25 shift from post-#2110 / post-#2168 archive-layout guard waves and rationale-comment block expansion); 1-row single-anchor doc-only sweep matching PR #1985/#1994/#1998/#1999/#2000/#2005/#2008/#2012/#2014/#2017/#2068/#2071/#2082/#2243 1-row tightening cadence; current :1209 lands inside an unrelated `if entry.method == 8` branch in readEntryData, not on the def list declaration; convention pinned to the (partial )def <name> declaration line per Decompression Limit Inventory table convention; sibling rows 1227-1229 (Archive.extract :1233 → :1258) and 1230-1231 (Archive.extractFile :1278 → :1303) queued separately as distinct anchors; linker-undetected drift class — the [...](...) form passes check-inventory-links.sh's URL existence check (Zip/Archive.lean has more than 1209 lines)

🤖 Prepared with Claude Code