### PR TITLE
human-oversight: Track D Phase 0b — wire zopfli as the compression-ratio quality ceiling

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -2,6 +2,7 @@ import Zip.Basic
 import Zip.Gzip
 import Zip.Checksum
 import Zip.RawDeflate
+import Zip.Zopfli
 import Zip.Tar
 import Zip.Archive
 import Zip.Spec.Adler32

--- a/Zip/Zopfli.lean
+++ b/Zip/Zopfli.lean
@@ -1,0 +1,23 @@
+import Zip.RawDeflate
+
+/-! FFI binding for [zopfli](https://github.com/google/zopfli) — Google's
+maximum-compression DEFLATE encoder.
+
+Zopfli is encode-only (no decompressor) and intentionally ~100× slower than
+zlib level 9. It produces strictly DEFLATE-compatible output, just smaller.
+Used as the compression-ratio quality ceiling in Track D benchmarks; not on
+any production hot path. -/
+
+namespace Zopfli
+
+/-- Compress `data` with zopfli using raw DEFLATE framing (no header/trailer,
+    matching `RawDeflate.compress`).
+
+    `iterations` is zopfli's moral equivalent of zlib's compression level:
+    more iterations of forward/backward LZ77 cost optimization → better
+    compression at the cost of runtime. Defaults to `15` (zopfli's recommended
+    default for small files); `1` is fastest, more is better. Must be ≥ 1. -/
+@[extern "lean_zopfli_deflate"]
+opaque compress (data : @& ByteArray) (iterations : UInt32 := 15) : IO ByteArray
+
+end Zopfli

--- a/ZipBench.lean
+++ b/ZipBench.lean
@@ -10,6 +10,7 @@ Operations:
   deflate        — native DEFLATE compression (fixed Huffman)
   deflate-lazy   — native DEFLATE compression (lazy matching)
   deflate-ffi    — zlib FFI compression
+  compress-zopfli — zopfli FFI raw-deflate compression (quality ceiling, slow)
   gzip           — native gzip decompression
   gzip-ffi       — zlib FFI gzip decompression
   zlib           — native zlib decompression
@@ -54,26 +55,54 @@ def mkPrngData (size : Nat) : ByteArray := Id.run do
     result := result.push (state &&& 0xFF).toUInt8
   return result
 
+/-- Pseudo-text: cycles through common English words with spaces and newlines.
+    Same shape as `ZipTest.Helpers.mkTextData` (deflate-friendly redundancy). -/
+def mkTextData (size : Nat) : ByteArray := Id.run do
+  let words := #["the", "of", "and", "to", "in", "a", "is", "that", "for", "it",
+                  "was", "on", "are", "be", "with", "as", "at", "this", "have", "from",
+                  "or", "by", "not", "but", "what", "all", "were", "when", "we", "there",
+                  "can", "an", "your", "which", "their", "if", "do", "will", "each", "how"]
+  let mut result := ByteArray.empty
+  let mut col : Nat := 0
+  let mut wi : Nat := 0
+  while result.size < size do
+    let word := words[wi % words.size]!
+    wi := wi + 1
+    if col > 0 then
+      if col + 1 + word.length > 72 then
+        result := result.push 0x0A
+        col := 0
+      else
+        result := result.push 0x20
+        col := col + 1
+    for c in word.toUTF8 do
+      if result.size < size then
+        result := result.push c
+    col := col + word.length
+  return result.extract 0 size
+
 def generateData (pattern : String) (size : Nat) : IO ByteArray :=
   match pattern with
   | "constant" => pure (mkConstantData size)
   | "cyclic"   => pure (mkCyclicData size)
   | "prng"     => pure (mkPrngData size)
+  | "text"     => pure (mkTextData size)
   | other      => throw (IO.userError s!"unknown pattern: {other}")
 
 def main (args : List String) : IO Unit := do
   match args with
-  | [op, sizeStr, pattern] => run op sizeStr pattern 6
+  | [op, sizeStr, pattern] => run op sizeStr pattern none
   | [op, sizeStr, pattern, levelStr] =>
     match levelStr.toNat? with
-    | some level => run op sizeStr pattern level
+    | some level => run op sizeStr pattern (some level)
     | none => usage
   | _ => usage
 where
   usage := throw (IO.userError
-    "usage: bench <operation> <size> <constant|cyclic|prng> [level]")
-  run (op sizeStr pattern : String) (level : Nat) : IO Unit := do
+    "usage: bench <operation> <size> <constant|cyclic|prng|text> [level]")
+  run (op sizeStr pattern : String) (levelOpt : Option Nat) : IO Unit := do
     let some size := sizeStr.toNat? | usage
+    let level := levelOpt.getD 6
     let data ← generateData pattern size
     match op with
     -- Decompression benchmarks (compress with FFI first, then decompress)
@@ -114,6 +143,16 @@ where
     | "deflate-ffi" =>
       let _ ← RawDeflate.compress data level.toUInt8
       pure ()
+    | "compress-zopfli" =>
+      let iterations := levelOpt.getD 15
+      -- Zopfli is intentionally ~100× zlib level 9. Cap by default at 64KB
+      -- so a stray bench run does not stall the harness; gate larger sizes
+      -- behind ZOPFLI_FORCE=1.
+      if size > 65536 ∧ (← IO.getEnv "ZOPFLI_FORCE") ≠ some "1" then
+        throw (IO.userError
+          s!"compress-zopfli: input size {size} exceeds 64KB cap; set ZOPFLI_FORCE=1 to override")
+      let compressed ← Zopfli.compress data iterations.toUInt32
+      IO.println compressed.size
     -- Checksum benchmarks
     | "crc32" =>
       let _ := Crc32.Native.crc32 0 data

--- a/ZipTest.lean
+++ b/ZipTest.lean
@@ -2,6 +2,7 @@ import ZipTest.BenchHelpers
 import ZipTest.Zlib
 import ZipTest.Gzip
 import ZipTest.RawDeflate
+import ZipTest.Zopfli
 import ZipTest.Checksum
 import ZipTest.Binary
 import ZipTest.Tar
@@ -28,6 +29,7 @@ def main : IO Unit := do
   ZipTest.Zlib.tests
   ZipTest.Gzip.tests
   ZipTest.RawDeflate.tests
+  ZipTest.Zopfli.tests
   ZipTest.Checksum.tests
   ZipTest.Binary.tests
   ZipTest.Tar.tests

--- a/ZipTest/Zopfli.lean
+++ b/ZipTest/Zopfli.lean
@@ -1,0 +1,47 @@
+import ZipTest.Helpers
+
+/-! Smoke tests for the zopfli FFI binding.
+
+Zopfli is the maximum-compression DEFLATE encoder used as the Track D
+ratio quality ceiling. It is encode-only and intentionally ~100× slower
+than zlib level 9, so we keep tests small (≤ 4 KB). -/
+
+def ZipTest.Zopfli.tests : IO Unit := do
+  -- 1. Roundtrip via the native (pure-Lean) inflate decoder, on a 4 KB
+  --    text input. This exercises the deflate framing zopfli emits.
+  let txt := mkTextData 4096
+  -- Use 5 iterations to keep the test fast; default 15 is for production runs.
+  let zopfliOut ← Zopfli.compress txt (iterations := 5)
+  match Zip.Native.Inflate.inflate zopfliOut with
+  | .ok decoded =>
+    unless decoded.beq txt do
+      throw (IO.userError "zopfli roundtrip: native inflate produced different bytes")
+  | .error e =>
+    throw (IO.userError s!"zopfli roundtrip: native inflate failed: {e}")
+
+  -- 2. Quality sanity check: zopfli output must be ≤ zlib level-9 output on
+  --    text. A fallback to plain zlib (or raw bytes) would fail this.
+  let zlib9 ← RawDeflate.compress txt (level := 9)
+  unless zopfliOut.size ≤ zlib9.size do
+    throw (IO.userError s!"zopfli quality regression: zopfli={zopfliOut.size} bytes \
+      > zlib level 9={zlib9.size} bytes (likely linked the wrong library)")
+
+  -- 3. Empty input still produces a decodable raw deflate stream.
+  let empty ← Zopfli.compress ByteArray.empty (iterations := 1)
+  unless empty.size > 0 do
+    throw (IO.userError "zopfli on empty input produced zero bytes")
+  match Zip.Native.Inflate.inflate empty with
+  | .ok decoded =>
+    unless decoded.beq ByteArray.empty do
+      throw (IO.userError "zopfli empty roundtrip: native inflate decoded non-empty bytes")
+  | .error e =>
+    throw (IO.userError s!"zopfli empty roundtrip: native inflate failed: {e}")
+
+  -- 4. iterations = 0 is rejected at the FFI boundary.
+  match ← (Zopfli.compress txt (iterations := 0)).toBaseIO with
+  | .ok _ => throw (IO.userError "zopfli iterations=0 should have been rejected")
+  | .error e =>
+    unless (toString e).contains "numIterations" do
+      throw (IO.userError s!"zopfli iterations=0 wrong error: {e}")
+
+  IO.println "Zopfli tests: OK"

--- a/c/zopfli_ffi.c
+++ b/c/zopfli_ffi.c
@@ -1,0 +1,68 @@
+#include <lean/lean.h>
+#include <zopfli.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <limits.h>
+
+/*
+ * Zopfli FFI shim. Zopfli is encode-only (no decompress entry point) and
+ * intentionally very slow — typically ~100× zlib level 9. Used as the
+ * compression-ratio quality ceiling in Track D benchmarks; not on any
+ * production hot path.
+ *
+ * Output is appended to a heap buffer that ZopfliCompress allocates via
+ * malloc/realloc. We copy it into a Lean ByteArray and free the original.
+ */
+
+static lean_obj_res mk_byte_array(const uint8_t *data, size_t len) {
+    lean_obj_res arr = lean_alloc_sarray(1, len, len);
+    memcpy(lean_sarray_cptr(arr), data, len);
+    return arr;
+}
+
+static lean_obj_res mk_io_error(const char *msg) {
+    return lean_io_result_mk_error(lean_mk_io_user_error(lean_mk_string(msg)));
+}
+
+/*
+ * Compress `data` with zopfli, raw deflate framing.
+ *
+ * lean_zopfli_deflate : @& ByteArray → UInt32 → IO ByteArray
+ *
+ * `numIterations` controls the optimization budget; must be ≥ 1.
+ * Zopfli treats it as `int`, so we reject values that would not round-trip.
+ */
+LEAN_EXPORT lean_obj_res lean_zopfli_deflate(b_lean_obj_arg data,
+                                             uint32_t numIterations,
+                                             lean_obj_arg _w) {
+    const uint8_t *src = lean_sarray_cptr(data);
+    size_t src_len = lean_sarray_size(data);
+
+    if (numIterations == 0) {
+        return mk_io_error("zopfli deflate: numIterations must be >= 1");
+    }
+    if (numIterations > (uint32_t)INT_MAX) {
+        return mk_io_error("zopfli deflate: numIterations too large");
+    }
+
+    ZopfliOptions options;
+    ZopfliInitOptions(&options);
+    options.numiterations = (int)numIterations;
+
+    unsigned char *out = NULL;
+    size_t out_len = 0;
+    ZopfliCompress(&options, ZOPFLI_FORMAT_DEFLATE, src, src_len, &out, &out_len);
+
+    /* ZopfliCompress always emits at least one deflate block (e.g. an empty
+     * stored block for empty input), so out should be non-NULL on success.
+     * If the underlying realloc failed, zopfli aborts the process — there is
+     * no error-return path. Guard anyway in case of API drift. */
+    if (out == NULL) {
+        return mk_io_error("zopfli deflate: output buffer is null");
+    }
+
+    lean_obj_res result = mk_byte_array(out, out_len);
+    free(out);
+    return lean_io_result_mk_ok(result);
+}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -81,13 +81,16 @@ def zlibLinkFlags : IO (Array String) := do
     primary working path on NixOS. We always include `-lm` because libzopfli
     references `log` from libm.
 
-    We pass `-Wl,--allow-shlib-undefined` because Lean's bundled toolchain
-    ships an old glibc (only `log@GLIBC_2.2.5`) while a Nix-built libzopfli
-    links against `log@GLIBC_2.29`. The strict default of `ld.lld`
+    On Linux we pass `-Wl,--allow-shlib-undefined` because Lean's bundled
+    toolchain ships an old glibc (only `log@GLIBC_2.2.5`) while a Nix-built
+    libzopfli links against `log@GLIBC_2.29`. The strict default of `ld.lld`
     (`--no-allow-shlib-undefined`) refuses such links even though the
-    dynamic loader resolves the symbol at runtime via libzopfli's RUNPATH. -/
+    dynamic loader resolves the symbol at runtime via libzopfli's RUNPATH.
+    macOS's ld64 does not recognize the flag, and the issue does not arise
+    there — Homebrew's libzopfli links against the same libSystem the Lean
+    toolchain uses. -/
 def zopfliLinkFlags : IO (Array String) := do
-  let lazyFlag := #["-Wl,--allow-shlib-undefined"]
+  let lazyFlag := if Platform.isOSX then #[] else #["-Wl,--allow-shlib-undefined"]
   if let some flags := (← IO.getEnv "ZOPFLI_LDFLAGS") then
     return splitFlags flags.trimAscii.toString
   let zopfliFlags ← pkgConfig "zopfli" "--libs"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -34,14 +34,34 @@ def zlibCFlags : IO (Array String) := do
     return #["-I", (sdk / "usr/include").toString]
   return #[]
 
+/-- Get zopfli include flags, respecting `ZOPFLI_CFLAGS` env var override.
+    Zopfli on Nix does not ship a `.pc` file, so we rely on `NIX_CFLAGS_COMPILE`
+    being inherited by `cc` for the include path on NixOS. -/
+def zopfliCFlags : IO (Array String) := do
+  if let some flags := (← IO.getEnv "ZOPFLI_CFLAGS") then
+    return splitFlags flags.trimAscii.toString
+  let flags ← pkgConfig "zopfli" "--cflags"
+  if !flags.isEmpty then
+    return flags
+  return #[]
+
 /-- Extract `-L` library paths from `NIX_LDFLAGS` (set by nix-shell). -/
 def nixLdLibPaths : IO (Array String) := do
   let some val := (← IO.getEnv "NIX_LDFLAGS") | return #[]
   return val.splitOn " " |>.filter (·.startsWith "-L") |>.toArray
 
+/-- Convert `-L<path>` flags into `-Wl,-rpath,<path>` so the linked binary
+    can find the dynamic libraries at runtime even outside the nix-shell. -/
+def nixLdRpathFlags : IO (Array String) := do
+  let paths ← nixLdLibPaths
+  return paths.map fun lflag =>
+    -- Strip the leading "-L" and re-emit as a runtime rpath.
+    let path : String := (lflag.toSubstring.drop 2).toString
+    "-Wl,-rpath," ++ path
+
 /-- Get link flags for zlib.
     Tries `ZLIB_LDFLAGS`, then pkg-config, then macOS SDK / Nix fallbacks. -/
-def linkFlags : IO (Array String) := do
+def zlibLinkFlags : IO (Array String) := do
   if let some flags := (← zlibLdFlagsOverride) then
     return flags
   let libPaths ← nixLdLibPaths
@@ -54,6 +74,35 @@ def linkFlags : IO (Array String) := do
     return libPaths ++ zlibFlags
   -- pkg-config unavailable — try NIX_LDFLAGS for -L paths
   return libPaths ++ #["-lz"]
+
+/-- Get link flags for zopfli.
+    Tries `ZOPFLI_LDFLAGS`, then pkg-config, then `NIX_LDFLAGS` + `-lzopfli -lm`.
+    Zopfli on Nix does not ship a `.pc` file, so the Nix fallback is the
+    primary working path on NixOS. We always include `-lm` because libzopfli
+    references `log` from libm.
+
+    We pass `-Wl,--allow-shlib-undefined` because Lean's bundled toolchain
+    ships an old glibc (only `log@GLIBC_2.2.5`) while a Nix-built libzopfli
+    links against `log@GLIBC_2.29`. The strict default of `ld.lld`
+    (`--no-allow-shlib-undefined`) refuses such links even though the
+    dynamic loader resolves the symbol at runtime via libzopfli's RUNPATH. -/
+def zopfliLinkFlags : IO (Array String) := do
+  let lazyFlag := #["-Wl,--allow-shlib-undefined"]
+  if let some flags := (← IO.getEnv "ZOPFLI_LDFLAGS") then
+    return splitFlags flags.trimAscii.toString
+  let zopfliFlags ← pkgConfig "zopfli" "--libs"
+  if !zopfliFlags.isEmpty && zopfliFlags.any (·.startsWith "-L") then
+    return zopfliFlags ++ #["-lm"] ++ lazyFlag
+  let libPaths ← nixLdLibPaths
+  if !zopfliFlags.isEmpty then
+    return libPaths ++ zopfliFlags ++ #["-lm"] ++ lazyFlag
+  return libPaths ++ #["-lzopfli", "-lm"] ++ lazyFlag
+
+/-- Combined link flags for the package (zlib + zopfli) plus runtime
+    rpath entries so the binary can locate the shared libraries outside of
+    nix-shell. -/
+def linkFlags : IO (Array String) := do
+  return (← zlibLinkFlags) ++ (← zopfliLinkFlags) ++ (← nixLdRpathFlags)
 
 package «lean-zip» where
   moreLinkArgs := run_io linkFlags
@@ -78,6 +127,23 @@ target zlib_ffi.o pkg : FilePath := do
 extern_lib libzlib_ffi pkg := do
   let ffiO ← zlib_ffi.o.fetch
   let name := nameToStaticLib "zlib_ffi"
+  buildStaticLib (pkg.staticLibDir / name) #[ffiO]
+
+-- zopfli FFI (encode-only DEFLATE quality ceiling)
+input_file zopfli_ffi.c where
+  path := "c" / "zopfli_ffi.c"
+  text := true
+
+target zopfli_ffi.o pkg : FilePath := do
+  let srcJob ← zopfli_ffi.c.fetch
+  let oFile := pkg.buildDir / "c" / "zopfli_ffi.o"
+  let weakArgs := #["-I", (← getLeanIncludeDir).toString] ++ (← zopfliCFlags)
+  let hardArgs := if Platform.isWindows then #[] else #["-fPIC"]
+  buildO oFile srcJob weakArgs hardArgs "cc"
+
+extern_lib libzopfli_ffi pkg := do
+  let ffiO ← zopfli_ffi.o.fetch
+  let name := nameToStaticLib "zopfli_ffi"
   buildStaticLib (pkg.staticLibDir / name) #[ffiO]
 
 lean_lib ZipTest where

--- a/progress/20260428T101603Z_625a7898.md
+++ b/progress/20260428T101603Z_625a7898.md
@@ -1,0 +1,86 @@
+# Session 625a7898 — Track D Phase 0b: zopfli FFI
+
+UTC 2026-04-28T10:16Z. `feature` worker. Issue #2347
+(`human-oversight: Track D Phase 0b — wire zopfli as the
+compression-ratio quality ceiling`).
+
+## What landed
+
+- `c/zopfli_ffi.c` — `lean_zopfli_deflate` shim around
+  `ZopfliCompress(ZOPFLI_FORMAT_DEFLATE, ...)`. Rejects `numIterations == 0`
+  and `> INT_MAX` at the FFI boundary; copies zopfli's malloc'd output into
+  a Lean ByteArray and `free`s the original.
+- `Zip/Zopfli.lean` — `Zopfli.compress (data) (iterations := 15) : IO ByteArray`.
+  Default 15 matches zopfli's recommended default for small files.
+- `lakefile.lean`
+  - Split `linkFlags` into `zlibLinkFlags` + `zopfliLinkFlags` and combine
+    them.
+  - Added `zopfliCFlags` (env override + pkg-config; falls back to the
+    inherited `NIX_CFLAGS_COMPILE` include path on NixOS).
+  - Added `nixLdRpathFlags` deriving `-Wl,-rpath,<path>` entries from each
+    `-L<path>` in `NIX_LDFLAGS` so the binary resolves libzopfli/libz
+    outside `nix-shell`. Pre-existing zlib path also benefits but already
+    worked because of system libz.
+  - Added `-Wl,--allow-shlib-undefined` (Linux only) for zopfli: Lean's
+    bundled toolchain ships glibc 2.2.5 only, while a Nix-built libzopfli
+    references `log@GLIBC_2.29`. Strict ld.lld would otherwise refuse the
+    link even though the dynamic loader resolves it at runtime via the
+    shlib's RUNPATH.
+  - Added `zopfli_ffi.o` target + `extern_lib libzopfli_ffi`.
+- `shell.nix` — add `pkgs.zopfli` to buildInputs.
+- `ZipBench.lean`
+  - `compress-zopfli` operation: iterations parameter (default 15), prints
+    output size on success.
+  - 64KB default cap; `ZOPFLI_FORCE=1` env var overrides.
+  - Added `text` pseudo-text generator pattern (cycles common English
+    words; same shape as `ZipTest.Helpers.mkTextData`).
+- `ZipTest/Zopfli.lean` — smoke tests:
+  1. 4KB text round-trip: zopfli → native pure-Lean inflate → original.
+  2. Quality sanity: zopfli output ≤ zlib level-9 output on 4KB text.
+     Catches a silent fallback to a non-zopfli compressor.
+  3. Empty input round-trips.
+  4. `iterations = 0` is rejected at the FFI boundary.
+- `Zip.lean` + `ZipTest.lean` — register new modules.
+
+## Verification (issue criteria)
+
+- `lake build` ✓ (199/199 jobs).
+- `lake exe test` ✓ (Zopfli tests + full suite green; zopfli ≤ zlib9 on
+  4KB text confirmed inside the suite).
+- `lake exe bench compress-zopfli 4096 text` → `172` bytes (smaller than
+  the corresponding zlib level 9 by construction of the in-suite check).
+- 64KB cap exercised manually: 100KB rejected with the documented error
+  message; 70KB passes with `ZOPFLI_FORCE=1`.
+
+## Decisions
+
+- **`-Wl,--allow-shlib-undefined`**: ld.lld's strict default (introduced
+  several major versions ago) flags any unresolved symbol referenced by
+  any loaded shlib at link time. Lean's bundled toolchain ships an old
+  glibc whose `libm.so` has only `log@GLIBC_2.2.5`. Nix-built libzopfli
+  references `log@GLIBC_2.29`. There is no clean static-link path through
+  the Nix derivation, and rewiring Lean's toolchain to use the Nix glibc
+  is out of scope. Allowing the unresolved symbol at link time is the
+  correct call: at runtime, libzopfli's own RUNPATH points to a glibc
+  that does export `log@GLIBC_2.29`. Guarded behind `Platform.isOSX`
+  because ld64 does not recognise the flag and the version-skew does not
+  arise there.
+- **rpath propagation**: `nix-shell` adds `-rpath <ephemeral>` entries
+  that vanish post-shell-exit. The actual library locations are in the
+  `-L<path>` flags. We translate every `-L<path>` into a matching
+  `-Wl,-rpath,<path>` so the binary stays runnable in plain shells.
+- **64KB bench cap**: zopfli at default settings on 100KB is several
+  seconds; cap is intentionally annoying-to-override to keep stray
+  `lake exe bench` runs fast.
+
+## What remains for later phases
+
+- Phase 0a (libdeflate runtime/ratio comparator) — separate issue #2346,
+  in flight.
+- Phase 0c (miniz_oxide) — issue #2349, unclaimed.
+- Phase 1 (two-dimensional bench harness with median-of-N variance) —
+  issue #2348, blocked on 0a/0b/0c.
+
+## Quality metric delta
+
+`grep -rc sorry Zip/`: 0 → 0 (no new sorries; this is a pure FFI binding).

--- a/shell.nix
+++ b/shell.nix
@@ -3,5 +3,6 @@ pkgs.mkShell {
   buildInputs = [
     pkgs.pkg-config
     pkgs.zlib
+    pkgs.zopfli
   ];
 }


### PR DESCRIPTION
Closes #2347

Session: `625a7898-8ea9-4745-9028-53c49fc8442b`

d8dea56 doc: progress entry for #2347 zopfli FFI feature session
d018544 fix: guard zopfli --allow-shlib-undefined behind non-OSX platform check
1ab1dc2 feat: wire zopfli FFI as Track D Phase 0b compression-ratio ceiling

🤖 Prepared with Claude Code