### PR TITLE
human-oversight: Track D Phase 0a — wire libdeflate as a runtime/ratio comparator

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -2,6 +2,7 @@ import Zip.Basic
 import Zip.Gzip
 import Zip.Checksum
 import Zip.RawDeflate
+import Zip.Libdeflate
 import Zip.Tar
 import Zip.Archive
 import Zip.Spec.Adler32

--- a/Zip/Libdeflate.lean
+++ b/Zip/Libdeflate.lean
@@ -1,0 +1,24 @@
+/-! FFI bindings for libdeflate (raw DEFLATE only).
+
+    Track D Phase 0a comparator: libdeflate is an optimised C DEFLATE
+    library, often faster than zlib at higher compression ratios. Wired
+    here as an unverified runtime/ratio reference point — no equivalence
+    proofs, no streaming API (libdeflate provides whole-buffer only). -/
+
+namespace Libdeflate
+
+/-- Compress data using raw DEFLATE via libdeflate.
+    `level` ranges from 0 (no compression) to 12 (slowest, best). Levels
+    0..9 match the zlib scale; 10..12 are libdeflate-only. Default 6. -/
+@[extern "lean_libdeflate_compress"]
+opaque compress (data : @& ByteArray) (level : UInt8 := 6) : IO ByteArray
+
+/-- Decompress raw DEFLATE data via libdeflate.
+    `maxDecompressedSize` caps output size; default 1 GiB; pass `0` to opt
+    into unlimited mode (bomb-unsafe for untrusted input). Overflow raises
+    `IO.userError` containing `"decompressed size exceeds limit"`. -/
+@[extern "lean_libdeflate_decompress"]
+opaque decompress (data : @& ByteArray)
+    (maxDecompressedSize : UInt64 := 1024 * 1024 * 1024) : IO ByteArray
+
+end Libdeflate

--- a/ZipBench.lean
+++ b/ZipBench.lean
@@ -7,9 +7,11 @@ Usage:
 Operations:
   inflate        — native DEFLATE decompression
   inflate-ffi    — zlib FFI decompression
+  inflate-libdeflate — libdeflate FFI decompression
   deflate        — native DEFLATE compression (fixed Huffman)
   deflate-lazy   — native DEFLATE compression (lazy matching)
   deflate-ffi    — zlib FFI compression
+  compress-libdeflate — libdeflate FFI compression
   gzip           — native gzip decompression
   gzip-ffi       — zlib FFI gzip decompression
   zlib           — native zlib decompression
@@ -113,6 +115,13 @@ where
       pure ()
     | "deflate-ffi" =>
       let _ ← RawDeflate.compress data level.toUInt8
+      pure ()
+    | "compress-libdeflate" =>
+      let _ ← Libdeflate.compress data level.toUInt8
+      pure ()
+    | "inflate-libdeflate" =>
+      let compressed ← Libdeflate.compress data level.toUInt8
+      let _ ← Libdeflate.decompress compressed
       pure ()
     -- Checksum benchmarks
     | "crc32" =>

--- a/ZipTest.lean
+++ b/ZipTest.lean
@@ -2,6 +2,7 @@ import ZipTest.BenchHelpers
 import ZipTest.Zlib
 import ZipTest.Gzip
 import ZipTest.RawDeflate
+import ZipTest.Libdeflate
 import ZipTest.Checksum
 import ZipTest.Binary
 import ZipTest.Tar
@@ -28,6 +29,7 @@ def main : IO Unit := do
   ZipTest.Zlib.tests
   ZipTest.Gzip.tests
   ZipTest.RawDeflate.tests
+  ZipTest.Libdeflate.tests
   ZipTest.Checksum.tests
   ZipTest.Binary.tests
   ZipTest.Tar.tests

--- a/ZipTest/Libdeflate.lean
+++ b/ZipTest/Libdeflate.lean
@@ -1,0 +1,56 @@
+import ZipTest.Helpers
+
+/-! Smoke tests for the libdeflate FFI comparator (Track D Phase 0a).
+
+    libdeflate is unverified; these checks are conformance against zlib /
+    the native inflate decoder, not correctness proofs. The point is that
+    libdeflate emits valid raw DEFLATE that the rest of the pipeline can
+    decode, so it can be used as a runtime/ratio reference. -/
+
+-- Compile-time probe: FFI default is 1 GiB (mirrors the `RawDeflate` probe).
+example (d : ByteArray) : Libdeflate.decompress d = @Libdeflate.decompress d (1024 * 1024 * 1024) := rfl
+
+def ZipTest.Libdeflate.tests : IO Unit := do
+  let big ← mkTestData
+
+  -- Whole-buffer roundtrip via libdeflate alone.
+  let ldCompressed ← Libdeflate.compress big
+  let ldDecompressed ← Libdeflate.decompress ldCompressed
+  assert! ldDecompressed.beq big
+
+  -- Cross-check: libdeflate compress + zlib FFI inflate decodes correctly.
+  let zlibDecomp ← RawDeflate.decompress ldCompressed
+  assert! zlibDecomp.beq big
+
+  -- Cross-check: libdeflate compress + native inflate decodes correctly.
+  match Zip.Native.Inflate.inflate ldCompressed with
+  | .ok bytes => assert! bytes.beq big
+  | .error e => throw (IO.userError s!"native inflate of libdeflate output failed: {e}")
+
+  -- Empty input edge case.
+  let ldCE ← Libdeflate.compress ByteArray.empty
+  let ldDE ← Libdeflate.decompress ldCE
+  assert! ldDE.beq ByteArray.empty
+
+  -- Single byte edge case.
+  let one := ByteArray.mk #[0x42]
+  let ldC1 ← Libdeflate.compress one
+  let ldD1 ← Libdeflate.decompress ldC1
+  assert! ldD1.beq one
+
+  -- Decompression limit: rejected with the shared "exceeds limit" wording.
+  assertThrows "libdeflate decompress limit"
+    (do let _ ← Libdeflate.decompress ldCompressed (maxDecompressedSize := 10); pure ())
+    "exceeds limit"
+
+  -- Bad data is rejected.
+  assertThrows "libdeflate bad data"
+    (do let _ ← Libdeflate.decompress (ByteArray.mk #[0xFF, 0xFF, 0xFF, 0xFF]); pure ())
+    "libdeflate decompress"
+
+  -- Higher levels (10-12) are libdeflate-only and must succeed.
+  let ldC12 ← Libdeflate.compress big 12
+  let ldD12 ← Libdeflate.decompress ldC12
+  assert! ldD12.beq big
+
+  IO.println "Libdeflate tests: OK"

--- a/c/libdeflate_ffi.c
+++ b/c/libdeflate_ffi.c
@@ -1,0 +1,162 @@
+#include <lean/lean.h>
+#include <libdeflate.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <limits.h>
+
+/*
+ * libdeflate FFI: raw DEFLATE compress/decompress for Track D ratio/runtime
+ * comparison against zlib. Whole-buffer only — libdeflate has no streaming
+ * API, which is the comparator-relevant point (zlib leaves room above it).
+ *
+ * Error wording follows the existing family in c/zlib_ffi.c so callers can
+ * `msg.contains "exceeds limit"` (see error-wording-catalogue skill).
+ */
+
+static lean_obj_res mk_byte_array(const uint8_t *data, size_t len) {
+    lean_obj_res arr = lean_alloc_sarray(1, len, len);
+    memcpy(lean_sarray_cptr(arr), data, len);
+    return arr;
+}
+
+static lean_obj_res mk_io_error(const char *msg) {
+    return lean_io_result_mk_error(lean_mk_io_user_error(lean_mk_string(msg)));
+}
+
+/* Translate a libdeflate_result into a human-readable suffix. */
+static const char *libdeflate_result_str(enum libdeflate_result r) {
+    switch (r) {
+        case LIBDEFLATE_SUCCESS:             return "success";
+        case LIBDEFLATE_BAD_DATA:             return "bad data";
+        case LIBDEFLATE_SHORT_OUTPUT:         return "short output";
+        case LIBDEFLATE_INSUFFICIENT_SPACE:   return "insufficient output space";
+        default:                              return "unknown";
+    }
+}
+
+/*
+ * lean_libdeflate_compress : @& ByteArray → UInt8 → IO ByteArray
+ *
+ * Raw DEFLATE compression. `level` ranges 0..12 (libdeflate's range);
+ * callers passing zlib-style 0..9 work unchanged because libdeflate
+ * accepts the same lower range.
+ */
+LEAN_EXPORT lean_obj_res lean_libdeflate_compress(b_lean_obj_arg data, uint8_t level, lean_obj_arg _w) {
+    const uint8_t *src = lean_sarray_cptr(data);
+    size_t src_len = lean_sarray_size(data);
+
+    if (level > 12) {
+        return mk_io_error("libdeflate compress: invalid level (must be 0..12)");
+    }
+
+    struct libdeflate_compressor *c = libdeflate_alloc_compressor((int)level);
+    if (!c) {
+        return mk_io_error("libdeflate compress: out of memory or invalid level");
+    }
+
+    size_t bound = libdeflate_deflate_compress_bound(c, src_len);
+    lean_obj_res arr = lean_alloc_sarray(1, 0, bound);
+    uint8_t *dest = lean_sarray_cptr(arr);
+
+    size_t out_len = libdeflate_deflate_compress(c, src, src_len, dest, bound);
+    libdeflate_free_compressor(c);
+    if (out_len == 0) {
+        lean_dec_ref(arr);
+        return mk_io_error("libdeflate compress: did not fit into compress_bound buffer");
+    }
+
+    lean_sarray_set_size(arr, out_len);
+    return lean_io_result_mk_ok(arr);
+}
+
+/*
+ * lean_libdeflate_decompress : @& ByteArray → UInt64 → IO ByteArray
+ *
+ * Raw DEFLATE decompression. libdeflate has no streaming API and requires
+ * a sized output buffer; we start with a 4× guess and double on
+ * LIBDEFLATE_INSUFFICIENT_SPACE, capping at `max_output` (0 = unlimited).
+ *
+ * Honours `maxDecompressedSize` with the shared "exceeds limit" wording.
+ */
+LEAN_EXPORT lean_obj_res lean_libdeflate_decompress(b_lean_obj_arg data, uint64_t max_output, lean_obj_arg _w) {
+    const uint8_t *src = lean_sarray_cptr(data);
+    size_t src_len = lean_sarray_size(data);
+    char errbuf[256];
+
+    struct libdeflate_decompressor *d = libdeflate_alloc_decompressor();
+    if (!d) {
+        return mk_io_error("libdeflate decompress: out of memory");
+    }
+
+    size_t buf_size;
+    if (src_len <= SIZE_MAX / 4) {
+        buf_size = src_len * 4;
+        if (buf_size < 1024) buf_size = 1024;
+    } else {
+        buf_size = src_len;
+    }
+    if (max_output > 0 && (uint64_t)buf_size > max_output) {
+        buf_size = (size_t)max_output;
+        if (buf_size == 0) buf_size = 1;
+    }
+
+    uint8_t *buf = (uint8_t *)malloc(buf_size);
+    if (!buf) {
+        libdeflate_free_decompressor(d);
+        return mk_io_error("libdeflate decompress: out of memory");
+    }
+
+    size_t actual_out = 0;
+    enum libdeflate_result r;
+    for (;;) {
+        r = libdeflate_deflate_decompress(d, src, src_len, buf, buf_size, &actual_out);
+        if (r == LIBDEFLATE_SUCCESS) break;
+        if (r != LIBDEFLATE_INSUFFICIENT_SPACE) {
+            free(buf);
+            libdeflate_free_decompressor(d);
+            snprintf(errbuf, sizeof(errbuf), "libdeflate decompress: %s", libdeflate_result_str(r));
+            return mk_io_error(errbuf);
+        }
+        /* Insufficient space: double the buffer, but respect max_output. */
+        if (max_output > 0 && (uint64_t)buf_size >= max_output) {
+            free(buf);
+            libdeflate_free_decompressor(d);
+            snprintf(errbuf, sizeof(errbuf),
+                     "libdeflate decompress: decompressed size exceeds limit (%llu bytes)",
+                     (unsigned long long)max_output);
+            return mk_io_error(errbuf);
+        }
+        if (buf_size > SIZE_MAX / 2) {
+            free(buf);
+            libdeflate_free_decompressor(d);
+            return mk_io_error("libdeflate decompress: output buffer overflow");
+        }
+        size_t new_size = buf_size * 2;
+        if (max_output > 0 && (uint64_t)new_size > max_output) {
+            new_size = (size_t)max_output;
+        }
+        uint8_t *newbuf = (uint8_t *)realloc(buf, new_size);
+        if (!newbuf) {
+            free(buf);
+            libdeflate_free_decompressor(d);
+            return mk_io_error("libdeflate decompress: out of memory");
+        }
+        buf = newbuf;
+        buf_size = new_size;
+    }
+    libdeflate_free_decompressor(d);
+
+    if (max_output > 0 && (uint64_t)actual_out > max_output) {
+        free(buf);
+        snprintf(errbuf, sizeof(errbuf),
+                 "libdeflate decompress: decompressed size exceeds limit (%llu bytes)",
+                 (unsigned long long)max_output);
+        return mk_io_error(errbuf);
+    }
+
+    lean_obj_res result = mk_byte_array(buf, actual_out);
+    free(buf);
+    return lean_io_result_mk_ok(result);
+}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -39,21 +39,53 @@ def nixLdLibPaths : IO (Array String) := do
   let some val := (← IO.getEnv "NIX_LDFLAGS") | return #[]
   return val.splitOn " " |>.filter (·.startsWith "-L") |>.toArray
 
+/-- Prefer an explicit libdeflate linker override when supplied by the environment. -/
+def libdeflateLdFlagsOverride : IO (Option (Array String)) := do
+  return (← IO.getEnv "LIBDEFLATE_LDFLAGS") |>.map (splitFlags ·.trimAscii.toString)
+
+/-- Get libdeflate include flags, respecting `LIBDEFLATE_CFLAGS` env var override. -/
+def libdeflateCFlags : IO (Array String) := do
+  if let some flags := (← IO.getEnv "LIBDEFLATE_CFLAGS") then
+    return splitFlags flags.trimAscii.toString
+  let flags ← pkgConfig "libdeflate" "--cflags"
+  if !flags.isEmpty then
+    return flags
+  if let some sdk := (← macSdkPath) then
+    return #["-I", (sdk / "usr/include").toString]
+  return #[]
+
 /-- Get link flags for zlib.
     Tries `ZLIB_LDFLAGS`, then pkg-config, then macOS SDK / Nix fallbacks. -/
 def linkFlags : IO (Array String) := do
-  if let some flags := (← zlibLdFlagsOverride) then
-    return flags
-  let libPaths ← nixLdLibPaths
-  let zlibFlags ← pkgConfig "zlib" "--libs"
-  if !zlibFlags.isEmpty && zlibFlags.any (·.startsWith "-L") then
-    return zlibFlags
-  if let some sdk := (← macSdkPath) then
-    return #["-L", (sdk / "usr/lib").toString, "-lz"]
-  if !zlibFlags.isEmpty then
-    return libPaths ++ zlibFlags
-  -- pkg-config unavailable — try NIX_LDFLAGS for -L paths
-  return libPaths ++ #["-lz"]
+  let zFlags ← do
+    if let some flags := (← zlibLdFlagsOverride) then
+      pure flags
+    else
+      let libPaths ← nixLdLibPaths
+      let zlibFlags ← pkgConfig "zlib" "--libs"
+      if !zlibFlags.isEmpty && zlibFlags.any (·.startsWith "-L") then
+        pure zlibFlags
+      else if let some sdk := (← macSdkPath) then
+        pure #["-L", (sdk / "usr/lib").toString, "-lz"]
+      else if !zlibFlags.isEmpty then
+        pure (libPaths ++ zlibFlags)
+      else
+        pure (libPaths ++ #["-lz"])
+  let dFlags ← do
+    if let some flags := (← libdeflateLdFlagsOverride) then
+      pure flags
+    else
+      let libPaths ← nixLdLibPaths
+      let dlibFlags ← pkgConfig "libdeflate" "--libs"
+      if !dlibFlags.isEmpty && dlibFlags.any (·.startsWith "-L") then
+        pure dlibFlags
+      else if let some sdk := (← macSdkPath) then
+        pure #["-L", (sdk / "usr/lib").toString, "-ldeflate"]
+      else if !dlibFlags.isEmpty then
+        pure (libPaths ++ dlibFlags)
+      else
+        pure (libPaths ++ #["-ldeflate"])
+  return zFlags ++ dFlags
 
 package «lean-zip» where
   moreLinkArgs := run_io linkFlags
@@ -78,6 +110,23 @@ target zlib_ffi.o pkg : FilePath := do
 extern_lib libzlib_ffi pkg := do
   let ffiO ← zlib_ffi.o.fetch
   let name := nameToStaticLib "zlib_ffi"
+  buildStaticLib (pkg.staticLibDir / name) #[ffiO]
+
+-- libdeflate FFI (Track D Phase 0a comparator)
+input_file libdeflate_ffi.c where
+  path := "c" / "libdeflate_ffi.c"
+  text := true
+
+target libdeflate_ffi.o pkg : FilePath := do
+  let srcJob ← libdeflate_ffi.c.fetch
+  let oFile := pkg.buildDir / "c" / "libdeflate_ffi.o"
+  let weakArgs := #["-I", (← getLeanIncludeDir).toString] ++ (← libdeflateCFlags)
+  let hardArgs := if Platform.isWindows then #[] else #["-fPIC"]
+  buildO oFile srcJob weakArgs hardArgs "cc"
+
+extern_lib libLibdeflate_ffi pkg := do
+  let ffiO ← libdeflate_ffi.o.fetch
+  let name := nameToStaticLib "libdeflate_ffi"
   buildStaticLib (pkg.staticLibDir / name) #[ffiO]
 
 lean_lib ZipTest where

--- a/progress/20260428T084746Z_43204025.md
+++ b/progress/20260428T084746Z_43204025.md
@@ -1,0 +1,68 @@
+# Progress: libdeflate FFI comparator (Track D Phase 0a)
+
+- Date: 2026-04-28 08:47 UTC
+- Session: 43204025
+- Type: feature
+- Issue: #2346
+
+## What was accomplished
+
+Wired libdeflate as a Track D Phase 0a comparator alongside the existing
+zlib FFI:
+
+- `c/libdeflate_ffi.c` — raw DEFLATE compress/decompress shim. Whole-buffer
+  only (libdeflate has no streaming API, by design). Honours
+  `maxDecompressedSize` via the shared `"exceeds limit"` wording family.
+  Doubling-on-`INSUFFICIENT_SPACE` decompression loop, capped at the limit.
+- `Zip/Libdeflate.lean` — `Libdeflate.compress` / `Libdeflate.decompress`
+  opaque FFI wrappers, paralleling `Zip/RawDeflate.lean`.
+- `lakefile.lean` — new pkg-config helpers (`libdeflateCFlags`,
+  `libdeflateLdFlagsOverride`), `LIBDEFLATE_CFLAGS` / `LIBDEFLATE_LDFLAGS`
+  env-override, macOS SDK + Nix fallback chain matching the zlib block.
+  Added `libdeflate_ffi.o` target and `libLibdeflate_ffi` extern_lib.
+- `shell.nix` — `libdeflate` added to `buildInputs`.
+- `ZipBench.lean` — `compress-libdeflate` and `inflate-libdeflate` operations.
+- `ZipTest/Libdeflate.lean` — smoke roundtrip via libdeflate alone, cross-
+  decoded with both zlib FFI inflate and the native inflate decoder, plus
+  empty-input / single-byte / level-12 / bomb-limit / bad-data assertions.
+
+## Decisions
+
+- **No streaming API.** libdeflate is whole-buffer; matched in the FFI by
+  not exposing `DeflateState`/`InflateState`. Streaming benchmarks will only
+  compare native vs zlib, with libdeflate as a whole-buffer reference point.
+- **No equivalence proofs.** The issue is explicit that libdeflate is
+  unverified; this is a comparator, not a target for correctness proofs.
+- **Compression level range 0..12** rather than zlib's 0..9. Levels 10-12
+  are libdeflate-only optimisation levels and are exercised in the test.
+- **Lakefile composition.** Refactored `linkFlags` to compose zlib flags +
+  libdeflate flags rather than picking one. Both stacks share the
+  `nixLdLibPaths` helper, the macOS-SDK fallback, and the env override.
+- **Error wording.** Reused the existing `"exceeds limit"` family from
+  `error-wording-catalogue` so the new bomb-limit assertion uses the same
+  substring as `RawDeflate.decompress`.
+
+## Verification
+
+- `nix-shell --run "lake build"` → 199/199 succeed.
+- `nix-shell --run "LD_LIBRARY_PATH=...:... lake exe test"` → all suites
+  pass, including the new `Libdeflate tests: OK`. (LD_LIBRARY_PATH override
+  is just the local nix-store loader path — same constraint as the existing
+  zlib FFI; CI on a system with libdeflate-dev would not need it.)
+- `lake exe bench compress-libdeflate 65536 cyclic 6` and
+  `lake exe bench inflate-libdeflate 65536 cyclic 6` complete cleanly.
+
+The bench operations use the existing `constant`/`cyclic`/`prng` patterns
+(the issue's example mentions `text`, but `text` isn't currently in
+`ZipBench.lean`'s `generateData`; that would be a separate Phase 1 change).
+
+## Quality metric delta
+
+- sorry count: `0 → 0` (no proofs added).
+
+## What remains for Phase 0b/0c/1
+
+- Phase 0b: zopfli quality-ceiling wiring (separate issue).
+- Phase 0c: miniz_oxide via Rust (separate issue).
+- Phase 1: bench harness extension to use these comparators in two
+  dimensions (runtime + ratio).

--- a/shell.nix
+++ b/shell.nix
@@ -3,5 +3,6 @@ pkgs.mkShell {
   buildInputs = [
     pkgs.pkg-config
     pkgs.zlib
+    pkgs.libdeflate
   ];
 }


### PR DESCRIPTION
Closes #2346

Session: `43204025-c1d0-42e5-af6d-03b9fca9fed3`

15c9775 doc: progress entry for #2346 (libdeflate Track D Phase 0a)
acea236 feat: wire libdeflate as runtime/ratio comparator (Track D Phase 0a)

🤖 Prepared with Claude Code