### PR TITLE
Refresh stale ZipTest/ZipFixtures.lean:638 source-side bare-text cite — Zip/Archive.lean:1199 → :1224 (Archive.extract late 'CRC32 mismatch' throw inside cd-empty-entry-crc-nonzero.zip fixture-block prose; +25 shift; linker-undetected drift sibling of PR #2309)

### DIFF
--- a/ZipTest/ZipFixtures.lean
+++ b/ZipTest/ZipFixtures.lean
@@ -635,7 +635,7 @@ def ZipTest.ZipFixtures.tests : IO Unit := do
   -- `Entry.crc32` verbatim — callers routing on `entry.crc32` saw the
   -- smuggled value) and `Archive.extract` (pre-PR caught the mismatch
   -- only post-extraction via the `"CRC32 mismatch"` guard at
-  -- Zip/Archive.lean:1199, after any I/O work had been performed)
+  -- Zip/Archive.lean:1224, after any I/O work had been performed)
   -- dimensions simultaneously.  Sibling of PR #1773 (stored-method
   -- size invariant) at the CD-parse mathematical-invariant family:
   -- #1773 closes the `compSize == uncompSize` column; this fixture

--- a/progress/2026-04-26T0830_e3debbbb.md
+++ b/progress/2026-04-26T0830_e3debbbb.md
@@ -1,0 +1,42 @@
+# Session: Refresh stale source-side cite in ZipTest/ZipFixtures.lean (#2313)
+
+**UTC**: 2026-04-26T08:30
+**Type**: feature (1-row source-side cite refresh)
+**Branch**: agent/e3debbbb
+**Issue**: #2313
+
+## Accomplished
+
+Refreshed the bare parenthetical cite in
+`ZipTest/ZipFixtures.lean:638` (inside the
+`cd-empty-entry-crc-nonzero.zip` fixture-block prose):
+
+- `Zip/Archive.lean:1199` → `Zip/Archive.lean:1224`
+
+Verified `Zip/Archive.lean:1224` is the
+`throw (IO.userError s!"zip: CRC32 mismatch …")` line inside
+`Archive.extract`'s post-extraction late-throw lifecycle, matching the
+fixture-block narrative attribution (PR #1857).
+
+Build was clean (full `lake -R build` succeeded with all 191 jobs).
+
+## Context / drift class
+
+This is a 1-row single-anchor linker-undetected drift sweep matching
+PR #2309's source-side fixture-block cite refresh precedent (uniform
++25 shift from post-#2110 / post-#2168 archive-layout guard waves).
+`scripts/check-inventory-links.sh` does not scan source files, so
+this drift is invisible to the linker.
+
+## Sibling work (separate issues)
+
+Still queued under same drift class:
+
+- #2314: ZipFixtures.lean:704 (Binary.isPathSafe call sites
+  :1244+:1248 → :1269+:1273)
+- #2315: ZipFixtures.lean:803 (bad LH signature throw :1081 → :1106)
+
+## Quality metrics
+
+- sorry count: unchanged (this is a doc-only edit)
+- Build: clean


### PR DESCRIPTION
Closes #2313

Session: `e3debbbb-4da0-4822-9dd0-4bf91bb99d7f`

0e1cf3d chore: progress entry for #2313 (refresh stale ZipFixtures cite)
7f7736a chore: refresh stale ZipFixtures.lean source-side cite (Zip/Archive.lean:1199 → :1224)

🤖 Prepared with Claude Code