### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md narrative-paragraph dual cite L434 + L437 (ZIP64 duplicate-0x0001 extra-field paragraph — hasDuplicateZip64Extra CD/LH callers) — Zip/Archive.lean:742 → :767 (CD-side caller in parseCentralDir) + :1123 → :1148 (LH-side caller in readEntryData), uniform +25 shift from post-#2110 / post-#2168 archive-layout guard waves; 1-paragraph narrative dual-anchor sweep matching PR #2266 / PR #1995 / PR #1959 / PR #2004 multi-anchor precedent; convention pinned to the hasDuplicateZip64Extra *call line* (do NOT use surrounding validateExtraFieldStructure :763/:1141 anchors which belong to row 1472 PR #2279); current :742 + :1123 both land inside unrelated comment blocks; sibling :449 def line + :73-80 / :66-71 writer-side anchors in the same paragraph remain fresh; linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -432,9 +432,9 @@ Summary — what this pattern catches and what it does not:
     [Zip/Archive.lean:449](/home/kim/lean-zip/Zip/Archive.lean:449)
     walks the TLV structure once and is invoked by both the CD-side
     caller in `parseCentralDir`
-    ([Zip/Archive.lean:742](/home/kim/lean-zip/Zip/Archive.lean:742))
+    ([Zip/Archive.lean:767](/home/kim/lean-zip/Zip/Archive.lean:767))
     and the LH-side caller in `readEntryData`
-    ([Zip/Archive.lean:1123](/home/kim/lean-zip/Zip/Archive.lean:1123))
+    ([Zip/Archive.lean:1148](/home/kim/lean-zip/Zip/Archive.lean:1148))
     before `parseZip64Extra` is called. The two error wordings
     (`"duplicate ZIP64 extra field"` vs `"duplicate ZIP64 local extra
     field"`) keep attribution distinct between layers. Sibling of the

--- a/progress/2026-04-26T05-15-12Z_65d9b87d.md
+++ b/progress/2026-04-26T05-15-12Z_65d9b87d.md
@@ -1,0 +1,31 @@
+# Session 65d9b87d — Inventory re-anchor: hasDuplicateZip64Extra callers (L434+L437)
+
+## Issue
+#2288 — Inventory: re-anchor stale SECURITY_INVENTORY.md narrative-paragraph
+dual cite L434 + L437 (hasDuplicateZip64Extra CD/LH callers), uniform +25
+shift from post-#2110 / post-#2168 archive-layout guard waves.
+
+## Deliverables
+
+Doc-only sweep on `SECURITY_INVENTORY.md`:
+
+- L434 caller-cite for `parseCentralDir`: `Zip/Archive.lean:742` → `:767`
+  (Markdown link text + URL fragment).
+- L437 caller-cite for `readEntryData`: `Zip/Archive.lean:1123` → `:1148`
+  (Markdown link text + URL fragment).
+
+Sibling anchors in the same paragraph (`:449` def, `:73-80` writer central,
+`:66-71` writer local) were already fresh and were not touched.
+
+## Verification
+
+- `grep -n "hasDuplicateZip64Extra" Zip/Archive.lean` confirms the live call
+  sites land on `:767` (CD-side) and `:1148` (LH-side).
+- `bash scripts/check-inventory-links.sh` reports `errors=0, warnings=18`,
+  unchanged from pre-edit state — no warning references L434/L437 or the
+  `:742`/`:1123` anchors. Narrative-paragraph cites are not subject to the
+  substring-window heuristic, as anticipated by the issue body.
+
+## Quality metric
+
+`grep -rc sorry Zip/` unchanged — no source file changes.


### PR DESCRIPTION
Closes #2288

Session: `65d9b87d-f633-4379-ac31-355974a1a1e0`

b25334d chore: progress entry for #2288
bbf492d doc: re-anchor inventory L434+L437 :742->:767, :1123->:1148 (hasDuplicateZip64Extra callers)

🤖 Prepared with Claude Code