### PR TITLE
Inventory: tighten SECURITY_INVENTORY.md:459 narrative-paragraph cite Zip/Archive.lean:93-94 (LH) → :83 (writeLocalHeader def-line) + bare-text :120-121 (CD) → :109 (writeCentralHeader def-line) — 2-anchor range-to-single-line tightening sweep matching PR #2327 unification convention (collapse range anchors to single-line def-line cites that shift atomically; minimises future drift surface area); CD-vs-LH lastModTime/lastModDate consistency-check writer-site cites for the inventory narrative paragraph; sibling tightening shape to in-flight #2330 (writeEndRecords narrative at :357 → :142 def-line) / #2331 (Zip/Archive.lean:322 source-side parallel); third anchor at :462 (shared :62-63 constants) left alone (already at per-constant def-lines, maximum-tightness convention); not currently stale (linker pass (a) and ±2 substring window both happen to match because field writes are at cited offsets) — stability/maintenance refresh, not staleness fix; linker-undetected drift class

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -456,8 +456,8 @@ Summary — what this pattern catches and what it does not:
     the timestamp fields are not legitimately zeroed by the
     data-descriptor bit. Closes the last CD/LH header-metadata
     smuggling dimension; writer-side at
-    [Zip/Archive.lean:93-94](/home/kim/lean-zip/Zip/Archive.lean:93)
-    (LH) and :120-121 (CD) both emit `defaultDosTime` /
+    [Zip/Archive.lean:83](/home/kim/lean-zip/Zip/Archive.lean:83)
+    (LH) and :109 (CD) both emit `defaultDosTime` /
     `defaultDosDate` via the shared constants at
     [Zip/Archive.lean:62-63](/home/kim/lean-zip/Zip/Archive.lean:62).
     Net-new dimension observed during the CD/LH header-metadata

--- a/progress/2026-04-26T11-51-19_dee0a6bb.md
+++ b/progress/2026-04-26T11-51-19_dee0a6bb.md
@@ -1,0 +1,48 @@
+# Progress: feature session dee0a6bb (2026-04-26T11:51 UTC)
+
+Session type: feature
+Issue: #2336
+
+## Accomplished
+
+Tightened the CD-vs-LH `lastModTime`/`lastModDate` consistency-check
+narrative paragraph at `SECURITY_INVENTORY.md:459`-`:460` from
+2-line range anchors to single-line def-line cites:
+
+- markdown link `[Zip/Archive.lean:93-94](/home/kim/lean-zip/Zip/Archive.lean:93)` (LH range, 2 lines) → `[Zip/Archive.lean:83](/home/kim/lean-zip/Zip/Archive.lean:83)` (writeLocalHeader def-line, single-line)
+- bare-text `:120-121 (CD)` (CD range, 2 lines) → `:109 (CD)` (writeCentralHeader def-line, single-line)
+
+The `:62-63` constants cite at `:462` was deliberately left alone — both
+constants are themselves def-lines, so the anchor is already at the
+per-constant maximum-tightness convention.
+
+## Verification
+
+- `bash scripts/check-inventory-links.sh` reports 0 errors / 14 warnings,
+  none of which are at lines 459–462. (All 14 warnings are pre-existing,
+  about other sites covered by the in-flight repair PR queue.)
+- `git grep ':93-94' SECURITY_INVENTORY.md` → no matches
+- `git grep ':120-121' SECURITY_INVENTORY.md` → no matches
+- Anchor verification at the new def-lines:
+  - `Zip/Archive.lean:83` = `private def writeLocalHeader (entry : Entry) : ByteArray := Id.run do`
+  - `Zip/Archive.lean:109` = `private def writeCentralHeader (entry : Entry) : ByteArray := Id.run do`
+- `lake build` not run — doc-only change touching only
+  `SECURITY_INVENTORY.md`.
+
+## Decisions / patterns
+
+- Used the `Edit` tool with the full bare-text-plus-markdown-link block
+  as `old_string` to make a single atomic edit covering both anchors,
+  rather than two separate single-line edits. This kept the diff to
+  exactly two `-`/`+` line-pairs and avoided uniqueness ambiguity for
+  partial substrings (`:93-94` / `:120-121`).
+- Sibling shape matches PR #2327 (writeZip64ExtraLocal/Central
+  range-collapse, merged) and the now-merged sibling pair #2330 / #2331
+  for the writeEndRecords paragraph — the convention "collapse range
+  anchors to single-line def-line cites that shift atomically" is now
+  applied uniformly across the writer-cluster narrative paragraphs.
+
+## Quality metrics
+
+- sorry count: not tracked (doc-only PR)
+- diff: 1 file changed, 2 insertions(+), 2 deletions(-)


### PR DESCRIPTION
Closes #2336

Session: `dee0a6bb-3a00-4e68-b03e-56596327cd7a`

e57ff20 chore: progress entry for feature session dee0a6bb (#2336 inventory tightening)
b833226 doc: tighten SECURITY_INVENTORY.md:459 narrative-paragraph cite Zip/Archive.lean:93-94 (LH 2-line range) → :83 (writeLocalHeader def-line, single-line) + bare-text :120-121 (CD 2-line range) → :109 (writeCentralHeader def-line, single-line) — 2-anchor range-to-single-line tightening sweep matching PR #2327 unification convention (collapse range anchors to single-line def-line cites that shift atomically; minimises future drift surface area); CD-vs-LH lastModTime/lastModDate consistency-check writer-site cites for the inventory narrative paragraph; sibling tightening shape to in-flight #2330 (writeEndRecords narrative at :357 → :142 def-line, merged) / #2331 (Zip/Archive.lean:322 source-side parallel, merged); third anchor at :462 (shared :62-63 constants) left alone (already at per-constant def-lines, maximum-tightness convention); not currently stale (linker pass (a) and ±2 substring window both happen to match because field writes are at cited offsets) — stability/maintenance refresh, not staleness fix; linker-undetected drift class

🤖 Prepared with Claude Code