### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md Decompression Limit Inventory rows 1227-1229 (Archive.extract three-row cluster — maxCentralDirSize / maxEntrySize / maxTotalSize) — Zip/Archive.lean:1233 → :1258 (def extract, +25 shift from post-#2110 / post-#2168 archive-layout guard waves); 3-row same-anchor doc-only sweep matching PR #1995/#1959/#2004 multi-row same-anchor precedent (all three rows share the def extract anchor, distinguished by parameter name); sibling rows 1226 (Archive.list :1209 → :1234) and 1230-1231 (Archive.extractFile :1278 → :1303) queued separately; linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1224,9 +1224,9 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Zip.Native.ZlibDecode.decompress](/home/kim/lean-zip/Zip/Native/Gzip.lean:140) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | no unlimited mode; default is 1 GiB (unified with `Inflate.inflate` per Rec. 5). |
 | [Zip.Native.decompressAuto](/home/kim/lean-zip/Zip/Native/Gzip.lean:240) | `maxOutputSize : Nat` | `1 * 1024^3` (1 GiB) | hard cap at 0 bytes (explicit) | format-auto dispatch over the three natives above. |
 | [Archive.list](/home/kim/lean-zip/Zip/Archive.lean:1209) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | metadata-only; caps CD allocation, not decompressed payload. |
-| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
-| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap on the decompressed payload. |
-| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all entries; intended as a second line of defence against many-small-entries bombs. |
+| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1258) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
+| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1258) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap on the decompressed payload. |
+| [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1258) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all entries; intended as a second line of defence against many-small-entries bombs. |
 | [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1278) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
 | [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1278) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap. |
 | [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:651](/home/kim/lean-zip/Zip/Tar.lean:651)). |


### PR DESCRIPTION
Closes #2247

Session: `95a10d82-38ef-412d-94bc-e7ee0b0185b2`

a94aa4b doc: re-anchor SECURITY_INVENTORY.md Decompression Limit Inventory rows 1227-1229 to Archive.extract :1258

🤖 Prepared with Claude Code