### PR TITLE
Track E (miniz_oxide TCB): treat rust/miniz_oxide_shim/Cargo.lock as security-critical artefact + add scripts/check-cargo-lock.sh drift detector + flip Missing-work bullet

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -238,6 +238,23 @@ Summary — what this pattern catches and what it does not:
     `lean_alloc_sarray` buffer in `c/miniz_oxide_ffi.c` and then calls
     `lean_miniz_oxide_free`, so the Rust-allocated buffer is released
     on every successful return
+  - **`Cargo.lock` is tracked and treated as security-critical.**
+    [`rust/miniz_oxide_shim/Cargo.lock`](/home/kim/lean-zip/rust/miniz_oxide_shim/Cargo.lock)
+    pins the resolved versions of `miniz_oxide` and its transitive
+    dependencies (`adler2`) along with their registry checksums. The
+    caret-range declaration in
+    [`rust/miniz_oxide_shim/Cargo.toml`](/home/kim/lean-zip/rust/miniz_oxide_shim/Cargo.toml)
+    is intentionally narrowed by the lockfile to a specific
+    build-reproducible set.
+    Snapshot as of 2026-04-29: `miniz_oxide` 0.8.9, `adler2` 2.0.1.
+    Any change to these resolved versions requires re-evaluating the
+    *Why trusted* paragraph above and updating this snapshot. Drift
+    is surfaced advisorily by
+    [`scripts/check-cargo-lock.sh`](/home/kim/lean-zip/scripts/check-cargo-lock.sh)
+    (modelled on
+    [`scripts/check-c-allocations.sh`](/home/kim/lean-zip/scripts/check-c-allocations.sh)),
+    intended to be run before opening a PR that touches
+    `rust/miniz_oxide_shim/`.
 - Missing work:
   - **No fuzz / ASan / UBSan recipe currently covers the Rust crate
     or its C-ABI shim.** The existing
@@ -253,17 +270,23 @@ Summary — what this pattern catches and what it does not:
     sanitised static lib into the existing fuzz-inflate driver so
     miniz_oxide-decompressed buffers flow through the same xorshift
     payload generator as the zlib path.
-  - **No upstream-tracking entry pinning the `miniz_oxide` crate
-    version against a known-good audit.** The crate is reputable but
-    is consumed transitively through `cargo` and inherits whatever
-    Rust / `miniz_oxide` versions are on the build host;
-    `Cargo.lock` records the resolved version but is not currently
-    treated as a security-critical artefact in this inventory.
   - **If a downstream caller wires `MinizOxide.compress` /
     `MinizOxide.decompress` into a non-bench codepath, this row's
     `guarded-locally` status must be re-evaluated** alongside the
     sibling fuzz / sanitizer recipe above.
 - Recent wins:
+  - **`Cargo.lock` is now treated as a security-critical artefact** in
+    PR #TBD-VERIFY-PR — the
+    [`rust/miniz_oxide_shim/Cargo.lock`](/home/kim/lean-zip/rust/miniz_oxide_shim/Cargo.lock)
+    snapshot (`miniz_oxide` 0.8.9, `adler2` 2.0.1) is recorded under
+    *Current local guardrails* above, and a new advisory drift
+    detector
+    [`scripts/check-cargo-lock.sh`](/home/kim/lean-zip/scripts/check-cargo-lock.sh)
+    (modelled on
+    [`scripts/check-c-allocations.sh`](/home/kim/lean-zip/scripts/check-c-allocations.sh))
+    flags resolved-version churn at PR-review time. Closes the
+    *"No upstream-tracking entry pinning the `miniz_oxide` crate
+    version"* Missing-work bullet.
   - **`MinizOxide.compress` level argument now clamped to 0–9** in
     PR #2378 — the public `compress` is a thin wrapper that
     clamps `level` via `if level > 9 then 9 else level` before

--- a/scripts/check-cargo-lock.sh
+++ b/scripts/check-cargo-lock.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# check-cargo-lock.sh -- trip wire for miniz_oxide / adler2 version drift.
+#
+# Advisory only: always exits 0. Prints a warning at PR-review time if
+# the resolved `miniz_oxide` / `adler2` versions in
+# rust/miniz_oxide_shim/Cargo.lock have drifted from the snapshot
+# audited in SECURITY_INVENTORY.md § "miniz_oxide via Rust" (the
+# *"`Cargo.lock` is tracked and treated as security-critical"* bullet
+# under *Current local guardrails*).
+#
+# Drift does not mean "broken"; it means "re-read the *Why trusted*
+# paragraph for `miniz_oxide via Rust`, decide whether the new resolved
+# versions are acceptable, and update the *Snapshot as of …* line in
+# SECURITY_INVENTORY.md to match (or roll back the lockfile change)."
+#
+# Run before opening a PR that touches `rust/miniz_oxide_shim/`.
+#
+# This is a trip wire, not a fence. It is not wired into CI — the goal
+# is to make accidental Cargo.lock churn visible in a `git diff`, not
+# to reject it automatically. Sibling helper to
+# scripts/check-c-allocations.sh, which performs the same role for
+# c/zlib_ffi.c allocation sites.
+#
+# Requirements: pure POSIX shell + standard text tools (grep, awk,
+# sed). No Cargo or Rust toolchain required.
+#
+# Manual smoke test: temporarily edit the *Snapshot as of …* line in
+# SECURITY_INVENTORY.md to mention an obviously wrong version (e.g.
+# `miniz_oxide` 9.9.9), re-run this script, expect a single WARNING
+# block followed by exit 0, then revert the edit.
+
+set -u
+
+LOCK="rust/miniz_oxide_shim/Cargo.lock"
+INVENTORY="SECURITY_INVENTORY.md"
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    cat <<EOF
+check-cargo-lock.sh -- compare $LOCK against the audited snapshot in
+$INVENTORY § "miniz_oxide via Rust".
+
+Prints a warning if the resolved miniz_oxide / adler2 versions drift
+from the snapshot. Advisory only; always exits 0. Run from the
+repository root.
+
+Usage:
+    bash scripts/check-cargo-lock.sh
+    bash scripts/check-cargo-lock.sh --help
+EOF
+    exit 0
+fi
+
+if [ ! -f "$LOCK" ]; then
+    echo "check-cargo-lock.sh: $LOCK not found (run from repo root)." >&2
+    exit 0
+fi
+
+if [ ! -f "$INVENTORY" ]; then
+    echo "check-cargo-lock.sh: $INVENTORY not found (run from repo root)." >&2
+    exit 0
+fi
+
+# Parse the resolved version of a named package out of Cargo.lock.
+# Cargo.lock blocks look like:
+#   [[package]]
+#   name = "miniz_oxide"
+#   version = "0.8.9"
+#   ...
+get_lock_version() {
+    awk -v pkg="$1" '
+        $0 == "[[package]]" { in_pkg = 1; name = ""; ver = "" }
+        in_pkg && $1 == "name" { gsub(/"/, "", $3); name = $3 }
+        in_pkg && $1 == "version" { gsub(/"/, "", $3); ver = $3 }
+        in_pkg && name == pkg && ver != "" { print ver; exit }
+    ' "$LOCK"
+}
+
+current_miniz=$(get_lock_version miniz_oxide)
+current_adler=$(get_lock_version adler2)
+
+# Pull the inventory snapshot line. The bullet body uses the literal
+# prefix "Snapshot as of YYYY-MM-DD: `miniz_oxide` X.Y.Z, `adler2` A.B.C."
+snap_line=$(grep -E "Snapshot as of [0-9]{4}-[0-9]{2}-[0-9]{2}: \`miniz_oxide\`" "$INVENTORY" | head -n 1)
+
+if [ -z "$snap_line" ]; then
+    echo "check-cargo-lock.sh: WARNING — no \"Snapshot as of …: \`miniz_oxide\` …\" line found in $INVENTORY (expected under § 'miniz_oxide via Rust')."
+    exit 0
+fi
+
+expected_miniz=$(printf '%s\n' "$snap_line" | sed -nE 's/.*\`miniz_oxide\` ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+expected_adler=$(printf '%s\n' "$snap_line" | sed -nE 's/.*\`adler2\` ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+
+if [ "$current_miniz" = "$expected_miniz" ] && [ "$current_adler" = "$expected_adler" ]; then
+    echo "check-cargo-lock.sh: $LOCK matches snapshot (miniz_oxide $current_miniz, adler2 $current_adler)."
+else
+    echo "check-cargo-lock.sh: $LOCK has drifted from snapshot in $INVENTORY (DRIFT)."
+    echo "  expected: miniz_oxide $expected_miniz, adler2 $expected_adler"
+    echo "  current:  miniz_oxide $current_miniz, adler2 $current_adler"
+    echo "  --> Re-read the \"Why trusted\" paragraph for 'miniz_oxide via Rust'"
+    echo "      and update the \"Snapshot as of …\" line in $INVENTORY (or roll back $LOCK)."
+fi
+
+exit 0


### PR DESCRIPTION
Closes #2376

Session: `ac9093f4-fdb0-47fd-ac74-8fae79bcbb5c`

dc32bbd doc(security-inventory): track Cargo.lock as security-critical artefact + flip Missing-work bullet
ad9560d doc: add scripts/check-cargo-lock.sh drift detector for miniz_oxide Cargo.lock

🤖 Prepared with Claude Code