### PR TITLE
chore: bump lean-toolchain v4.29.1 → v4.30.0-rc2 (closes runtime allocation hazard)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -14,27 +14,51 @@ known gaps that sit outside the formally verified codec core.
 
 ### Lean Runtime: `ByteArray`, scalar-array allocation, `IO`
 
-- Status: `upstream-risk`
+- Status: `guarded-locally` (was `upstream-risk` while
+  https://github.com/leanprover/lean4/issues/13388 was open; closed by
+  https://github.com/leanprover/lean4/pull/13392, released in v4.30.0-rc2;
+  the project's `lean-toolchain` is now pinned at v4.30.0-rc2 or later)
 - Why trusted: all Lean code ultimately relies on runtime allocation and
   `IO` primitives for `ByteArray`, `Handle.read`, and stream operations.
-- Current local guardrails:
+- Current local guardrails (kept as defense-in-depth even after the
+  upstream fix; see *"Re-evaluation after v4.30.0-rc2"* below):
   - `Zip/Archive.lean` checks `n.toUSize.toNat == n` before `Handle.read`
   - `Zip/Archive.lean` checks file-bounds for central directory before reading it
   - native inflate APIs carry explicit `maxOutputSize` bounds
-- Known concern:
-  - crafted oversized reads can become runtime-allocation hazards if
-    unchecked sizes reach `Handle.read`
+- Known concern (historical):
+  - crafted oversized reads triggered a heap-buffer overflow in the
+    runtime's `lean_io_prim_handle_read` allocation path. Closed in
+    v4.30.0-rc2 by adding checked arithmetic on every relevant
+    allocation site so overflow now throws OOM instead of corrupting
+    the heap.
 - Upstream tracking:
-  - Report: no upstream link yet — local tracking only. The April 2026
-    report against Lean runtime allocation/read paths is recorded in
-    this repository (see *"Current local guardrails"* above and
-    *"Local guard inventory for `Handle.read` and `Stream.read`"*
-    below) but has not yet been filed as a leanprover/lean4 issue.
-  - Status: not yet reported upstream (as of 2026-04-22). An honest
-    search of `progress/`, the lean-zip issue tracker, and
-    leanprover/lean4 (`allocation`, `ByteArray`, `Handle.read`
-    queries) did not find a matching upstream issue. Re-triage
-    required once one is filed.
+  - Bug report: https://github.com/leanprover/lean4/issues/13388 —
+    *"Buffer overflow in `lean_io_prim_handle_read`"*, filed
+    2026-04-13 by @kiranandcode with a 4-line MWE reproducing under
+    valgrind. The bug surfaced via Kiran Gopinathan's fuzzing of
+    lean-zip — see https://kirancodes.me/posts/log-who-watches-the-watchers.html
+  - Fix: https://github.com/leanprover/lean4/pull/13392 — *"fix: file
+    read buffer overflow"*, merged 2026-04-13 by @hargoniX. Adds
+    checked arithmetic on all relevant allocation paths in
+    `lean_io_prim_handle_read`; overflow now throws OOM instead of a
+    heap overflow.
+  - Release: https://github.com/leanprover/lean4/releases/tag/v4.30.0-rc2
+    (2026-04-17). The project's `lean-toolchain` is now pinned at this
+    version (see the file at the repo root).
+  - Status: closed upstream and consumed by this repository.
+- Re-evaluation after v4.30.0-rc2: the local `Nat → USize` roundtrip
+  check (`n.toUSize.toNat == n`) was authored as a workaround for the
+  upstream truncation hazard. Now that overflow throws OOM instead of
+  corrupting memory, the check is no longer load-bearing for memory
+  safety, but it is kept as defense-in-depth because (a) it produces a
+  named, catchable error before allocation rather than a late OOM,
+  (b) it is a no-op on 64-bit platforms and a meaningful guard on any
+  future 32-bit `USize` target, and (c) the cost is negligible. The
+  `assertSpanInFile` checks, `maxCentralDirSize` / `maxEntrySize` caps,
+  CD-vs-LH consistency checks, and native `maxOutputSize` caps were
+  never compensating for the runtime bug — they bound metadata-driven
+  allocation against bombs and are unaffected by the upstream fix. No
+  guardrails are dropped by this bump.
   - Local regression coverage (fixtures + assertion sites that guard
     this attack surface today):
     - `testdata/zip/malformed/oversized-compressed-size.zip` —
@@ -74,10 +98,15 @@ known gaps that sit outside the formally verified codec core.
     - see *"Local guard inventory for `Handle.read` and `Stream.read`"*
       below for the per-site audit of what protections are currently in
       place
-  - file or link the upstream Lean runtime issue so the *"Report"* and
-    *"Status"* fields in *"Upstream tracking"* above can be updated
-    with a concrete target
+  - re-run the original fuzz harness from
+    https://kirancodes.me/posts/log-who-watches-the-watchers.html
+    against current master on v4.30.0-rc2 to confirm closure of the
+    runtime buffer-overflow class
 - Recent wins:
+  - upstream `lean_io_prim_handle_read` buffer-overflow fix consumed
+    via the v4.30.0-rc2 toolchain bump — closes the previous
+    `upstream-risk` status; no local guardrails dropped (see
+    *"Re-evaluation after v4.30.0-rc2"* above)
   - oversized ZIP64 compressed-size fixture — PR #1543
     (`testdata/zip/malformed/oversized-zip64-compressed-size.zip`)
   - oversized ZIP64 uncompressed-size fixture — PR #1544
@@ -1317,9 +1346,13 @@ Per-callsite audit of every `Handle.read`, `Stream.read`, and
 `Zip/Archive.lean` and `Zip/Tar.lean`. This documents which guards
 **already run before** each read, so a reader does not have to trace
 back through the source to confirm that every metadata-driven read is
-protected. The *"Failure mode"* column states the residual
-upstream-runtime risk for each site — it is the behaviour that would
-surface if the caller bypassed the guard.
+protected. The *"Failure mode"* column states the behaviour that would
+surface if the caller bypassed the guard. Since v4.30.0-rc2 the
+runtime's own `lean_io_prim_handle_read` does checked arithmetic on
+allocation paths and raises OOM on overflow rather than corrupting the
+heap, so the local guards primarily exist to surface a clean,
+catchable error before allocation rather than to prevent memory
+corruption.
 
 The creator-side `h.read` in `Zip/Tar.lean` `create` at
 [Zip/Tar.lean:599](/home/kim/lean-zip/Zip/Tar.lean:599) is **not**

--- a/Zip/Spec/BitstreamWriteCorrect.lean
+++ b/Zip/Spec/BitstreamWriteCorrect.lean
@@ -301,7 +301,6 @@ theorem bytesToBits_bitsToBytes_take (bits : List Bool) :
         by_cases hi8 : i < 8
         · rw [List.getElem_append_left (by simp only [List.length_ofFn]; exact hi8)]
           simp only [List.getElem_ofFn, show i < (b :: rest).length from by omega, ↓reduceDIte]
-          rfl
         · rw [List.getElem_append_right (by simp only [List.length_ofFn]; omega)]
           simp only [List.length_ofFn]
           have hih := ih _ (drop8_cons_length_lt b rest) ((b :: rest).drop 8) rfl

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.29.1
+leanprover/lean4:v4.30.0-rc2

--- a/progress/20260428T080633Z_2e0978e1.md
+++ b/progress/20260428T080633Z_2e0978e1.md
@@ -1,0 +1,56 @@
+# Toolchain bump v4.29.1 → v4.30.0-rc2 (closes runtime allocation hazard)
+
+- Date: 2026-04-28 (UTC)
+- Session type: feature (human-oversight)
+- Issue: #2344
+- Branch: agent/2e0978e1
+
+## What landed
+
+- `lean-toolchain` bumped to `leanprover/lean4:v4.30.0-rc2`
+- `SECURITY_INVENTORY.md` "Lean Runtime" row rewritten:
+  - Status flipped from `upstream-risk` → `guarded-locally` (with
+    historical note pointing at the closed upstream issue/PR/release)
+  - Bug, fix, and release URLs added (issues/13388, PR #13392,
+    v4.30.0-rc2 release tag, plus Kiran Gopinathan's blog post that
+    surfaced the bug via lean-zip fuzzing)
+  - Function name corrected to `lean_io_prim_handle_read`
+  - "Re-evaluation after v4.30.0-rc2" paragraph documents that no
+    local guardrails are dropped: the `Nat → USize` roundtrip is kept
+    as cheap defense-in-depth (catchable error before allocation,
+    32-bit `USize` futureproofing); the `assertSpanInFile` checks,
+    `maxCentralDirSize` / `maxEntrySize` caps, `maxOutputSize` caps,
+    and CD-vs-LH consistency checks were never compensating for the
+    runtime bug — they bound metadata-driven allocation against bombs
+    and remain load-bearing
+  - Missing-work bullet "file or link the upstream Lean runtime issue"
+    replaced by "re-run the original fuzz harness on v4.30.0-rc2 to
+    confirm closure" (the previous bullet was satisfied by the bump
+    itself)
+  - Recent-wins bullet added for the upstream fix
+  - "Local guard inventory for `Handle.read` and `Stream.read`" intro
+    updated to note that since v4.30.0-rc2 the runtime's own checked
+    arithmetic raises OOM on overflow rather than corrupting the
+    heap, so the local guards primarily exist to surface a clean
+    error before allocation
+- `Zip/Spec/BitstreamWriteCorrect.lean:304`: dropped a now-redundant
+  `rfl` whose goal is closed by the preceding `simp only` under the
+  new toolchain ("No goals to be solved" error on rebuild)
+
+## Verification
+
+- `lake build` clean on v4.30.0-rc2
+- `lake exe test` all green
+- `scripts/check-inventory-links.sh` errors=0; the 14 remaining
+  warnings are all pre-existing line-anchor drift (a separate
+  human-oversight issue, #2345, decides to retire that tracking
+  regime entirely; not in this PR's scope)
+
+## Out of scope (not done in this PR)
+
+- Re-running Kiran's original fuzz harness against current master on
+  v4.30.0-rc2 to confirm the runtime buffer-overflow class is closed
+  in practice (recorded as a Missing-work bullet in the inventory)
+- Stripping line-number anchors from `SECURITY_INVENTORY.md` per
+  human-oversight #2345 (separate PR)
+- Wiring libdeflate / zopfli (#2346, #2347)


### PR DESCRIPTION
Closes #2344

Session: `2e0978e1-5667-4432-95b7-08db4231dc65`

8161be0 doc: progress entry for toolchain bump v4.29.1 → v4.30.0-rc2
7a66de4 chore: bump lean-toolchain v4.29.1 → v4.30.0-rc2

🤖 Prepared with Claude Code