### PR TITLE
feat: cross-block DEFLATE splitting — shared 32 KiB window across dynamic blocks

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -453,6 +453,61 @@ def deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (level : UInt8) 
     correctness or regression concern). -/
 def splitChunkSize : Nat := 32768
 
+/-! ## Cross-block (shared-window) block-split dynamic compression
+
+Unlike the self-contained variant, this matches the **whole** input *once* with
+the full 32 KiB window (`lz77ChainIter`), producing one token stream whose
+back-references are valid against the running output, then **partitions that
+token stream** by token count into per-block groups. Each group is re-Huffman
+coded with its own dynamic tree; references freely cross block boundaries
+(RFC 1951 §3.2), so this recovers the cross-chunk matches the self-contained
+split discards — the lever for the text-ratio gap. `pickSmaller` gates it so it
+can never regress. -/
+
+/-- Emit one shared-window dynamic block for a *slice* `group` of the
+    whole-stream token array onto `bw` (`BFINAL = isFinal`). The whole (non-empty)
+    `data` is passed only to satisfy `emitDynBlock`'s empty-input guard, so the
+    group's tokens are always emitted; the Huffman trees fit `group`'s own
+    frequencies. -/
+def emitSharedBlock (bw : BitWriter) (data : ByteArray) (group : Array LZ77Token)
+    (isFinal : Bool) : BitWriter :=
+  let f := tokenFreqs group
+  let lens := dynamicCodeLengths f.1 f.2
+  emitDynBlock bw data group lens.1 lens.2
+    (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 isFinal
+
+/-- Emit the shared-window block sequence for the whole-stream token array `toks`
+    from token index `pos`, one block per `tokChunk` tokens (the last carries
+    `BFINAL`). Well-founded on the remaining token count so the roundtrip can
+    induct through it. -/
+def emitSharedBlocks (data : ByteArray) (toks : Array LZ77Token) (tokChunk : Nat)
+    (pos : Nat) (bw : BitWriter) : BitWriter :=
+  let step := max tokChunk 1
+  let j := min (pos + step) toks.size
+  let bw := emitSharedBlock bw data (toks.extract pos j) (decide (j ≥ toks.size))
+  if j ≥ toks.size then bw
+  else emitSharedBlocks data toks tokChunk j bw
+termination_by toks.size - pos
+decreasing_by simp_all only [Nat.not_le]; omega
+
+/-- Token-group size for cross-block splitting in `deflateRaw`: number of LZ77
+    tokens per block. A pure ratio knob (`pickSmaller` guards regression); 4096
+    is the measured optimum on text (smaller groups are dominated by per-block
+    header overhead, larger ones by coarser local-statistics tracking). -/
+def sharedTokChunk : Nat := 4096
+
+/-- Cross-block (shared-window) block-split dynamic compression. Matches the
+    whole input once, then partitions the token stream into `tokChunk`-token
+    blocks. See `emitSharedBlock`. -/
+def deflateDynamicBlocksShared (data : ByteArray) (tokChunk : Nat) (level : UInt8) : ByteArray :=
+  if data.size == 0 then
+    let f := tokenFreqs #[]
+    (emitDynBlock BitWriter.empty data #[] (dynamicCodeLengths f.1 f.2).1 (dynamicCodeLengths f.1 f.2).2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
+  else
+    (emitSharedBlocks data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+      tokChunk 0 BitWriter.empty).flush
+
 /-- The compressed-block dispatch (no stored fallback). Every level ≥ 1 uses the
     hash-chain matcher with the level's search depth (`chainDepth`) and interior
     insertion cap (`insertCap`): low levels defer insertion + search shallowly
@@ -490,18 +545,22 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
     let storedBytes := storedBlockBytes data
     if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
     else if fixedBytes < dynBytes then deflateFixedBlock data tokens
-    -- Dynamic Huffman. At the max-compression tiers (level ≥ 7) also try the
-    -- self-contained block-split stream (per-chunk Huffman trees, fresh window
-    -- per chunk) and emit whichever is smaller. `pickSmaller` guarantees we never
-    -- regress below the single block — splitting only ever wins (it helps inputs
-    -- whose statistics vary locally, e.g. structured binary; on text the lost
-    -- cross-chunk matches make the single block win, and we keep it). The default
-    -- level 6 stays single-block so it pays no extra compress time. Both branches
-    -- are roundtrip-verified.
+    -- Dynamic Huffman. At the max-compression tiers (level ≥ 7) also try two
+    -- block-split streams and emit the smallest of all three candidates:
+    --   * self-contained split — per-chunk Huffman trees, fresh window per chunk
+    --     (wins on locally-varying statistics, e.g. structured binary);
+    --   * cross-block (shared-window) split — one whole-file match pass, token
+    --     stream partitioned per block, references cross block boundaries (wins on
+    --     text, where the self-contained split loses cross-chunk matches).
+    -- `pickSmaller` guarantees we never regress below the single block — splitting
+    -- only ever wins. The default level 6 stays single-block so it pays no extra
+    -- compress time. All branches are roundtrip-verified.
     else
       let single := deflateDynamicBlockCore data tokens lens.1 lens.2
         (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
-      if 7 ≤ level then pickSmaller single (deflateDynamicBlocksSC data splitChunkSize level)
+      if 7 ≤ level then
+        pickSmaller (pickSmaller single (deflateDynamicBlocksSC data splitChunkSize level))
+          (deflateDynamicBlocksShared data sharedTokChunk level)
       else single
 
 end Zip.Native.Deflate

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -525,42 +525,48 @@ def deflateCompressed (data : ByteArray) (level : UInt8) : ByteArray :=
   else deflateDynamicBlockCore data tokens lens.1 lens.2
     (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
 
-/-- Unified raw DEFLATE compression dispatch. Level 0 = stored; every level ≥ 1
-    runs the hash-chain matcher with per-level `(chainDepth, insertCap)` (a zlib-style
-    speed/ratio ladder) and falls back to a stored block whenever that is smaller,
-    so incompressible input never expands. The stored/fixed/dynamic candidates are
-    all *sized* from one shared token pass and only the winner is emitted. -/
+/-- The single-block cost-model dispatch for level ≥ 1: stored / fixed / dynamic,
+    all *sized* from one shared token pass, emitting only the winner. Falls back to
+    a stored block whenever that is smaller, so incompressible input never expands.
+    This is the base candidate that the block-split streams are compared against. -/
+def deflateRawBase (data : ByteArray) (level : UInt8) : ByteArray :=
+  let tokens := lz77ChainIter data (chainDepth level) 32768 (insertCap level)
+  let f := tokenFreqs tokens
+  let lens := dynamicCodeLengths f.1 f.2
+  let fixedBytes := fixedBlockBytes f.1 f.2
+  let dynBytes := dynBlockBytes f.1 f.2 lens.1 lens.2
+  -- Size the stored candidate in O(⌈|data|/65535⌉) via `storedBlockBytes`
+  -- (= `(deflateStoredPure data).size`, `storedBlockBytes_eq`) and *only*
+  -- materialize the ~|data|-byte stored block when it actually wins — otherwise
+  -- every compressible input paid to build and discard a full-size copy.
+  let storedBytes := storedBlockBytes data
+  if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
+  else if fixedBytes < dynBytes then deflateFixedBlock data tokens
+  else deflateDynamicBlockCore data tokens lens.1 lens.2
+    (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
+
+/-- Unified raw DEFLATE compression dispatch. Level 0 = stored; level ≥ 1 runs the
+    single-block cost-model dispatch (`deflateRawBase`). At the max-compression
+    tiers (level ≥ 7) two block-split streams are also tried, and the smallest of
+    all candidates is emitted:
+      * self-contained split — per-chunk Huffman trees, fresh window per chunk
+        (wins on locally-varying statistics, e.g. structured binary);
+      * cross-block (shared-window) split — one whole-file match pass, token stream
+        partitioned per block, references cross block boundaries (wins on large
+        text, where the self-contained split loses cross-chunk matches).
+    The splits are first-class candidates compared against the whole base via
+    `pickSmaller`, *not* nested inside the dynamic branch: on large heterogeneous
+    inputs a single dynamic tree loses to fixed Huffman, so a base-internal gate
+    would never reach the split even though it wins by 15–19%. `pickSmaller`
+    guarantees we never regress below the base; the default level 6 stays
+    single-block so it pays no extra compress time. All branches are
+    roundtrip-verified. -/
 def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   if level == 0 then deflateStoredPure data
-  else
-    let tokens := lz77ChainIter data (chainDepth level) 32768 (insertCap level)
-    let f := tokenFreqs tokens
-    let lens := dynamicCodeLengths f.1 f.2
-    let fixedBytes := fixedBlockBytes f.1 f.2
-    let dynBytes := dynBlockBytes f.1 f.2 lens.1 lens.2
-    -- Size the stored candidate in O(⌈|data|/65535⌉) via `storedBlockBytes`
-    -- (= `(deflateStoredPure data).size`, `storedBlockBytes_eq`) and *only*
-    -- materialize the ~|data|-byte stored block when it actually wins — otherwise
-    -- every compressible input paid to build and discard a full-size copy.
-    let storedBytes := storedBlockBytes data
-    if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
-    else if fixedBytes < dynBytes then deflateFixedBlock data tokens
-    -- Dynamic Huffman. At the max-compression tiers (level ≥ 7) also try two
-    -- block-split streams and emit the smallest of all three candidates:
-    --   * self-contained split — per-chunk Huffman trees, fresh window per chunk
-    --     (wins on locally-varying statistics, e.g. structured binary);
-    --   * cross-block (shared-window) split — one whole-file match pass, token
-    --     stream partitioned per block, references cross block boundaries (wins on
-    --     text, where the self-contained split loses cross-chunk matches).
-    -- `pickSmaller` guarantees we never regress below the single block — splitting
-    -- only ever wins. The default level 6 stays single-block so it pays no extra
-    -- compress time. All branches are roundtrip-verified.
-    else
-      let single := deflateDynamicBlockCore data tokens lens.1 lens.2
-        (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
-      if 7 ≤ level then
-        pickSmaller (pickSmaller single (deflateDynamicBlocksSC data splitChunkSize level))
-          (deflateDynamicBlocksShared data sharedTokChunk level)
-      else single
+  else if 7 ≤ level then
+    pickSmaller (deflateRawBase data level)
+      (pickSmaller (deflateDynamicBlocksSC data splitChunkSize level)
+        (deflateDynamicBlocksShared data sharedTokChunk level))
+  else deflateRawBase data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -220,6 +220,284 @@ theorem emitChunkBlocks_decodeR (data : ByteArray) (chunkSize : Nat) (level : UI
           extract_data_append data pos (min (pos + max chunkSize 1) data.size) data.size
             (by omega) hjle]
 
+/-! ## Cross-block (shared-window) block-split roundtrip
+
+`deflateDynamicBlocksShared` matches the whole input *once* (full 32 KiB window),
+then partitions the single token stream into per-block groups whose
+back-references may reach into earlier blocks. Unlike the self-contained fold,
+the per-tail output is *acc-dependent*, so the fold threads the concrete
+accumulated output and supplies each block an acc-threaded resolve fact, peeled
+off the whole-stream resolve via `resolveLZ77_append_eobFree`. -/
+
+set_option maxHeartbeats 800000 in
+/-- One shared-window block: its bits append to `bw`, it preserves `wf`, and given
+    the acc-threaded resolve `resolveLZ77 (tokensToSymbols group) accOut = some out`,
+    `decode.go`/`decode.goR` consume it — returning `out` (final) or continuing on
+    the trailing bits from `out` (non-final). -/
+theorem emitSharedBlock_decode (data : ByteArray) (group : Array LZ77Token)
+    (bw : BitWriter) (hbw : bw.wf) (isFinal : Bool) (hdata : data.size ≠ 0)
+    (hgenc : ∀ t ∈ group.toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768)
+    (accOut out : List UInt8)
+    (hres : Deflate.Spec.resolveLZ77 (tokensToSymbols group) accOut = some out) :
+    ∃ blockBits,
+      (emitSharedBlock bw data group isFinal).toBits = bw.toBits ++ blockBits ∧
+      (emitSharedBlock bw data group isFinal).wf ∧
+      (∀ (rest : List Bool),
+        Deflate.Spec.decode.go (blockBits ++ rest) accOut =
+          if isFinal then some out else Deflate.Spec.decode.go rest out) ∧
+      (∀ (rest : List Bool),
+        Deflate.Spec.decode.goR (blockBits ++ rest) accOut =
+          if isFinal then some (out, rest) else Deflate.Spec.decode.goR rest out) := by
+  obtain ⟨litLens, distLens, headerBits, symBits, _hll, _hdl, hlv, hdv,
+      hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+    emitDynBlock_spec bw hbw data group hgenc (fun hz => absurd hz hdata) isFinal
+  have hvalid := tokensToSymbols_validSymbolList group
+  refine ⟨[isFinal, false, true] ++ headerBits ++ symBits, ?_, ?_, ?_, ?_⟩
+  · simp only [emitSharedBlock]; rw [htoBits]; simp only [List.append_assoc]
+  · simp only [emitSharedBlock]; exact hwf
+  · intro rest
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables
+      litLens distLens headerBits (symBits ++ rest) hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    cases isFinal
+    · simp only [Bool.false_eq_true, if_false]
+      exact Deflate.Spec.decode_go_dynBlock_nonfinal_acc _ out accOut litLens distLens
+        headerBits symBits rest hlv hdv hheader hsyms hres hvalid
+    · simp only [if_true]
+      exact Deflate.Spec.decode_go_dynBlock_final_acc _ out accOut litLens distLens
+        headerBits symBits rest hlv hdv hheader hsyms hres hvalid
+  · intro rest
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables
+      litLens distLens headerBits (symBits ++ rest) hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    cases isFinal
+    · simp only [Bool.false_eq_true, if_false]
+      exact Deflate.Spec.decode_goR_dynBlock_nonfinal_acc _ out accOut litLens distLens
+        headerBits symBits rest hlv hdv hheader hsyms hres hvalid
+    · simp only [if_true]
+      exact Deflate.Spec.decode_goR_dynBlock_final_acc _ out accOut litLens distLens
+        headerBits symBits rest hlv hdv hheader hsyms hres hvalid
+
+/-- Membership in an extracted token array's `toList` is membership in the whole. -/
+private theorem mem_extract_toList {α} (a : Array α) (s e : Nat) (x : α)
+    (h : x ∈ (a.extract s e).toList) : x ∈ a.toList := by
+  rw [Array.toList_extract, List.extract_eq_take_drop] at h
+  exact List.mem_of_mem_drop (List.mem_of_mem_take h)
+
+/-- Decode fold over the shared-window blocks: from token index `pos < toks.size`,
+    with `accOut` the output of blocks `0..pos` and the residual resolve fact
+    `resolveLZ77 (drop pos of the mapped tokens) accOut = some wholeOut`, the bits
+    emitted by `emitSharedBlocks` (with `bw`'s bits stripped as `B`) decode — from
+    `accOut` — to `wholeOut`. The last block is final, so it returns regardless of
+    the trailing `tail`. -/
+theorem emitSharedBlocks_decode (data : ByteArray) (toks : Array LZ77Token) (tokChunk : Nat)
+    (hdata : data.size ≠ 0)
+    (henc : ∀ t ∈ toks.toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768) :
+    ∀ (fuel pos : Nat) (accOut wholeOut : List UInt8) (bw : BitWriter),
+      toks.size - pos ≤ fuel → pos < toks.size → bw.wf →
+      Deflate.Spec.resolveLZ77 ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos) accOut =
+        some wholeOut →
+      ∃ B, (emitSharedBlocks data toks tokChunk pos bw).toBits = bw.toBits ++ B ∧
+        (emitSharedBlocks data toks tokChunk pos bw).wf ∧
+        ∀ (tail : List Bool),
+          Deflate.Spec.decode.go (B ++ tail) accOut = some wholeOut := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos accOut wholeOut bw hf hpos _ _; omega
+  | succ fuel ih =>
+    intro pos accOut wholeOut bw hf hpos hbw hres
+    have hjle : min (pos + max tokChunk 1) toks.size ≤ toks.size := Nat.min_le_right _ _
+    have hstep1 : 1 ≤ max tokChunk 1 := Nat.le_max_right _ _
+    have hjgt : pos < min (pos + max tokChunk 1) toks.size := by simp only [Nat.lt_min]; omega
+    have hMfree : ∀ s ∈ toks.toList.map LZ77Token.toLZ77Symbol,
+        s ≠ Deflate.Spec.LZ77Symbol.endOfBlock := mem_map_toLZ77Symbol_ne_endOfBlock toks.toList
+    have hgmfree : ∀ s ∈ ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+        (min (pos + max tokChunk 1) toks.size - pos), s ≠ Deflate.Spec.LZ77Symbol.endOfBlock :=
+      fun s hs => hMfree s (List.mem_of_mem_drop (List.mem_of_mem_take hs))
+    -- Split the residual at the partition point.
+    have hsplit : (toks.toList.map LZ77Token.toLZ77Symbol).drop pos =
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (pos + max tokChunk 1) toks.size - pos)
+        ++ (toks.toList.map LZ77Token.toLZ77Symbol).drop (min (pos + max tokChunk 1) toks.size) := by
+      conv => lhs; rw [← List.take_append_drop (min (pos + max tokChunk 1) toks.size - pos)
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos)]
+      rw [List.drop_drop, show pos + (min (pos + max tokChunk 1) toks.size - pos)
+        = min (pos + max tokChunk 1) toks.size from by omega]
+    rw [hsplit, Deflate.Spec.resolveLZ77_append_eobFree _ _ accOut hgmfree] at hres
+    -- Peel off the block's resolve and the recursive residual.
+    obtain ⟨out', hout'1, hout'2⟩ :
+        ∃ out', Deflate.Spec.resolveLZ77 (((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+            (min (pos + max tokChunk 1) toks.size - pos)) accOut = some out' ∧
+          Deflate.Spec.resolveLZ77 ((toks.toList.map LZ77Token.toLZ77Symbol).drop
+            (min (pos + max tokChunk 1) toks.size)) out' = some wholeOut := by
+      cases hgm : Deflate.Spec.resolveLZ77 (((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (pos + max tokChunk 1) toks.size - pos)) accOut with
+      | none => rw [hgm] at hres; simp only [Option.bind_none, reduceCtorEq] at hres
+      | some o => rw [hgm] at hres; exact ⟨o, rfl, hres⟩
+    -- The block's symbol list resolves against `accOut` to `out'`.
+    have htts : tokensToSymbols (toks.extract pos (min (pos + max tokChunk 1) toks.size)) =
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (pos + max tokChunk 1) toks.size - pos)
+        ++ [Deflate.Spec.LZ77Symbol.endOfBlock] := by
+      unfold tokensToSymbols
+      congr 1
+      simp only [Array.toList_extract, List.extract_eq_take_drop, List.map_take, List.map_drop]
+    have hblockres : Deflate.Spec.resolveLZ77
+        (tokensToSymbols (toks.extract pos (min (pos + max tokChunk 1) toks.size))) accOut =
+        some out' := by
+      rw [htts, Deflate.Spec.resolveLZ77_eobFree_eob _ accOut hgmfree]; exact hout'1
+    obtain ⟨blockBits, htoBits, hwfblk, hdecblk, _⟩ :=
+      emitSharedBlock_decode data (toks.extract pos (min (pos + max tokChunk 1) toks.size)) bw hbw
+        (decide (min (pos + max tokChunk 1) toks.size ≥ toks.size)) hdata
+        (fun t ht => henc t (mem_extract_toList toks pos _ t ht)) accOut out' hblockres
+    by_cases hend : min (pos + max tokChunk 1) toks.size ≥ toks.size
+    · -- Final block: j = toks.size, so the residual forces `out' = wholeOut`.
+      have hjeq : min (pos + max tokChunk 1) toks.size = toks.size := by omega
+      have hdropnil : (toks.toList.map LZ77Token.toLZ77Symbol).drop
+          (min (pos + max tokChunk 1) toks.size) = [] := by
+        rw [hjeq, show toks.size = (toks.toList.map LZ77Token.toLZ77Symbol).length from by
+          rw [List.length_map, Array.length_toList], List.drop_length]
+      have hwo : out' = wholeOut := by
+        rw [hdropnil, Deflate.Spec.resolveLZ77_nil, Option.some.injEq] at hout'2; exact hout'2
+      have hstep : emitSharedBlocks data toks tokChunk pos bw =
+          emitSharedBlock bw data (toks.extract pos (min (pos + max tokChunk 1) toks.size))
+            (decide (min (pos + max tokChunk 1) toks.size ≥ toks.size)) := by
+        conv => lhs; unfold emitSharedBlocks
+        simp only [if_pos hend]
+      refine ⟨blockBits, ?_, ?_, ?_⟩
+      · rw [hstep]; exact htoBits
+      · rw [hstep]; exact hwfblk
+      · intro tail
+        have hd := hdecblk tail
+        rw [if_pos (decide_eq_true hend)] at hd
+        rw [hd, hwo]
+    · -- Non-final block: recurse on the next token group.
+      have hbw' : (emitSharedBlock bw data (toks.extract pos (min (pos + max tokChunk 1) toks.size))
+          (decide (min (pos + max tokChunk 1) toks.size ≥ toks.size))).wf := hwfblk
+      have hstep : emitSharedBlocks data toks tokChunk pos bw =
+          emitSharedBlocks data toks tokChunk (min (pos + max tokChunk 1) toks.size)
+            (emitSharedBlock bw data (toks.extract pos (min (pos + max tokChunk 1) toks.size))
+              (decide (min (pos + max tokChunk 1) toks.size ≥ toks.size))) := by
+        conv => lhs; unfold emitSharedBlocks
+        simp only [if_neg hend]
+      obtain ⟨B', htoBits', hwf', hdec'⟩ :=
+        ih (min (pos + max tokChunk 1) toks.size) out' wholeOut _ (by omega) (by omega) hbw' hout'2
+      refine ⟨blockBits ++ B', ?_, ?_, ?_⟩
+      · rw [hstep, htoBits', htoBits, List.append_assoc]
+      · rw [hstep]; exact hwf'
+      · intro tail
+        rw [List.append_assoc]
+        have hd := hdecblk (B' ++ tail)
+        rw [if_neg (by simp only [decide_eq_true_eq]; exact hend)] at hd
+        rw [hd]; exact hdec' tail
+
+/-- `decode.goR` variant of `emitSharedBlocks_decode`: the remaining bits after
+    decoding all shared blocks are exactly the trailing `tail`. -/
+theorem emitSharedBlocks_decodeR (data : ByteArray) (toks : Array LZ77Token) (tokChunk : Nat)
+    (hdata : data.size ≠ 0)
+    (henc : ∀ t ∈ toks.toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768) :
+    ∀ (fuel pos : Nat) (accOut wholeOut : List UInt8) (bw : BitWriter),
+      toks.size - pos ≤ fuel → pos < toks.size → bw.wf →
+      Deflate.Spec.resolveLZ77 ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos) accOut =
+        some wholeOut →
+      ∃ B, (emitSharedBlocks data toks tokChunk pos bw).toBits = bw.toBits ++ B ∧
+        (emitSharedBlocks data toks tokChunk pos bw).wf ∧
+        ∀ (tail : List Bool),
+          Deflate.Spec.decode.goR (B ++ tail) accOut = some (wholeOut, tail) := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos accOut wholeOut bw hf hpos _ _; omega
+  | succ fuel ih =>
+    intro pos accOut wholeOut bw hf hpos hbw hres
+    have hjle : min (pos + max tokChunk 1) toks.size ≤ toks.size := Nat.min_le_right _ _
+    have hstep1 : 1 ≤ max tokChunk 1 := Nat.le_max_right _ _
+    have hjgt : pos < min (pos + max tokChunk 1) toks.size := by simp only [Nat.lt_min]; omega
+    have hMfree : ∀ s ∈ toks.toList.map LZ77Token.toLZ77Symbol,
+        s ≠ Deflate.Spec.LZ77Symbol.endOfBlock := mem_map_toLZ77Symbol_ne_endOfBlock toks.toList
+    have hgmfree : ∀ s ∈ ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+        (min (pos + max tokChunk 1) toks.size - pos), s ≠ Deflate.Spec.LZ77Symbol.endOfBlock :=
+      fun s hs => hMfree s (List.mem_of_mem_drop (List.mem_of_mem_take hs))
+    have hsplit : (toks.toList.map LZ77Token.toLZ77Symbol).drop pos =
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (pos + max tokChunk 1) toks.size - pos)
+        ++ (toks.toList.map LZ77Token.toLZ77Symbol).drop (min (pos + max tokChunk 1) toks.size) := by
+      conv => lhs; rw [← List.take_append_drop (min (pos + max tokChunk 1) toks.size - pos)
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos)]
+      rw [List.drop_drop, show pos + (min (pos + max tokChunk 1) toks.size - pos)
+        = min (pos + max tokChunk 1) toks.size from by omega]
+    rw [hsplit, Deflate.Spec.resolveLZ77_append_eobFree _ _ accOut hgmfree] at hres
+    obtain ⟨out', hout'1, hout'2⟩ :
+        ∃ out', Deflate.Spec.resolveLZ77 (((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+            (min (pos + max tokChunk 1) toks.size - pos)) accOut = some out' ∧
+          Deflate.Spec.resolveLZ77 ((toks.toList.map LZ77Token.toLZ77Symbol).drop
+            (min (pos + max tokChunk 1) toks.size)) out' = some wholeOut := by
+      cases hgm : Deflate.Spec.resolveLZ77 (((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (pos + max tokChunk 1) toks.size - pos)) accOut with
+      | none => rw [hgm] at hres; simp only [Option.bind_none, reduceCtorEq] at hres
+      | some o => rw [hgm] at hres; exact ⟨o, rfl, hres⟩
+    have htts : tokensToSymbols (toks.extract pos (min (pos + max tokChunk 1) toks.size)) =
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (pos + max tokChunk 1) toks.size - pos)
+        ++ [Deflate.Spec.LZ77Symbol.endOfBlock] := by
+      unfold tokensToSymbols
+      congr 1
+      simp only [Array.toList_extract, List.extract_eq_take_drop, List.map_take, List.map_drop]
+    have hblockres : Deflate.Spec.resolveLZ77
+        (tokensToSymbols (toks.extract pos (min (pos + max tokChunk 1) toks.size))) accOut =
+        some out' := by
+      rw [htts, Deflate.Spec.resolveLZ77_eobFree_eob _ accOut hgmfree]; exact hout'1
+    obtain ⟨blockBits, htoBits, hwfblk, _, hdecblk⟩ :=
+      emitSharedBlock_decode data (toks.extract pos (min (pos + max tokChunk 1) toks.size)) bw hbw
+        (decide (min (pos + max tokChunk 1) toks.size ≥ toks.size)) hdata
+        (fun t ht => henc t (mem_extract_toList toks pos _ t ht)) accOut out' hblockres
+    by_cases hend : min (pos + max tokChunk 1) toks.size ≥ toks.size
+    · have hjeq : min (pos + max tokChunk 1) toks.size = toks.size := by omega
+      have hdropnil : (toks.toList.map LZ77Token.toLZ77Symbol).drop
+          (min (pos + max tokChunk 1) toks.size) = [] := by
+        rw [hjeq, show toks.size = (toks.toList.map LZ77Token.toLZ77Symbol).length from by
+          rw [List.length_map, Array.length_toList], List.drop_length]
+      have hwo : out' = wholeOut := by
+        rw [hdropnil, Deflate.Spec.resolveLZ77_nil, Option.some.injEq] at hout'2; exact hout'2
+      have hstep : emitSharedBlocks data toks tokChunk pos bw =
+          emitSharedBlock bw data (toks.extract pos (min (pos + max tokChunk 1) toks.size))
+            (decide (min (pos + max tokChunk 1) toks.size ≥ toks.size)) := by
+        conv => lhs; unfold emitSharedBlocks
+        simp only [if_pos hend]
+      refine ⟨blockBits, ?_, ?_, ?_⟩
+      · rw [hstep]; exact htoBits
+      · rw [hstep]; exact hwfblk
+      · intro tail
+        have hd := hdecblk tail
+        rw [if_pos (decide_eq_true hend)] at hd
+        rw [hd, hwo]
+    · have hbw' : (emitSharedBlock bw data (toks.extract pos (min (pos + max tokChunk 1) toks.size))
+          (decide (min (pos + max tokChunk 1) toks.size ≥ toks.size))).wf := hwfblk
+      have hstep : emitSharedBlocks data toks tokChunk pos bw =
+          emitSharedBlocks data toks tokChunk (min (pos + max tokChunk 1) toks.size)
+            (emitSharedBlock bw data (toks.extract pos (min (pos + max tokChunk 1) toks.size))
+              (decide (min (pos + max tokChunk 1) toks.size ≥ toks.size))) := by
+        conv => lhs; unfold emitSharedBlocks
+        simp only [if_neg hend]
+      obtain ⟨B', htoBits', hwf', hdec'⟩ :=
+        ih (min (pos + max tokChunk 1) toks.size) out' wholeOut _ (by omega) (by omega) hbw' hout'2
+      refine ⟨blockBits ++ B', ?_, ?_, ?_⟩
+      · rw [hstep, htoBits', htoBits, List.append_assoc]
+      · rw [hstep]; exact hwf'
+      · intro tail
+        rw [List.append_assoc]
+        have hd := hdecblk (B' ++ tail)
+        rw [if_neg (by simp only [decide_eq_true_eq]; exact hend)] at hd
+        rw [hd]; exact hdec' tail
+
 /-- Block-splitting roundtrip: decoding the self-contained chunk-block stream
     reproduces the input. The empty input is a single final block; otherwise the
     chunk-block fold (`emitChunkBlocks_decode`) reconstructs `data[0:]`. -/
@@ -357,6 +635,176 @@ theorem deflateDynamicBlocksSC_pad (data : ByteArray) (chunkSize : Nat) (level :
     obtain ⟨B, _, hwf, _⟩ :=
       emitChunkBlocks_decode data chunkSize level data.size 0 BitWriter.empty
         (by omega) hpos BitWriter.empty_wf
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+
+/-! ## Cross-block (shared-window) top-level roundtrip -/
+
+/-- Common facts for the `data.size > 0` branch of the shared-window theorems:
+    the whole-stream token list is non-empty and its mapped form resolves (from
+    `[]`, drop 0) to the input. Derived from `lz77ChainIter_resolves`. -/
+private theorem deflateDynamicBlocksShared_facts (data : ByteArray) (level : UInt8)
+    (hpos : 0 < data.size) :
+    (∀ t ∈ (lz77ChainIter data (chainDepth level) 32768 (insertCap level)).toList,
+        match t with
+        | .literal _ => True
+        | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768) ∧
+      0 < (lz77ChainIter data (chainDepth level) 32768 (insertCap level)).size ∧
+      Deflate.Spec.resolveLZ77
+        (((lz77ChainIter data (chainDepth level) 32768 (insertCap level)).toList.map
+          LZ77Token.toLZ77Symbol).drop 0) [] = some data.data.toList := by
+  have henc := lz77ChainIter_encodable data (chainDepth level) 32768 (insertCap level)
+    (by omega) (by omega)
+  have hwhole := lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (by omega)
+  have hMfree := mem_map_toLZ77Symbol_ne_endOfBlock
+    (lz77ChainIter data (chainDepth level) 32768 (insertCap level)).toList
+  have hM : Deflate.Spec.resolveLZ77
+      ((lz77ChainIter data (chainDepth level) 32768 (insertCap level)).toList.map
+        LZ77Token.toLZ77Symbol) [] = some data.data.toList := by
+    simp only [tokensToSymbols] at hwhole
+    rwa [Deflate.Spec.resolveLZ77_eobFree_eob _ [] hMfree] at hwhole
+  refine ⟨henc, ?_, ?_⟩
+  · rcases Nat.eq_zero_or_pos
+      (lz77ChainIter data (chainDepth level) 32768 (insertCap level)).size with h0 | h0
+    · exfalso
+      have hnil : (lz77ChainIter data (chainDepth level) 32768 (insertCap level)).toList = [] :=
+        List.eq_nil_of_length_eq_zero (by rw [Array.length_toList]; omega)
+      rw [hnil, List.map_nil, Deflate.Spec.resolveLZ77_nil, Option.some.injEq] at hM
+      have hl := congrArg List.length hM
+      simp only [List.length_nil, Array.length_toList, ByteArray.size_data] at hl
+      omega
+    · exact h0
+  · rw [List.drop_zero]; exact hM
+
+/-- Cross-block roundtrip: decoding the shared-window block stream reproduces the
+    input. The empty input is a single final block; otherwise the shared-window
+    fold (`emitSharedBlocks_decode`), seeded by `lz77ChainIter_resolves`,
+    reconstructs the input. -/
+theorem decode_deflateDynamicBlocksShared (data : ByteArray) (tokChunk : Nat) (level : UInt8) :
+    Deflate.Spec.decode
+      (Deflate.Spec.bytesToBits (deflateDynamicBlocksShared data tokChunk level)) =
+      some data.data.toList := by
+  unfold deflateDynamicBlocksShared
+  split
+  · -- data.size = 0: one final block over the empty token list (as in SC).
+    rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+      (symBits ++ List.replicate
+        ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+      hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+      have he : data.data.toList = [] :=
+        List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+      rw [he]; rfl
+    exact Deflate.Spec.encodeDynamic_decode_append (tokensToSymbols #[]) data.data.toList
+      litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+      (tokensToSymbols_validSymbolList _)
+  · -- data.size > 0: the shared-window fold.
+    rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksShared_facts data level hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocks_decode data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+        tokChunk (by omega) henc
+        (lz77ChainIter data (chainDepth level) 32768 (insertCap level)).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    exact hdec (List.replicate ((8 - B.length % 8) % 8) false)
+
+/-- Cross-block roundtrip: inflating `deflateDynamicBlocksShared` recovers the
+    input, for any `maxOutputSize` large enough to hold it. -/
+theorem inflate_deflateDynamicBlocksShared (data : ByteArray) (tokChunk : Nat) (level : UInt8)
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    Zip.Native.Inflate.inflate (deflateDynamicBlocksShared data tokChunk level) maxOutputSize =
+      .ok data := by
+  have hlen : data.data.toList.length ≤ maxOutputSize := by
+    simp only [Array.length_toList, ByteArray.size_data]; omega
+  rw [← show ByteArray.mk ⟨data.data.toList⟩ = data from by simp only [Array.toArray_toList]]
+  exact inflate_complete (deflateDynamicBlocksShared data tokChunk level) data.data.toList
+    maxOutputSize hlen (decode_deflateDynamicBlocksShared data tokChunk level)
+
+/-- The `decode.goR` of `deflateDynamicBlocksShared` returns the input and short
+    (< 8-bit) trailing padding — needed to show the native decoder consumes all
+    of the deflated bytes. -/
+theorem deflateDynamicBlocksShared_goR_pad (data : ByteArray) (tokChunk : Nat) (level : UInt8) :
+    ∃ remaining,
+      Deflate.Spec.decode.goR
+          (Deflate.Spec.bytesToBits (deflateDynamicBlocksShared data tokChunk level)) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+  unfold deflateDynamicBlocksShared
+  split
+  · -- data.size = 0
+    rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate
+      ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false, ?_, ?_⟩
+    · have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+        (symBits ++ List.replicate
+          ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+        hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+      rw [← List.append_assoc] at hheader
+      have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+        have he : data.data.toList = [] :=
+          List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+        rw [he]; rfl
+      exact Deflate.Spec.encodeDynamic_goR_rest (tokensToSymbols #[]) data.data.toList
+        litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+        (tokensToSymbols_validSymbolList _)
+    · simp only [List.length_replicate]; omega
+  · -- data.size > 0
+    rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksShared_facts data level hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocks_decodeR data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+        tokChunk (by omega) henc
+        (lz77ChainIter data (chainDepth level) 32768 (insertCap level)).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate ((8 - B.length % 8) % 8) false, hdec _, ?_⟩
+    simp only [List.length_replicate]; omega
+
+/-- The output of `deflateDynamicBlocksShared` decomposes into content bits plus
+    short (< 8-bit) padding. -/
+theorem deflateDynamicBlocksShared_pad (data : ByteArray) (tokChunk : Nat) (level : UInt8) :
+    ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits (deflateDynamicBlocksShared data tokChunk level) =
+        contentBits ++ padding ∧ padding.length < 8 := by
+  unfold deflateDynamicBlocksShared
+  split
+  · obtain ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksShared_facts data level hpos
+    obtain ⟨B, _, hwf, _⟩ :=
+      emitSharedBlocks_decode data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+        tokChunk (by omega) henc
+        (lz77ChainIter data (chainDepth level) 32768 (insertCap level)).size 0 []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
     exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateEncode.lean
+++ b/Zip/Spec/DeflateEncode.lean
@@ -697,6 +697,130 @@ lets `resolveLZ77_shift` lift the resolve to `resolveLZ77 syms acc =
 some (acc ++ chunk)`, so the block's bytes simply append to `acc`. These
 compose into the block-splitting roundtrip. -/
 
+/-! ### Output-parametric (`_acc`) variants
+
+These take the *acc-threaded* resolve fact `resolveLZ77 syms acc = some out`
+directly and conclude in terms of the concrete output `out`. They are the
+cross-block (shared-window) workhorses: a back-reference in one block may reach
+into earlier blocks' output, so the resolve cannot be lifted from a
+self-contained `resolveLZ77 syms [] = some chunk` via `resolveLZ77_shift` — the
+caller supplies the threaded fact built from the whole-stream resolve. The
+self-contained lemmas below are thin wrappers that derive `hres` via the shift
+and delegate (instantiating `out := acc ++ chunk`). -/
+
+/-- `decode.go` on a *final* dynamic block, given the threaded resolve
+    `resolveLZ77 syms acc = some out`: returns `out`. -/
+theorem decode_go_dynBlock_final_acc (syms : List LZ77Symbol) (out acc : List UInt8)
+    (litLens distLens : List Nat) (headerBits symBits rest : List Bool)
+    (hv_lit : Huffman.Spec.ValidLengths litLens 15)
+    (hv_dist : Huffman.Spec.ValidLengths distLens 15)
+    (hheader : decodeDynamicTables (headerBits ++ symBits ++ rest) =
+        some (litLens, distLens, symBits ++ rest))
+    (henc : encodeSymbols litLens distLens syms = some symBits)
+    (hres : resolveLZ77 syms acc = some out)
+    (hvalid : ValidSymbolList syms) :
+    decode.go ([true, false, true] ++ headerBits ++ symBits ++ rest) acc = some out := by
+  unfold decode.go
+  simp only [List.cons_append, readBitsLSB_1_true, bind, Option.bind]
+  simp only [readBitsLSB_2_false_true]
+  simp only [List.nil_append]
+  rw [hheader]; dsimp only
+  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
+    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
+      henc hv_lit hv_dist hvalid
+  rw [hdec]
+  simp only [hres]
+  exact if_pos rfl
+
+/-- `decode.go` on a *non-final* dynamic block, given the threaded resolve
+    `resolveLZ77 syms acc = some out`: continues on the trailing bits from `out`. -/
+theorem decode_go_dynBlock_nonfinal_acc (syms : List LZ77Symbol) (out acc : List UInt8)
+    (litLens distLens : List Nat) (headerBits symBits rest : List Bool)
+    (hv_lit : Huffman.Spec.ValidLengths litLens 15)
+    (hv_dist : Huffman.Spec.ValidLengths distLens 15)
+    (hheader : decodeDynamicTables (headerBits ++ symBits ++ rest) =
+        some (litLens, distLens, symBits ++ rest))
+    (henc : encodeSymbols litLens distLens syms = some symBits)
+    (hres : resolveLZ77 syms acc = some out)
+    (hvalid : ValidSymbolList syms) :
+    decode.go ([false, false, true] ++ headerBits ++ symBits ++ rest) acc =
+        decode.go rest out := by
+  conv => lhs; unfold decode.go
+  simp only [List.cons_append, readBitsLSB_1_false, bind, Option.bind]
+  simp only [readBitsLSB_2_false_true]
+  simp only [List.nil_append]
+  rw [hheader]; dsimp only
+  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
+    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
+      henc hv_lit hv_dist hvalid
+  rw [hdec]
+  simp only [hres]
+  rw [if_neg (by decide)]
+  rw [dif_pos (show rest.length <
+      (false :: false :: true :: (headerBits ++ symBits ++ rest)).length by
+    simp only [List.length_cons, List.length_append]; omega)]
+
+/-- `decode.goR` on a *final* dynamic block, given `resolveLZ77 syms acc = some out`:
+    returns `out` with the trailing bits `rest`. -/
+theorem decode_goR_dynBlock_final_acc (syms : List LZ77Symbol) (out acc : List UInt8)
+    (litLens distLens : List Nat) (headerBits symBits rest : List Bool)
+    (hv_lit : Huffman.Spec.ValidLengths litLens 15)
+    (hv_dist : Huffman.Spec.ValidLengths distLens 15)
+    (hheader : decodeDynamicTables (headerBits ++ symBits ++ rest) =
+        some (litLens, distLens, symBits ++ rest))
+    (henc : encodeSymbols litLens distLens syms = some symBits)
+    (hres : resolveLZ77 syms acc = some out)
+    (hvalid : ValidSymbolList syms) :
+    decode.goR ([true, false, true] ++ headerBits ++ symBits ++ rest) acc =
+        some (out, rest) := by
+  unfold decode.goR
+  simp only [List.cons_append, readBitsLSB_1_true, bind, Option.bind]
+  simp only [readBitsLSB_2_false_true]
+  simp only [List.nil_append]
+  rw [hheader]; dsimp only
+  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
+    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
+      henc hv_lit hv_dist hvalid
+  rw [hdec]
+  simp only [hres]
+  exact if_pos rfl
+
+/-- `decode.goR` on a *non-final* dynamic block, given `resolveLZ77 syms acc = some out`:
+    continues on the trailing bits from `out`. -/
+theorem decode_goR_dynBlock_nonfinal_acc (syms : List LZ77Symbol) (out acc : List UInt8)
+    (litLens distLens : List Nat) (headerBits symBits rest : List Bool)
+    (hv_lit : Huffman.Spec.ValidLengths litLens 15)
+    (hv_dist : Huffman.Spec.ValidLengths distLens 15)
+    (hheader : decodeDynamicTables (headerBits ++ symBits ++ rest) =
+        some (litLens, distLens, symBits ++ rest))
+    (henc : encodeSymbols litLens distLens syms = some symBits)
+    (hres : resolveLZ77 syms acc = some out)
+    (hvalid : ValidSymbolList syms) :
+    decode.goR ([false, false, true] ++ headerBits ++ symBits ++ rest) acc =
+        decode.goR rest out := by
+  conv => lhs; unfold decode.goR
+  simp only [List.cons_append, readBitsLSB_1_false, bind, Option.bind]
+  simp only [readBitsLSB_2_false_true]
+  simp only [List.nil_append]
+  rw [hheader]; dsimp only
+  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
+    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
+      henc hv_lit hv_dist hvalid
+  rw [hdec]
+  simp only [hres]
+  rw [if_neg (by decide)]
+  rw [dif_pos (show rest.length <
+      (false :: false :: true :: (headerBits ++ symBits ++ rest)).length by
+    simp only [List.length_cons, List.length_append]; omega)]
+
+/-- Self-contained shift from `[]` to an arbitrary accumulator: lifts
+    `resolveLZ77 syms [] = some chunk` to `resolveLZ77 syms acc = some (acc ++ chunk)`. -/
+private theorem resolveLZ77_acc_of_nil {syms : List LZ77Symbol} {chunk acc : List UInt8}
+    (hresolve : resolveLZ77 syms [] = some chunk) :
+    resolveLZ77 syms acc = some (acc ++ chunk) := by
+  have h := resolveLZ77_shift syms acc [] chunk hresolve
+  rwa [List.append_nil] at h
+
 /-- `decode.go` on a *final* (`BFINAL = 1`) dynamic block from accumulator `acc`
     appends the block's chunk and returns. -/
 theorem decode_go_dynBlock_final (syms : List LZ77Symbol) (chunk acc : List UInt8)
@@ -709,21 +833,9 @@ theorem decode_go_dynBlock_final (syms : List LZ77Symbol) (chunk acc : List UInt
     (hresolve : resolveLZ77 syms [] = some chunk)
     (hvalid : ValidSymbolList syms) :
     decode.go ([true, false, true] ++ headerBits ++ symBits ++ rest) acc =
-        some (acc ++ chunk) := by
-  unfold decode.go
-  simp only [List.cons_append, readBitsLSB_1_true, bind, Option.bind]
-  simp only [readBitsLSB_2_false_true]
-  simp only [List.nil_append]
-  rw [hheader]; dsimp only
-  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
-    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
-      henc hv_lit hv_dist hvalid
-  rw [hdec]
-  have hres : resolveLZ77 syms acc = some (acc ++ chunk) := by
-    have h := resolveLZ77_shift syms acc [] chunk hresolve
-    rwa [List.append_nil] at h
-  simp only [hres]
-  exact if_pos rfl
+        some (acc ++ chunk) :=
+  decode_go_dynBlock_final_acc syms (acc ++ chunk) acc litLens distLens headerBits symBits rest
+    hv_lit hv_dist hheader henc (resolveLZ77_acc_of_nil hresolve) hvalid
 
 /-- `decode.go` on a *non-final* (`BFINAL = 0`) dynamic block from accumulator
     `acc` appends the block's chunk and continues on the trailing bits. -/
@@ -737,24 +849,9 @@ theorem decode_go_dynBlock_nonfinal (syms : List LZ77Symbol) (chunk acc : List U
     (hresolve : resolveLZ77 syms [] = some chunk)
     (hvalid : ValidSymbolList syms) :
     decode.go ([false, false, true] ++ headerBits ++ symBits ++ rest) acc =
-        decode.go rest (acc ++ chunk) := by
-  conv => lhs; unfold decode.go
-  simp only [List.cons_append, readBitsLSB_1_false, bind, Option.bind]
-  simp only [readBitsLSB_2_false_true]
-  simp only [List.nil_append]
-  rw [hheader]; dsimp only
-  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
-    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
-      henc hv_lit hv_dist hvalid
-  rw [hdec]
-  have hres : resolveLZ77 syms acc = some (acc ++ chunk) := by
-    have h := resolveLZ77_shift syms acc [] chunk hresolve
-    rwa [List.append_nil] at h
-  simp only [hres]
-  rw [if_neg (by decide)]
-  rw [dif_pos (show rest.length <
-      (false :: false :: true :: (headerBits ++ symBits ++ rest)).length by
-    simp only [List.length_cons, List.length_append]; omega)]
+        decode.go rest (acc ++ chunk) :=
+  decode_go_dynBlock_nonfinal_acc syms (acc ++ chunk) acc litLens distLens headerBits symBits rest
+    hv_lit hv_dist hheader henc (resolveLZ77_acc_of_nil hresolve) hvalid
 
 /-- `decode.goR` on a *final* dynamic block from `acc`: appends the chunk and
     returns the trailing bits `rest` as the remaining. -/
@@ -768,21 +865,9 @@ theorem decode_goR_dynBlock_final (syms : List LZ77Symbol) (chunk acc : List UIn
     (hresolve : resolveLZ77 syms [] = some chunk)
     (hvalid : ValidSymbolList syms) :
     decode.goR ([true, false, true] ++ headerBits ++ symBits ++ rest) acc =
-        some (acc ++ chunk, rest) := by
-  unfold decode.goR
-  simp only [List.cons_append, readBitsLSB_1_true, bind, Option.bind]
-  simp only [readBitsLSB_2_false_true]
-  simp only [List.nil_append]
-  rw [hheader]; dsimp only
-  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
-    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
-      henc hv_lit hv_dist hvalid
-  rw [hdec]
-  have hres : resolveLZ77 syms acc = some (acc ++ chunk) := by
-    have h := resolveLZ77_shift syms acc [] chunk hresolve
-    rwa [List.append_nil] at h
-  simp only [hres]
-  exact if_pos rfl
+        some (acc ++ chunk, rest) :=
+  decode_goR_dynBlock_final_acc syms (acc ++ chunk) acc litLens distLens headerBits symBits rest
+    hv_lit hv_dist hheader henc (resolveLZ77_acc_of_nil hresolve) hvalid
 
 /-- `decode.goR` on a *non-final* dynamic block from `acc`: appends the chunk and
     continues on the trailing bits. -/
@@ -796,23 +881,8 @@ theorem decode_goR_dynBlock_nonfinal (syms : List LZ77Symbol) (chunk acc : List 
     (hresolve : resolveLZ77 syms [] = some chunk)
     (hvalid : ValidSymbolList syms) :
     decode.goR ([false, false, true] ++ headerBits ++ symBits ++ rest) acc =
-        decode.goR rest (acc ++ chunk) := by
-  conv => lhs; unfold decode.goR
-  simp only [List.cons_append, readBitsLSB_1_false, bind, Option.bind]
-  simp only [readBitsLSB_2_false_true]
-  simp only [List.nil_append]
-  rw [hheader]; dsimp only
-  have hdec : decodeSymbols litLens distLens (symBits ++ rest) = some (syms, rest) :=
-    encodeSymbols_decodeSymbols litLens distLens syms symBits rest
-      henc hv_lit hv_dist hvalid
-  rw [hdec]
-  have hres : resolveLZ77 syms acc = some (acc ++ chunk) := by
-    have h := resolveLZ77_shift syms acc [] chunk hresolve
-    rwa [List.append_nil] at h
-  simp only [hres]
-  rw [if_neg (by decide)]
-  rw [dif_pos (show rest.length <
-      (false :: false :: true :: (headerBits ++ symBits ++ rest)).length by
-    simp only [List.length_cons, List.length_append]; omega)]
+        decode.goR rest (acc ++ chunk) :=
+  decode_goR_dynBlock_nonfinal_acc syms (acc ++ chunk) acc litLens distLens headerBits symBits rest
+    hv_lit hv_dist hheader henc (resolveLZ77_acc_of_nil hresolve) hvalid
 
 end Deflate.Spec

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -99,8 +99,10 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
         (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
         (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
       split
-      · exact inflate_pickSmaller _ _ data maxOutputSize hsingle
-          (inflate_deflateDynamicBlocksSC data splitChunkSize level _ hsize)
+      · exact inflate_pickSmaller _ _ data maxOutputSize
+          (inflate_pickSmaller _ _ data maxOutputSize hsingle
+            (inflate_deflateDynamicBlocksSC data splitChunkSize level _ hsize))
+          (inflate_deflateDynamicBlocksShared data sharedTokChunk level _ hsize)
       · exact hsingle
 
 /-- Padding decomposition for the compressed-block dispatch. -/
@@ -171,7 +173,12 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
       · exact pickSmaller_bytesToBits
           (P := fun bits => ∃ (contentBits padding : List Bool),
             bits = contentBits ++ padding ∧ padding.length < 8)
-          _ _ hdyn (deflateDynamicBlocksSC_pad data splitChunkSize level)
+          _ _
+          (pickSmaller_bytesToBits
+            (P := fun bits => ∃ (contentBits padding : List Bool),
+              bits = contentBits ++ padding ∧ padding.length < 8)
+            _ _ hdyn (deflateDynamicBlocksSC_pad data splitChunkSize level))
+          (deflateDynamicBlocksShared_pad data sharedTokChunk level)
       · exact hdyn
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
@@ -315,7 +322,13 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
           (P := fun bits => ∃ remaining,
             Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
               remaining.length < 8)
-          _ _ hsingle (deflateDynamicBlocksSC_goR_pad data splitChunkSize level)
+          _ _
+          (pickSmaller_bytesToBits
+            (P := fun bits => ∃ remaining,
+              Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+                remaining.length < 8)
+            _ _ hsingle (deflateDynamicBlocksSC_goR_pad data splitChunkSize level))
+          (deflateDynamicBlocksShared_goR_pad data sharedTokChunk level)
       · exact hsingle
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -72,38 +72,45 @@ theorem inflate_deflateCompressed (data : ByteArray) (level : UInt8)
       (cRes data level) _ (by omega)
 
 set_option maxRecDepth 8000 in
+/-- Roundtrip for the single-block cost-model dispatch (`deflateRawBase`): the
+    `deflateRaw` level-≥1 base without the block-split candidates.
+
+    `maxRecDepth` is raised because `split`ting the selection forces the
+    elaborator to whnf the nested size comparison. -/
+theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    Zip.Native.Inflate.inflate (deflateRawBase data level) maxOutputSize = .ok data := by
+  unfold deflateRawBase
+  dsimp only []
+  -- stored / fixed / dynamic, sized from one chain token pass. The outer `split`
+  -- fires on `fixedBytes < dynBytes`, then each side on the stored comparison.
+  split <;> split
+  · exact inflate_deflateStoredPure data _ hsize
+  · exact inflate_deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+      (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
+  · exact inflate_deflateStoredPure data _ hsize
+  · exact inflate_deflateDynamicBlock data
+      (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+      (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
+
 /-- Unified DEFLATE roundtrip: inflate ∘ deflateRaw = identity.
     This is the Phase B4 capstone theorem from PLAN.md. Generalized to any
     `maxOutputSize` large enough to hold the input. The stored-block fallback
-    (for incompressible input) is covered by the `pickSmaller` case.
-
-    `maxRecDepth` is raised because `split`ting the level-≥5 selection forces the
-    elaborator to whnf the nested size comparison. -/
+    (for incompressible input) is covered by `deflateRawBase`; the level-≥7
+    block-split candidates are covered by the `pickSmaller` cases. -/
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
   split
   · exact inflate_deflateStoredPure data _ (by omega)
-  · -- Levels ≥ 1: stored / fixed / dynamic all sized from one chain token pass.
-    -- The outer `split` fires on `fixedBytes < dynBytes`, then each side on the
-    -- stored-vs-compressed comparison.
-    dsimp only []
-    split <;> split
-    · exact inflate_deflateStoredPure data _ hsize
-    · exact inflate_deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
-        (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
-    · exact inflate_deflateStoredPure data _ hsize
-    · -- Dynamic: `if 7 ≤ level then pickSmaller single split else single`.
-      have hsingle := inflate_deflateDynamicBlock data
-        (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
-        (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
-      split
-      · exact inflate_pickSmaller _ _ data maxOutputSize
-          (inflate_pickSmaller _ _ data maxOutputSize hsingle
-            (inflate_deflateDynamicBlocksSC data splitChunkSize level _ hsize))
-          (inflate_deflateDynamicBlocksShared data sharedTokChunk level _ hsize)
-      · exact hsingle
+  · split
+    · exact inflate_pickSmaller _ _ data maxOutputSize
+        (inflate_deflateRawBase data level _ hsize)
+        (inflate_pickSmaller _ _ data maxOutputSize
+          (inflate_deflateDynamicBlocksSC data splitChunkSize level _ hsize)
+          (inflate_deflateDynamicBlocksShared data sharedTokChunk level _ hsize))
+    · exact inflate_deflateRawBase data level _ hsize
 
 /-- Padding decomposition for the compressed-block dispatch. -/
 theorem deflateCompressed_pad (data : ByteArray) (level : UInt8) :
@@ -127,6 +134,43 @@ theorem deflateCompressed_pad (data : ByteArray) (level : UInt8) :
       hbytes, by simp only [List.length_replicate]; omega⟩
 
 set_option maxRecDepth 8000 in
+/-- Padding decomposition for the single-block cost-model dispatch (`deflateRawBase`). -/
+theorem deflateRawBase_pad (data : ByteArray) (level : UInt8) :
+    ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits (deflateRawBase data level) = contentBits ++ padding ∧
+      padding.length < 8 := by
+  unfold deflateRawBase
+  dsimp only []
+  -- stored / fixed / dynamic sized; emit only the winner. The outer `split` fires
+  -- on `fixedBytes < dynBytes`, then each side on the stored comparison.
+  have hstored : ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits
+          (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data) = contentBits ++ padding ∧
+        padding.length < 8 :=
+    ⟨Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data),
+      [], by simp only [List.append_nil], by decide⟩
+  have hfixed : ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits (deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))) =
+        contentBits ++ padding ∧ padding.length < 8 := by
+    obtain ⟨bits, _, hbytes⟩ := deflateFixedBlock_spec_of data
+      (lz77ChainIter data (chainDepth level) 32768 (insertCap level)) (cEnc data level) (fun hz => cEmpty data level hz)
+    exact ⟨bits, List.replicate ((8 - bits.length % 8) % 8) false,
+      hbytes, by simp only [List.length_replicate]; omega⟩
+  have hdyn : ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits (deflateDynamicBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))) =
+        contentBits ++ padding ∧ padding.length < 8 := by
+    obtain ⟨_, _, headerBits, symBits, _, _, _, _, _, _, _, _, _, _, hbytes⟩ :=
+      deflateDynamicBlock_spec data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+        (cEnc data level) (fun hz => cEmpty data level hz)
+    exact ⟨[true, false, true] ++ headerBits ++ symBits,
+      List.replicate ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false,
+      hbytes, by simp only [List.length_replicate]; omega⟩
+  split <;> split
+  · exact hstored
+  · exact hfixed
+  · exact hstored
+  · exact hdyn
+
 /-- The output of `deflateRaw` decomposes into content bits plus short padding.
     This is needed by `inflateRaw_endPos_ge` to establish that the native decoder
     consumes all of the deflated byte array. -/
@@ -139,47 +183,17 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
   · -- Level 0: stored blocks — all byte-aligned, padding = []
     exact ⟨Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data),
       [], by simp only [List.append_nil], by decide⟩
-  · -- Levels ≥ 1: stored / fixed / dynamic sized; emit only the winner.
-    -- The outer `split` fires on `fixedBytes < dynBytes`, then each side on the
-    -- stored-vs-compressed comparison (stored appears in both).
-    dsimp only []
-    have hstored : ∃ (contentBits padding : List Bool),
-        Deflate.Spec.bytesToBits
-            (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data) = contentBits ++ padding ∧
-          padding.length < 8 :=
-      ⟨Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data),
-        [], by simp only [List.append_nil], by decide⟩
-    have hfixed : ∃ (contentBits padding : List Bool),
-        Deflate.Spec.bytesToBits (deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))) =
-          contentBits ++ padding ∧ padding.length < 8 := by
-      obtain ⟨bits, _, hbytes⟩ := deflateFixedBlock_spec_of data
-        (lz77ChainIter data (chainDepth level) 32768 (insertCap level)) (cEnc data level) (fun hz => cEmpty data level hz)
-      exact ⟨bits, List.replicate ((8 - bits.length % 8) % 8) false,
-        hbytes, by simp only [List.length_replicate]; omega⟩
-    have hdyn : ∃ (contentBits padding : List Bool),
-        Deflate.Spec.bytesToBits (deflateDynamicBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))) =
-          contentBits ++ padding ∧ padding.length < 8 := by
-      obtain ⟨_, _, headerBits, symBits, _, _, _, _, _, _, _, _, _, _, hbytes⟩ :=
-        deflateDynamicBlock_spec data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
-          (cEnc data level) (fun hz => cEmpty data level hz)
-      exact ⟨[true, false, true] ++ headerBits ++ symBits,
-        List.replicate ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false,
-        hbytes, by simp only [List.length_replicate]; omega⟩
-    split <;> split
-    · exact hstored
-    · exact hfixed
-    · exact hstored
-    · split
-      · exact pickSmaller_bytesToBits
+  · split
+    · exact pickSmaller_bytesToBits
+        (P := fun bits => ∃ (contentBits padding : List Bool),
+          bits = contentBits ++ padding ∧ padding.length < 8)
+        _ _ (deflateRawBase_pad data level)
+        (pickSmaller_bytesToBits
           (P := fun bits => ∃ (contentBits padding : List Bool),
             bits = contentBits ++ padding ∧ padding.length < 8)
-          _ _
-          (pickSmaller_bytesToBits
-            (P := fun bits => ∃ (contentBits padding : List Bool),
-              bits = contentBits ++ padding ∧ padding.length < 8)
-            _ _ hdyn (deflateDynamicBlocksSC_pad data splitChunkSize level))
-          (deflateDynamicBlocksShared_pad data sharedTokChunk level)
-      · exact hdyn
+          _ _ (deflateDynamicBlocksSC_pad data splitChunkSize level)
+          (deflateDynamicBlocksShared_pad data sharedTokChunk level))
+    · exact deflateRawBase_pad data level
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
     the level 2-4 path and the level ≥ 5 fixed candidate (both `= deflateLazy`). -/
@@ -291,6 +305,27 @@ theorem deflateCompressed_goR_pad (data : ByteArray) (level : UInt8) :
       (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
 
 set_option maxRecDepth 8000 in
+/-- `goR` short-remaining for the single-block cost-model dispatch (`deflateRawBase`). -/
+private theorem deflateRawBase_goR_pad (data : ByteArray) (level : UInt8) :
+    ∃ remaining,
+      Deflate.Spec.decode.goR (Deflate.Spec.bytesToBits (deflateRawBase data level)) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+  unfold deflateRawBase
+  dsimp only []
+  have hfixed : ∃ remaining,
+      Deflate.Spec.decode.goR
+          (Deflate.Spec.bytesToBits (deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level)))) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 :=
+    deflateFixedBlock_goR_pad data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+      (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
+  split <;> split
+  · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
+  · exact hfixed
+  · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
+  · exact deflateDynamicBlock_goR_pad data
+      (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+      (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
+
 /-- For the encoder's output, `decode.goR` returns a short remaining (< 8 bits).
     This is the key fact connecting encoder structure to decoder bit consumption,
     needed by `inflateRaw_endPos_ge` to prove the decoder consumes all of `deflated`. -/
@@ -302,33 +337,18 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
   split
   · -- Level 0: stored blocks — byte-aligned, remaining = []
     exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
-  · -- Levels ≥ 1: stored / fixed / dynamic sized; emit only the winner.
-    dsimp only []
-    have hfixed : ∃ remaining,
-        Deflate.Spec.decode.goR
-            (Deflate.Spec.bytesToBits (deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level)))) []
-          = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
-      exact deflateFixedBlock_goR_pad data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
-        (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
-    split <;> split
-    · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
-    · exact hfixed
-    · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
-    · have hsingle := deflateDynamicBlock_goR_pad data
-        (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
-        (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
-      split
-      · exact pickSmaller_bytesToBits
+  · split
+    · exact pickSmaller_bytesToBits
+        (P := fun bits => ∃ remaining,
+          Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
+            remaining.length < 8)
+        _ _ (deflateRawBase_goR_pad data level)
+        (pickSmaller_bytesToBits
           (P := fun bits => ∃ remaining,
             Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
               remaining.length < 8)
-          _ _
-          (pickSmaller_bytesToBits
-            (P := fun bits => ∃ remaining,
-              Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
-                remaining.length < 8)
-            _ _ hsingle (deflateDynamicBlocksSC_goR_pad data splitChunkSize level))
-          (deflateDynamicBlocksShared_goR_pad data sharedTokChunk level)
-      · exact hsingle
+          _ _ (deflateDynamicBlocksSC_goR_pad data splitChunkSize level)
+          (deflateDynamicBlocksShared_goR_pad data sharedTokChunk level))
+    · exact deflateRawBase_goR_pad data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -9,15 +9,20 @@ import Zip.Spec.DeflateBlockSplit
 Proves the unified roundtrip theorem for `deflateRaw`:
 `inflate (deflateRaw data level) = .ok data`.
 
-`deflateRaw` is defined in `Zip/Native/DeflateDynamic.lean` and selects the
-compression strategy based on level (0 = stored, 1 = fixed Huffman,
-2-4 = lazy LZ77 + fixed, 5+ = dynamic Huffman).
+`deflateRaw` is defined in `Zip/Native/DeflateDynamic.lean`. Level 0 is a stored
+block; level ≥ 1 runs the single-block cost-model dispatch `deflateRawBase`
+(stored / fixed / dynamic, all sized from one hash-chain token pass, emitting
+only the smallest); and level ≥ 7 additionally compares two block-split streams
+(self-contained #2524 and cross-block shared-window #2525) against that base via
+`pickSmaller`, so the split is a first-class candidate that can only ever win.
 
-This composes the per-level roundtrip theorems:
-- `inflate_deflateStoredPure` (Level 0)
-- `inflate_deflateFixed` (Level 1)
-- `inflate_deflateLazyIter` (Levels 2-4)
-- `inflate_deflateDynamic` (Levels 5+)
+This composes:
+- `inflate_deflateRawBase` — the stored / fixed / dynamic base, in turn built
+  from `inflate_deflateStoredPure`, `inflate_deflateFixedBlock`,
+  `inflate_deflateDynamicBlock`
+- `inflate_deflateDynamicBlocksSC` / `inflate_deflateDynamicBlocksShared` — the
+  two block-split candidates (`Zip/Spec/DeflateBlockSplit.lean`)
+- `inflate_pickSmaller` — selecting the smaller of two roundtripping candidates
 -/
 
 namespace Zip.Native.Deflate

--- a/Zip/Spec/LZ77.lean
+++ b/Zip/Spec/LZ77.lean
@@ -178,6 +178,55 @@ theorem resolveLZ77_shift (syms : List LZ77Symbol) :
       simp only [resolveLZ77_copied_shift acc win len dist hdle, List.append_assoc] at h ⊢
       exact ih acc _ out h
 
+/-- Fold-composition of `resolveLZ77` over a symbol-list append, when the prefix
+    `a` contains no `endOfBlock`: resolving `a ++ b` is resolving `a`, then
+    resolving `b` from the resulting accumulator. `resolveLZ77` is a left fold
+    except for `endOfBlock` (early stop) and reference-failure (`none`); excluding
+    `endOfBlock` from `a` makes it compose cleanly. Resolving `a` never inspects
+    `b`, and a back-reference in `b` simply indexes the accumulator (which already
+    holds `a`'s output), so boundary-crossing references are handled for free.
+    This is what lets a single match pass be partitioned into per-block token
+    groups whose references cross block boundaries. -/
+theorem resolveLZ77_append_eobFree : ∀ (a b : List LZ77Symbol) (acc : List UInt8),
+    (∀ s ∈ a, s ≠ .endOfBlock) →
+    resolveLZ77 (a ++ b) acc = (resolveLZ77 a acc).bind (fun out => resolveLZ77 b out)
+  | [], b, acc, _ => by
+    simp only [List.nil_append, resolveLZ77_nil]; rfl
+  | s :: rest, b, acc, ha => by
+    have ha' : ∀ s ∈ rest, s ≠ .endOfBlock := fun s hs => ha s (List.mem_cons_of_mem _ hs)
+    cases s with
+    | literal c =>
+      simp only [List.cons_append, resolveLZ77_literal]
+      exact resolveLZ77_append_eobFree rest b (acc ++ [c]) ha'
+    | endOfBlock => exact absurd rfl (ha _ List.mem_cons_self)
+    | reference len dist =>
+      by_cases hd0 : dist = 0
+      · subst hd0
+        rw [List.cons_append, resolveLZ77_reference_dist_zero len (rest ++ b) acc,
+          resolveLZ77_reference_dist_zero len rest acc]
+        rfl
+      · by_cases hdle : dist ≤ acc.length
+        · rw [List.cons_append,
+            resolveLZ77_reference_valid len dist (rest ++ b) acc hd0 hdle,
+            resolveLZ77_reference_valid len dist rest acc hd0 hdle]
+          dsimp only
+          exact resolveLZ77_append_eobFree rest b _ ha'
+        · rw [List.cons_append,
+            resolveLZ77_reference_dist_too_large len dist (rest ++ b) acc (by omega),
+            resolveLZ77_reference_dist_too_large len dist rest acc (by omega)]
+          rfl
+
+/-- Terminal `endOfBlock` is a no-op after an `endOfBlock`-free list: resolving
+    `g ++ [endOfBlock]` equals resolving `g`. A corollary of
+    `resolveLZ77_append_eobFree` (since `resolveLZ77 [endOfBlock] out = some out`).
+    Bridges the whole-stream resolve fact (one trailing `endOfBlock`) to each
+    block's `tokensToSymbols group = groupMapped ++ [endOfBlock]`. -/
+theorem resolveLZ77_eobFree_eob (g : List LZ77Symbol) (acc : List UInt8)
+    (hg : ∀ s ∈ g, s ≠ .endOfBlock) :
+    resolveLZ77 (g ++ [.endOfBlock]) acc = resolveLZ77 g acc := by
+  rw [resolveLZ77_append_eobFree g [.endOfBlock] acc hg]
+  cases resolveLZ77 g acc <;> rfl
+
 /-- Count consecutive matching bytes at position `pos` with source at
     distance `dist` back, using DEFLATE's overlapping-copy semantics.
     Returns 0 if `dist > pos` or `dist = 0`. -/

--- a/Zip/Spec/LZ77NativeCorrect.lean
+++ b/Zip/Spec/LZ77NativeCorrect.lean
@@ -16,6 +16,21 @@ def LZ77Token.toLZ77Symbol : LZ77Token → Deflate.Spec.LZ77Symbol
 def tokensToSymbols (tokens : Array LZ77Token) : List Deflate.Spec.LZ77Symbol :=
   tokens.toList.map LZ77Token.toLZ77Symbol ++ [.endOfBlock]
 
+/-- `toLZ77Symbol` never produces an `endOfBlock` symbol (it maps literals to
+    literals and references to references). -/
+theorem toLZ77Symbol_ne_endOfBlock (t : LZ77Token) :
+    LZ77Token.toLZ77Symbol t ≠ Deflate.Spec.LZ77Symbol.endOfBlock := by
+  cases t <;> simp only [LZ77Token.toLZ77Symbol, ne_eq, reduceCtorEq, not_false_eq_true]
+
+/-- A list of mapped tokens contains no `endOfBlock` — the hypothesis the
+    `endOfBlock`-free fold-composition lemmas require for each per-block group. -/
+theorem mem_map_toLZ77Symbol_ne_endOfBlock (toks : List LZ77Token) :
+    ∀ s ∈ toks.map LZ77Token.toLZ77Symbol, s ≠ Deflate.Spec.LZ77Symbol.endOfBlock := by
+  intro s hs
+  rw [List.mem_map] at hs
+  obtain ⟨t, _, rfl⟩ := hs
+  exact toLZ77Symbol_ne_endOfBlock t
+
 /-! ## countMatch correctness -/
 
 /-- The inner `go` loop of `countMatch` counts consecutive matching bytes

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -314,4 +314,43 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
   | .ok result => assert! result == largeCyclic
   | .error e => throw (IO.userError s!"deflateRaw(1) 256KB roundtrip failed: {e}")
 
+  -- Cross-block (shared-window) block splitting: deflateDynamicBlocksShared runs
+  -- one whole-file match pass (full window) and partitions the token stream into
+  -- per-block groups whose back-references cross block boundaries. Verify the
+  -- roundtrip via both native and FFI inflate, across token-group sizes (small
+  -- tokChunk forces many blocks and genuine cross-block references).
+  let textRepeat := String.toUTF8 (String.join (List.replicate 300
+    "the quick brown fox jumps over the lazy dog. "))
+  for (name, data) in [("empty", ByteArray.empty), ("single", singleByte),
+                        ("hello", helloBytes), ("big", big),
+                        ("text", textRepeat), ("cyclic16K", mkCyclicData 16384)] do
+    for tokChunk in [4, 256, 8192] do
+      let shared := Zip.Native.Deflate.deflateDynamicBlocksShared data tokChunk 9
+      match Zip.Native.Inflate.inflate shared with
+      | .ok result => unless result == data do
+          throw (IO.userError s!"deflateDynamicBlocksShared→native inflate mismatch on {name} (tokChunk={tokChunk})")
+      | .error e => throw (IO.userError s!"deflateDynamicBlocksShared→native inflate failed on {name} (tokChunk={tokChunk}): {e}")
+      let decomp ← RawDeflate.decompress shared
+      unless decomp == data do
+        throw (IO.userError s!"deflateDynamicBlocksShared→FFI inflate mismatch on {name} (tokChunk={tokChunk})")
+
+  -- Stress the many-block cross-reference path: one token per block on a highly
+  -- repetitive input, so almost every block references earlier blocks' output.
+  let sharedTiny := Zip.Native.Deflate.deflateDynamicBlocksShared textRepeat 1 9
+  match Zip.Native.Inflate.inflate sharedTiny with
+  | .ok result => unless result == textRepeat do
+      throw (IO.userError "deflateDynamicBlocksShared(tokChunk=1)→inflate mismatch on text")
+  | .error e => throw (IO.userError s!"deflateDynamicBlocksShared(tokChunk=1)→inflate failed: {e}")
+
+  -- deflateRaw at the max-compression tiers (≥ 7) now considers the shared-window
+  -- split via pickSmaller; verify roundtrip on text and large inputs.
+  for level in [7, 8, 9] do
+    for (name, data) in [("text", textRepeat), ("256K-cyclic", largeCyclic),
+                          ("256K-prng", mkPrngData 262144)] do
+      let raw := Zip.Native.Deflate.deflateRaw data level.toUInt8
+      match Zip.Native.Inflate.inflate raw with
+      | .ok result => unless result == data do
+          throw (IO.userError s!"deflateRaw({level})→inflate mismatch on {name}")
+      | .error e => throw (IO.userError s!"deflateRaw({level})→inflate failed on {name}: {e}")
+
   IO.println "  NativeDeflate tests passed."


### PR DESCRIPTION
This PR adds cross-block (shared-window) DEFLATE splitting: it matches the whole input once with the full 32 KiB window, partitions the single token stream into per-block groups, re-Huffman-codes each group with its own dynamic tree, and proves the roundtrip. Back-references freely cross block boundaries (RFC 1951 §3.2), recovering the cross-chunk matches that the self-contained split (https://github.com/kim-em/lean-zip/pull/2524) discards — the lever the issue identifies for the text-ratio gap. It is gated behind `pickSmaller` at the max-compression tiers (level ≥ 7), so it can only ever win and never regresses.

The decode side already threaded the accumulated output through `resolveLZ77` for every block, so only the encode-side proof is new. The load-bearing lemma is `resolveLZ77_append_eobFree`: for an `endOfBlock`-free prefix, `resolveLZ77 (a ++ b) acc = (resolveLZ77 a acc).bind (resolveLZ77 b ·)` — a fold-composition that lets the whole-stream resolve fact (`lz77ChainIter_resolves`) be split at any partition point, handing each block a valid partial resolve against its accumulated window. Its corollary `resolveLZ77_eobFree_eob` bridges the single trailing `endOfBlock` to each block's per-block terminator. The four `decode_{go,goR}_dynBlock_{final,nonfinal}` lemmas are generalized to output-parametric `_acc` variants that take the acc-threaded resolve fact directly; the self-contained lemmas now delegate to them via `resolveLZ77_shift`. The shared-window fold (`emitSharedBlocks_decode`/`_decodeR`) threads the actual accumulated output rather than a byte position — back-references make the per-tail output acc-dependent — peeling each block's resolve off the whole-stream fact at the partition point.

Validating the ratio on the real corpora surfaced a dispatch bug that gated the split out on exactly the inputs it helps: `deflateRaw` chose fixed-vs-dynamic from the *single-block* cost model, and on large heterogeneous inputs a single dynamic tree loses to fixed Huffman, so it took the fixed branch and never reached the split. This PR extracts the cost-model dispatch into `deflateRawBase` and makes both block-split streams first-class candidates compared against it via an outer `pickSmaller`. The payoff (Silesia/Canterbury, level 9, vs the previously-emitted stream): dickens −19.5%, webster −16.3%, reymont −16.4%, nci −15.3%, xml −15%, and kennedy.xls now compresses *smaller than zlib*. On large prose this brings the native encoder to within ~3–4% of zlib (it was ~30% behind via the fixed-branch fallback). `pickSmaller` keeps the no-regression guarantee everywhere.

The capstone `inflate_deflateRaw` continues to hold; the base and the two split candidates are threaded through the existing `pickSmaller` roundtrip and padding lemmas (`inflate_deflateRawBase` / `deflateRawBase_pad` / `deflateRawBase_goR_pad`). Zero `sorry`, full suite green, with new conformance tests (native + FFI inflate) over empty/single/sub-block/multi-block-text inputs and token-group sizes down to one token per block. `sharedTokChunk = 4096` is a pure ratio knob (the swept optimum on text); a cost-model boundary heuristic is left for a follow-up.

Closes #2525.

🤖 Prepared with Claude Code