### PR TITLE
Refresh stale ZipTest/Archive.lean source-side inline self-reference at :86 — Zip/Archive.lean:1072-1074 → :1097-1099 (readEntryData maxEntrySize uncompressed-size reject; +25 shift; linker-undetected drift sibling of PR #2309)

### DIFF
--- a/ZipTest/Archive.lean
+++ b/ZipTest/Archive.lean
@@ -83,7 +83,7 @@ def ZipTest.Archive.tests : IO Unit := do
       throw (IO.userError s!"zip: CD size limit wrong error: {e}")
 
   -- maxEntrySize bomb regression: an uncompressedSize larger than the limit
-  -- must be rejected before any decompression happens (Zip/Archive.lean:1072-1074).
+  -- must be rejected before any decompression happens (Zip/Archive.lean:1099-1101).
   let bombSrcDir : System.FilePath := "/tmp/lean-zlib-zip-bomb-src"
   let bombZipPath : System.FilePath := "/tmp/lean-zlib-zip-bomb.zip"
   let bombExtractDir : System.FilePath := "/tmp/lean-zlib-zip-bomb-extract"

--- a/progress/2026-04-26T08-33-45Z_a3144141.md
+++ b/progress/2026-04-26T08-33-45Z_a3144141.md
@@ -1,0 +1,35 @@
+# Progress: 2026-04-26T08:33Z (a3144141)
+
+**Session type:** feature
+**Issue:** #2312 — Refresh stale ZipTest/Archive.lean :86 source-side cite
+
+## Accomplished
+
+Refreshed the parenthetical cite in `ZipTest/Archive.lean:86` from
+`Zip/Archive.lean:1072-1074` to `:1099-1101` to re-anchor on the
+`readEntryData` maxEntrySize uncompressed-size reject (if/throw pair
+plus the `Span-validate` boundary line).
+
+Note: actual shift was +27, not the +25 the issue body estimated —
+additional PRs landed after the issue was created. Picked the range
+by reading `Zip/Archive.lean:1090-1110` and bracketing the if (1099),
+throw (1100), and Span-validate comment (1101) the same way the
+original 3-line range bracketed the equivalent lines pre-shift.
+
+`lake build -R` succeeded (191/191 jobs, no warnings on `ZipTest.Archive`).
+
+## Decisions
+
+Used `1099-1101` instead of the issue body's suggested `1097-1099`
+or `1097-1100` because the issue's deliverable explicitly says to
+"bracket the if/throw pair AND the Span-validate boundary line",
+which matches `1099-1101` in the current master tree.
+
+## Quality metrics
+
+No `sorry` count change (doc-only edit).
+
+## What remains
+
+Sibling source-side cite refreshes (#2313, #2314, #2315) are still
+unclaimed and out of scope for this session.


### PR DESCRIPTION
Closes #2312

Session: `a3144141-eda9-43bf-b4c7-b5e0c543776e`

d3de455 progress: 2026-04-26T08:33Z a3144141 (#2312)
52e9ad8 chore: refresh stale ZipTest/Archive.lean :86 source-side cite to Zip/Archive.lean:1099-1101

🤖 Prepared with Claude Code