### PR TITLE
Refresh stale scripts/build-ustar-malformed-fixtures.lean (5 anchors) + scripts/build-pax-malformed-fixtures.lean (1 anchor) line citations to current Zip/Tar.lean — :515/:517/:519/:522 → :531/:533/:535/:542 and :122 → :145; 6-anchor 2-script doc-only sweep across the UStar 5-slot interior-NUL fixture-builder linkname+prefix docstrings and the PAX value-side NUL-guard fixture-builder docstring; linker-undetected drift class (scripts/check-inventory-links.sh scans only SECURITY_INVENTORY.md); sibling source-side cite refresh shape to PR #2309 (Zip/Archive.lean self-references) / PRs #2318/#2319/#2321 (ZipTest/ source-side) / in-flight PR #2323 — but novel scope: scripts/ fixture-builder docstrings, no test or build impact

### DIFF
--- a/progress/20260426T104643Z_54de79df.md
+++ b/progress/20260426T104643Z_54de79df.md
@@ -1,0 +1,52 @@
+# Session 54de79df — refresh stale `scripts/` source-side cites
+
+- Date/time: 2026-04-26T10:46Z
+- Session type: feature
+- Issue: #2324
+
+## Accomplished
+
+Refreshed 6 stale `Zip/Tar.lean` line citations in two fixture-builder
+docstrings — same shape as PR #2309 (Zip/Archive.lean self-references)
+and the ZipTest/ source-side sweeps (PRs #2318/#2319/#2321/#2323), but
+in scripts/ scope which is not scanned by `scripts/check-inventory-links.sh`.
+
+`scripts/build-ustar-malformed-fixtures.lean` (5 anchors):
+- L59 `at line 517` → `at line 533` (UStar linkname-NUL guard throw)
+- L61 `at line 515 cannot fire first` → `at line 531 cannot fire first` (UStar name-NUL guard throw)
+- L85 `at line 519` → `at line 535` (UStar prefix-NUL guard throw)
+- L88 `[Zip/Tar.lean:522]` → `[Zip/Tar.lean:542]` (parseHeader fullPath join)
+- L91 `at line 515 cannot fire` → `at line 531 cannot fire` (UStar name-NUL guard throw, second cite)
+
+`scripts/build-pax-malformed-fixtures.lean` (1 anchor):
+- L88 `[Zip/Tar.lean:122]` → `[Zip/Tar.lean:145]` (parsePaxRecords keyBytes NUL guard)
+
+Fresh cites left untouched as required: UStar L82 `:389`, PAX L100 `:146`,
+PAX L106 `:161-162`.
+
+## Decisions
+
+- Used `replace_all` to handle the two identical-suffix `at line 515 cannot fire`
+  occurrences (L61 and L91), then a separate edit for the unique-prefixed L61
+  variant after re-grepping confirmed it remained.
+- Skipped `lake build` / `lake exe test` per the issue's explicit
+  "no Lean source touched" guidance — `scripts/*.lean` files are not part
+  of the Lake project (no `scripts` reference in `lakefile.*`), and the
+  edits are entirely inside `/-- ... -/` docstrings.
+
+## Verification
+
+- `git grep -nE 'Zip/Tar\.lean:(515|517|519|522)\b' scripts/` — empty.
+- `git grep -nE 'Zip/Tar\.lean:122\b' scripts/` — empty.
+- `git grep -nE 'Zip/Tar\.lean:(531|533|535|542|145)\b' scripts/` — shows the two new URL anchors at the expected docstring lines.
+- `grep -nE 'line (515|517|519|522)\b' scripts/build-ustar-malformed-fixtures.lean` — empty (bare-text `line N` cites also refreshed).
+- `bash scripts/check-inventory-links.sh` exits 0 with `errors=0, warnings=14` — warning count unchanged from master (the script does not scan `scripts/`).
+
+## Quality metrics
+
+- `grep -rc sorry Zip/`: unchanged at 0 (no `Zip/` source touched).
+- Diff scope: 6 line edits across 2 files, all inside docstrings.
+
+## Remaining work
+
+None for this issue. Sibling drift sweeps still queued: #2326 (`scripts/build-cd-lh-mismatch.py`), #2328/#2329 (`plans/track-e-current-audit-checklist.md`), #2330/#2331 (range→def-line tightening for `writeEndRecords`).

--- a/scripts/build-pax-malformed-fixtures.lean
+++ b/scripts/build-pax-malformed-fixtures.lean
@@ -85,7 +85,7 @@ def fixtureInconsistentLength : ByteArray :=
 /-- PAX record `"14 path=a\x00b/c\n"` — a `path` override whose value
     carries an embedded NUL byte. `String.fromUTF8?` accepts U+0000 as
     valid UTF-8, so without the NUL guard on `keyBytes` / `valueBytes`
-    at [Zip/Tar.lean:122] the override would reach `applyPaxOverrides`
+    at [Zip/Tar.lean:145] the override would reach `applyPaxOverrides`
     and set `entry.path := "a\x00b/c"` — a filesystem-truncation smuggle
     that POSIX `open` reduces to `a`. With the guard, the record is
     silently dropped (matching the existing invalid-UTF-8 precedent)

--- a/scripts/build-ustar-malformed-fixtures.lean
+++ b/scripts/build-ustar-malformed-fixtures.lean
@@ -56,9 +56,9 @@ def buildUstarNameNulInName : IO ByteArray := do
     terminator). `Tar.buildHeader` routes through `Binary.writeString`,
     which copies each UTF-8 byte verbatim — including U+0000 — and
     pads the remaining 87 bytes with NUL. The `Tar.parseHeader` guard
-    at line 517 rejects on the raw block before `Binary.readString`
+    at line 533 rejects on the raw block before `Binary.readString`
     would otherwise truncate the linkname to `"evil.lnk"`. The `path`
-    is `"safe"` so the `name`-arm guard at line 515 cannot fire first
+    is `"safe"` so the `name`-arm guard at line 531 cannot fire first
     — attribution pins on the `linkname` arm specifically. Two
     trailing zero blocks (1024 B) form a well-formed end-of-archive
     matching the `name`-slot sibling fixture. -/
@@ -82,13 +82,13 @@ def buildUstarLinknameNulInName : IO ByteArray := do
     [Zip/Tar.lean:389], bypassing the auto-`splitPath` logic.
     `Binary.writeString` copies UTF-8 bytes verbatim — including
     U+0000 — and pads the remaining 145 bytes with NUL. The
-    `Tar.parseHeader` guard at line 519 rejects on the raw block
+    `Tar.parseHeader` guard at line 535 rejects on the raw block
     before `Binary.readString` would otherwise truncate the prefix
     to `"badpfx"`, after which `pfx ++ "/" ++ name` at
-    [Zip/Tar.lean:522] would yield `"badpfx/name.txt"` (parser
+    [Zip/Tar.lean:542] would yield `"badpfx/name.txt"` (parser
     sees short form) while POSIX `open(2)` truncates at the same
     NUL on `Tar.extract`. The `name` slot carries the clean
-    `"name.txt"` so the `name`-arm guard at line 515 cannot fire
+    `"name.txt"` so the `name`-arm guard at line 531 cannot fire
     first — attribution pins on the `prefix` arm specifically.
     Two trailing zero blocks (1024 B) match the sibling fixtures'
     well-formed end-of-archive. -/


### PR DESCRIPTION
Closes #2324

Session: `54de79df-d1e7-465c-b921-9cd5b8c811fe`

de11b94 Refresh stale scripts/build-ustar-malformed-fixtures.lean (5 anchors) + scripts/build-pax-malformed-fixtures.lean (1 anchor) source-side cites — Zip/Tar.lean :515/:517/:519/:522 → :531/:533/:535/:542 (parseHeader UStar interior-NUL guards + fullPath join) and :122 → :145 (parsePaxRecords keyBytes NUL guard); 6-anchor 2-script doc-only sweep across the UStar 5-slot interior-NUL fixture-builder linkname+prefix docstrings and the PAX value-side NUL-guard fixture-builder docstring; sibling source-side cite refresh shape to PR #2309 (Zip/Archive.lean self-references) and PRs #2318/#2319/#2321/#2323 (ZipTest/ source-side); novel scope: scripts/ fixture-builder docstrings, no test or build impact (scripts/*.lean files not in lakefile); linker-undetected drift class (scripts/check-inventory-links.sh scans only SECURITY_INVENTORY.md); fresh cites untouched (UStar L82 :389, PAX L100 :146, L106 :161-162) (#2324)

🤖 Prepared with Claude Code