### PR TITLE
perf: @[inline] the per-byte hash3 in the LZ77 matchers

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -202,7 +202,7 @@ def lz77Greedy (data : ByteArray) (windowSize : Nat := 32768) :
     (mainLoop data windowSize hashSize
       (.replicate hashSize 0) (.replicate hashSize false) 0).toArray
 where
-  hash3 (data : ByteArray) (pos : Nat) (hashSize : Nat)
+  @[inline] hash3 (data : ByteArray) (pos : Nat) (hashSize : Nat)
       (h : pos + 2 < data.size) : Nat :=
     -- Hash arithmetic in `UInt32` (single machine ops) rather than `Nat`
     -- (whose bitwise XOR/shift are slow); `.toNat % hashSize` keeps the exact
@@ -298,7 +298,7 @@ def lz77GreedyIter (data : ByteArray) (windowSize : Nat := 32768) :
     mainLoop data windowSize hashSize
       (.replicate hashSize 0) (.replicate hashSize false) 0 #[]
 where
-  hash3 (data : ByteArray) (pos : Nat) (hashSize : Nat)
+  @[inline] hash3 (data : ByteArray) (pos : Nat) (hashSize : Nat)
       (h : pos + 2 < data.size) : Nat :=
     -- Hash arithmetic in `UInt32` (single machine ops) rather than `Nat`
     -- (whose bitwise XOR/shift are slow); `.toNat % hashSize` keeps the exact
@@ -583,7 +583,7 @@ def lz77Lazy (data : ByteArray) (windowSize : Nat := 32768) :
     (mainLoop data windowSize hashSize
       (.replicate hashSize 0) (.replicate hashSize false) 0).toArray
 where
-  hash3 (data : ByteArray) (pos : Nat) (hashSize : Nat)
+  @[inline] hash3 (data : ByteArray) (pos : Nat) (hashSize : Nat)
       (h : pos + 2 < data.size) : Nat :=
     -- Hash arithmetic in `UInt32` (single machine ops) rather than `Nat`
     -- (whose bitwise XOR/shift are slow); `.toNat % hashSize` keeps the exact


### PR DESCRIPTION
This PR marks the LZ77 matchers' `hash3` (called once per input byte on the compress hot path) `@[inline]`, removing the per-byte call overhead. The matcher runs ~8% faster on text (115 → 124 MB/s, 4 MiB level 6) and ~3% on prng, across all compression levels. Output is byte-identical — an inlining hint changes no value — so every existing proof is unaffected and there are 0 sorries.

It's the one free win from a runtime audit (prompted by Henrik's Lean-runtime talk): the matcher's `Array.set!` is already in-place (compress throughput *rises* with input size, the opposite of an O(n²) copy), and the read-only `data`/`prev` borrows are already inferred by the compiler (an explicit `@&` changed nothing), so there is no non-linearity to fix.

🤖 Prepared with Claude Code