### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md Decompression Limit Inventory rows 1230-1231 (Archive.extractFile two-row cluster — maxCentralDirSize / maxEntrySize) — Zip/Archive.lean:1278 → :1303 (def extractFile, +25 shift from post-#2110 / post-#2168 archive-layout guard waves); 2-row same-anchor doc-only sweep matching PR #2004 multi-row same-anchor precedent; sibling rows 1226 (Archive.list :1209 → :1234) and 1227-1229 (Archive.extract :1233 → :1258) queued separately; linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1227,8 +1227,8 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap on the decompressed payload. |
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all entries; intended as a second line of defence against many-small-entries bombs. |
-| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1278) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
-| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1278) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap. |
+| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1303) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
+| [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1303) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap. |
 | [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:651](/home/kim/lean-zip/Zip/Tar.lean:651)). |
 | [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all regular-file entries; directories and symlinks contribute zero. |
 | [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |

--- a/progress/2026-04-26T0245_3bc16e01.md
+++ b/progress/2026-04-26T0245_3bc16e01.md
@@ -1,0 +1,25 @@
+# Session 3bc16e01 — feature
+
+UTC: 2026-04-26T02:45
+
+## Issue
+#2248 — Inventory re-anchor: SECURITY_INVENTORY.md rows 1230-1231
+(Archive.extractFile two-row cluster), Zip/Archive.lean:1278 → :1303.
+
+## Accomplished
+- Refreshed both `[Archive.extractFile](…/Zip/Archive.lean:1278)` cites
+  to `:1303` (def extractFile declaration, +25 line shift from
+  post-#2110 / post-#2168 archive-layout guard waves).
+- Verified `awk 'NR==1303' Zip/Archive.lean` lands on the
+  `def extractFile (inputPath : System.FilePath) (filename : String)`
+  declaration line.
+- Verified `grep -n "Zip/Archive.lean:1278" SECURITY_INVENTORY.md` is
+  empty after the edit (no other rows cite :1278).
+- `bash scripts/check-inventory-links.sh` warnings at lines 1230 and
+  1231 disappeared. Other warnings unchanged (sibling rows queued
+  separately).
+- `lake build -R` clean.
+
+## Quality metrics
+- sorry count unchanged (doc-only).
+- Build green.


### PR DESCRIPTION
Closes #2248

Session: `3bc16e01-f57d-42ab-a390-a3b5f9c1579a`

f395db1 doc: progress entry for session 3bc16e01 (#2248 inventory re-anchor)
089cd4b doc: re-anchor SECURITY_INVENTORY.md Decompression Limit Inventory rows 1230-1231 (Archive.extractFile two-row cluster)

🤖 Prepared with Claude Code