### PR TITLE
feat: clamp MinizOxide.compress level argument to 0–9 (closes #2374)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -259,18 +259,17 @@ Summary — what this pattern catches and what it does not:
     Rust / `miniz_oxide` versions are on the build host;
     `Cargo.lock` records the resolved version but is not currently
     treated as a security-critical artefact in this inventory.
-  - **`MinizOxide.compress` does not clamp the level argument.** The
-    Lean signature accepts a `UInt8` and the docstring documents an
-    intended 0–9 cap, but neither the Lean wrapper nor the C/Rust
-    shim enforces it; out-of-range values are passed through to
-    `miniz_oxide::deflate::compress_to_vec`. Bench callers always
-    pass 0–9, but a downstream caller wiring this API into a
-    non-bench codepath should wrap with their own clamp.
   - **If a downstream caller wires `MinizOxide.compress` /
     `MinizOxide.decompress` into a non-bench codepath, this row's
     `guarded-locally` status must be re-evaluated** alongside the
     sibling fuzz / sanitizer recipe above.
 - Recent wins:
+  - **`MinizOxide.compress` level argument now clamped to 0–9** in
+    PR #TBD-VERIFY-PR — the public `compress` is a thin wrapper that
+    clamps `level` via `if level > 9 then 9 else level` before
+    delegating to a `private opaque compressUnsafe` extern; smoke
+    tests assert levels 9, 10, and 255 produce byte-identical
+    compressed output, confirming the clamp is observable end-to-end.
   - Track D Phase 0c initial wiring — PR #2356
     (`Zip/MinizOxide.lean`, `c/miniz_oxide_ffi.c`,
     `rust/miniz_oxide_shim/` static-lib Cargo crate, `BENCH.md`

--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -265,7 +265,7 @@ Summary — what this pattern catches and what it does not:
     sibling fuzz / sanitizer recipe above.
 - Recent wins:
   - **`MinizOxide.compress` level argument now clamped to 0–9** in
-    PR #TBD-VERIFY-PR — the public `compress` is a thin wrapper that
+    PR #2378 — the public `compress` is a thin wrapper that
     clamps `level` via `if level > 9 then 9 else level` before
     delegating to a `private opaque compressUnsafe` extern; smoke
     tests assert levels 9, 10, and 255 produce byte-identical

--- a/Zip/MinizOxide.lean
+++ b/Zip/MinizOxide.lean
@@ -10,13 +10,21 @@
 
 namespace MinizOxide
 
-/-- Compress data using miniz_oxide raw DEFLATE (no zlib header / trailer).
-    `level` is the standard DEFLATE level 0–10 that miniz_oxide accepts; we
-    cap callers to 0–9 here to match the rest of the bench. Raises
-    `IO.userError` containing `"miniz_oxide: not built with Rust support"`
-    when the comparator toolchain was unavailable at build time. -/
+/-- Underlying FFI extern for `compress`. Forwards `level` unchanged to the
+    Rust shim, which silently treats out-of-range values as level 0 / level
+    10. Use `compress` instead — it clamps `level` to the documented 0–9
+    range before calling this function. -/
 @[extern "lean_miniz_oxide_compress_ffi"]
-opaque compress (data : @& ByteArray) (level : UInt8 := 6) : IO ByteArray
+private opaque compressUnsafe (data : @& ByteArray) (level : UInt8) : IO ByteArray
+
+/-- Compress data using miniz_oxide raw DEFLATE (no zlib header / trailer).
+    `level` is the standard DEFLATE level; values above 9 are clamped to 9
+    before forwarding to the Rust shim, matching the documented 0–9 range
+    used by the rest of the bench. Raises `IO.userError` containing
+    `"miniz_oxide: not built with Rust support"` when the comparator
+    toolchain was unavailable at build time. -/
+def compress (data : @& ByteArray) (level : UInt8 := 6) : IO ByteArray :=
+  compressUnsafe data (if level > 9 then 9 else level)
 
 /-- Decompress raw DEFLATE data using miniz_oxide.
     `maxDecompressedSize` caps the output (default 1 GiB; pass `0` to opt

--- a/ZipTest/MinizOxide.lean
+++ b/ZipTest/MinizOxide.lean
@@ -63,6 +63,15 @@ def tests : IO Unit := do
     let backConst0 ← MinizOxide.decompress mzConst0
     assert! backConst0.beq constant
 
+    -- Level clamp: values above 9 must be clamped to 9 before reaching
+    -- the Rust shim (otherwise miniz_oxide silently treats them as 0 or
+    -- 10). All three of these must produce byte-identical output.
+    let mzLevel9   ← MinizOxide.compress prng 9
+    let mzLevel10  ← MinizOxide.compress prng 10
+    let mzLevel255 ← MinizOxide.compress prng 255
+    assert! mzLevel10.beq mzLevel9
+    assert! mzLevel255.beq mzLevel9
+
     -- Empty input roundtrip.
     let mzEmpty ← MinizOxide.compress ByteArray.empty
     let backEmpty ← MinizOxide.decompress mzEmpty

--- a/progress/20260429T071145Z_b73ca1b0.md
+++ b/progress/20260429T071145Z_b73ca1b0.md
@@ -1,0 +1,145 @@
+# 2026-04-29T07:11Z — feature session b73ca1b0
+
+Session type: `/feature` (worker).
+Issues touched: #2366 (claimed → skipped), #2374 (claimed → PR).
+
+## Summary
+
+Closed one of the three Missing-work bullets under
+`SECURITY_INVENTORY.md` *Trusted Computing Base → miniz_oxide via Rust*
+(added by PR #2371): the public `MinizOxide.compress` now clamps its
+`level` argument to the documented 0–9 range before forwarding to the
+Rust shim.
+
+## Issue ledger
+
+- **#2366** (sanitize-ffi.sh re-run + April 2026 ASan + UBSan claim
+  refresh): claimed and immediately skipped per the issue's own
+  *"Platform requirement: Linux only"* preamble — this worktree is
+  running on Darwin, where Apple Clang's `cc -print-file-name=libasan.so`
+  is not an absolute path and `scripts/sanitize-ffi.sh`'s environment
+  guard exits 2. The previous three claims (`cbd9c8a0`, `82c9309b`,
+  `d02bf9c1`) released for the same / unrelated reasons; this is the
+  fourth release and the second specifically for the platform-mismatch
+  reason. The next claim from a Linux-host session will execute the
+  actual run.
+- **#2374** (clamp `MinizOxide.compress` level argument): executed
+  fully — see deliverables below.
+
+## What changed (#2374)
+
+### `Zip/MinizOxide.lean`
+
+Refactored the public `compress` from a direct extern into a thin
+clamp wrapper:
+
+- Renamed the extern from `compress` to `private opaque compressUnsafe`,
+  removed the default-level argument (the wrapper provides it), and
+  added a docstring explicitly noting that out-of-range values reach
+  miniz_oxide unchanged.
+- Added a public `def compress (data : @& ByteArray) (level : UInt8 := 6)`
+  that delegates to `compressUnsafe data (if level > 9 then 9 else level)`.
+- Updated the public-`compress` docstring to accurately describe the
+  clamp (the previous `"we cap callers to 0–9 here"` phrasing was
+  false: nothing in the Lean wrapper, the C shim, or the Rust shim
+  enforced the cap).
+
+The `compressUnsafe` extern preserves the existing FFI symbol
+`lean_miniz_oxide_compress_ffi`, so neither the C shim
+(`c/miniz_oxide_ffi.c`) nor the Rust shim
+(`rust/miniz_oxide_shim/src/lib.rs`) needed any change. The clamp is
+a pure Lean-side wrapper.
+
+### `ZipTest/MinizOxide.lean`
+
+Added three smoke-test assertions inside the existing `withMiniz`
+skip-guard so the disabled-toolchain path stays clean:
+
+```lean
+let mzLevel9   ← MinizOxide.compress prng 9
+let mzLevel10  ← MinizOxide.compress prng 10
+let mzLevel255 ← MinizOxide.compress prng 255
+assert! mzLevel10.beq mzLevel9
+assert! mzLevel255.beq mzLevel9
+```
+
+The PRNG payload is the existing `mkPrngData 4096` test fixture (less
+compressible than the `cyclic` payload, so different levels would
+naturally produce different bytes if the clamp wasn't observable). The
+test fails closed if the clamp regresses on either path:
+
+- without the clamp, `level=10` would reach `miniz_oxide` and return
+  level-10 bytes (different from level 9), and
+- without the clamp, `level=255` would silently wrap to level 0
+  (stored blocks) at the Rust shim, which is again byte-different
+  from level 9.
+
+### `SECURITY_INVENTORY.md`
+
+Moved the *"`MinizOxide.compress` does not clamp the level argument"*
+bullet from *Missing work* to *Recent wins*, in executed-past-tense
+one-liner shape per the `inventory-reconciliation` skill, citing
+`#TBD-VERIFY-PR` (placeholder; will be substituted on the same branch
+after PR creation per the pattern used by PR #2364 /
+`progress/20260428T122256Z_293ae374_anchor-refresh-closeout.md`).
+
+The *"If a downstream caller wires …"* re-evaluation bullet was kept
+in *Missing work* — it is an architectural reminder, not a closeable
+gap.
+
+## Verification
+
+- `lake build` — full project build succeeds (199/199 jobs).
+- `lake exe test` — full test suite passes including
+  `MinizOxide tests: OK` (the smoke tests ran end-to-end against the
+  Rust shim, not the disabled-toolchain skip path).
+- `bash scripts/check-inventory-links.sh` — `errors=0, warnings=1`;
+  the single warning is the expected `#TBD-VERIFY-PR` placeholder
+  warning, which the script surfaces as a *warning* (not an error)
+  precisely so the post-PR-creation substitution flow can proceed.
+- `git diff origin/master..HEAD --stat` — three files changed
+  (`Zip/MinizOxide.lean`, `ZipTest/MinizOxide.lean`,
+  `SECURITY_INVENTORY.md`), no other surface area touched.
+- Sorry count unchanged (0).
+
+## Decisions
+
+- **Lean-side clamp, not C-shim clamp.** The issue offered both
+  shapes; the Lean-side wrapper is preferred because the docstring is
+  the canonical user-facing contract (callers read `Zip/MinizOxide.lean`,
+  not `c/miniz_oxide_ffi.c`), and adding a clamp at the C-ABI surface
+  while leaving the Lean docstring as the contract would be a smaller
+  diff at the cost of a more confusing layering. The wrapper shape
+  also keeps the unsafe-without-clamp escape hatch available
+  module-internally as `compressUnsafe`, matching the
+  `compressUnsafe` / `compress` naming convention common in
+  bounds-checked APIs (cf. the `proven-bounds` skill family).
+- **PRNG payload as the clamp witness, not constant or text.** The
+  PRNG payload's compressibility differs across levels enough that
+  level 9 and level 10 produce different bytes through the unclamped
+  path, but constant-pattern payloads can produce identical bytes at
+  multiple adjacent levels (because the dictionary is saturated at
+  any non-trivial level). Using PRNG makes the test a sharper witness
+  of the clamp.
+
+## What remains (this row only)
+
+Two of the three Missing-work bullets under the `### miniz_oxide via
+Rust` row remain open after this PR lands:
+
+1. *No fuzz / ASan / UBSan recipe currently covers the Rust crate or
+   its C-ABI shim* — tracked separately; not in scope for this issue.
+2. *No upstream-tracking entry pinning the `miniz_oxide` crate
+   version against a known-good audit* — tracked by **#2376** (the
+   sibling Track E issue this session left unclaimed in the queue
+   for the next worker; the `Cargo.lock`-as-security-artefact
+   bullet).
+
+## Cross-links
+
+- Closes #2374.
+- Releases #2366 back to the queue with platform-mismatch reason
+  (4th release on that issue).
+- Sibling-row issue #2376 left in the unclaimed queue.
+
+🤖 Progress entry prepared with Claude Code

--- a/progress/20260429T071145Z_b73ca1b0.md
+++ b/progress/20260429T071145Z_b73ca1b0.md
@@ -79,7 +79,7 @@ test fails closed if the clamp regresses on either path:
 Moved the *"`MinizOxide.compress` does not clamp the level argument"*
 bullet from *Missing work* to *Recent wins*, in executed-past-tense
 one-liner shape per the `inventory-reconciliation` skill, citing
-`#TBD-VERIFY-PR` (placeholder; will be substituted on the same branch
+`#2378` (placeholder; will be substituted on the same branch
 after PR creation per the pattern used by PR #2364 /
 `progress/20260428T122256Z_293ae374_anchor-refresh-closeout.md`).
 
@@ -94,7 +94,7 @@ gap.
   `MinizOxide tests: OK` (the smoke tests ran end-to-end against the
   Rust shim, not the disabled-toolchain skip path).
 - `bash scripts/check-inventory-links.sh` — `errors=0, warnings=1`;
-  the single warning is the expected `#TBD-VERIFY-PR` placeholder
+  the single warning is the expected `#2378` placeholder
   warning, which the script surfaces as a *warning* (not an error)
   precisely so the post-PR-creation substitution flow can proceed.
 - `git diff origin/master..HEAD --stat` — three files changed


### PR DESCRIPTION
Closes #2374

Session: `b73ca1b0-32d8-43fb-aa1e-e61490cd91b7`

d16af09 doc(progress): feature session b73ca1b0 — MinizOxide.compress level clamp (#2374)
86f4478 doc(security-inventory): flip 'MinizOxide.compress level clamp' Missing-work bullet to Recent wins
6a236a1 feat: clamp MinizOxide.compress level argument to 0–9

🤖 Prepared with Claude Code