### PR TITLE
Inventory: re-anchor stale SECURITY_INVENTORY.md Decompression Limit Inventory rows 1232-1235 (Tar.extract maxEntrySize/maxTotalSize + Tar.extractTarGz maxEntrySize/maxTotalSize) — Zip/Tar.lean:651 → :748 (partial def extract, +97 shift) / :779 → :876 (partial def extractTarGz, +97 shift); 4-row 2-anchor doc-only sweep with one row-1232 dual-anchor (primary column + parenthetical), Tar sibling of in-flight #2247 Archive.extract triple in same inventory table; distinct inventory section from #2027/#2035 (Public extraction APIs cluster rows 1192-1195) which cites same source anchors but in different section; once landed, Decompression Limit Inventory section free of stale anchors (Archive cluster #2247 + this Tar cluster + already-fresh extractTarGzNative cluster :945)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -1229,10 +1229,10 @@ source. The corresponding checklist item is Priority 2 items 1–2 in
 | [Archive.extract](/home/kim/lean-zip/Zip/Archive.lean:1233) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all entries; intended as a second line of defence against many-small-entries bombs. |
 | [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1303) | `maxCentralDirSize : Nat` | `67108864` (64 MiB) | no limit | CD allocation cap. |
 | [Archive.extractFile](/home/kim/lean-zip/Zip/Archive.lean:1303) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited (FFI backend only; native inflate rejects `0`) | per-entry cap. |
-| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:651](/home/kim/lean-zip/Zip/Tar.lean:651)). |
-| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:651) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all regular-file entries; directories and symlinks contribute zero. |
-| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |
-| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:779) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
+| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:748) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry byte cap, applied via header `e.size` before any I/O (see [Zip/Tar.lean:748](/home/kim/lean-zip/Zip/Tar.lean:748)). |
+| [Tar.extract](/home/kim/lean-zip/Zip/Tar.lean:748) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | running sum across all regular-file entries; directories and symlinks contribute zero. |
+| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:876) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. Outer gzip decode is streaming via `Gzip.InflateState`; no per-stream output cap. |
+| [Tar.extractTarGz](/home/kim/lean-zip/Zip/Tar.lean:876) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
 | [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:945) | `maxEntrySize : UInt64` | `1 * 1024^3` (1 GiB) | pass `0` for unlimited | per-entry cap. |
 | [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:945) | `maxTotalSize : UInt64` | `0` | no whole-archive cap | forwarded to inner `Tar.extract`. |
 | [Tar.extractTarGzNative](/home/kim/lean-zip/Zip/Tar.lean:948) | `maxOutputSize : Nat` | `256 * 1024^2` (256 MiB) | hard cap at 0 bytes (explicit) | whole-archive tar-buffer cap for the outer native gzip decode. |

--- a/progress/20260426T094706Z_f9ce4ec3.md
+++ b/progress/20260426T094706Z_f9ce4ec3.md
@@ -1,0 +1,37 @@
+# Feature session — 2026-04-26 09:47 UTC
+
+Session: f9ce4ec3 / feature
+Issue: #2320 — Inventory row 1232-1235 Tar.extract / Tar.extractTarGz anchor refresh
+
+## Accomplished
+
+- Refreshed `SECURITY_INVENTORY.md:1232-1235` (Decompression Limit
+  Inventory table, four rows for `Tar.extract` and `Tar.extractTarGz`).
+- 5 markdown-link anchor updates in 4 rows:
+  - Row 1232: primary `Zip/Tar.lean:651` → `:748` AND parenthetical
+    `[Zip/Tar.lean:651](.../Zip/Tar.lean:651)` → both link-text + URL
+    `:748` (dual anchor).
+  - Row 1233: primary `:651` → `:748`.
+  - Row 1234: primary `:779` → `:876`.
+  - Row 1235: primary `:779` → `:876`.
+
+## Verification
+
+- `bash scripts/check-inventory-links.sh` warning count: 18 → 14
+  (the four warnings on lines 1232-1235 are gone; surviving 14 are
+  for other in-flight issues / repair-queue PRs).
+- `awk 'NR==748' Zip/Tar.lean` confirms `partial def extract`.
+- `awk 'NR==876' Zip/Tar.lean` confirms `partial def extractTarGz`.
+- `lake build -R` clean.
+- `lake exe test` — all tests passed.
+- `git diff` shows exactly 5 line-anchor changes (4 rows; row 1232
+  contributes 2 pair-changes due to the dual anchor).
+- `sorry` count unchanged (doc-only).
+
+## Decisions / patterns
+
+- Pure doc-only sweep, 1 commit, matches PR #2059 row-1310 4-anchor
+  precedent and PR #2309 / #2318 / #2319 / #2321 / #2323 cadence.
+- Lake required `-R` (compiled configuration was stale from worktree
+  reuse) — flagged here so future workers in this worktree run
+  `lake build -R` first.


### PR DESCRIPTION
Closes #2320

Session: `f9ce4ec3-6867-4b1f-b85c-172758caa45c`

d66893d chore: progress entry for #2320
8ef9771 Refresh stale SECURITY_INVENTORY.md Decompression Limit Inventory rows 1232-1235 (Tar.extract maxEntrySize/maxTotalSize + Tar.extractTarGz maxEntrySize/maxTotalSize) — Zip/Tar.lean:651 → :748 / :779 → :876

🤖 Prepared with Claude Code