### PR TITLE
Refresh stale scripts/build-cd-lh-mismatch.py source-side line citations to current Zip/Archive.lean — 6 anchors at script :65/:301/:414/:510/:586/:694 → :1106 (late LH-signature throw, twice) / :170-171 (writer-side numEntries16 EOCD writes, narrative tightening from prior :146-147+:160-161 4-line range) / :1269+:1273 (extract-time isPathSafe directory-arm+regular-file-arm) / :1224 (post-extraction CRC32 mismatch throw) / :1172 (CD/LH flags mismatch throw); 1-script 6-anchor doc-only sweep; sibling source-side cite refresh shape to in-flight #2324 (scripts/build-{ustar,pax}-malformed-fixtures.lean) / PR #2309 (Zip/Archive.lean self-references) / merged PRs #2318/#2319/#2321/#2323 (ZipTest/ source-side); novel scope (scripts/*.py docstrings, no test or build impact); linker-undetected drift class (scripts/check-inventory-links.sh only scans SECURITY_INVENTORY.md)

### DIFF
--- a/progress/20260426T105347Z_a3cd847f.md
+++ b/progress/20260426T105347Z_a3cd847f.md
@@ -1,0 +1,57 @@
+# Progress: 2026-04-26T10:53Z (session a3cd847f)
+
+**Session type:** feature
+**Issue:** #2326 — refresh stale `scripts/build-cd-lh-mismatch.py`
+source-side cites to current `Zip/Archive.lean`.
+
+## What was accomplished
+
+Single-commit doc-only sweep:
+
+- 6 line-number anchors in `scripts/build-cd-lh-mismatch.py`
+  docstring/comment blocks refreshed to match current master:
+  - `:65`  `:1081` → `:1106` (late LH-signature throw default-value
+    docstring inside `make_lh`)
+  - `:301` `:146-147, :160-161` → `:170-171` (collapsed 4-line
+    cross-block writer-side reference into 2-line same-block
+    reference per Deliverable 2 narrative tightening)
+  - `:414` `:1081` → `:1106` (sibling reference inside the
+    `cd-bad-lh-signature.zip` fixture-block prose)
+  - `:510` `:1070 / :1074` → `:1269 / :1273` (extract-time
+    `Binary.isPathSafe` calls, directory-arm + regular-file-arm)
+  - `:586` `:1088` → `:1224` (post-extraction `CRC32 mismatch` throw)
+  - `:694` `:1147` → `:1172` (CD/LH `flags mismatch` throw)
+- Each new anchor verified directly by
+  `awk 'NR==<N>' Zip/Archive.lean` before committing — line content
+  matches the cite description in every case.
+- Fresh cites at `:640` (Zip/Archive.lean:615), `:680` (:91 / :118),
+  and `:687` (:634) confirmed unchanged and untouched per issue
+  guidance.
+- `python3 scripts/build-cd-lh-mismatch.py` runs to completion;
+  `git status testdata/zip/malformed/` clean (byte-identical
+  fixtures, no logic touched).
+- `lake -R build` clean (191/191 jobs).
+- `lake exe test` — all tests pass.
+- `bash scripts/check-inventory-links.sh` exits 0 with the existing
+  baseline 14 warnings (unchanged — script does not scan
+  `scripts/*.py`, by design).
+
+## Decisions made
+
+- Took the FIFO-oldest unclaimed `feature` issue per the worker skill
+  priority order (no `human-oversight` issues open).
+- Confirmed branch `agent/a3cd847f` had no open PR before resetting
+  to `origin/master` to clear stale uncommitted skill-edit churn
+  from a prior session reuse.
+
+## Quality metric deltas
+
+- `grep -rc sorry Zip/` unchanged — no Lean code touched.
+- Stale-anchor count in `scripts/build-cd-lh-mismatch.py`: 6 → 0.
+  All other anchors in the script remain as they were (FRESH).
+
+## What remains
+
+Nothing for this issue. Sibling source-side cite refresh issues
+(#2328, #2329, #2330, #2331) remain open and unrelated to this
+script.

--- a/scripts/build-cd-lh-mismatch.py
+++ b/scripts/build-cd-lh-mismatch.py
@@ -62,7 +62,7 @@ def make_lh(method, comp_size, uncomp_size, crc=CRC, version=20,
     # §4.3.7).  The default is load-bearing for every existing fixture;
     # only `cd-bad-lh-signature.zip` exercises the non-default branch
     # (`0xCAFEBABE`) to trip the late LH-signature guard at
-    # Zip/Archive.lean:1081.
+    # Zip/Archive.lean:1106.
     nb = NAME if name_bytes is None else name_bytes
     return struct.pack(
         "<IHHHHHIIIHH",
@@ -298,7 +298,7 @@ write(
 )
 # EOCD entry-count anomaly: `numEntriesThisDisk=2` while `totalEntries=1`.
 # Single-disk archives must have both fields equal (writer-side at
-# Zip/Archive.lean:146-147, :160-161).  The CD itself contains one
+# Zip/Archive.lean:170-171).  The CD itself contains one
 # entry, so the `totalEntries` check would pass (1 == 1); only the
 # `numEntriesThisDisk` sibling disagrees.  Companion to
 # `eocd-numentries-mismatch.zip` (which fires the `totalEntries` check).
@@ -411,7 +411,7 @@ write(
 # method ∈ {0, 8}, `compSize == uncompSize` for stored, etc.) and
 # `assertSpanInFile` / `readBoundedSpanFromHandle` clear the LH span
 # (30 B at offset 0 ≤ fileSize 122).  The 4-byte mismatch trips the late
-# guard at Zip/Archive.lean:1081 — *"bad local header signature for {label}"*
+# guard at Zip/Archive.lean:1106 — *"bad local header signature for {label}"*
 # — which is `Archive.extract`'s defense-in-depth catch for archives that
 # slip past every CD-parse and span guard.  `Archive.list` never reads
 # the LH and lists the fixture cleanly; only `Archive.extract` throws,
@@ -507,7 +507,7 @@ write(
 # (the decoded `String` preserves the component structure), exposing the
 # full smuggled form to callers who routed on `entry.path` before any
 # filesystem I/O — the extract-time `Binary.isPathSafe` calls in
-# `Archive.extract` at Zip/Archive.lean:1070 / :1074 caught only the
+# `Archive.extract` at Zip/Archive.lean:1269 / :1273 caught only the
 # extract path.  `parseCentralDir` now rejects at CD parse time with
 # `"CD entry has unsafe path"`, closing both `Archive.list` and
 # `Archive.extract` dimensions simultaneously.  The 11-byte name is 2
@@ -583,7 +583,7 @@ write(
 # CRC into `Entry.crc32` verbatim (callers routing on `entry.crc32`
 # saw the smuggled value) and `Archive.extract` caught the mismatch
 # only post-extraction via the `"CRC32 mismatch"` guard at
-# Zip/Archive.lean:1088 — after any I/O work had been performed.
+# Zip/Archive.lean:1224 — after any I/O work had been performed.
 write(
     os.path.join(OUT_DIR, "cd-empty-entry-crc-nonzero.zip"),
     lh_method=0, cd_method=0,
@@ -691,7 +691,7 @@ write(
 # fixture maximally close to a legitimate archive in every other
 # respect.  Both LH and CD flag words match (`flag_bits_override =
 # 0x0880` sets both sides) so the CD-vs-LH bit-3-masked flags
-# consistency check (PR #1715, Zip/Archive.lean:1147) does not fire
+# consistency check (PR #1715, Zip/Archive.lean:1172) does not fire
 # first; matching is load-bearing.  `parseCentralDir` rejects at CD
 # parse time pre-ZIP64-resolution with
 # `"flags reserved bits set"`, immediately after the method allowlist


### PR DESCRIPTION
Closes #2326

Session: `a3cd847f-fb25-448e-90ae-d0195b229b65`

faf71d6 chore: progress entry for #2326 (build-cd-lh-mismatch.py cite refresh)
ef6fc5e doc: refresh stale scripts/build-cd-lh-mismatch.py source-side cites

🤖 Prepared with Claude Code