### PR TITLE
Refresh: tighten Zip/Archive.lean:322 source-side cite Zip/Archive.lean:141-177 (36-line range) → :142 (writeEndRecords def-line, single-line) — 1-anchor source-side range-to-single-line tightening sweep matching PR #2327 unification convention (collapse range anchors to single-line def-line cites that shift atomically; minimises future drift surface area); parseCentralDir EOCD64 layout-invariant explainer comment 'Writer-side at … emits the three records contiguously in APPNOTE order'; sibling inventory cite at SECURITY_INVENTORY.md:357 (currently :148-176, same claim) queued separately for parallel def-line consolidation; novel scope: source-side range-to-single-line tightening (rather than line-shift refresh); linker-undetected drift class (scripts/check-inventory-links.sh scans only SECURITY_INVENTORY.md, not source files)

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -319,7 +319,7 @@ private def findEndOfCentralDir (data : ByteArray) (baseOffset : Nat := 0)
             -- at line 304 only bounds the record against `data.size`
             -- and therefore remains in place as defense-in-depth but is
             -- strictly weaker than this layout invariant.  Writer-side
-            -- at `Zip/Archive.lean:141-177` emits the three records
+            -- at `Zip/Archive.lean:142` emits the three records
             -- contiguously in APPNOTE order, so the invariant holds
             -- trivially for every lean-zip-produced archive.
             -- Archive-level macro sibling: `cdOffset + cdSize ≤ eocdPos`

--- a/progress/20260426T114053Z_0cc8dea3.md
+++ b/progress/20260426T114053Z_0cc8dea3.md
@@ -1,0 +1,47 @@
+# Progress: 2026-04-26 11:40 UTC — feature session 0cc8dea3
+
+## Summary
+
+Closed issue #2331: tightened `Zip/Archive.lean:322` source-side cite from
+`Zip/Archive.lean:141-177` (36-line range across the full `writeEndRecords`
+definition) to `:142` (def-line only), inside the parseCentralDir EOCD64
+layout-invariant explainer comment block ("Writer-side at … emits the three
+records contiguously in APPNOTE order").
+
+## Deliverables
+
+- One-line edit at `Zip/Archive.lean:322`: `:141-177` → `:142`
+- Build clean (`lake -R build`, 191 jobs)
+- Tests pass (`lake exe test`)
+- `bash scripts/check-inventory-links.sh` warning count unchanged (14 →
+  14, baseline confirmed via `git stash` round-trip)
+
+## Context / decisions
+
+- Convention pinned by merged PR #2327 (range anchors → single-line
+  def-line anchors that shift atomically). Sibling inventory cite at
+  `SECURITY_INVENTORY.md:357` was tightened to the same `:142` def-line
+  by PR #2337, which landed before this session started — the
+  source-side parallel queued in #2331 is now closed by this PR,
+  completing the def-line consolidation for the EOCD64 contiguity
+  claim.
+- L527's `:156-157` / `:170-171` writer-side cites for the EOCD
+  entry-count consistency check were correctly left out of scope (those
+  point to exact field-write positions where the matching values are
+  emitted; collapsing to def line would lose specificity).
+- Linker-undetected drift class: `scripts/check-inventory-links.sh`
+  scans only `SECURITY_INVENTORY.md`, not source files; the L322 cite
+  has no automated drift detector.
+
+## Quality metrics
+
+- `sorry` count unchanged (no proof work; doc-only comment edit).
+- Build/test status unchanged (no compilation impact).
+- Inventory link warnings unchanged (file not scanned for source-side
+  cites).
+
+## Remaining work
+
+None for this issue. Parallel def-line consolidation for the EOCD64
+contiguity-claim cluster (inventory side at L357 + source side at L322)
+is now complete.


### PR DESCRIPTION
Closes #2331

Session: `0cc8dea3-e762-433b-8e49-ab915cbbd22c`

16ce75a chore: progress entry for 0cc8dea3 session (issue #2331)
2ccecf3 doc: tighten Zip/Archive.lean:322 source-side cite Zip/Archive.lean:141-177 (36-line range) → :142 (writeEndRecords def-line, single-line) — 1-anchor source-side range-to-single-line tightening sweep matching PR #2327 unification convention (collapse range anchors to single-line def-line cites that shift atomically; minimises future drift surface area); parseCentralDir EOCD64 layout-invariant explainer comment 'Writer-side at … emits the three records contiguously in APPNOTE order'; sibling inventory cite at SECURITY_INVENTORY.md:357 already tightened by PR #2337 (parallel def-line consolidation now complete); novel scope: source-side range-to-single-line tightening (rather than line-shift refresh); linker-undetected drift class (scripts/check-inventory-links.sh scans only SECURITY_INVENTORY.md, not source files)

🤖 Prepared with Claude Code