### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md '### 3. Unlimited decompression knobs' audit-section header cite (line 1194) — Zip/Archive.lean:1233 → :1258 (def extract, +25 shift from post-#2110 / post-#2168 archive-layout guard waves); 1-anchor doc-only sweep matching PR #2174 / PR #2177 / PR #2254 audit-section header anchor refresh trio precedent (sections 1 readExact :1005, 2 splitPath :317 stay current; section 3 def extract drifts +25 again); identical underlying shift to in-flight PR #2257 / issue #2247 (Decompression Limit Inventory rows 1227-1229 :1233 → :1258) but distinct inventory location (audit-section header at line 1194 vs. table-row anchors at lines 1227-1229) — must NOT be conflated; current :1233 lands on the closing -/ of def list doc comment block (unrelated); sibling Zip/Basic.lean:9 cite on line 1193 stays out of scope; linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1191,7 +1191,7 @@ Regression fixtures live under `testdata/tar/security/`:
 
 - Files:
   - [Zip/Basic.lean](/home/kim/lean-zip/Zip/Basic.lean:9)
-  - [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:1233)
+  - [Zip/Archive.lean](/home/kim/lean-zip/Zip/Archive.lean:1258)
 - Concern:
   - `0 = no limit` is convenient but weak as a default for hostile inputs
 - Needed:

--- a/progress/2026-04-26T0700_cbc3ee48.md
+++ b/progress/2026-04-26T0700_cbc3ee48.md
@@ -1,0 +1,17 @@
+# 2026-04-26T07:00 UTC — feature session cbc3ee48
+
+## Issue
+#2297 — Re-anchor SECURITY_INVENTORY.md L1194 audit-section header cite for *Known Immediate Audit Targets §3 (Unlimited decompression knobs)*: `Zip/Archive.lean:1233` → `:1258` (`def extract`).
+
+## What landed
+- Single link change at SECURITY_INVENTORY.md:1194 (bracketed `:1258` + href). +25 shift consistent with the post-#2110 / post-#2168 archive-layout-guard wave.
+- Sibling table rows 1227–1229 (queued as #2247 / PR #2257) untouched — verified post-edit that all remaining `:1233` occurrences are in those rows.
+- Sibling `Zip/Basic.lean:9` cite on line 1193 verified current and out of scope.
+
+## Verification
+- `grep -n "^def extract " Zip/Archive.lean` → `1258:def extract …` ✓
+- `./scripts/check-inventory-links.sh` → errors=0 (warnings unchanged from pre-edit baseline; none reference L1194)
+- `git diff` confirms a single-line change.
+
+## Quality metric delta
+None (doc-only edit, no Lean files touched).


### PR DESCRIPTION
Closes #2297

Session: `cbc3ee48-3126-4c90-8db3-08d90b3e70dd`

e01442c chore: progress entry for feature session cbc3ee48 (#2297)
dd01087 doc: re-anchor SECURITY_INVENTORY.md L1194 audit-section header cite (#2297)

🤖 Prepared with Claude Code