### PR TITLE
Refresh stale ZipTest/ZipFixtures.lean:803 source-side markdown-link cite — Zip/Archive.lean:1081 → :1106 (Archive.extract late 'bad local header signature' throw inside cd-bad-lh-signature.zip fixture-block prose; both link-text + URL must shift; +25 shift; linker-undetected drift sibling of PR #2309)

### DIFF
--- a/ZipTest/ZipFixtures.lean
+++ b/ZipTest/ZipFixtures.lean
@@ -800,7 +800,7 @@ def ZipTest.ZipFixtures.tests : IO Unit := do
   -- `compSize == uncompSize`, etc.) and `assertSpanInFile` /
   -- `readBoundedSpanFromHandle` clear the LH span (30 B at offset 0 ≤
   -- fileSize 122).  The 4-byte mismatch trips the late LH-signature
-  -- guard at [Zip/Archive.lean:1081](/home/kim/lean-zip/Zip/Archive.lean:1081)
+  -- guard at [Zip/Archive.lean:1106](/home/kim/lean-zip/Zip/Archive.lean:1106)
   -- — *"bad local header signature for {label}"* — which is
   -- `Archive.extract`'s defense-in-depth catch for archives that slip
   -- past every CD-parse and span guard.  `Archive.list` never reads the

--- a/progress/20260426T093009Z_24bdf1dc.md
+++ b/progress/20260426T093009Z_24bdf1dc.md
@@ -1,0 +1,36 @@
+# Progress entry — 2026-04-26 (UTC)
+
+Session type: feature
+Session UUID prefix: 24bdf1dc
+Issue: #2315
+
+## Accomplished
+
+Refreshed stale markdown-link cite in `ZipTest/ZipFixtures.lean:803`:
+- Link text and URL both shifted from `Zip/Archive.lean:1081` to
+  `:1106` (the `bad local header signature for {label}` throw inside
+  `Archive.extract`).
+- Verified `sed -n '1106p' Zip/Archive.lean` matches the expected
+  late LH-signature throw.
+- `lake build -R` clean (191 jobs).
+
+This is a 1-line doc-only change inside a `--` comment block; no
+generated code is affected. Linker-undetected drift sibling of PR
+\#2309 source-side cite cluster.
+
+## Quality metrics
+
+No code change, no test change, no `sorry` count delta.
+
+## What remains
+
+The issue body lists three sibling stale ZipTest source-side cites in
+the same drift class, queued separately:
+- `ZipTest/Archive.lean:86` (`:1072-1074` → `:1097-1099`) — already
+  landed as PR #2318.
+- `ZipTest/ZipFixtures.lean:638` (`:1199` → `:1224`) — already landed
+  as PR #2319.
+- `ZipTest/ZipFixtures.lean:704` (`:1244` and `:1248` → `:1269` and
+  `:1273`) — already landed as PR #2321.
+
+So this PR closes the last open sibling in the cluster.


### PR DESCRIPTION
Closes #2315

Session: `24bdf1dc-b416-49e8-9c04-a95fa90efeae`

60b0155 chore: progress entry for #2315
ec87968 doc: refresh stale ZipTest/ZipFixtures.lean:803 source-side markdown-link cite — Zip/Archive.lean:1081 → :1106

🤖 Prepared with Claude Code