### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md narrative-paragraph cite L515 (PR #1813 CD-entry localOffset+30 ≤ cdOffset archive-layout invariant bullet inside *Recommended policy* / *Closed in this batch*) — Zip/Archive.lean:771 → :796 'entry local offset overlaps central directory' parseCentralDir per-entry archive-layout micro-invariant throw, +25 shift from post-#2110 / post-#2168 archive-layout guard waves; 1-row single-anchor narrative-paragraph sweep matching PR #2240/#2243/#2244/#2255/#2256/#2258/#2261/#2266/#2275/#2276/#2277/#2278/#2279/#2281/#2287/#2289 1-row tightening cadence; current :771 lands on the unrelated 'malformed ZIP64 extra field' throw inside parseZip64Extra; sibling Reproducer Corpus row 1470 already refreshed by PR #2276; sibling writer-side cite at L519 :192 stays fresh; linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -512,7 +512,7 @@ Summary — what this pattern catches and what it does not:
     rejects CD entries whose resolved `localOffset` plus the 30-byte
     fixed LH header (APPNOTE §4.3.7) reaches into or past the CD
     region at `parseCentralDir` time
-    ([Zip/Archive.lean:771](/home/kim/lean-zip/Zip/Archive.lean:771)).
+    ([Zip/Archive.lean:796](/home/kim/lean-zip/Zip/Archive.lean:796)).
     APPNOTE §4.3.6 pins the archive layout as `[LH+data]* [CD]
     [EOCD]`, so every entry's LH must be readable strictly before the
     CD start; writer-side at

--- a/progress/20260426T054451Z_537cd880.md
+++ b/progress/20260426T054451Z_537cd880.md
@@ -1,0 +1,35 @@
+# Progress: feature session 537cd880
+
+- **Date (UTC):** 2026-04-26T05:44:51Z
+- **Session type:** feature
+- **Issue:** #2293
+- **Branch:** `agent/537cd880`
+
+## What was accomplished
+
+Closed #2293 — re-anchored stale `SECURITY_INVENTORY.md:515` cite from
+`Zip/Archive.lean:771` to `:796` ('entry local offset overlaps central
+directory' throw inside `parseCentralDir`). Standard `+25` shift from
+the post-#2110 / post-#2168 archive-layout guard waves.
+
+## Verification
+
+- `awk 'NR==796' Zip/Archive.lean` confirms the entry-localoffset throw.
+- `awk 'NR==771' Zip/Archive.lean` confirms the unrelated ZIP64 throw.
+- `grep -o 'Zip/Archive\.lean:771' SECURITY_INVENTORY.md | wc -l`:
+  4 → 2 (dropped by 2).
+- `grep -o 'Zip/Archive\.lean:796' SECURITY_INVENTORY.md | wc -l`:
+  2 → 4 (increased by 2).
+- `bash scripts/check-inventory-links.sh` reports `errors=0,
+  warnings=18` (unchanged on this row).
+- `lake build -R` clean (191/191 jobs).
+
+## Quality metrics
+
+- Doc-only edit; no code change.
+- `grep -rc sorry Zip/` unchanged.
+
+## Remaining
+
+None for this row. Sibling rows 1470 (Reproducer Corpus) already closed
+by PR #2276; sibling writer-side cite at L519 :192 stays fresh.


### PR DESCRIPTION
Closes #2293

Session: `537cd880-524c-4ce4-804b-21faeb7bc18e`

3164bd6 chore: progress entry for #2293 (537cd880)
6ea5245 doc: re-anchor inventory L515 :771 -> :796 (entry-localoffset overlap)

🤖 Prepared with Claude Code