### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md narrative-paragraph cite L519 (PR #1813 CD-entry localOffset+30 ≤ cdOffset archive-layout invariant writer-side reference) — Zip/Archive.lean:192 → :204 'outStream.write localHdr' inside Archive.create per-entry loop; 1-row single-anchor narrative-paragraph sweep matching PR #2240/#2287/#2295/#2298/#2299/#2301/#2305/#2307 1-row tightening cadence; sibling cite at L497 stays fresh (PR #1801 method-allowlist narrative explicitly quotes 'let method := ...' which still matches :192); current :192 lands on the method-field assignment (correct for L497 but mismatched for L519's 'emits all LH bytes' claim); linker-undetected drift class (no backtick-quoted substring in cite for ±2 window heuristic to anchor)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -516,7 +516,7 @@ Summary — what this pattern catches and what it does not:
     APPNOTE §4.3.6 pins the archive layout as `[LH+data]* [CD]
     [EOCD]`, so every entry's LH must be readable strictly before the
     CD start; writer-side at
-    [Zip/Archive.lean:192](/home/kim/lean-zip/Zip/Archive.lean:192)
+    [Zip/Archive.lean:204](/home/kim/lean-zip/Zip/Archive.lean:204)
     emits all LH bytes before the CD block, so the invariant is
     universal for legitimate archives. Per-entry micro-shape sibling
     of the archive-level macro-shape `cdOffset + cdSize ≤ eocdPos`

--- a/progress/20260426T082906Z_f12518e5.md
+++ b/progress/20260426T082906Z_f12518e5.md
@@ -1,0 +1,33 @@
+# 2026-04-26 08:29 UTC — feature session f12518e5
+
+Closed issue #2308 — refresh stale `SECURITY_INVENTORY.md:519` cite for
+the PR #1813 CD-entry `localOffset + 30 ≤ cdOffset` writer-side
+narrative: `Zip/Archive.lean:192` → `:204` (the `outStream.write
+localHdr` call inside `Archive.create`'s per-entry loop).
+
+## Verification
+
+- L192 still carries `let method : UInt16 := if useDeflate then 8 else 0`
+  (the line content the *L497* PR #1801 method-allowlist narrative
+  quotes) — confirmed unchanged; L497 cite stays correct and untouched.
+- L204 is `outStream.write localHdr`, which is what the L519 narrative
+  actually claims about the writer "emit[ting] all LH bytes before the
+  CD block".
+- `lake build` clean.
+- `lake exe test` — all tests pass (doc-only change).
+- `bash scripts/check-inventory-links.sh` — exits 0 with 18 pre-existing
+  warnings, none on line 519.
+- Diff: 1 line changed in `SECURITY_INVENTORY.md`, no other file.
+
+## Decisions
+
+- 1-row single-anchor narrative-paragraph sweep — cadence sibling of
+  PR #2240 / #2287 / #2295 / #2298 / #2299 / #2301 / #2305 / #2307.
+- Linker-undetected drift class (the cite text contains no
+  backtick-quoted substring for the ±2 substring window heuristic to
+  anchor against), so this kind of stale anchor needs to ride
+  human-curated planner waves rather than the linker.
+
+## Quality metric delta
+
+- sorry count: unchanged (doc-only).


### PR DESCRIPTION
Closes #2308

Session: `f12518e5-5acd-4f57-8e65-797546335418`

c4e4c91 chore: progress entry for #2308 (inventory L519 :192 -> :204)
339fc80 doc: re-anchor inventory L519 :192 -> :204 (PR #1813 writer-side LH-emit cite)

🤖 Prepared with Claude Code