### PR TITLE
feature: roundtrip theorems parametric over maxOutputSize (≤ bound)

### DIFF
--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -417,7 +417,7 @@ theorem deflateDynamic_spec (data : ByteArray) :
     codes then decompressing recovers the original data. Generalized to any
     `maxOutputSize` large enough to hold the input. -/
 theorem inflate_deflateDynamic (data : ByteArray)
-    (maxOutputSize : Nat) (hsize : data.size < maxOutputSize) :
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateDynamic data) maxOutputSize = .ok data := by
   have hspec := deflateDynamic_spec data
   match hspec with

--- a/Zip/Spec/DeflateFixedCorrect.lean
+++ b/Zip/Spec/DeflateFixedCorrect.lean
@@ -368,7 +368,7 @@ theorem inflate_complete (bytes : ByteArray) (result : List UInt8)
     and an inflate completeness bridge, native inflate recovers the original data. -/
 private theorem inflate_of_encodeFixed_spec (compressed data : ByteArray)
     (syms : List Deflate.Spec.LZ77Symbol)
-    (maxOutputSize : Nat) (hsize : data.size < maxOutputSize)
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize)
     (hresolve : Deflate.Spec.resolveLZ77 syms [] = some data.data.toList)
     (hvalid : Deflate.Spec.ValidSymbolList syms)
     (hspec : ∃ bits, Deflate.Spec.encodeFixed syms = some bits ∧
@@ -400,7 +400,7 @@ private theorem inflate_of_encodeFixed_spec (compressed data : ByteArray)
     decompressing recovers the original data. Generalized to any
     `maxOutputSize` large enough to hold the input. -/
 theorem inflate_deflateFixed (data : ByteArray)
-    (maxOutputSize : Nat) (hsize : data.size < maxOutputSize) :
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateFixed data) maxOutputSize = .ok data :=
   inflate_of_encodeFixed_spec (deflateFixed data) data
     (tokensToSymbols (lz77Greedy data)) maxOutputSize hsize
@@ -590,7 +590,7 @@ theorem lz77GreedyIter_eq_lz77Greedy (data : ByteArray) (ws : Nat) :
 /-- Roundtrip for the iterative fixed Huffman compressor.
     Follows from `lz77GreedyIter_eq_lz77Greedy` + `inflate_deflateFixed`. -/
 theorem inflate_deflateFixedIter (data : ByteArray)
-    (maxOutputSize : Nat) (hsize : data.size < maxOutputSize) :
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateFixedIter data) maxOutputSize = .ok data := by
   unfold deflateFixedIter
   rw [lz77GreedyIter_eq_lz77Greedy]
@@ -620,7 +620,7 @@ theorem deflateLazy_spec (data : ByteArray) :
     then decompressing recovers the original data. Generalized to any
     `maxOutputSize` large enough to hold the input. -/
 theorem inflate_deflateLazy (data : ByteArray)
-    (maxOutputSize : Nat) (hsize : data.size < maxOutputSize) :
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateLazy data) maxOutputSize = .ok data :=
   inflate_of_encodeFixed_spec (deflateLazy data) data
     (tokensToSymbols (lz77Lazy data)) maxOutputSize hsize
@@ -781,7 +781,7 @@ theorem deflateLazyIter_eq_deflateLazy (data : ByteArray) :
 /-- Roundtrip for the iterative lazy Huffman compressor.
     Follows from `deflateLazyIter_eq_deflateLazy` + `inflate_deflateLazy`. -/
 theorem inflate_deflateLazyIter (data : ByteArray)
-    (maxOutputSize : Nat) (hsize : data.size < maxOutputSize) :
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateLazyIter data) maxOutputSize = .ok data := by
   rw [deflateLazyIter_eq_deflateLazy]
   exact inflate_deflateLazy data maxOutputSize hsize

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -26,7 +26,7 @@ open Zip.Spec.DeflateStoredCorrect (inflate_deflateStoredPure)
     This is the Phase B4 capstone theorem from PLAN.md. Generalized to any
     `maxOutputSize` large enough to hold the input. -/
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
-    (maxOutputSize : Nat) (hsize : data.size < maxOutputSize) :
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
   split

--- a/Zip/Spec/GzipCorrect.lean
+++ b/Zip/Spec/GzipCorrect.lean
@@ -142,17 +142,18 @@ theorem bytesToBits_drop_prefix_three (a b c : ByteArray) :
 /-- If `inflate deflated = .ok data`, then the spec decode succeeds on
     `bytesToBits deflated`. -/
 theorem inflate_to_spec_decode (deflated : ByteArray) (result : ByteArray)
-    (h : Inflate.inflate deflated = .ok result) :
+    (maxOutputSize : Nat)
+    (h : Inflate.inflate deflated maxOutputSize = .ok result) :
     Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits deflated) [] =
       some result.data.toList := by
   simp only [Inflate.inflate, bind, Except.bind] at h
-  cases hinf : Inflate.inflateRaw deflated 0 (1024 * 1024 * 1024) with
+  cases hinf : Inflate.inflateRaw deflated 0 maxOutputSize with
   | error e => exact nomatch (hinf ▸ h)
   | ok p =>
-    simp only [Nat.reduceMul, hinf, pure, Except.pure, Except.ok.injEq] at h
+    simp only [hinf, pure, Except.pure, Except.ok.injEq] at h
     have hdec :=
-      Deflate.Correctness.inflate_correct deflated 0 (1024 * 1024 * 1024) p.1 p.2
+      Deflate.Correctness.inflate_correct deflated 0 maxOutputSize p.1 p.2
         (by rw [hinf])
     simp only [Nat.zero_mul, List.drop_zero] at hdec
     rw [← h]
@@ -163,18 +164,19 @@ theorem inflate_to_spec_decode (deflated : ByteArray) (result : ByteArray)
 /-! ## Gzip roundtrip -/
 
 /-- Gzip roundtrip: decompressing the output of compress returns the original data.
-    The size bound (1 GiB) is inherited from `inflate_deflateRaw`. -/
+    Parametric in the decoder's `maxOutputSize`: holds whenever the input fits
+    under the cap (`data.size ≤ maxOutputSize`). -/
 theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
-    (hsize : data.size < 1024 * 1024 * 1024) :
-    GzipDecode.decompressSingle (GzipEncode.compress data level) = .ok data := by
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    GzipDecode.decompressSingle (GzipEncode.compress data level) maxOutputSize = .ok data := by
   -- DEFLATE roundtrip: inflate ∘ deflateRaw = id
-  have hinfl : Inflate.inflate (Deflate.deflateRaw data level) = .ok data :=
+  have hinfl : Inflate.inflate (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
     Deflate.inflate_deflateRaw data level _ hsize
   -- Spec decode on deflated
   have hspec_go : Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits (Deflate.deflateRaw data level)) [] =
       some data.data.toList :=
-    inflate_to_spec_decode _ data hinfl
+    inflate_to_spec_decode _ data maxOutputSize hinfl
   -- Suffix invariance: spec decode ignores trailer bits after the DEFLATE stream
   have hspec_compressed : ∀ (header trailer : ByteArray) (hh : header.size = 10),
       Deflate.Spec.decode.go
@@ -187,8 +189,8 @@ theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
       (by rw [Deflate.Spec.bytesToBits_length]; omega)
       hspec_go
   -- Use data.size bound to get result.length ≤ maxOutputSize
-  have hdata_le : data.data.toList.length ≤ 1024 * 1024 * 1024 := by
-    simp only [Array.length_toList, ByteArray.size_data, Nat.reduceMul]; omega
+  have hdata_le : data.data.toList.length ≤ maxOutputSize := by
+    simp only [Array.length_toList, ByteArray.size_data]; omega
   -- Spec decode on compressed bits at offset 10 (via compress_eq decomposition)
   have hspec_at10 : Deflate.Spec.decode.go
       ((Deflate.Spec.bytesToBits (GzipEncode.compress data level)).drop (10 * 8))
@@ -219,7 +221,7 @@ theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
       data.data.toList hdata_le hspec_hd
   -- By suffix invariance, inflateRaw on (header ++ deflated) ++ trailer gives same endPos'
   have hinflRaw'' : Inflate.inflateRaw ((header ++ Deflate.deflateRaw data level) ++ trailer)
-      10 (1024 * 1024 * 1024) = .ok (⟨⟨data.data.toList⟩⟩, endPos') :=
+      10 maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') :=
     inflateRaw_append_suffix _ trailer 10 _ _ _ hinflRaw'
   rw [hceq.symm] at hinflRaw''
   -- endPos' = endPos by injectivity
@@ -230,7 +232,7 @@ theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
   -- endPos exactness: endPos = (header ++ deflated).size
   have hep_exact : endPos' = (header ++ Deflate.deflateRaw data level).size := by
     have h' : Inflate.inflateRaw (header ++ Deflate.deflateRaw data level)
-        header.size (1024 * 1024 * 1024) = .ok (⟨⟨data.data.toList⟩⟩, endPos') := by
+        header.size maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') := by
       rw [hhsz]; exact hinflRaw'
     exact inflateRaw_endPos_eq header (Deflate.deflateRaw data level) _ _ _ h'
       hspec_go (Deflate.deflateRaw_goR_pad data level) hdata_le

--- a/Zip/Spec/ZlibCorrect.lean
+++ b/Zip/Spec/ZlibCorrect.lean
@@ -142,18 +142,19 @@ theorem compress_adler32 (data : ByteArray) (level : UInt8) :
 end ZlibEncode
 
 /-- Zlib roundtrip: decompressing the output of compress returns the original data.
-    The size bound (1 GiB) is inherited from `inflate_deflateRaw`. -/
+    Parametric in the decoder's `maxOutputSize`: holds whenever the input fits
+    under the cap (`data.size ≤ maxOutputSize`). -/
 theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
-    (hsize : data.size < 1024 * 1024 * 1024) :
-    ZlibDecode.decompressSingle (ZlibEncode.compress data level) = .ok data := by
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    ZlibDecode.decompressSingle (ZlibEncode.compress data level) maxOutputSize = .ok data := by
   -- DEFLATE roundtrip: inflate ∘ deflateRaw = id
-  have hinfl : Inflate.inflate (Deflate.deflateRaw data level) = .ok data :=
+  have hinfl : Inflate.inflate (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
     Deflate.inflate_deflateRaw data level _ hsize
   -- Spec decode on deflated
   have hspec_go : Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits (Deflate.deflateRaw data level)) [] =
       some data.data.toList :=
-    inflate_to_spec_decode _ data hinfl
+    inflate_to_spec_decode _ data maxOutputSize hinfl
   -- Suffix invariance: spec decode ignores trailer bits after the DEFLATE stream
   have hspec_compressed : ∀ (header trailer : ByteArray) (hh : header.size = 2),
       Deflate.Spec.decode.go
@@ -166,8 +167,8 @@ theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
       (by rw [Deflate.Spec.bytesToBits_length]; omega)
       hspec_go
   -- Use data.size bound to get result.length ≤ maxOutputSize
-  have hdata_le : data.data.toList.length ≤ 1024 * 1024 * 1024 := by
-    simp only [Array.length_toList, ByteArray.size_data, Nat.reduceMul]; omega
+  have hdata_le : data.data.toList.length ≤ maxOutputSize := by
+    simp only [Array.length_toList, ByteArray.size_data]; omega
   -- Spec decode on compressed bits at offset 2 (via compress_eq decomposition)
   have hspec_at2 : Deflate.Spec.decode.go
       ((Deflate.Spec.bytesToBits (ZlibEncode.compress data level)).drop (2 * 8))
@@ -196,7 +197,7 @@ theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
       data.data.toList hdata_le hspec_hd
   -- By suffix invariance, inflateRaw on full compressed data gives same endPos'
   have hinflRaw'' : Inflate.inflateRaw ((header ++ Deflate.deflateRaw data level) ++ trailer)
-      2 (1024 * 1024 * 1024) = .ok (⟨⟨data.data.toList⟩⟩, endPos') :=
+      2 maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') :=
     inflateRaw_append_suffix _ trailer 2 _ _ _ hinflRaw'
   -- endPos' = endPos by injectivity
   have hep_eq : endPos = endPos' := by
@@ -207,7 +208,7 @@ theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
   -- endPos exactness via inflateRaw_endPos_eq
   have hep_exact : endPos' = (header ++ Deflate.deflateRaw data level).size := by
     have h' : Inflate.inflateRaw (header ++ Deflate.deflateRaw data level)
-        header.size (1024 * 1024 * 1024) = .ok (⟨⟨data.data.toList⟩⟩, endPos') := by
+        header.size maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') := by
       rw [hhsz]; exact hinflRaw'
     exact inflateRaw_endPos_eq header (Deflate.deflateRaw data level) _ _ _ h'
       hspec_go (Deflate.deflateRaw_goR_pad data level) hdata_le

--- a/progress/2026-06-02T01-28-37Z_aa30cb1e.md
+++ b/progress/2026-06-02T01-28-37Z_aa30cb1e.md
@@ -1,0 +1,47 @@
+# Session 2026-06-02T01:28:37Z — feature (one-shot #2467)
+
+## Task
+Issue #2467 (directive): make the gzip and zlib framing roundtrip theorems
+parametric in the decoder's `maxOutputSize`, with the correct `≤` bound
+(`data.size ≤ maxOutputSize`). Part of PLAN.md Track C (closes the bound
+properly after #2466).
+
+## What was accomplished
+**Part A — DEFLATE per-level chain `<` → `≤`.** Relaxed the hypothesis on
+seven roundtrip theorems from `data.size < maxOutputSize` to
+`data.size ≤ maxOutputSize`. The strict inequality was unused slack: each
+lemma funnels into `inflate_complete` (requirement already
+`result.length ≤ maxOutputSize`), so every internal `omega`/`hlen` still
+closes. Theorems:
+- `DeflateFixedCorrect.lean`: `inflate_of_encodeFixed_spec`,
+  `inflate_deflateFixed`, `inflate_deflateFixedIter`, `inflate_deflateLazy`,
+  `inflate_deflateLazyIter`
+- `DeflateDynamicCorrect.lean`: `inflate_deflateDynamic`
+- `DeflateRoundtrip.lean`: `inflate_deflateRaw`
+
+**Part B — thread `maxOutputSize` through gzip/zlib framing.**
+- `GzipCorrect.lean`: generalized `inflate_to_spec_decode` to take
+  `(maxOutputSize : Nat)` (was hardcoded `1024*1024*1024`); made
+  `gzip_decompressSingle_compress` quantify over `maxOutputSize` with
+  `data.size ≤ maxOutputSize`, passing it to `decompressSingle` and through
+  every `inflateRaw_*` call site.
+- `ZlibCorrect.lean`: same change to `zlib_decompressSingle_compress`.
+- Updated both framing docstrings: replaced "size bound (1 GiB) inherited"
+  with a note that the theorem is parametric in `maxOutputSize`.
+
+Function defaults (`:= 1024 * 1024 * 1024`) on `decompressSingle` /
+`Inflate.inflate` / `inflateRaw` left intact — they are the security cap.
+Removed now-dead `Nat.reduceMul` from one simp set when the literal went away.
+
+## Verification
+- `nix-shell --run "lake -R build && lake exe test"` — all 201 jobs built,
+  all tests passed. (Needed `-R` to reconfigure: worktree had a stale
+  compiled Lake config.)
+- `grep -rc sorry Zip/` total: 0 (unchanged).
+- No `1024 * 1024 * 1024` literal remains in any of the three changed
+  *statements* (only in function-signature defaults).
+- No strict `< maxOutputSize` remains anywhere in the chain.
+
+## Notes
+No external callers of the changed theorems exist (grep across `Zip/`,
+`ZipTest/`), so signature changes were self-contained.


### PR DESCRIPTION
Closes #2467

Session: `aa30cb1e-3727-4608-b7a2-b7678ae7e6b6`

e1b5772 doc: progress entry for #2467 (maxOutputSize parametric roundtrips)
e291274 feat: make gzip/zlib roundtrip theorems parametric over maxOutputSize (≤ bound)

🤖 Prepared with Claude Code