### PR TITLE
feat: self-contained DEFLATE block splitting (formally verified, max-compression tiers)

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -446,6 +446,13 @@ def deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (level : UInt8) 
   else
     (emitChunkBlocks data chunkSize level 0 BitWriter.empty).flush
 
+/-- Chunk size for block splitting in `deflateRaw`: each ~32 KiB run gets its own
+    dynamic Huffman tree and a fresh match window. Large enough to keep per-block
+    header overhead negligible, small enough to let the trees track local
+    statistics. `pickSmaller` makes the exact value a pure ratio knob (never a
+    correctness or regression concern). -/
+def splitChunkSize : Nat := 32768
+
 /-- The compressed-block dispatch (no stored fallback). Every level ≥ 1 uses the
     hash-chain matcher with the level's search depth (`chainDepth`) and interior
     insertion cap (`insertCap`): low levels defer insertion + search shallowly
@@ -483,9 +490,14 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
     let storedBytes := storedBlockBytes data
     if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
     else if fixedBytes < dynBytes then deflateFixedBlock data tokens
-    -- Reuse the sized `lens` for emission (= `deflateDynamicBlock data tokens`,
-    -- but without recomputing the code lengths).
-    else deflateDynamicBlockCore data tokens lens.1 lens.2
-      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
+    -- Dynamic Huffman. Emit the smaller of the single whole-file block and the
+    -- self-contained block-split stream (per-chunk Huffman trees, fresh window
+    -- per chunk). `pickSmaller` guarantees we never regress below the single
+    -- block — splitting only ever wins, never loses (small inputs collapse to a
+    -- single chunk = the single block). Both branches are roundtrip-verified.
+    else pickSmaller
+      (deflateDynamicBlockCore data tokens lens.1 lens.2
+        (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2)
+      (deflateDynamicBlocksSC data splitChunkSize level)
 
 end Zip.Native.Deflate

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -281,6 +281,32 @@ def deflateDynamicBlock (data : ByteArray) (tokens : Array LZ77Token) : ByteArra
     (dynamicCodeLengths_length litFreqs distFreqs).1
     (dynamicCodeLengths_length litFreqs distFreqs).2
 
+/-- Emit one dynamic Huffman block into an existing `BitWriter` (no flush), with
+    `BFINAL = isFinal`. Same body as `deflateDynamicBlockCore` but bit-packed onto
+    a running writer so a sequence of blocks shares the bitstream. -/
+def emitDynBlock (bw : BitWriter) (data : ByteArray) (tokens : Array LZ77Token)
+    (litLens distLens : List Nat)
+    (hlit : litLens.length = 286) (hdist : distLens.length = 30)
+    (isFinal : Bool) : BitWriter :=
+  let litCodes := canonicalCodes (litLens.toArray.map Nat.toUInt8)
+  let distCodes := canonicalCodes (distLens.toArray.map Nat.toUInt8)
+  let bw := bw.writeBits 1 (if isFinal then 1 else 0)  -- BFINAL (1 bit)
+  let bw := bw.writeBits 2 2                            -- BTYPE = 10 (dynamic)
+  let bw := writeDynamicHeader bw litLens distLens
+  have hlit_size : litCodes.size ≥ 286 := by
+    show (canonicalCodes (litLens.toArray.map Nat.toUInt8)).size ≥ 286
+    rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  have hdist_size : distCodes.size ≥ 30 := by
+    show (canonicalCodes (distLens.toArray.map Nat.toUInt8)).size ≥ 30
+    rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  have h256 : 256 < litCodes.size := by
+    show 256 < (canonicalCodes (litLens.toArray.map Nat.toUInt8)).size
+    rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  let bw := if data.size == 0 then bw
+            else emitTokensWithCodes bw tokens litCodes distCodes hlit_size hdist_size 0
+  let (code, len) := litCodes[256]'h256
+  bw.writeHuffCode code len
+
 /-- Compress data using dynamic Huffman codes and greedy LZ77 (Level 5).
     Produces a single DEFLATE block with BFINAL=1, BTYPE=10. Thin wrapper over
     `deflateDynamicBlock` that runs the greedy matcher first. -/
@@ -377,6 +403,48 @@ def insertCap (level : UInt8) : Nat :=
   else if level ≤ 2 then 32
   else if level ≤ 3 then 64
   else 1000000000
+
+/-! ## Self-contained block-split dynamic compression
+
+Split `data` into `chunkSize`-byte chunks, match each chunk independently (fresh
+32 KiB window, so its back-references stay within the chunk), and emit one dynamic
+block per chunk — each with its own frequency-fit Huffman trees, `BFINAL` only on
+the last — packed onto one bitstream. Because every block references only its own
+chunk, the blocks decode independently and compose; the per-block trees recover
+most of the ratio a single whole-file tree leaves on large/heterogeneous inputs. -/
+
+/-- Emit one self-contained dynamic block for the chunk `data[pos, j)` onto `bw`
+    (`BFINAL = isFinal`), matching the chunk in isolation. -/
+def emitChunkBlock (bw : BitWriter) (data : ByteArray) (pos j : Nat) (level : UInt8)
+    (isFinal : Bool) : BitWriter :=
+  let chunk := data.extract pos j
+  let toks := lz77ChainIter chunk (chainDepth level) 32768 (insertCap level)
+  let f := tokenFreqs toks
+  let lens := dynamicCodeLengths f.1 f.2
+  emitDynBlock bw chunk toks lens.1 lens.2
+    (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 isFinal
+
+/-- Emit the block sequence for `data` from `pos` onward, one block per
+    `chunkSize`-byte chunk (the last carries `BFINAL`). Well-founded on the
+    remaining bytes so the roundtrip can induct through it. -/
+def emitChunkBlocks (data : ByteArray) (chunkSize : Nat) (level : UInt8)
+    (pos : Nat) (bw : BitWriter) : BitWriter :=
+  let step := max chunkSize 1
+  let j := min (pos + step) data.size
+  let bw := emitChunkBlock bw data pos j level (decide (j ≥ data.size))
+  if j ≥ data.size then bw
+  else emitChunkBlocks data chunkSize level j bw
+termination_by data.size - pos
+decreasing_by simp_all only [Nat.not_le]; omega
+
+/-- Self-contained block-split dynamic compression. See `emitChunkBlock`. -/
+def deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (level : UInt8) : ByteArray :=
+  if data.size == 0 then
+    let f := tokenFreqs #[]
+    (emitDynBlock BitWriter.empty data #[] (dynamicCodeLengths f.1 f.2).1 (dynamicCodeLengths f.1 f.2).2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
+  else
+    (emitChunkBlocks data chunkSize level 0 BitWriter.empty).flush
 
 /-- The compressed-block dispatch (no stored fallback). Every level ≥ 1 uses the
     hash-chain matcher with the level's search depth (`chainDepth`) and interior

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -490,14 +490,18 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
     let storedBytes := storedBlockBytes data
     if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
     else if fixedBytes < dynBytes then deflateFixedBlock data tokens
-    -- Dynamic Huffman. Emit the smaller of the single whole-file block and the
+    -- Dynamic Huffman. At the max-compression tiers (level ≥ 7) also try the
     -- self-contained block-split stream (per-chunk Huffman trees, fresh window
-    -- per chunk). `pickSmaller` guarantees we never regress below the single
-    -- block — splitting only ever wins, never loses (small inputs collapse to a
-    -- single chunk = the single block). Both branches are roundtrip-verified.
-    else pickSmaller
-      (deflateDynamicBlockCore data tokens lens.1 lens.2
-        (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2)
-      (deflateDynamicBlocksSC data splitChunkSize level)
+    -- per chunk) and emit whichever is smaller. `pickSmaller` guarantees we never
+    -- regress below the single block — splitting only ever wins (it helps inputs
+    -- whose statistics vary locally, e.g. structured binary; on text the lost
+    -- cross-chunk matches make the single block win, and we keep it). The default
+    -- level 6 stays single-block so it pays no extra compress time. Both branches
+    -- are roundtrip-verified.
+    else
+      let single := deflateDynamicBlockCore data tokens lens.1 lens.2
+        (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
+      if 7 ≤ level then pickSmaller single (deflateDynamicBlocksSC data splitChunkSize level)
+      else single
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -15,18 +15,23 @@ namespace Zip.Native.Deflate
 
 open Deflate.Spec (decode)
 
+set_option maxHeartbeats 800000 in
 /-- One self-contained chunk block: its bits append to `bw`, it preserves `wf`,
-    and `decode.go` consumes it — appending the chunk's bytes and either returning
-    (final block) or continuing on the trailing bits (non-final block). -/
+    and `decode.go`/`decode.goR` consume it — appending the chunk's bytes and
+    either returning (final block) or continuing on the trailing bits. -/
 theorem emitChunkBlock_decode (data : ByteArray) (pos j : Nat) (level : UInt8)
     (bw : BitWriter) (hbw : bw.wf) (isFinal : Bool) :
     ∃ blockBits,
       (emitChunkBlock bw data pos j level isFinal).toBits = bw.toBits ++ blockBits ∧
       (emitChunkBlock bw data pos j level isFinal).wf ∧
-      ∀ (acc : List UInt8) (rest : List Bool),
+      (∀ (acc : List UInt8) (rest : List Bool),
         Deflate.Spec.decode.go (blockBits ++ rest) acc =
           if isFinal then some (acc ++ (data.extract pos j).data.toList)
-          else Deflate.Spec.decode.go rest (acc ++ (data.extract pos j).data.toList) := by
+          else Deflate.Spec.decode.go rest (acc ++ (data.extract pos j).data.toList)) ∧
+      (∀ (acc : List UInt8) (rest : List Bool),
+        Deflate.Spec.decode.goR (blockBits ++ rest) acc =
+          if isFinal then some (acc ++ (data.extract pos j).data.toList, rest)
+          else Deflate.Spec.decode.goR rest (acc ++ (data.extract pos j).data.toList)) := by
   obtain ⟨litLens, distLens, headerBits, symBits, _hll, _hdl, hlv, hdv,
       hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
     emitDynBlock_spec bw hbw (data.extract pos j)
@@ -35,27 +40,39 @@ theorem emitChunkBlock_decode (data : ByteArray) (pos j : Nat) (level : UInt8)
         (by omega) (by omega))
       (fun hz => lz77ChainIter_empty (data.extract pos j) (chainDepth level) 32768 (insertCap level) hz)
       isFinal
-  refine ⟨[isFinal, false, true] ++ headerBits ++ symBits, ?_, ?_, ?_⟩
+  have hresolve := lz77ChainIter_resolves (data.extract pos j)
+    (chainDepth level) 32768 (insertCap level) (by omega)
+  have hvalid := tokensToSymbols_validSymbolList
+    (lz77ChainIter (data.extract pos j) (chainDepth level) 32768 (insertCap level))
+  refine ⟨[isFinal, false, true] ++ headerBits ++ symBits, ?_, ?_, ?_, ?_⟩
   · -- toBits
     simp only [emitChunkBlock]
     rw [htoBits]; simp only [List.append_assoc]
   · -- wf
     simp only [emitChunkBlock]; exact hwf
-  · -- decode
+  · -- decode.go
     intro acc rest
     have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables
       litLens distLens headerBits (symBits ++ rest) hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
     rw [← List.append_assoc] at hheader
-    have hresolve := lz77ChainIter_resolves (data.extract pos j)
-      (chainDepth level) 32768 (insertCap level) (by omega)
-    have hvalid := tokensToSymbols_validSymbolList
-      (lz77ChainIter (data.extract pos j) (chainDepth level) 32768 (insertCap level))
     cases isFinal
     · simp only [Bool.false_eq_true, if_false]
       exact Deflate.Spec.decode_go_dynBlock_nonfinal _ _ acc litLens distLens
         headerBits symBits rest hlv hdv hheader hsyms hresolve hvalid
     · simp only [if_true]
       exact Deflate.Spec.decode_go_dynBlock_final _ _ acc litLens distLens
+        headerBits symBits rest hlv hdv hheader hsyms hresolve hvalid
+  · -- decode.goR
+    intro acc rest
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables
+      litLens distLens headerBits (symBits ++ rest) hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    cases isFinal
+    · simp only [Bool.false_eq_true, if_false]
+      exact Deflate.Spec.decode_goR_dynBlock_nonfinal _ _ acc litLens distLens
+        headerBits symBits rest hlv hdv hheader hsyms hresolve hvalid
+    · simp only [if_true]
+      exact Deflate.Spec.decode_goR_dynBlock_final _ _ acc litLens distLens
         headerBits symBits rest hlv hdv hheader hsyms hresolve hvalid
 
 /-- `M.take p ++ (M.drop p).take q = M.take (p + q)` — a contiguous prefix split. -/
@@ -99,7 +116,7 @@ theorem emitChunkBlocks_decode (data : ByteArray) (chunkSize : Nat) (level : UIn
   | zero => intro pos bw hf hpos _; omega
   | succ fuel ih =>
     intro pos bw hf hpos hbw
-    obtain ⟨blockBits, htoBits, hwfblk, hdecblk⟩ :=
+    obtain ⟨blockBits, htoBits, hwfblk, hdecblk, _⟩ :=
       emitChunkBlock_decode data pos (min (pos + max chunkSize 1) data.size) level bw hbw
         (decide (min (pos + max chunkSize 1) data.size ≥ data.size))
     have hjle : min (pos + max chunkSize 1) data.size ≤ data.size := Nat.min_le_right _ _
@@ -123,6 +140,63 @@ theorem emitChunkBlocks_decode (data : ByteArray) (chunkSize : Nat) (level : UIn
         exact hd
     · -- Non-final block: recurse on the next chunk.
       have hbw' : (emitChunkBlock bw data pos (min (pos + max chunkSize 1) data.size) level
+          (decide (min (pos + max chunkSize 1) data.size ≥ data.size))).wf := hwfblk
+      have hstep : emitChunkBlocks data chunkSize level pos bw =
+          emitChunkBlocks data chunkSize level (min (pos + max chunkSize 1) data.size)
+            (emitChunkBlock bw data pos (min (pos + max chunkSize 1) data.size) level
+              (decide (min (pos + max chunkSize 1) data.size ≥ data.size))) := by
+        conv => lhs; unfold emitChunkBlocks
+        simp only [if_neg hend]
+      obtain ⟨B', htoBits', hwf', hdec'⟩ :=
+        ih (min (pos + max chunkSize 1) data.size) _ (by omega) (by omega) hbw'
+      refine ⟨blockBits ++ B', ?_, ?_, ?_⟩
+      · rw [hstep, htoBits', htoBits, List.append_assoc]
+      · rw [hstep]; exact hwf'
+      · intro acc tail
+        rw [List.append_assoc]
+        have hd := hdecblk acc (B' ++ tail)
+        rw [if_neg (by simp only [decide_eq_true_eq]; exact hend)] at hd
+        rw [hd, hdec' (acc ++ (data.extract pos (min (pos + max chunkSize 1) data.size)).data.toList) tail,
+          List.append_assoc,
+          extract_data_append data pos (min (pos + max chunkSize 1) data.size) data.size
+            (by omega) hjle]
+
+/-- `decode.goR` variant of `emitChunkBlocks_decode`: the remaining bits after
+    decoding all chunk blocks are exactly the trailing `tail`. -/
+theorem emitChunkBlocks_decodeR (data : ByteArray) (chunkSize : Nat) (level : UInt8) :
+    ∀ (fuel pos : Nat) (bw : BitWriter), data.size - pos ≤ fuel → pos < data.size → bw.wf →
+      ∃ B, (emitChunkBlocks data chunkSize level pos bw).toBits = bw.toBits ++ B ∧
+        (emitChunkBlocks data chunkSize level pos bw).wf ∧
+        ∀ (acc : List UInt8) (tail : List Bool),
+          Deflate.Spec.decode.goR (B ++ tail) acc =
+            some (acc ++ (data.extract pos data.size).data.toList, tail) := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos bw hf hpos _; omega
+  | succ fuel ih =>
+    intro pos bw hf hpos hbw
+    obtain ⟨blockBits, htoBits, hwfblk, _, hdecblk⟩ :=
+      emitChunkBlock_decode data pos (min (pos + max chunkSize 1) data.size) level bw hbw
+        (decide (min (pos + max chunkSize 1) data.size ≥ data.size))
+    have hjle : min (pos + max chunkSize 1) data.size ≤ data.size := Nat.min_le_right _ _
+    have hstep1 : 1 ≤ max chunkSize 1 := Nat.le_max_right _ _
+    have hjgt : pos < min (pos + max chunkSize 1) data.size := by
+      simp only [Nat.lt_min]; omega
+    by_cases hend : min (pos + max chunkSize 1) data.size ≥ data.size
+    · have hjeq : min (pos + max chunkSize 1) data.size = data.size := by omega
+      have hstep : emitChunkBlocks data chunkSize level pos bw =
+          emitChunkBlock bw data pos (min (pos + max chunkSize 1) data.size) level
+            (decide (min (pos + max chunkSize 1) data.size ≥ data.size)) := by
+        conv => lhs; unfold emitChunkBlocks
+        simp only [if_pos hend]
+      refine ⟨blockBits, ?_, ?_, ?_⟩
+      · rw [hstep]; exact htoBits
+      · rw [hstep]; exact hwfblk
+      · intro acc tail
+        have hd := hdecblk acc tail
+        rw [if_pos (decide_eq_true hend), hjeq] at hd
+        exact hd
+    · have hbw' : (emitChunkBlock bw data pos (min (pos + max chunkSize 1) data.size) level
           (decide (min (pos + max chunkSize 1) data.size ≥ data.size))).wf := hwfblk
       have hstep : emitChunkBlocks data chunkSize level pos bw =
           emitChunkBlocks data chunkSize level (min (pos + max chunkSize 1) data.size)
@@ -205,5 +279,61 @@ theorem inflate_deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (lev
   rw [← show ByteArray.mk ⟨data.data.toList⟩ = data from by simp only [Array.toArray_toList]]
   exact inflate_complete (deflateDynamicBlocksSC data chunkSize level) data.data.toList
     maxOutputSize hlen (decode_deflateDynamicBlocksSC data chunkSize level)
+
+/-- The `decode.goR` of `deflateDynamicBlocksSC` returns the input and short
+    (< 8-bit) trailing padding — the block-split analogue of
+    `deflateDynamicBlock_goR_pad`, needed to show the native decoder consumes all
+    of the deflated bytes. -/
+theorem deflateDynamicBlocksSC_goR_pad (data : ByteArray) (chunkSize : Nat) (level : UInt8) :
+    ∃ remaining,
+      Deflate.Spec.decode.goR
+          (Deflate.Spec.bytesToBits (deflateDynamicBlocksSC data chunkSize level)) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+  unfold deflateDynamicBlocksSC
+  split
+  · -- data.size = 0
+    rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate
+      ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false, ?_, ?_⟩
+    · have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+        (symBits ++ List.replicate
+          ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+        hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+      rw [← List.append_assoc] at hheader
+      have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+        have he : data.data.toList = [] :=
+          List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+        rw [he]; rfl
+      exact Deflate.Spec.encodeDynamic_goR_rest (tokensToSymbols #[]) data.data.toList
+        litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+        (tokensToSymbols_validSymbolList _)
+    · simp only [List.length_replicate]; omega
+  · -- data.size > 0
+    rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitChunkBlocks_decodeR data chunkSize level data.size 0 BitWriter.empty
+        (by omega) hpos BitWriter.empty_wf
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate ((8 - B.length % 8) % 8) false, ?_, ?_⟩
+    · have hthis := hdec [] (List.replicate ((8 - B.length % 8) % 8) false)
+      have hwhole : (data.extract 0 data.size).data.toList = data.data.toList := by
+        simp only [ByteArray.data_extract, Array.toList_extract, List.extract_eq_take_drop,
+          Nat.sub_zero, List.drop_zero]
+        rw [show data.size = data.data.toList.length from by
+          rw [Array.length_toList, ByteArray.size_data], List.take_length]
+      rw [List.nil_append, hwhole] at hthis
+      exact hthis
+    · simp only [List.length_replicate]; omega
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -144,4 +144,66 @@ theorem emitChunkBlocks_decode (data : ByteArray) (chunkSize : Nat) (level : UIn
           extract_data_append data pos (min (pos + max chunkSize 1) data.size) data.size
             (by omega) hjle]
 
+/-- Block-splitting roundtrip: decoding the self-contained chunk-block stream
+    reproduces the input. The empty input is a single final block; otherwise the
+    chunk-block fold (`emitChunkBlocks_decode`) reconstructs `data[0:]`. -/
+theorem decode_deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (level : UInt8) :
+    Deflate.Spec.decode
+      (Deflate.Spec.bytesToBits (deflateDynamicBlocksSC data chunkSize level)) =
+      some data.data.toList := by
+  unfold deflateDynamicBlocksSC
+  split
+  · -- data.size = 0: one final block over the empty token list.
+    rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+      (symBits ++ List.replicate
+        ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+      hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+      have he : data.data.toList = [] :=
+        List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+      rw [he]; rfl
+    exact Deflate.Spec.encodeDynamic_decode_append (tokensToSymbols #[]) data.data.toList
+      litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+      (tokensToSymbols_validSymbolList _)
+  · -- data.size > 0: the chunk-block fold.
+    rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitChunkBlocks_decode data chunkSize level data.size 0 BitWriter.empty
+        (by omega) hpos BitWriter.empty_wf
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    have hthis := hdec [] (List.replicate ((8 - B.length % 8) % 8) false)
+    rw [List.nil_append] at hthis
+    have hwhole : (data.extract 0 data.size).data.toList = data.data.toList := by
+      simp only [ByteArray.data_extract, Array.toList_extract, List.extract_eq_take_drop,
+        Nat.sub_zero, List.drop_zero]
+      rw [show data.size = data.data.toList.length from by
+        rw [Array.length_toList, ByteArray.size_data], List.take_length]
+    rw [hwhole] at hthis
+    exact hthis
+
+/-- Block-splitting roundtrip: inflating `deflateDynamicBlocksSC` recovers the
+    input, for any `maxOutputSize` large enough to hold it. -/
+theorem inflate_deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (level : UInt8)
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    Zip.Native.Inflate.inflate (deflateDynamicBlocksSC data chunkSize level) maxOutputSize =
+      .ok data := by
+  have hlen : data.data.toList.length ≤ maxOutputSize := by
+    simp only [Array.length_toList, ByteArray.size_data]; omega
+  rw [← show ByteArray.mk ⟨data.data.toList⟩ = data from by simp only [Array.toArray_toList]]
+  exact inflate_complete (deflateDynamicBlocksSC data chunkSize level) data.data.toList
+    maxOutputSize hlen (decode_deflateDynamicBlocksSC data chunkSize level)
+
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -1,4 +1,6 @@
-import Zip.Spec.DeflateRoundtrip
+import Zip.Spec.DeflateFixedCorrect
+import Zip.Spec.DeflateDynamicCorrect
+import Zip.Spec.LZ77ChainCorrect
 
 /-!
 # Self-contained block-splitting roundtrip
@@ -335,5 +337,26 @@ theorem deflateDynamicBlocksSC_goR_pad (data : ByteArray) (chunkSize : Nat) (lev
       rw [List.nil_append, hwhole] at hthis
       exact hthis
     · simp only [List.length_replicate]; omega
+
+/-- The output of `deflateDynamicBlocksSC` decomposes into content bits plus
+    short (< 8-bit) padding — the block-split analogue of `deflateCompressed_pad`. -/
+theorem deflateDynamicBlocksSC_pad (data : ByteArray) (chunkSize : Nat) (level : UInt8) :
+    ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits (deflateDynamicBlocksSC data chunkSize level) =
+        contentBits ++ padding ∧ padding.length < 8 := by
+  unfold deflateDynamicBlocksSC
+  split
+  · obtain ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨B, _, hwf, _⟩ :=
+      emitChunkBlocks_decode data chunkSize level data.size 0 BitWriter.empty
+        (by omega) hpos BitWriter.empty_wf
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -1,0 +1,61 @@
+import Zip.Spec.DeflateRoundtrip
+
+/-!
+# Self-contained block-splitting roundtrip
+
+`deflateDynamicBlocksSC` chops the input into chunks, matches each chunk against
+a *fresh* window (so its back-references stay within the chunk), and emits one
+dynamic Huffman block per chunk (final flag on the last). Because each block is
+self-contained, `resolveLZ77_shift` lets every block's bytes simply append to the
+running output, and the blocks compose: decoding the concatenation reproduces the
+whole input. This file proves `inflate (deflateDynamicBlocksSC …) = .ok data`.
+-/
+
+namespace Zip.Native.Deflate
+
+open Deflate.Spec (decode)
+
+/-- One self-contained chunk block: its bits append to `bw`, it preserves `wf`,
+    and `decode.go` consumes it — appending the chunk's bytes and either returning
+    (final block) or continuing on the trailing bits (non-final block). -/
+theorem emitChunkBlock_decode (data : ByteArray) (pos j : Nat) (level : UInt8)
+    (bw : BitWriter) (hbw : bw.wf) (isFinal : Bool) :
+    ∃ blockBits,
+      (emitChunkBlock bw data pos j level isFinal).toBits = bw.toBits ++ blockBits ∧
+      (emitChunkBlock bw data pos j level isFinal).wf ∧
+      ∀ (acc : List UInt8) (rest : List Bool),
+        Deflate.Spec.decode.go (blockBits ++ rest) acc =
+          if isFinal then some (acc ++ (data.extract pos j).data.toList)
+          else Deflate.Spec.decode.go rest (acc ++ (data.extract pos j).data.toList) := by
+  obtain ⟨litLens, distLens, headerBits, symBits, _hll, _hdl, hlv, hdv,
+      hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+    emitDynBlock_spec bw hbw (data.extract pos j)
+      (lz77ChainIter (data.extract pos j) (chainDepth level) 32768 (insertCap level))
+      (lz77ChainIter_encodable (data.extract pos j) (chainDepth level) 32768 (insertCap level)
+        (by omega) (by omega))
+      (fun hz => lz77ChainIter_empty (data.extract pos j) (chainDepth level) 32768 (insertCap level) hz)
+      isFinal
+  refine ⟨[isFinal, false, true] ++ headerBits ++ symBits, ?_, ?_, ?_⟩
+  · -- toBits
+    simp only [emitChunkBlock]
+    rw [htoBits]; simp only [List.append_assoc]
+  · -- wf
+    simp only [emitChunkBlock]; exact hwf
+  · -- decode
+    intro acc rest
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables
+      litLens distLens headerBits (symBits ++ rest) hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    have hresolve := lz77ChainIter_resolves (data.extract pos j)
+      (chainDepth level) 32768 (insertCap level) (by omega)
+    have hvalid := tokensToSymbols_validSymbolList
+      (lz77ChainIter (data.extract pos j) (chainDepth level) 32768 (insertCap level))
+    cases isFinal
+    · simp only [Bool.false_eq_true, if_false]
+      exact Deflate.Spec.decode_go_dynBlock_nonfinal _ _ acc litLens distLens
+        headerBits symBits rest hlv hdv hheader hsyms hresolve hvalid
+    · simp only [if_true]
+      exact Deflate.Spec.decode_go_dynBlock_final _ _ acc litLens distLens
+        headerBits symBits rest hlv hdv hheader hsyms hresolve hvalid
+
+end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -58,4 +58,90 @@ theorem emitChunkBlock_decode (data : ByteArray) (pos j : Nat) (level : UInt8)
       exact Deflate.Spec.decode_go_dynBlock_final _ _ acc litLens distLens
         headerBits symBits rest hlv hdv hheader hsyms hresolve hvalid
 
+/-- `M.take p ++ (M.drop p).take q = M.take (p + q)` — a contiguous prefix split. -/
+private theorem take_append_take_drop {α} : ∀ (p : Nat) (M : List α) (q : Nat),
+    M.take p ++ (M.drop p).take q = M.take (p + q) := by
+  intro p
+  induction p with
+  | zero => intro M q; simp
+  | succ p ih =>
+    intro M q
+    cases M with
+    | nil => simp
+    | cons a M' =>
+      rw [List.take_succ_cons, List.drop_succ_cons, List.cons_append, ih M' q,
+        show p + 1 + q = (p + q) + 1 from by omega, List.take_succ_cons]
+
+/-- Two adjacent chunks of a byte array concatenate to the spanning chunk. -/
+private theorem extract_data_append (data : ByteArray) (a b c : Nat)
+    (hab : a ≤ b) (hbc : b ≤ c) :
+    (data.extract a b).data.toList ++ (data.extract b c).data.toList =
+      (data.extract a c).data.toList := by
+  simp only [ByteArray.data_extract, Array.toList_extract, List.extract_eq_take_drop]
+  rw [show data.data.toList.drop b = (data.data.toList.drop a).drop (b - a) by
+        rw [List.drop_drop]; congr 1; omega,
+      show c - a = (b - a) + (c - b) by omega,
+      take_append_take_drop]
+
+/-- Decode fold over the self-contained chunk blocks: from `pos < data.size`,
+    the bits emitted by `emitChunkBlocks` (with `bw`'s bits stripped as `B`)
+    decode — appended to any `acc` — to the remaining input `data[pos:]`. The
+    last block is final so it returns regardless of the trailing `tail`. -/
+theorem emitChunkBlocks_decode (data : ByteArray) (chunkSize : Nat) (level : UInt8) :
+    ∀ (fuel pos : Nat) (bw : BitWriter), data.size - pos ≤ fuel → pos < data.size → bw.wf →
+      ∃ B, (emitChunkBlocks data chunkSize level pos bw).toBits = bw.toBits ++ B ∧
+        (emitChunkBlocks data chunkSize level pos bw).wf ∧
+        ∀ (acc : List UInt8) (tail : List Bool),
+          Deflate.Spec.decode.go (B ++ tail) acc =
+            some (acc ++ (data.extract pos data.size).data.toList) := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos bw hf hpos _; omega
+  | succ fuel ih =>
+    intro pos bw hf hpos hbw
+    obtain ⟨blockBits, htoBits, hwfblk, hdecblk⟩ :=
+      emitChunkBlock_decode data pos (min (pos + max chunkSize 1) data.size) level bw hbw
+        (decide (min (pos + max chunkSize 1) data.size ≥ data.size))
+    have hjle : min (pos + max chunkSize 1) data.size ≤ data.size := Nat.min_le_right _ _
+    have hstep1 : 1 ≤ max chunkSize 1 := Nat.le_max_right _ _
+    have hjgt : pos < min (pos + max chunkSize 1) data.size := by
+      simp only [Nat.lt_min]; omega
+    by_cases hend : min (pos + max chunkSize 1) data.size ≥ data.size
+    · -- Final block: j = data.size.
+      have hjeq : min (pos + max chunkSize 1) data.size = data.size := by omega
+      have hstep : emitChunkBlocks data chunkSize level pos bw =
+          emitChunkBlock bw data pos (min (pos + max chunkSize 1) data.size) level
+            (decide (min (pos + max chunkSize 1) data.size ≥ data.size)) := by
+        conv => lhs; unfold emitChunkBlocks
+        simp only [if_pos hend]
+      refine ⟨blockBits, ?_, ?_, ?_⟩
+      · rw [hstep]; exact htoBits
+      · rw [hstep]; exact hwfblk
+      · intro acc tail
+        have hd := hdecblk acc tail
+        rw [if_pos (decide_eq_true hend), hjeq] at hd
+        exact hd
+    · -- Non-final block: recurse on the next chunk.
+      have hbw' : (emitChunkBlock bw data pos (min (pos + max chunkSize 1) data.size) level
+          (decide (min (pos + max chunkSize 1) data.size ≥ data.size))).wf := hwfblk
+      have hstep : emitChunkBlocks data chunkSize level pos bw =
+          emitChunkBlocks data chunkSize level (min (pos + max chunkSize 1) data.size)
+            (emitChunkBlock bw data pos (min (pos + max chunkSize 1) data.size) level
+              (decide (min (pos + max chunkSize 1) data.size ≥ data.size))) := by
+        conv => lhs; unfold emitChunkBlocks
+        simp only [if_neg hend]
+      obtain ⟨B', htoBits', hwf', hdec'⟩ :=
+        ih (min (pos + max chunkSize 1) data.size) _ (by omega) (by omega) hbw'
+      refine ⟨blockBits ++ B', ?_, ?_, ?_⟩
+      · rw [hstep, htoBits', htoBits, List.append_assoc]
+      · rw [hstep]; exact hwf'
+      · intro acc tail
+        rw [List.append_assoc]
+        have hd := hdecblk acc (B' ++ tail)
+        rw [if_neg (by simp only [decide_eq_true_eq]; exact hend)] at hd
+        rw [hd, hdec' (acc ++ (data.extract pos (min (pos + max chunkSize 1) data.size)).data.toList) tail,
+          List.append_assoc,
+          extract_data_append data pos (min (pos + max chunkSize 1) data.size) data.size
+            (by omega) hjle]
+
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -21,19 +21,26 @@ private theorem getElem!_le_of_forall_mem_le (l : List Nat) (i n : Nat)
     (hi : i < l.length) (h : ∀ x ∈ l, x ≤ n) : l[i]! ≤ n := by
   rw [getElem!_pos l i hi]; exact h _ (List.getElem_mem hi)
 
-/-- `deflateDynamicBlock` produces a bytestream whose bits correspond to the
-    spec-level dynamic Huffman encoding of the given LZ77 tokens, plus padding to
-    byte alignment. Generalized over the token array: its only hypotheses are the
-    per-token encodability bound (supplied by any matcher's `_encodable` lemma) and
-    that an empty input yields no tokens. `deflateDynamic_spec` below is the
-    `lz77GreedyIter` instance. -/
-theorem deflateDynamicBlock_spec (data : ByteArray) (tokens : Array LZ77Token)
+/-- The lit/len and distance code lengths a block uses for `tokens`. -/
+abbrev dynLens (tokens : Array LZ77Token) : List Nat × List Nat :=
+  dynamicCodeLengths (tokenFreqs tokens).1 (tokenFreqs tokens).2
+
+/-- `emitDynBlock` (one dynamic block onto a running writer, `BFINAL = isFinal`,
+    no flush) produces `bw`'s bits followed by the block: the `BFINAL` bit, the
+    `BTYPE = 10` bits `[false, true]`, the spec dynamic-tree header, and the
+    encoded symbols. It also preserves `BitWriter.wf`. The whole-block flushed
+    `deflateDynamicBlock_spec` is the `(empty, true)` corollary below. Hypotheses:
+    the per-token encodability bound (any matcher's `_encodable` lemma) and that
+    empty input yields no tokens. -/
+theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
+    (data : ByteArray) (tokens : Array LZ77Token)
     (htok_enc : ∀ t ∈ tokens.toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768)
-    (hempty : data.size = 0 → tokens = #[]) :
+    (hempty : data.size = 0 → tokens = #[]) (isFinal : Bool) :
     ∃ (litLens distLens : List Nat) (headerBits symBits : List Bool),
+      litLens = (dynLens tokens).1 ∧ distLens = (dynLens tokens).2 ∧
       Huffman.Spec.ValidLengths litLens 15 ∧
       Huffman.Spec.ValidLengths distLens 15 ∧
       litLens.length ≥ 257 ∧ litLens.length ≤ 288 ∧
@@ -42,11 +49,15 @@ theorem deflateDynamicBlock_spec (data : ByteArray) (tokens : Array LZ77Token)
       Deflate.Spec.encodeDynamicTrees litLens distLens = some headerBits ∧
       Deflate.Spec.encodeSymbols litLens distLens
         (tokensToSymbols tokens) = some symBits ∧
-      Deflate.Spec.bytesToBits (deflateDynamicBlock data tokens) =
-        [true, false, true] ++ headerBits ++ symBits ++
-        List.replicate
-          ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8)
-          false := by
+      (emitDynBlock bw data tokens (dynLens tokens).1 (dynLens tokens).2
+          (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).1
+          (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).2
+          isFinal).toBits =
+        bw.toBits ++ [isFinal, false, true] ++ headerBits ++ symBits ∧
+      (emitDynBlock bw data tokens (dynLens tokens).1 (dynLens tokens).2
+          (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).1
+          (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).2
+          isFinal).wf := by
   -- Extract the intermediate values from deflateDynamicBlock
   let litFreqs := (tokenFreqs tokens).1
   let distFreqs := (tokenFreqs tokens).2
@@ -283,11 +294,6 @@ theorem deflateDynamicBlock_spec (data : ByteArray) (tokens : Array LZ77Token)
         (tokensToSymbols tokens) with
     | none => exact nomatch henc_syms ▸ henc_syms_some
     | some symBits =>
-      refine ⟨litLens, distLens, headerBits, symBits,
-        hlit_valid, hdist_valid,
-        by omega, by omega, by omega, by omega,
-        hlit_bound, hdist_bound,
-        henc_trees, henc_syms, ?_⟩
       -- bytesToBits decomposition
       -- Split symBits into tokBits ++ eobBits
       have htoks_eq : tokensToSymbols tokens =
@@ -339,20 +345,20 @@ theorem deflateDynamicBlock_spec (data : ByteArray) (tokens : Array LZ77Token)
           (by simp only [Deflate.Spec.encodeLitLen] at henc_eob; rwa [hlit_roundtrip])
         have h256_lt : 256 < litCodes.size := by rw [hlit_codes_size]; omega
         rw [getElem!_pos litCodes 256 h256_lt] at heob_cw heob_len
-        -- BitWriter chain
-        have hwf0 := BitWriter.empty_wf
-        have hwf1 := BitWriter.writeBits_wf _ 1 1 hwf0 (by omega)
+        -- Pre-flush BitWriter chain from `bw` with BFINAL = isFinal.
+        have hwf1 := BitWriter.writeBits_wf bw 1 (if isFinal then 1 else 0) hbw (by omega)
         have hwf2 := BitWriter.writeBits_wf _ 2 2 hwf1 (by omega)
-        -- Header bits: [true, false, true]
-        have hbw2_bits : (BitWriter.empty.writeBits 1 1 |>.writeBits 2 2).toBits =
-            [true, false, true] := by
-          have h1 := BitWriter.writeBits_toBits _ 1 1 hwf0 (by omega)
-          have h2 := BitWriter.writeBits_toBits _ 2 2 hwf1 (by omega)
-          rw [BitWriter.empty_toBits] at h1
-          simp only [List.nil_append] at h1
-          rw [h1] at h2; exact h2
+        -- Header bits: [isFinal, false, true]
+        have hbw01_bits : (bw.writeBits 1 (if isFinal then 1 else 0) |>.writeBits 2 2).toBits =
+            bw.toBits ++ [isFinal, false, true] := by
+          have h1 := BitWriter.writeBits_toBits bw 1 (if isFinal then 1 else 0) hbw (by omega)
+          have h2 := BitWriter.writeBits_toBits (bw.writeBits 1 (if isFinal then 1 else 0))
+            2 2 hwf1 (by omega)
+          rw [h1] at h2
+          rw [h2, List.append_assoc]
+          cases isFinal <;> rfl
         -- writeDynamicHeader
-        let bw2 := BitWriter.empty.writeBits 1 1 |>.writeBits 2 2
+        let bw2 := bw.writeBits 1 (if isFinal then 1 else 0) |>.writeBits 2 2
         have hwf_hdr := writeDynamicHeader_wf bw2 litLens distLens hwf2 hlit_bound hdist_bound
         have hbw_hdr := writeDynamicHeader_spec bw2 litLens distLens headerBits hwf2
           hlit_bound hdist_bound ⟨by omega, by omega⟩ ⟨by omega, by omega⟩ henc_trees
@@ -375,17 +381,14 @@ theorem deflateDynamicBlock_spec (data : ByteArray) (tokens : Array LZ77Token)
         have hbw_eob := BitWriter.writeHuffCode_toBits bw4
           (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2 hwf_emit hlen256_le
         -- Chain all the bits
-        rw [hemit, hbw_hdr, hbw2_bits] at hbw_eob
-        -- Show deflateDynamicBlock data tokens equals the flushed writer.
-        -- `deflateDynamicBlock` opens with `let (litFreqs, distFreqs) := tokenFreqs tokens`,
-        -- so a bare `split` would hit that tuple match first; reframe the goal as the
-        -- (definitionally equal) `data.size == 0` branch directly via `show`.
-        have hdef : deflateDynamicBlock data tokens =
-            (bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2).flush := by
-          show (if (data.size == 0) = true
-                then (bw3.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2).flush
-                else (bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2).flush)
-                = (bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2).flush
+        rw [hemit, hbw_hdr, hbw01_bits] at hbw_eob
+        -- `emitDynBlock bw … isFinal = bw4.writeHuffCode EOB`: the `data.size = 0`
+        -- branch collapses `bw4` to `bw3` since `tokens = #[]`, so both agree.
+        have hdef : emitDynBlock bw data tokens litLens distLens hlit_len hdist_len isFinal =
+            bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2 := by
+          show (if (data.size == 0) = true then bw3 else bw4).writeHuffCode
+                (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2 =
+              bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2
           split
           · rename_i hzero
             rw [beq_iff_eq] at hzero
@@ -395,31 +398,79 @@ theorem deflateDynamicBlock_spec (data : ByteArray) (tokens : Array LZ77Token)
               rw [htok_empty]; unfold emitTokensWithCodes; rfl
             rw [hemit_id]
           · rfl
-        rw [hdef]
-        have hflush := BitWriter.flush_toBits _ hwf_eob
-        -- The bits decomposition
-        have hbits_eq : (bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2).toBits =
-            [true, false, true] ++ headerBits ++ symBits := by
-          rw [hbw_eob, hsymBits_eq, heob_eq, heob_cw]
+        have htoBits :
+            (emitDynBlock bw data tokens litLens distLens hlit_len hdist_len isFinal).toBits =
+            bw.toBits ++ [isFinal, false, true] ++ headerBits ++ symBits := by
+          rw [hdef, hbw_eob, hsymBits_eq, heob_eq, heob_cw]
           simp only [List.append_assoc]
-        rw [hflush, hbits_eq]
-        -- Align the bitCount % 8
-        suffices hmod : (bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2).bitCount.toNat % 8 =
-            ([true, false, true] ++ headerBits ++ symBits).length % 8 by
-          simp only [hmod]
-        have htoBits_len : (bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2).toBits.length =
-            (bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2).data.data.toList.length * 8 +
-            (bw4.writeHuffCode (litCodes[256]'h256_lt).1 (litCodes[256]'h256_lt).2).bitCount.toNat := by
-          simp only [BitWriter.toBits, List.length_append, List.length_flatMap,
-            Deflate.Spec.bytesToBits.byteToBits_length, List.length_map, List.length_range]
-          have hsum : ∀ (l : List UInt8),
-              (l.map (fun _ => 8)).sum = l.length * 8 := by
-            intro l; induction l with
-            | nil => rfl
-            | cons _ _ ih => simp only [List.map_cons, List.sum_cons, List.length_cons, ih]; omega
-          rw [hsum]
-        rw [hbits_eq] at htoBits_len
-        omega
+        have hwf_blk :
+            (emitDynBlock bw data tokens litLens distLens hlit_len hdist_len isFinal).wf := by
+          rw [hdef]; exact hwf_eob
+        exact ⟨litLens, distLens, headerBits, symBits, rfl, rfl,
+          hlit_valid, hdist_valid, by omega, by omega, by omega, by omega,
+          hlit_bound, hdist_bound, henc_trees, henc_syms, htoBits, hwf_blk⟩
+
+/-- Flushing a `wf` writer pads its bits up to the next byte boundary, where the
+    pad count is computed from the bit length (not the internal `bitCount`). -/
+theorem flush_toBits_aligned (bw : BitWriter) (hwf : bw.wf) :
+    Deflate.Spec.bytesToBits bw.flush =
+      bw.toBits ++ List.replicate ((8 - bw.toBits.length % 8) % 8) false := by
+  rw [BitWriter.flush_toBits _ hwf]
+  have hlen : bw.toBits.length = bw.data.data.toList.length * 8 + bw.bitCount.toNat := by
+    simp only [BitWriter.toBits, List.length_append, List.length_flatMap,
+      Deflate.Spec.bytesToBits.byteToBits_length, List.length_map, List.length_range]
+    have hsum : ∀ (l : List UInt8), (l.map (fun _ => 8)).sum = l.length * 8 := by
+      intro l; induction l with
+      | nil => rfl
+      | cons _ _ ih => simp only [List.map_cons, List.sum_cons, List.length_cons, ih]; omega
+    rw [hsum]
+  have hbc : bw.bitCount.toNat < 8 := hwf.1
+  congr 2
+  omega
+
+/-- `deflateDynamicBlock` produces a bytestream whose bits correspond to the
+    spec-level dynamic Huffman encoding of the given LZ77 tokens, plus padding to
+    byte alignment. The whole-block `(empty, BFINAL = true)` flushed corollary of
+    `emitDynBlock_spec`. -/
+theorem deflateDynamicBlock_spec (data : ByteArray) (tokens : Array LZ77Token)
+    (htok_enc : ∀ t ∈ tokens.toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768)
+    (hempty : data.size = 0 → tokens = #[]) :
+    ∃ (litLens distLens : List Nat) (headerBits symBits : List Bool),
+      Huffman.Spec.ValidLengths litLens 15 ∧
+      Huffman.Spec.ValidLengths distLens 15 ∧
+      litLens.length ≥ 257 ∧ litLens.length ≤ 288 ∧
+      distLens.length ≥ 1 ∧ distLens.length ≤ 32 ∧
+      (∀ x ∈ litLens, x ≤ 15) ∧ (∀ x ∈ distLens, x ≤ 15) ∧
+      Deflate.Spec.encodeDynamicTrees litLens distLens = some headerBits ∧
+      Deflate.Spec.encodeSymbols litLens distLens
+        (tokensToSymbols tokens) = some symBits ∧
+      Deflate.Spec.bytesToBits (deflateDynamicBlock data tokens) =
+        [true, false, true] ++ headerBits ++ symBits ++
+        List.replicate
+          ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8)
+          false := by
+  obtain ⟨litLens, distLens, headerBits, symBits, _hll, _hdl, hlv, hdv,
+      hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+    emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data tokens htok_enc hempty true
+  refine ⟨litLens, distLens, headerBits, symBits, hlv, hdv, hge1, hle1, hge2, hle2,
+    hb1, hb2, htrees, hsyms, ?_⟩
+  rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+  -- deflateDynamicBlock = (emitDynBlock empty … true).flush  (collapse the
+  -- outer/inner `data.size = 0` split; both reduce to the same writer).
+  have heq : deflateDynamicBlock data tokens =
+      (emitDynBlock BitWriter.empty data tokens (dynLens tokens).1 (dynLens tokens).2
+        (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).1
+        (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).2 true).flush := by
+    show deflateDynamicBlockCore data tokens (dynLens tokens).1 (dynLens tokens).2
+        (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).1
+        (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).2 = _
+    unfold deflateDynamicBlockCore emitDynBlock
+    cases hz : data.size == 0 <;>
+      simp only [hz, Bool.false_eq_true, ↓reduceIte] <;> rfl
+  rw [heq, flush_toBits_aligned _ hwf, htoBits]
 
 /-- `deflateDynamic` (greedy LZ77 + dynamic Huffman) produces a bytestream whose
     bits correspond to the spec-level dynamic Huffman encoding, plus padding to

--- a/Zip/Spec/DeflateEncode.lean
+++ b/Zip/Spec/DeflateEncode.lean
@@ -738,7 +738,7 @@ theorem decode_go_dynBlock_nonfinal (syms : List LZ77Symbol) (chunk acc : List U
     (hvalid : ValidSymbolList syms) :
     decode.go ([false, false, true] ++ headerBits ++ symBits ++ rest) acc =
         decode.go rest (acc ++ chunk) := by
-  conv_lhs => unfold decode.go
+  conv => lhs; unfold decode.go
   simp only [List.cons_append, readBitsLSB_1_false, bind, Option.bind]
   simp only [readBitsLSB_2_false_true]
   simp only [List.nil_append]
@@ -751,10 +751,9 @@ theorem decode_go_dynBlock_nonfinal (syms : List LZ77Symbol) (chunk acc : List U
     have h := resolveLZ77_shift syms acc [] chunk hresolve
     rwa [List.append_nil] at h
   simp only [hres]
-  have hlen : rest.length <
-      ([false, false, true] ++ headerBits ++ symBits ++ rest).length := by
-    simp only [List.length_append, List.length_cons, List.length_nil]
-    omega
-  rw [dif_pos hlen]
+  rw [if_neg (by decide)]
+  rw [dif_pos (show rest.length <
+      (false :: false :: true :: (headerBits ++ symBits ++ rest)).length by
+    simp only [List.length_cons, List.length_append]; omega)]
 
 end Deflate.Spec

--- a/Zip/Spec/DeflateEncode.lean
+++ b/Zip/Spec/DeflateEncode.lean
@@ -684,4 +684,77 @@ theorem encodeDynamic_goR_rest (syms : List LZ77Symbol) (data : List UInt8)
   simp only [hresolve]
   exact if_pos rfl
 
+private theorem readBitsLSB_1_false (rest : List Bool) :
+    readBitsLSB 1 (false :: rest) = some (0, rest) := by
+  simp only [readBitsLSB, bind, Option.bind, pure, Pure.pure,
+    Bool.false_eq_true, ↓reduceIte]
+
+/-! ## Multi-block dynamic decode lemmas
+
+`decode.go` consuming one self-contained dynamic block from an arbitrary
+accumulator `acc`. Self-containedness (`resolveLZ77 syms [] = some chunk`)
+lets `resolveLZ77_shift` lift the resolve to `resolveLZ77 syms acc =
+some (acc ++ chunk)`, so the block's bytes simply append to `acc`. These
+compose into the block-splitting roundtrip. -/
+
+/-- `decode.go` on a *final* (`BFINAL = 1`) dynamic block from accumulator `acc`
+    appends the block's chunk and returns. -/
+theorem decode_go_dynBlock_final (syms : List LZ77Symbol) (chunk acc : List UInt8)
+    (litLens distLens : List Nat) (headerBits symBits rest : List Bool)
+    (hv_lit : Huffman.Spec.ValidLengths litLens 15)
+    (hv_dist : Huffman.Spec.ValidLengths distLens 15)
+    (hheader : decodeDynamicTables (headerBits ++ symBits ++ rest) =
+        some (litLens, distLens, symBits ++ rest))
+    (henc : encodeSymbols litLens distLens syms = some symBits)
+    (hresolve : resolveLZ77 syms [] = some chunk)
+    (hvalid : ValidSymbolList syms) :
+    decode.go ([true, false, true] ++ headerBits ++ symBits ++ rest) acc =
+        some (acc ++ chunk) := by
+  unfold decode.go
+  simp only [List.cons_append, readBitsLSB_1_true, bind, Option.bind]
+  simp only [readBitsLSB_2_false_true]
+  simp only [List.nil_append]
+  rw [hheader]; dsimp only
+  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
+    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
+      henc hv_lit hv_dist hvalid
+  rw [hdec]
+  have hres : resolveLZ77 syms acc = some (acc ++ chunk) := by
+    have h := resolveLZ77_shift syms acc [] chunk hresolve
+    rwa [List.append_nil] at h
+  simp only [hres]
+  exact if_pos rfl
+
+/-- `decode.go` on a *non-final* (`BFINAL = 0`) dynamic block from accumulator
+    `acc` appends the block's chunk and continues on the trailing bits. -/
+theorem decode_go_dynBlock_nonfinal (syms : List LZ77Symbol) (chunk acc : List UInt8)
+    (litLens distLens : List Nat) (headerBits symBits rest : List Bool)
+    (hv_lit : Huffman.Spec.ValidLengths litLens 15)
+    (hv_dist : Huffman.Spec.ValidLengths distLens 15)
+    (hheader : decodeDynamicTables (headerBits ++ symBits ++ rest) =
+        some (litLens, distLens, symBits ++ rest))
+    (henc : encodeSymbols litLens distLens syms = some symBits)
+    (hresolve : resolveLZ77 syms [] = some chunk)
+    (hvalid : ValidSymbolList syms) :
+    decode.go ([false, false, true] ++ headerBits ++ symBits ++ rest) acc =
+        decode.go rest (acc ++ chunk) := by
+  conv_lhs => unfold decode.go
+  simp only [List.cons_append, readBitsLSB_1_false, bind, Option.bind]
+  simp only [readBitsLSB_2_false_true]
+  simp only [List.nil_append]
+  rw [hheader]; dsimp only
+  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
+    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
+      henc hv_lit hv_dist hvalid
+  rw [hdec]
+  have hres : resolveLZ77 syms acc = some (acc ++ chunk) := by
+    have h := resolveLZ77_shift syms acc [] chunk hresolve
+    rwa [List.append_nil] at h
+  simp only [hres]
+  have hlen : rest.length <
+      ([false, false, true] ++ headerBits ++ symBits ++ rest).length := by
+    simp only [List.length_append, List.length_cons, List.length_nil]
+    omega
+  rw [dif_pos hlen]
+
 end Deflate.Spec

--- a/Zip/Spec/DeflateEncode.lean
+++ b/Zip/Spec/DeflateEncode.lean
@@ -756,4 +756,63 @@ theorem decode_go_dynBlock_nonfinal (syms : List LZ77Symbol) (chunk acc : List U
       (false :: false :: true :: (headerBits ++ symBits ++ rest)).length by
     simp only [List.length_cons, List.length_append]; omega)]
 
+/-- `decode.goR` on a *final* dynamic block from `acc`: appends the chunk and
+    returns the trailing bits `rest` as the remaining. -/
+theorem decode_goR_dynBlock_final (syms : List LZ77Symbol) (chunk acc : List UInt8)
+    (litLens distLens : List Nat) (headerBits symBits rest : List Bool)
+    (hv_lit : Huffman.Spec.ValidLengths litLens 15)
+    (hv_dist : Huffman.Spec.ValidLengths distLens 15)
+    (hheader : decodeDynamicTables (headerBits ++ symBits ++ rest) =
+        some (litLens, distLens, symBits ++ rest))
+    (henc : encodeSymbols litLens distLens syms = some symBits)
+    (hresolve : resolveLZ77 syms [] = some chunk)
+    (hvalid : ValidSymbolList syms) :
+    decode.goR ([true, false, true] ++ headerBits ++ symBits ++ rest) acc =
+        some (acc ++ chunk, rest) := by
+  unfold decode.goR
+  simp only [List.cons_append, readBitsLSB_1_true, bind, Option.bind]
+  simp only [readBitsLSB_2_false_true]
+  simp only [List.nil_append]
+  rw [hheader]; dsimp only
+  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
+    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
+      henc hv_lit hv_dist hvalid
+  rw [hdec]
+  have hres : resolveLZ77 syms acc = some (acc ++ chunk) := by
+    have h := resolveLZ77_shift syms acc [] chunk hresolve
+    rwa [List.append_nil] at h
+  simp only [hres]
+  exact if_pos rfl
+
+/-- `decode.goR` on a *non-final* dynamic block from `acc`: appends the chunk and
+    continues on the trailing bits. -/
+theorem decode_goR_dynBlock_nonfinal (syms : List LZ77Symbol) (chunk acc : List UInt8)
+    (litLens distLens : List Nat) (headerBits symBits rest : List Bool)
+    (hv_lit : Huffman.Spec.ValidLengths litLens 15)
+    (hv_dist : Huffman.Spec.ValidLengths distLens 15)
+    (hheader : decodeDynamicTables (headerBits ++ symBits ++ rest) =
+        some (litLens, distLens, symBits ++ rest))
+    (henc : encodeSymbols litLens distLens syms = some symBits)
+    (hresolve : resolveLZ77 syms [] = some chunk)
+    (hvalid : ValidSymbolList syms) :
+    decode.goR ([false, false, true] ++ headerBits ++ symBits ++ rest) acc =
+        decode.goR rest (acc ++ chunk) := by
+  conv => lhs; unfold decode.goR
+  simp only [List.cons_append, readBitsLSB_1_false, bind, Option.bind]
+  simp only [readBitsLSB_2_false_true]
+  simp only [List.nil_append]
+  rw [hheader]; dsimp only
+  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
+    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
+      henc hv_lit hv_dist hvalid
+  rw [hdec]
+  have hres : resolveLZ77 syms acc = some (acc ++ chunk) := by
+    have h := resolveLZ77_shift syms acc [] chunk hresolve
+    rwa [List.append_nil] at h
+  simp only [hres]
+  rw [if_neg (by decide)]
+  rw [dif_pos (show rest.length <
+      (false :: false :: true :: (headerBits ++ symBits ++ rest)).length by
+    simp only [List.length_cons, List.length_append]; omega)]
+
 end Deflate.Spec

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -1,6 +1,7 @@
 import Zip.Spec.DeflateFixedCorrect
 import Zip.Spec.DeflateDynamicCorrect
 import Zip.Spec.LZ77ChainCorrect
+import Zip.Spec.DeflateBlockSplit
 
 /-!
 # Unified DEFLATE Roundtrip (Phase B4 Capstone)
@@ -42,6 +43,20 @@ private theorem cRes (data : ByteArray) (level : UInt8) :
       some data.data.toList :=
   lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (by omega)
 
+set_option maxRecDepth 8000 in
+/-- `pickSmaller` of two byte arrays that both roundtrip also roundtrips. -/
+theorem inflate_pickSmaller (a b dataOut : ByteArray) (m : Nat)
+    (ha : Zip.Native.Inflate.inflate a m = .ok dataOut)
+    (hb : Zip.Native.Inflate.inflate b m = .ok dataOut) :
+    Zip.Native.Inflate.inflate (pickSmaller a b) m = .ok dataOut := by
+  unfold pickSmaller; split <;> assumption
+
+/-- `pickSmaller` preserves any predicate on the bit stream both candidates meet. -/
+theorem pickSmaller_bytesToBits {P : List Bool → Prop} (a b : ByteArray)
+    (ha : P (Deflate.Spec.bytesToBits a)) (hb : P (Deflate.Spec.bytesToBits b)) :
+    P (Deflate.Spec.bytesToBits (pickSmaller a b)) := by
+  unfold pickSmaller; split <;> assumption
+
 /-- Roundtrip for the compressed-block dispatch (`deflateCompressed`), i.e. the
     `deflateRaw` cases without the stored-block fallback. -/
 theorem inflate_deflateCompressed (data : ByteArray) (level : UInt8)
@@ -79,9 +94,10 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     · exact inflate_deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
         (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
     · exact inflate_deflateStoredPure data _ hsize
-    · exact inflate_deflateDynamicBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
-        (cEnc data level) (fun hz => cEmpty data level hz)
-        (cRes data level) _ hsize
+    · exact inflate_pickSmaller _ _ data maxOutputSize
+        (inflate_deflateDynamicBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+          (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize)
+        (inflate_deflateDynamicBlocksSC data splitChunkSize level _ hsize)
 
 /-- Padding decomposition for the compressed-block dispatch. -/
 theorem deflateCompressed_pad (data : ByteArray) (level : UInt8) :
@@ -147,7 +163,10 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
     · exact hstored
     · exact hfixed
     · exact hstored
-    · exact hdyn
+    · exact pickSmaller_bytesToBits
+        (P := fun bits => ∃ (contentBits padding : List Bool),
+          bits = contentBits ++ padding ∧ padding.length < 8)
+        _ _ hdyn (deflateDynamicBlocksSC_pad data splitChunkSize level)
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
     the level 2-4 path and the level ≥ 5 fixed candidate (both `= deflateLazy`). -/
@@ -282,7 +301,13 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
     · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
     · exact hfixed
     · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
-    · exact deflateDynamicBlock_goR_pad data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
-        (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
+    · exact pickSmaller_bytesToBits
+        (P := fun bits => ∃ remaining,
+          Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+            remaining.length < 8)
+        _ _
+        (deflateDynamicBlock_goR_pad data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+          (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level))
+        (deflateDynamicBlocksSC_goR_pad data splitChunkSize level)
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -94,10 +94,14 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     · exact inflate_deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
         (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
     · exact inflate_deflateStoredPure data _ hsize
-    · exact inflate_pickSmaller _ _ data maxOutputSize
-        (inflate_deflateDynamicBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
-          (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize)
-        (inflate_deflateDynamicBlocksSC data splitChunkSize level _ hsize)
+    · -- Dynamic: `if 7 ≤ level then pickSmaller single split else single`.
+      have hsingle := inflate_deflateDynamicBlock data
+        (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+        (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
+      split
+      · exact inflate_pickSmaller _ _ data maxOutputSize hsingle
+          (inflate_deflateDynamicBlocksSC data splitChunkSize level _ hsize)
+      · exact hsingle
 
 /-- Padding decomposition for the compressed-block dispatch. -/
 theorem deflateCompressed_pad (data : ByteArray) (level : UInt8) :
@@ -163,10 +167,12 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
     · exact hstored
     · exact hfixed
     · exact hstored
-    · exact pickSmaller_bytesToBits
-        (P := fun bits => ∃ (contentBits padding : List Bool),
-          bits = contentBits ++ padding ∧ padding.length < 8)
-        _ _ hdyn (deflateDynamicBlocksSC_pad data splitChunkSize level)
+    · split
+      · exact pickSmaller_bytesToBits
+          (P := fun bits => ∃ (contentBits padding : List Bool),
+            bits = contentBits ++ padding ∧ padding.length < 8)
+          _ _ hdyn (deflateDynamicBlocksSC_pad data splitChunkSize level)
+      · exact hdyn
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
     the level 2-4 path and the level ≥ 5 fixed candidate (both `= deflateLazy`). -/
@@ -301,13 +307,15 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
     · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
     · exact hfixed
     · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
-    · exact pickSmaller_bytesToBits
-        (P := fun bits => ∃ remaining,
-          Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
-            remaining.length < 8)
-        _ _
-        (deflateDynamicBlock_goR_pad data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
-          (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level))
-        (deflateDynamicBlocksSC_goR_pad data splitChunkSize level)
+    · have hsingle := deflateDynamicBlock_goR_pad data
+        (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+        (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
+      split
+      · exact pickSmaller_bytesToBits
+          (P := fun bits => ∃ remaining,
+            Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+              remaining.length < 8)
+          _ _ hsingle (deflateDynamicBlocksSC_goR_pad data splitChunkSize level)
+      · exact hsingle
 
 end Zip.Native.Deflate

--- a/Zip/Spec/LZ77.lean
+++ b/Zip/Spec/LZ77.lean
@@ -124,7 +124,59 @@ theorem resolveLZ77_extends (syms : List LZ77Symbol) (acc output : List UInt8)
       · have := ih _ h
         exact List.IsPrefix.trans (List.prefix_append _ _) this
 
-/-! ## LZ77 matching (greedy encoder) -/
+/-- `(acc ++ win)[acc.length + k]! = win[k]!`. -/
+private theorem getElem!_append_add (acc win : List UInt8) (k : Nat) :
+    (acc ++ win)[acc.length + k]! = win[k]! := by
+  rw [List.getElem!_eq_getElem?_getD, List.getElem!_eq_getElem?_getD,
+    List.getElem?_append_right (by omega)]
+  congr 2; omega
+
+/-- The bytes a valid back-reference copies depend only on the last `dist` bytes
+    of the window, so when `dist ≤ win.length` they are unchanged by prepending
+    `acc`. -/
+private theorem resolveLZ77_copied_shift (acc win : List UInt8) (len dist : Nat)
+    (hd : dist ≤ win.length) :
+    (List.ofFn fun (i : Fin len) =>
+        (acc ++ win)[((acc ++ win).length - dist) + (i.val % dist)]!)
+      = (List.ofFn fun (i : Fin len) => win[(win.length - dist) + (i.val % dist)]!) := by
+  apply List.ext_getElem (by simp)
+  intro i h1 h2
+  simp only [List.getElem_ofFn, List.length_append]
+  rw [show acc.length + win.length - dist + (i % dist)
+        = acc.length + (win.length - dist + (i % dist)) from by omega]
+  exact getElem!_append_add acc win _
+
+/-- Window shift: if `syms` resolve from window `win` to `out`, they resolve
+    from `acc ++ win` to `acc ++ out`. A reference that succeeds from `win`
+    has distance ≤ the bytes produced so far, so prepending `acc` never changes
+    which bytes it copies — self-containedness comes for free from success. This
+    is what makes self-contained blocks compose. -/
+theorem resolveLZ77_shift (syms : List LZ77Symbol) :
+    ∀ (acc win out : List UInt8),
+      resolveLZ77 syms win = some out →
+      resolveLZ77 syms (acc ++ win) = some (acc ++ out) := by
+  induction syms with
+  | nil => intro acc win out h; simp only [resolveLZ77, Option.some.injEq] at h ⊢; rw [h]
+  | cons sym rest ih =>
+    intro acc win out h
+    cases sym with
+    | literal b =>
+      rw [resolveLZ77_literal] at h ⊢
+      have := ih acc (win ++ [b]) out h
+      rwa [← List.append_assoc] at this
+    | endOfBlock => simp only [resolveLZ77_endOfBlock, Option.some.injEq] at h ⊢; rw [h]
+    | reference len dist =>
+      have hd0 : dist ≠ 0 := by
+        intro h0; subst h0; rw [resolveLZ77_reference_dist_zero] at h; simp at h
+      have hdle : dist ≤ win.length := by
+        rcases Nat.lt_or_ge win.length dist with hgt | hle
+        · rw [resolveLZ77_reference_dist_too_large len dist rest win hgt] at h; simp at h
+        · exact hle
+      have hdle' : dist ≤ (acc ++ win).length := by simp only [List.length_append]; omega
+      rw [resolveLZ77_reference_valid len dist rest win hd0 hdle] at h
+      rw [resolveLZ77_reference_valid len dist rest (acc ++ win) hd0 hdle']
+      simp only [resolveLZ77_copied_shift acc win len dist hdle, List.append_assoc] at h ⊢
+      exact ih acc _ out h
 
 /-- Count consecutive matching bytes at position `pos` with source at
     distance `dist` back, using DEFLATE's overlapping-copy semantics.


### PR DESCRIPTION
This PR adds self-contained dynamic-Huffman block splitting to the DEFLATE compressor and proves the full roundtrip formally. At the max-compression tiers (level ≥ 7) `deflateRaw` now chops the input into ~32 KiB chunks, matches each chunk against a *fresh* window so its back-references stay within the chunk, and emits one dynamic block per chunk (final flag on the last) — then emits whichever is smaller, the single whole-file block or the split stream, via `pickSmaller`. Because each block is self-contained, `resolveLZ77_shift` lets every block's bytes append to the running output and the blocks compose: decoding the concatenation reconstructs the whole input. The default level 6 is unchanged (single block, no extra compress time); `pickSmaller` guarantees the split path never regresses ratio (inputs whose statistics vary locally win; on text the lost cross-chunk matches make the single block win and it is kept).

The roundtrip is verified end to end with zero `sorry`: `emitDynBlock_spec` generalizes the single-block spec to emit one block onto an arbitrary writer with `BFINAL = isFinal` (pre-flush bits + `wf`), recovering `deflateDynamicBlock_spec` as the `(empty, true)`-flush corollary; `decode_go_dynBlock_{final,nonfinal}` (and their `goR` variants) consume one self-contained block from an arbitrary accumulator; `emitChunkBlocks_decode`/`_decodeR` fold these over the chunk recursion by well-founded induction; and `inflate_deflateDynamicBlocksSC` bridges to `inflate_complete`. `inflate_deflateRaw`, `deflateRaw_pad`, and `deflateRaw_goR_pad` are extended through `pickSmaller` so Gzip/Zlib roundtrips transfer unchanged.

Measured on the Canterbury corpus (level 9 vs level 6): kennedy.xls −12.2% (245653 → 215721 bytes), ptt5 −2.7%, text files small wins, no file regresses. The split costs a second matcher pass on level-≥7 dynamic inputs, which is why it is gated to the tiers that already trade compress time for ratio.

🤖 Prepared with Claude Code