### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md narrative-paragraph cite L478 (PR #1773 CD-entry stored-method size invariant bullet) — Zip/Archive.lean:1201 → :1226 'size mismatch' throw, +25 shift from post-#2110 / post-#2168 archive-layout guard waves; 1-row single-anchor narrative-paragraph sweep matching PR #2240/#2243/#2244/#2255/#2256/#2258/#2261/#2266/#2275/#2276/#2277/#2278/#2279/#2281 1-row tightening cadence; predecessor closed PR #2124 (:976 → :1201 +225 wave); current :1201 lands on the unrelated 'unless localCrc == entry.crc32 do' line (CRC32-mismatch unless-line, not size-mismatch throw); sibling narrative-paragraph re-anchors at lines 529+541 (:1081 → :1106 'bad local header signature') and line 854 (:1199 → :1224 'CRC32 mismatch') queued separately; linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -475,7 +475,7 @@ Summary — what this pattern catches and what it does not:
     catches intra-CD invariant violation with no CD/LH divergence. Also
     makes the anomaly visible to `Archive.list`, which never reaches the
     late post-decode `"size mismatch"` guard at
-    [Zip/Archive.lean:1201](/home/kim/lean-zip/Zip/Archive.lean:1201).
+    [Zip/Archive.lean:1226](/home/kim/lean-zip/Zip/Archive.lean:1226).
     Net-new dimension observed during the CD-parse guard coverage
     sweep — the *Missing work* block had not previously flagged the
     stored-method invariant

--- a/progress/20260426T044104Z_1c8f68e2.md
+++ b/progress/20260426T044104Z_1c8f68e2.md
@@ -1,0 +1,31 @@
+# Session 1c8f68e2 — feature
+
+**UTC**: 2026-04-26T04:41:04Z
+**Type**: feature (inventory re-anchor)
+**Issue**: #2282
+
+## Accomplished
+
+Re-anchored `SECURITY_INVENTORY.md` line 478 narrative-paragraph cite
+from `Zip/Archive.lean:1201` → `:1226` (PR #1773 CD-entry stored-method
+size invariant bullet pointing at the late post-decode `"size mismatch"`
+throw). +25 shift consistent with the post-#2110 / post-#2168
+archive-layout guard waves; predecessor PR #2124 had pinned the
+previous wave at `:976 → :1201`.
+
+## Verification
+
+- `bash scripts/check-inventory-links.sh` → errors=0, warnings=18
+  (all pre-existing warnings, none on line 478).
+- `grep -n 'Zip/Archive.lean:1201' SECURITY_INVENTORY.md` → 0 matches
+  (only stale cite of `:1201` was line 478).
+- `sed -n '1226p' Zip/Archive.lean` →
+  `throw (IO.userError s!"zip: size mismatch for {label}")` ✓
+
+## Notes
+
+Single-anchor narrative-paragraph sweep matching the recent
+linker-undetected refresh cadence (#2240/#2243/#2244/#2255/#2256/#2258/
+#2261/#2266/#2275/#2276/#2277/#2278/#2279/#2281). Sibling rows 529/541
+(bad-LH-signature) and 854 (CRC32-mismatch) still queued separately
+(#2283 / #2284) — out of scope for this issue.


### PR DESCRIPTION
Closes #2282

Session: `1c8f68e2-3e75-4b30-abab-5c12325625da`

05f085b chore: progress entry for #2282 inventory re-anchor
bf4b936 doc: re-anchor SECURITY_INVENTORY.md L478 size-mismatch cite (:1201 → :1226)

🤖 Prepared with Claude Code