### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md narrative-paragraph cite cluster lines 764+765+768 (PR #1840 CD-entry path-safety rejection bullet, extract-time Binary.isPathSafe defense-in-depth + trailing-slash carve-out cluster) — Zip/Archive.lean:1244 → :1269 (first Binary.isPathSafe call in extract) + :1248 → :1273 (second Binary.isPathSafe call in extract) + :1242 → :1267 (trailing-slash carve-out checkPath), uniform +25 shift from post-#2110 / post-#2168 archive-layout guard waves; 1-paragraph 3-anchor sweep matching PR #2266 / PR #2294 / PR #1995 / PR #1959 / PR #2004 multi-anchor narrative-paragraph precedent; current :1244 / :1248 / :1242 all land inside unrelated docstring-comment text in the def extract documentation block; sibling rows 750 (:676) / 752 (:633-643) / 754 (:696) / 773 (:84) in same bullet stay out of scope (early-section anchors not affected by the +25 wave); linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -761,11 +761,11 @@ Summary — what this pattern catches and what it does not:
     unsafe `path` verbatim — exposing the full smuggled form to
     callers who route on `entry.path` before any filesystem I/O. The
     extract-time `Binary.isPathSafe` calls at
-    [Zip/Archive.lean:1244](/home/kim/lean-zip/Zip/Archive.lean:1244)
-    and :1248 remain in place as defense-in-depth but are now
+    [Zip/Archive.lean:1269](/home/kim/lean-zip/Zip/Archive.lean:1269)
+    and :1273 remain in place as defense-in-depth but are now
     unreachable for CD-parseable archives via the public API. Mirrors
     the trailing-slash carve-out at
-    [Zip/Archive.lean:1242](/home/kim/lean-zip/Zip/Archive.lean:1242)
+    [Zip/Archive.lean:1267](/home/kim/lean-zip/Zip/Archive.lean:1267)
     (directory entries end with `"/"`, checked on the slash-stripped
     form) so legitimate directory entries are not tripped. Quotes the
     name via `String.quote` so control bytes from the smuggled name

--- a/progress/20260426T055629Z_03731e34.md
+++ b/progress/20260426T055629Z_03731e34.md
@@ -1,0 +1,44 @@
+# Session 03731e34 — feature
+
+## Summary
+
+Closed #2296: re-anchored stale `SECURITY_INVENTORY.md` narrative-paragraph
+cite cluster lines 764+765+768 (PR #1840 CD-entry path-safety rejection
+bullet, extract-time `Binary.isPathSafe` defense-in-depth + trailing-slash
+carve-out cluster) — `Zip/Archive.lean:1244` → `:1269` (first
+`Binary.isPathSafe` call), `:1248` → `:1273` (second), `:1242` → `:1267`
+(trailing-slash carve-out checkPath). Uniform +25 shift consistent with
+post-#2110 / post-#2168 archive-layout-guard wave.
+
+## Verification
+
+- `grep -n "Binary.isPathSafe" Zip/Archive.lean` confirms `:1269` and
+  `:1273` are the two extract-time calls.
+- `grep -n "endsWith" Zip/Archive.lean` confirms `:1267` is the
+  trailing-slash carve-out `let checkPath` line.
+- `git grep "Zip/Archive.lean:1244\|:1248\|:1242"` returns one remaining
+  hit at SECURITY_INVENTORY.md:1482 (Reproducer Corpus row queued
+  separately as #2300 per issue body).
+- `./scripts/check-inventory-links.sh` errors=0; warning count
+  unchanged (18, all unrelated lines).
+
+## Quality metrics
+
+- sorry count: unchanged (doc-only edit).
+
+## Decisions
+
+- Followed the `inventory-reconciliation` convention of citing the
+  *call line* (the `unless Binary.isPathSafe` line, the
+  `let checkPath` line) rather than surrounding documentation lines,
+  matching PR #2294's precedent for `hasDuplicateZip64Extra`.
+- Preserved dual-anchor structure for the two `Binary.isPathSafe` call
+  sites (`:1269` directory branch, `:1273` regular-file branch) — they
+  are distinct enforcement points, not consolidation candidates.
+
+## What remains
+
+- #2300 (sibling Reproducer Corpus row 1482 secondary side-mention) is a
+  separate unclaimed work item.
+- #2297 (audit-section header line 1194) and other +25-shift drift rows
+  remain in the queue.


### PR DESCRIPTION
Closes #2296

Session: `03731e34-abd4-48b2-97e2-9798b55663aa`

0a64e32 doc: re-anchor SECURITY_INVENTORY.md path-safety cite cluster L764+L765+L768 (#2296)

🤖 Prepared with Claude Code