### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md narrative-paragraph cite L834 (PR #1857 CD-entry empty-entry CRC invariant primary anchor) — Zip/Archive.lean:820 → :845 'CD entry CRC must be zero when uncompressedSize is zero' throw, +25 shift from post-#2110 / post-#2168 archive-layout guard waves; 1-row single-anchor narrative-paragraph sweep matching PR #2240/#2243/#2244/#2255/#2256/#2258/#2261/#2266/#2275/#2276/#2277/#2278/#2279/#2281/#2287 1-row tightening cadence; current :820 lands on an unrelated self-reference comment line (-- [Zip/Archive.lean:189]...); sibling cites L854 + L1466 (:1199 → :1224) queued separately as #2284; sibling Reproducer Corpus row 1465 (cd-deflate-zero-compsize.zip Zip/Archive.lean:854 → :879) queued separately for next planner; linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -831,7 +831,7 @@ Summary — what this pattern catches and what it does not:
     (`testdata/zip/malformed/cd-empty-entry-crc-nonzero.zip`) rejects
     CD entries whose `uncompressedSize == 0` with any nonzero `crc32`
     at `parseCentralDir` time
-    ([Zip/Archive.lean:820](/home/kim/lean-zip/Zip/Archive.lean:820)),
+    ([Zip/Archive.lean:845](/home/kim/lean-zip/Zip/Archive.lean:845)),
     post-ZIP64-resolution, after the stored-method size invariant.
     APPNOTE §4.4.7 defines the CRC32 field as the ANSI-CRC-32 of the
     uncompressed payload; the empty byte string has CRC32 `0x00000000`

--- a/progress/20260426T051728Z_eb518eb6.md
+++ b/progress/20260426T051728Z_eb518eb6.md
@@ -1,0 +1,47 @@
+# Session eb518eb6 — feature
+
+Date: 2026-04-26T05:17Z
+Type: feature (inventory anchor refresh)
+Issue: #2290
+
+## What was done
+
+Refreshed `SECURITY_INVENTORY.md` line 834 stale source-line cite from
+`Zip/Archive.lean:820` to `:845` — the `parseCentralDir` throw site for
+"CD entry CRC must be zero when uncompressedSize is zero" (PR #1857
+CD-entry empty-entry CRC invariant rejection bullet).
+
++25 shift from post-#2110 / post-#2168 archive-layout guard waves;
+linker-undetected drift class.
+
+## Verification
+
+- `grep -n 'CD entry CRC must be zero' Zip/Archive.lean` → `:845`
+- `grep -n 'Zip/Archive.lean:820' SECURITY_INVENTORY.md` → no
+  occurrences
+- `grep -nc 'Zip/Archive.lean:845' SECURITY_INVENTORY.md` → 2 (L834
+  newly refreshed + L1466 already fresh, confirming convention)
+- `bash scripts/check-inventory-links.sh` → 0 errors, 18 pre-existing
+  warnings (unchanged by this PR — the row was not flagged)
+- `git diff master..HEAD` → 1 file (`SECURITY_INVENTORY.md`),
+  1 insertion / 1 deletion on a single line
+
+## Quality metrics
+
+- sorry count: unchanged (doc-only edit)
+- Build: not run (doc-only)
+- Tests: not run (doc-only)
+
+## Decisions
+
+- Followed the issue's "do not also touch L854 / L1466" guidance. L854
+  already shows `:1224` (PR #2284 had merged before claim, per
+  `git log --oneline`), and L1466 was already correctly cited at
+  `:845` per the issue body — this PR only edits L834.
+
+## What remains
+
+Sibling unclaimed inventory issues for the next worker:
+- #2292 — Reproducer Corpus row 1465 cd-deflate-zero-compsize.zip
+  `:854 → :879`
+- #2293 — narrative-paragraph cite L515 `:771 → :796`


### PR DESCRIPTION
Closes #2290

Session: `eb518eb6-62ee-47f5-837c-bcd493ff88df`

fe30314 chore: progress entry for #2290
3fddf88 doc: re-anchor SECURITY_INVENTORY.md L834 :820 -> :845 (CD-entry empty-entry CRC invariant)

🤖 Prepared with Claude Code