### PR TITLE
scripts/check-cargo-lock.sh: tighten snapshot-line parser to emit explicit "could not parse" diagnostic instead of blank-expected DRIFT

### DIFF
--- a/progress/20260429T191410Z_03c87f99_check-cargo-lock-parser-guard.md
+++ b/progress/20260429T191410Z_03c87f99_check-cargo-lock-parser-guard.md
@@ -1,0 +1,79 @@
+# Progress entry — 2026-04-29 (UTC) — `03c87f99`
+
+**Session type**: feature
+**Issue**: #2388 — `scripts/check-cargo-lock.sh`: tighten snapshot-line
+parser to emit explicit *"could not parse"* diagnostic instead of
+blank-expected DRIFT
+**Branch**: `agent/03c87f99`
+
+## What was accomplished
+
+Applied **Option A** from the issue's deliverables to
+`scripts/check-cargo-lock.sh`: after the two `sed -nE` extractions
+(lines 97–98), added a guard that surfaces a *parser regex mismatch*
+WARNING instead of falling through into the DRIFT branch with empty
+`expected:` fields.
+
+The guard prints both a human-readable diagnostic and the offending
+snapshot line, then `exit 0` (advisory-only semantics preserved on
+every path).
+
+The script's docstring smoke test (lines 28–31) was reshaped from a
+single bullet into two numbered bullets — the original *drift
+detection* test and a new *parser-mismatch diagnostic* test that
+exercises the guard via the exact reproduction the issue documents
+(replace the single space between the closing backtick and the version
+triple with two spaces).
+
+## Manual smoke tests run
+
+1. **Clean tree**: `bash scripts/check-cargo-lock.sh` →
+   `matches snapshot (miniz_oxide 0.8.9, adler2 2.0.1).` ✅
+2. **Extra whitespace** (snapshot line edited to
+   ``` `miniz_oxide`  0.8.9, `adler2` 2.0.1 ```) →
+   `WARNING — snapshot line found … parser regex mismatch …` ✅
+   (the previous behaviour would have been a DRIFT block with blank
+   `expected: miniz_oxide , adler2`)
+3. **Wrong version** (snapshot line edited to
+   ``` `miniz_oxide` 9.9.9 ```) →
+   `DRIFT … expected: miniz_oxide 9.9.9, adler2 2.0.1` ✅
+   (drift path still works; non-blank `expected:` field as before)
+4. **Revert**: `bash scripts/check-cargo-lock.sh` → `matches snapshot.`
+   ✅; `git diff --stat SECURITY_INVENTORY.md` clean.
+
+## Verification
+
+- `lake build` — 201 jobs, success.
+- `lake exe test` — `All tests passed!`
+- `bash scripts/check-inventory-links.sh` — `errors=0, warnings=0`.
+- `bash scripts/check-cargo-lock.sh` (clean tree, post-edit) — exits 0
+  with the matches-snapshot line, no WARNING block.
+- Sorry count: `Zip/` total = 0 (unchanged).
+
+## Decisions made
+
+- Picked **Option A** (explicit diagnostic) over Option B (loosen the
+  regex). Rationale matches the issue body: A makes parser failures
+  observably distinct from real version drift; B would silently
+  tolerate whitespace variation but still fail-open on punctuation
+  variation (e.g. `;` vs `,` separator).
+- Echoed the offending `snapshot line:` underneath the WARNING so the
+  PR reviewer can see the exact characters that defeated the regex.
+  This is a one-line addition that costs nothing on the success path
+  and saves a re-grep on the failure path.
+
+## What remains
+
+Nothing scoped to this issue. Out-of-scope items per the issue body
+(loosening the inventory snapshot-line shape, sibling
+`check-c-allocations.sh`, sanitizer / fuzz recipes) intentionally
+not touched.
+
+## Quality metrics
+
+| Metric                              | Before | After |
+|-------------------------------------|--------|-------|
+| Sorry count (`Zip/`)                | 0      | 0     |
+| `lake build` jobs                   | 201    | 201   |
+| `check-inventory-links.sh` errors   | 0      | 0     |
+| `check-inventory-links.sh` warnings | 0      | 0     |

--- a/scripts/check-cargo-lock.sh
+++ b/scripts/check-cargo-lock.sh
@@ -25,10 +25,16 @@
 # Requirements: pure POSIX shell + standard text tools (grep, awk,
 # sed). No Cargo or Rust toolchain required.
 #
-# Manual smoke test: temporarily edit the *Snapshot as of …* line in
-# SECURITY_INVENTORY.md to mention an obviously wrong version (e.g.
-# `miniz_oxide` 9.9.9), re-run this script, expect a single WARNING
-# block followed by exit 0, then revert the edit.
+# Manual smoke tests:
+#   1. Drift detection: temporarily edit the *Snapshot as of …* line in
+#      SECURITY_INVENTORY.md to mention an obviously wrong version
+#      (e.g. `miniz_oxide` 9.9.9), re-run this script, expect a single
+#      DRIFT WARNING block followed by exit 0, then revert the edit.
+#   2. Parser-mismatch diagnostic: temporarily replace the single space
+#      between the closing backtick and the version triple with two
+#      spaces (e.g. ``` `miniz_oxide`  0.8.9 ```), re-run this script,
+#      expect a *parser regex mismatch* WARNING block followed by
+#      exit 0 (not a blank-`expected:` DRIFT block), then revert.
 
 set -u
 
@@ -90,6 +96,17 @@ fi
 
 expected_miniz=$(printf '%s\n' "$snap_line" | sed -nE 's/.*\`miniz_oxide\` ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
 expected_adler=$(printf '%s\n' "$snap_line" | sed -nE 's/.*\`adler2\` ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+
+# Surface parser failure as an explicit diagnostic instead of letting it
+# masquerade as a real version drift with blank `expected:` fields. The
+# sed regexes above require exactly one space between the closing
+# backtick and the version triple; whitespace or punctuation variations
+# in the snapshot line silently produce empty captures.
+if [ -z "$expected_miniz" ] || [ -z "$expected_adler" ]; then
+    echo "check-cargo-lock.sh: WARNING — snapshot line found in $INVENTORY but could not extract miniz_oxide / adler2 versions (parser regex mismatch — check whitespace / punctuation in the snapshot line)."
+    echo "  snapshot line: $snap_line"
+    exit 0
+fi
 
 if [ "$current_miniz" = "$expected_miniz" ] && [ "$current_adler" = "$expected_adler" ]; then
     echo "check-cargo-lock.sh: $LOCK matches snapshot (miniz_oxide $current_miniz, adler2 $current_adler)."


### PR DESCRIPTION
Closes #2388

Session: `03c87f99-873f-4099-9226-cba5ba695c0e`

e39bf1c fix(scripts): check-cargo-lock.sh — explicit "could not parse" diagnostic instead of blank-expected DRIFT

🤖 Prepared with Claude Code