### PR TITLE
Refresh stale Zip/Archive.lean source-side inline self-references in parseCentralDir explainer comments — :655 cites :1244+:1248 → :1269+:1273 (extract-time Binary.isPathSafe call sites in Archive.extract / Archive.extractFile) + :659 cites :1242 → :1267 (trailing-slash carve-out endsWith) + :830 cites :1199 → :1224 (late CRC32-mismatch post-extraction throw); single-file 4-anchor source-side comment sweep, uniform +25 shift from post-#2110 / post-#2168 archive-layout guard waves; predecessor closed PR #2217 (same anchor cluster, prior wave); sibling source-side cluster PR #2219 (writeEndRecords/writeCentralHeader writer-site self-cites) covered a different cluster; inventory-side counterparts queued separately (in-flight #2300 + closed PR #2291); linker-undetected drift class (scripts/check-inventory-links.sh does not scan source files)

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -652,11 +652,11 @@ private def parseCentralDir (data : ByteArray)
     -- the unsafe `path` verbatim — exposing the full smuggled form
     -- to callers who route on `entry.path` before any filesystem
     -- I/O. The extract-time `Binary.isPathSafe` calls in
-    -- `Archive.extract` (around Zip/Archive.lean:1244 and :1248)
+    -- `Archive.extract` (around Zip/Archive.lean:1269 and :1273)
     -- remain in place as defense-in-depth — unreachable for
     -- CD-parseable archives via the public API, but kept for the
     -- precedence-shift story. Mirror the trailing-slash carve-out
-    -- at Zip/Archive.lean:1242: directory entries end with `"/"`
+    -- at Zip/Archive.lean:1267: directory entries end with `"/"`
     -- and `isPathSafe` is checked on the slash-stripped form, so
     -- legitimate directory entries (including the empty-component
     -- case produced by stripping `"/"`) are not tripped. Run on the
@@ -827,7 +827,7 @@ private def parseCentralDir (data : ByteArray)
     -- parsers or CRC-cross-checking callers reject. Pre-PR,
     -- `Archive.extract` caught the mismatch only post-extraction
     -- via the `"CRC32 mismatch"` guard at
-    -- [Zip/Archive.lean:1199](/home/kim/lean-zip/Zip/Archive.lean:1199),
+    -- [Zip/Archive.lean:1224](/home/kim/lean-zip/Zip/Archive.lean:1224),
     -- after any I/O work had been performed; `Archive.list` had no
     -- gate at all. Placed after the stored-method size invariant
     -- so `uncompSize : UInt64` is the resolved value (post-ZIP64)

--- a/progress/20260426T072601Z_f28b6846.md
+++ b/progress/20260426T072601Z_f28b6846.md
@@ -1,0 +1,62 @@
+# Progress entry: 2026-04-26 07:26 UTC
+
+- Session type: feature
+- Session UUID prefix: f28b6846
+- Issue: #2304 — Refresh stale `Zip/Archive.lean` source-side inline
+  self-references in `parseCentralDir` explainer comments
+
+## What was accomplished
+
+Refreshed three source-side inline self-references in the
+`parseCentralDir` explainer comments — uniform +25 line-number shift
+from the post-#2110 / post-#2168 archive-layout guard waves:
+
+- `Zip/Archive.lean:655`: `(around Zip/Archive.lean:1244 and :1248)`
+  → `(around Zip/Archive.lean:1269 and :1273)`. Extract-time
+  `Binary.isPathSafe` guard pair (directory + file branches inside
+  `Archive.extract`'s per-entry loop).
+- `Zip/Archive.lean:659`: `at Zip/Archive.lean:1242` →
+  `at Zip/Archive.lean:1267`. Trailing-slash carve-out
+  `endsWith "/"` line.
+- `Zip/Archive.lean:830`: `[Zip/Archive.lean:1199](/.../Zip/Archive.lean:1199)`
+  → `[Zip/Archive.lean:1224](/.../Zip/Archive.lean:1224)`. Late
+  post-extraction `"CRC32 mismatch"` throw — markdown link text + href URL.
+
+Total: 1 file, 3 commit-line edits, 4 anchor shifts. No logic change.
+
+## Verification
+
+- `lake -R build` → 191/191 jobs successful.
+- `bash scripts/check-inventory-links.sh` → 0 errors, 18 warnings
+  (unchanged baseline — no SECURITY_INVENTORY.md edits in this PR).
+- `grep -nE 'Zip/Archive\.lean:(1244|1248|1242|1199)' Zip/Archive.lean`
+  → no remaining stale source-side self-cite hits.
+- `awk 'NR==655 || NR==659 || NR==830' Zip/Archive.lean` → all three
+  comment lines show the refreshed anchor values.
+
+## Decisions / patterns
+
+- Standard linker-undetected drift class — `scripts/check-inventory-links.sh`
+  only scans `SECURITY_INVENTORY.md`, not source files. Source-side
+  inline self-references drift silently until manually refreshed.
+- Convention: bare-text comment cites use the `Zip/Archive.lean:NNN`
+  form (no markdown link); the existing markdown-link cite at line 830
+  was preserved (link text + href URL both updated).
+
+## What remains
+
+The issue body flagged that `Zip/Archive.lean` may also carry stale
+`writeEndRecords` / `writeCentralHeader` writer-site self-cites at
+lines 338 / 354 / 371 (likely a +2 shift from EOCD64 record-write
+insertion — distinct from the +25 shift addressed here). Those are
+out of scope for this issue and should be queued separately if they
+warrant a refresh.
+
+Inventory-side counterparts for the same anchor cluster are tracked
+elsewhere (in-flight #2300, in-flight #2296, closed PR #2291).
+
+## Quality metrics
+
+- Sorries: unchanged (no proof work).
+- Build: 191/191 jobs pass.
+- Diff scope: 1 file, 3 insertions, 3 deletions.


### PR DESCRIPTION
Closes #2304

Session: `f28b6846-b67f-483c-98d3-aa3e3768bb3d`

9520656 chore: progress entry for #2304
58b5b35 doc: refresh stale Zip/Archive.lean source-side self-references in parseCentralDir comments

🤖 Prepared with Claude Code