### PR TITLE
Inventory: unify three narrative-paragraph anchor-range conventions for writeZip64ExtraLocal/writeZip64ExtraCentral writer-site cites at SECURITY_INVENTORY.md L401 / L417 / L444 — replace six asymmetric range anchors (:66-71/:74-80, :65-71/:73-80, :66-71/:73-80) with six single-line def-line cites (:65 LH / :74 CD), matching the sibling :449 def-line convention used at L432-437 for hasDuplicateZip64Extra; 3-paragraph 6-anchor doc-only consolidation sweep; linker-undetected drift class (start-coordinate ±2 window passes for all six current anchors); minimises future drift surface area by collapsing range anchors to single-line anchors that shift atomically

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -398,8 +398,8 @@ Summary — what this pattern catches and what it does not:
     extra-data smuggling class (siblings of the inner-0x0001
     `zip64-extra-oversized-datasize.zip` `dataSize` exactness check).
     Writer side is well-formed by construction at
-    [Zip/Archive.lean:66-71](/home/kim/lean-zip/Zip/Archive.lean:66)
-    (LH) and :74-80 (CD): both paths emit either a single well-formed
+    [Zip/Archive.lean:66](/home/kim/lean-zip/Zip/Archive.lean:66)
+    (LH) and :74 (CD): both paths emit either a single well-formed
     0x0001 block or zero extra-data
   - ZIP64 per-entry extra-field `dataSize` exactness check — PR #1785
     (`testdata/zip/malformed/zip64-extra-oversized-datasize.zip`)
@@ -414,8 +414,8 @@ Summary — what this pattern catches and what it does not:
     conditional reads ([Zip/Archive.lean:495](/home/kim/lean-zip/Zip/Archive.lean:495)). Sibling of the outer
     `zip64-eocd64-bad-recsize.zip` record-size check (same
     parser-differential attack class, different layer); writer-side at
-    [Zip/Archive.lean:73-80](/home/kim/lean-zip/Zip/Archive.lean:73)
-    (CD) and :65-71 (LH) both emit exactly `N * 8` bytes of data
+    [Zip/Archive.lean:74](/home/kim/lean-zip/Zip/Archive.lean:74)
+    (CD) and :66 (LH) both emit exactly `N * 8` bytes of data
   - duplicate ZIP64 (`headerId 0x0001`) extra-block rejection — PR #1793
     (`testdata/zip/malformed/cd-zip64-extra-duplicate.zip` and
     `testdata/zip/malformed/lh-zip64-extra-duplicate.zip`) rejects CD
@@ -441,8 +441,8 @@ Summary — what this pattern catches and what it does not:
     sub-field `dataSize` exactness check (PR #1785) — together they
     close the ZIP64 extra-field layout-smuggling attack class at the
     CD/LH boundary; writer-side `writeZip64ExtraCentral`
-    ([Zip/Archive.lean:73-80](/home/kim/lean-zip/Zip/Archive.lean:73))
-    and `writeZip64ExtraLocal` (:66-71) emit at most one 0x0001 block
+    ([Zip/Archive.lean:74](/home/kim/lean-zip/Zip/Archive.lean:74))
+    and `writeZip64ExtraLocal` (:66) emit at most one 0x0001 block
     per entry, so the new guard never fires on legitimate archives
   - CD-vs-LH `versionNeededToExtract` downgrade check — PR #1736
     (`testdata/zip/malformed/cd-lh-version-mismatch.zip`) rejects LH

--- a/progress/20260426T095954Z_49d8662a.md
+++ b/progress/20260426T095954Z_49d8662a.md
@@ -1,0 +1,39 @@
+# 2026-04-26T09:59Z — feature session 49d8662a
+
+## Issue
+#2322 — Unify writeZip64ExtraLocal/writeZip64ExtraCentral writer-site
+cite convention at SECURITY_INVENTORY.md L401 / L417 / L444.
+
+## Outcome
+Doc-only sweep, single commit. Replaced six asymmetric range anchors
+across three narrative paragraphs with six single-line def-line cites.
+
+- L401 (LH+CD writer paragraph, well-formed-by-construction):
+  `:66-71` (LH) / `:74-80` (CD) → `:66` / `:74`
+- L417 (dataSize exactness paragraph):
+  `:73-80` (CD) / `:65-71` (LH) → `:74` / `:66`
+- L444 (duplicate-block rejection paragraph):
+  `:73-80` (CD) / `:66-71` (LH) → `:74` / `:66`
+
+Diff: 6 insertions / 6 deletions.
+
+## Discrepancy with issue body
+The issue's "current line layout" section claimed
+`writeZip64ExtraLocal` was at `:65` and that
+`awk 'NR==65' Zip/Archive.lean` would print the def line. Actual
+current layout has the LH docstring at `:65` and the def at `:66`
+(1-line shift versus the issue's view). I used `:66` for the def-line
+cite to match the actual source. The CD def line at `:74` was
+correct as stated in the issue.
+
+## Verification
+- `bash scripts/check-inventory-links.sh` — 0 errors, 14 warnings
+  (same as before; range-anchor checks dropped from 12 to 9 because
+  3 markdown-link range anchors collapsed to single lines)
+- `lake build && lake exe test` (under `nix-shell`) — clean
+- `awk 'NR==66 || NR==74' Zip/Archive.lean` — both def lines confirmed
+- `sorry` count — unchanged (no proof work)
+
+## What remains
+None for this issue. Sibling source-side cite refresh PRs continue in
+parallel (in-flight #2324, #2326).


### PR DESCRIPTION
Closes #2322

Session: `49d8662a-a4a1-4d4e-a5a5-43a90279a836`

3594a62 doc: add session progress entry for #2322
7f3bc7c Inventory: unify writeZip64ExtraLocal/writeZip64ExtraCentral writer-site cite convention to single-line def-line anchors at SECURITY_INVENTORY.md L401 / L417 / L444 — replace six asymmetric range anchors (:66-71/:74-80, :73-80/:65-71, :73-80/:66-71) with six single-line def-line cites (:66 LH / :74 CD), matching the sibling :449 def-line convention used at L432-437 for hasDuplicateZip64Extra; 3-paragraph 6-anchor doc-only consolidation sweep; minimises future drift surface area by collapsing range anchors to single-line anchors that shift atomically (closes #2322)

🤖 Prepared with Claude Code