### PR TITLE
perf: fast overlapping LZ77 back-reference copy, formally verified

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -251,6 +251,22 @@ def copyLoopGo (buf : ByteArray) (start distance : Nat)
   else buf
 termination_by length - k
 
+/-- Periodic extension of a non-empty `seed` window to at least `length` bytes by
+    repeated doubling — each step is a `ByteArray` append (a `memcpy`), so the
+    whole fill is `O(log (length / seed.size))` memcpys. `seed` is the
+    `distance`-byte back-reference window; doubling it preserves the period
+    (`seed.size` always divides the running size), so slot `i` of the result is
+    `seed[i % seed.size]`. Used by `copyLoop` for overlapping LZ77
+    back-references (`distance < length`, e.g. RLE), where a per-byte copy
+    otherwise dominates decode of highly repetitive data. -/
+def fillDouble (seed : ByteArray) (length : Nat) : ByteArray :=
+  if seed.size ≥ length ∨ seed.size = 0 then seed
+  else fillDouble (seed ++ seed) length
+termination_by length - seed.size
+decreasing_by
+  simp only [ByteArray.size_append]
+  omega
+
 /-- Copy `length` bytes from `buf` starting at `start`, repeating every
     `distance` bytes (LZ77 back-reference copy).
 
@@ -258,14 +274,19 @@ termination_by length - k
     every index `start + (k % distance)` is just `start + k`, so the whole copy is
     the contiguous slice `[start, start + length)` — one `extract` + one `append`
     (a `memcpy`) instead of `length` per-byte `push`es / bounds-checks / modular
-    indices. Otherwise (overlapping / RLE, or a partial `k`) it falls back to the
-    per-byte `copyLoopGo`. Proven equal to `copyLoopGo` via `copyLoop_eq_ofFn`,
-    so every decode correctness proof is unaffected. -/
+    indices. For an **overlapping** back-reference (`k = 0 ∧ length > distance`,
+    the RLE case) the copy is the periodic extension of the `distance`-byte window,
+    built by `fillDouble` (a handful of memcpys) instead of `length` per-byte
+    `push`es. A partial copy (`k ≠ 0`, never produced by the decoders) falls back
+    to the per-byte `copyLoopGo`. All three are proven equal to `copyLoopGo` via
+    `copyLoop_eq_ofFn`, so every decode correctness proof is unaffected. -/
 def copyLoop (buf : ByteArray) (start distance : Nat)
     (k length : Nat)
     (hd_pos : distance > 0 := by omega) (hsd : start + distance ≤ buf.size := by omega) : ByteArray :=
   if k = 0 ∧ length ≤ distance then
     buf ++ buf.extract start (start + length)
+  else if k = 0 then
+    buf ++ (fillDouble (buf.extract start (start + distance)) length).extract 0 length
   else
     copyLoopGo buf start distance k length hd_pos hsd
 

--- a/Zip/Spec/DecodeCorrect.lean
+++ b/Zip/Spec/DecodeCorrect.lean
@@ -539,11 +539,72 @@ private theorem extract_data_toList_ofFn (buf : ByteArray) (start length : Nat)
       List.getElem_drop, List.getElem_ofFn]
     rw [getElem!_pos buf.data.toList (start + i) (by omega)]
 
+/-- Element access into a `ByteArray` extract: slot `m` of `[start, start+len)`
+    is `buf[start + m]`. -/
+private theorem extract_getElem! (buf : ByteArray) (start m len : Nat)
+    (h : start + len ≤ buf.size) (hm : m < len) :
+    (buf.extract start (start + len)).data.toList[m]! = buf.data.toList[start + m]! := by
+  rw [extract_data_toList_ofFn buf start len h,
+      getElem!_pos _ m (by rw [List.length_ofFn]; exact hm), List.getElem_ofFn]
+
+/-- Indexing a self-append is periodic: for `j < 2 * seed.size`,
+    `(seed ++ seed)[j] = seed[j % seed.size]`. -/
+private theorem append_self_getElem! (seed : ByteArray) (j : Nat)
+    (hs : 0 < seed.size) (hj : j < seed.size + seed.size) :
+    (seed ++ seed).data.toList[j]! = seed.data.toList[j % seed.size]! := by
+  have hlen : seed.data.toList.length = seed.size := by
+    simp only [Array.length_toList, ByteArray.size_data]
+  rw [ByteArray.data_append, Array.toList_append]
+  by_cases hj1 : j < seed.size
+  · rw [getElem!_pos _ j (by rw [List.length_append, hlen]; omega),
+        List.getElem_append_left (by rw [hlen]; exact hj1),
+        Nat.mod_eq_of_lt hj1, getElem!_pos _ j (by rw [hlen]; exact hj1)]
+  · rw [getElem!_pos _ j (by rw [List.length_append, hlen]; omega),
+        List.getElem_append_right (by rw [hlen]; omega)]
+    have hmod : j % seed.size = j - seed.size := by
+      rw [Nat.mod_eq_sub_mod (by omega), Nat.mod_eq_of_lt (by omega)]
+    rw [hmod, getElem!_pos _ (j - seed.size) (by rw [hlen]; omega)]
+    congr 1 <;> rw [hlen]
+
+/-- `fillDouble` always produces at least `length` bytes (it doubles until it
+    reaches `length`, given a non-empty seed). -/
+private theorem fillDouble_size_ge (seed : ByteArray) (length : Nat) :
+    0 < seed.size → length ≤ (Zip.Native.Inflate.fillDouble seed length).size := by
+  fun_induction Zip.Native.Inflate.fillDouble seed length with
+  | case1 seed hbase =>
+    intro hs
+    rcases hbase with h | h
+    · exact h
+    · omega
+  | case2 seed hstep ih =>
+    intro _
+    exact ih (by simp only [ByteArray.size_append]; omega)
+
+/-- `fillDouble` is the periodic extension of `seed`: slot `i` is
+    `seed[i % seed.size]`. The doubling preserves the period because
+    `seed.size` divides the running size at every step. -/
+private theorem fillDouble_get (seed : ByteArray) (length : Nat) :
+    ∀ i, i < (Zip.Native.Inflate.fillDouble seed length).size →
+      (Zip.Native.Inflate.fillDouble seed length).data.toList[i]! =
+        seed.data.toList[i % seed.size]! := by
+  fun_induction Zip.Native.Inflate.fillDouble seed length with
+  | case1 seed hbase =>
+    intro i hi
+    rw [Nat.mod_eq_of_lt hi]
+  | case2 seed hstep ih =>
+    intro i hi
+    have hpos : 0 < seed.size := by simp only [not_or] at hstep; omega
+    have hsz2 : (seed ++ seed).size = seed.size + seed.size := by rw [ByteArray.size_append]
+    rw [ih i hi, hsz2,
+        append_self_getElem! seed (i % (seed.size + seed.size)) hpos (Nat.mod_lt i (by omega)),
+        Nat.mod_mod_of_dvd i ⟨2, by omega⟩]
+
 /-- The native copy loop produces the same result as the spec's `List.ofFn`
     for LZ77 back-references. `copyLoop` dispatches: the non-overlapping case
     (`length ≤ distance`) is the contiguous slice `[start, start+length)`
-    (`extract`+`append`); the overlapping case falls back to the per-byte
-    `copyLoopGo`. Both yield the same `List.ofFn` characterization. -/
+    (`extract`+`append`); the overlapping case is the periodic extension built by
+    `fillDouble`; a partial `k ≠ 0` falls back to the per-byte `copyLoopGo`. All
+    yield the same `List.ofFn` characterization. -/
 theorem copyLoop_eq_ofFn
     (output : ByteArray) (length distance : Nat)
     (hd_pos : distance > 0) (hd_le : distance ≤ output.size) :
@@ -567,10 +628,35 @@ theorem copyLoop_eq_ofFn
       have := i.isLt
       rw [Nat.mod_eq_of_lt (by omega)]
     rw [hfg]
-  · -- overlapping fallback: per-byte `copyLoopGo`
-    exact copyLoopGo_spec output (output.size - distance) distance 0 length output
-      hd_pos (by omega) (Nat.zero_le _) rfl (fun _ _ => rfl)
-      (by simp only [List.ofFn_zero, List.append_nil])
+  · -- else: split the nested `if k = 0`
+    split
+    · -- overlapping (k = 0, length > distance): `fillDouble` periodic extension
+      have hseed_size :
+          (output.extract (output.size - distance) (output.size - distance + distance)).size
+            = distance := by
+        rw [ByteArray.size_extract]; omega
+      have hge : length ≤ (Zip.Native.Inflate.fillDouble
+          (output.extract (output.size - distance) (output.size - distance + distance)) length).size :=
+        fillDouble_size_ge _ _ (by rw [hseed_size]; exact hd_pos)
+      rw [ByteArray.data_append, Array.toList_append]
+      congr 1
+      have hext := extract_data_toList_ofFn (Zip.Native.Inflate.fillDouble
+        (output.extract (output.size - distance) (output.size - distance + distance)) length)
+        0 length (by omega)
+      simp only [Nat.zero_add] at hext
+      rw [hext]
+      apply congrArg
+      funext i
+      rw [fillDouble_get
+            (output.extract (output.size - distance) (output.size - distance + distance)) length
+            i.val (by have := i.isLt; omega),
+          hseed_size]
+      exact extract_getElem! output (output.size - distance) (i.val % distance) distance
+        (by omega) (Nat.mod_lt i.val hd_pos)
+    · -- partial (k ≠ 0): per-byte `copyLoopGo`
+      exact copyLoopGo_spec output (output.size - distance) distance 0 length output
+        hd_pos (by omega) (Nat.zero_le _) rfl (fun _ _ => rfl)
+        (by simp only [List.ofFn_zero, List.append_nil])
 
 /-- Codewords in `allCodes` tables are nonempty. -/
 theorem specTable_cw_nonempty (lengths : List Nat) (maxBits : Nat) :


### PR DESCRIPTION
This PR adds a formally-verified fast path for overlapping LZ77 back-reference copies, closing the last sharp outlier in native decode throughput.

`copyLoop`'s memcpy fast path previously covered only non-overlapping back-references (`length ≤ distance`); overlapping/RLE copies (`distance < length`) fell through to a per-byte `copyLoopGo`, which dominated decode of highly repetitive data — cyclic level-6 sat ~11x behind zlib/miniz while everything else was ~2x. This adds a doubling fast path: the `distance`-byte window is extended to `length` bytes by repeated `ByteArray` append (`fillDouble`), turning a per-byte copy into O(log(length/distance)) memcpys.

`fillDouble` is proven to be the periodic extension of the window — slot `i` is `seed[i % seed.size]`, since doubling keeps `seed.size` dividing the running size at every step — so the new branch of `copyLoop_eq_ofFn` yields the same `List.ofFn` characterization as the per-byte `copyLoopGo`. Every existing decode correctness proof transfers unchanged; 0 sorries, no new axioms, no `@[extern]`/`@[implemented_by]`.

Measured on this machine (decode-only, same harness, old vs new `copyLoop`), now that the buffered decoder is the default:

| workload | before | after | |
|---|---|---|---|
| cyclic 1 MiB lvl 6 | 435 MB/s | 1902 MB/s | 4.4x |
| cyclic 256 KiB lvl 6 | 419 | 1674 | 4.0x |
| text 1 MiB lvl 6 | 4349 | 4349 | 1.0x (no overlapping copies) |

The decode charts will be regenerated once after this lands (kept out of this PR to avoid clashing with the dashboard committed in #2507).

🤖 Prepared with Claude Code
