### PR TITLE
feat: lazy LZ77 matching (distance-guarded) for levels ≥4

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -572,7 +572,7 @@ where
                 -- Longer & no-farther match at pos+1: emit literal at pos + reference at pos+1
                 have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                 let (hashTable, prev) :=
-                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen2 insertCap
+                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
                 .literal (data[pos]'(by omega)) ::
                   .reference matchLen2 (pos + 1 - matchPos2) ::
                   mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap
@@ -646,7 +646,7 @@ where
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                 let (hashTable, prev) :=
-                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen2 insertCap
+                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
                 mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1 + matchLen2)
                   (acc.push (.literal (data[pos]'(by omega))) |>.push
                     (.reference matchLen2 (pos + 1 - matchPos2)))

--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -517,10 +517,20 @@ where
 
 /-- Lazy (one-byte-lookahead, zlib `deflate_slow`-style) variant of `lz77Chain`.
     At each position it finds the best chain match `M` at `pos`; before emitting it
-    runs a *second* `chainWalk` at `pos+1` for `M'`. If `len M' > len M` it emits a
-    literal at `pos` and defers to `M'` (advancing to `pos+1+len M'`); otherwise it
-    emits `M` (advancing to `pos+len M`). Match-finding stays opaque to correctness
-    — `chainWalk_spec` holds for *any* chain state, so validity is re-established at
+    runs a *second* `chainWalk` at `pos+1` for `M'`. It defers — emits a literal at
+    `pos` and takes `M'` (advancing to `pos+1+len M'`) — only when `M'` is **both
+    longer and no farther** than `M` (`len M' > len M ∧ dist M' ≤ dist M`); otherwise
+    it emits `M` (advancing to `pos+len M`). The distance guard is the key to the
+    ratio win: a length-only deferral takes longer-but-farther matches whose extra
+    distance bits cost more than they save, which *regresses* large text badly
+    (measured: plrabn12/lcet10 up to +22%); guarding on distance keeps only the
+    beneficial deferrals (Canterbury levels 4–9: −5.2% vs greedy). It is not a
+    global optimum — `lcet10` at the shallow levels 4–5 still loses ~19% to a
+    Huffman-distribution effect no *local* deferral rule captures (that needs the
+    cost-model parse of #2526 part 2).
+
+    Match-finding stays opaque to correctness — `chainWalk_spec` holds for *any*
+    chain state and *any* deferral predicate, so validity is re-established at
     emission exactly as for `lz77Chain`. `pos+1` is intentionally *not* inserted
     before the lookahead walk (you cannot match a position against itself; matches
     zlib, and is correctness-irrelevant). Reuses `lz77Chain`'s `chainWalk`/
@@ -549,7 +559,7 @@ where
         lz77Chain.chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
-          -- Lazy: probe pos+1 for a longer match
+          -- Lazy: probe pos+1 for a longer, no-farther match (distance-guarded deferral)
           if h3lt : pos + 3 < data.size then
             let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
             let head2 := hashTable[h2]!
@@ -557,9 +567,9 @@ where
             have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
             let (matchLen2, matchPos2) :=
               lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
-            if matchLen2 > matchLen then
+            if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
-                -- Better match at pos+1: emit literal at pos + reference at pos+1
+                -- Longer & no-farther match at pos+1: emit literal at pos + reference at pos+1
                 have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen2 insertCap
@@ -632,7 +642,7 @@ where
             have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
             let (matchLen2, matchPos2) :=
               lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
-            if matchLen2 > matchLen then
+            if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                 let (hashTable, prev) :=

--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -515,6 +515,158 @@ where
   termination_by data.size - pos
   decreasing_by all_goals omega
 
+/-- Lazy (one-byte-lookahead, zlib `deflate_slow`-style) variant of `lz77Chain`.
+    At each position it finds the best chain match `M` at `pos`; before emitting it
+    runs a *second* `chainWalk` at `pos+1` for `M'`. If `len M' > len M` it emits a
+    literal at `pos` and defers to `M'` (advancing to `pos+1+len M'`); otherwise it
+    emits `M` (advancing to `pos+len M`). Match-finding stays opaque to correctness
+    — `chainWalk_spec` holds for *any* chain state, so validity is re-established at
+    emission exactly as for `lz77Chain`. `pos+1` is intentionally *not* inserted
+    before the lookahead walk (you cannot match a position against itself; matches
+    zlib, and is correctness-irrelevant). Reuses `lz77Chain`'s `chainWalk`/
+    `updateHashes` and `lz77Greedy.trailing`. Equal-quality contracts proven in
+    `LZ77ChainLazyCorrect`. -/
+def lz77ChainLazy (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
+    (insertCap : Nat := 1000000000) :
+    Array LZ77Token :=
+  if data.size < 3 then
+    (lz77Greedy.trailing data 0).toArray
+  else
+    let hashSize := 65536
+    (mainLoop data windowSize hashSize maxChain
+      (.replicate hashSize data.size) (.replicate data.size data.size) 0 insertCap).toArray
+where
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat)
+      (hashTable prev : Array Nat) (pos insertCap : Nat) : List LZ77Token :=
+    if hlt : pos + 2 < data.size then
+      let h := lz77Greedy.hash3 data pos hashSize hlt
+      let head := hashTable[h]!
+      let hashTable := hashTable.set! h pos
+      let prev := prev.set! pos head
+      let maxLen := min 258 (data.size - pos)
+      have hmaxLenP : pos + maxLen ≤ data.size := by omega
+      let (matchLen, matchPos) :=
+        lz77Chain.chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      if hge : matchLen ≥ 3 then
+        if hle : pos + matchLen ≤ data.size then
+          -- Lazy: probe pos+1 for a longer match
+          if h3lt : pos + 3 < data.size then
+            let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
+            let head2 := hashTable[h2]!
+            let maxLen2 := min 258 (data.size - (pos + 1))
+            have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
+            let (matchLen2, matchPos2) :=
+              lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+            if matchLen2 > matchLen then
+              if hle2 : pos + 1 + matchLen2 ≤ data.size then
+                -- Better match at pos+1: emit literal at pos + reference at pos+1
+                have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
+                let (hashTable, prev) :=
+                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen2 insertCap
+                .literal (data[pos]'(by omega)) ::
+                  .reference matchLen2 (pos + 1 - matchPos2) ::
+                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap
+              else
+                -- matchLen2 spills past data: keep match at pos
+                have : data.size - (pos + matchLen) < data.size - pos := by omega
+                let (hashTable, prev) :=
+                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+                .reference matchLen (pos - matchPos) ::
+                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap
+            else
+              -- No better match at pos+1: keep match at pos
+              have : data.size - (pos + matchLen) < data.size - pos := by omega
+              let (hashTable, prev) :=
+                lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+              .reference matchLen (pos - matchPos) ::
+                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap
+          else
+            -- Near end of data: keep match at pos
+            have : data.size - (pos + matchLen) < data.size - pos := by omega
+            .reference matchLen (pos - matchPos) ::
+              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap
+        else
+          .literal (data[pos]'(by omega)) ::
+            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap
+      else
+        .literal (data[pos]'(by omega)) ::
+          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap
+    else
+      lz77Greedy.trailing data pos
+  termination_by data.size - pos
+  decreasing_by all_goals omega
+
+/-- Iterative (tail-recursive, `Array`-accumulating) version of `lz77ChainLazy`.
+    Same output, no stack overflow on large inputs. Reuses `lz77Chain`'s
+    `chainWalk`/`updateHashes` and `lz77GreedyIter.trailing`; only the
+    token-emitting `mainLoop` differs (push vs. cons). Proven equal to
+    `lz77ChainLazy` in `LZ77ChainLazyCorrect`. -/
+def lz77ChainLazyIter (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
+    (insertCap : Nat := 1000000000) :
+    Array LZ77Token :=
+  if data.size < 3 then
+    lz77GreedyIter.trailing data 0 #[]
+  else
+    let hashSize := 65536
+    mainLoop data windowSize hashSize maxChain insertCap
+      (.replicate hashSize data.size) (.replicate data.size data.size) 0 #[]
+where
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+      (hashTable prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+      Array LZ77Token :=
+    if hlt : pos + 2 < data.size then
+      let h := lz77Greedy.hash3 data pos hashSize hlt
+      let head := hashTable[h]!
+      let hashTable := hashTable.set! h pos
+      let prev := prev.set! pos head
+      let maxLen := min 258 (data.size - pos)
+      have hmaxLenP : pos + maxLen ≤ data.size := by omega
+      let (matchLen, matchPos) :=
+        lz77Chain.chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      if hge : matchLen ≥ 3 then
+        if hle : pos + matchLen ≤ data.size then
+          if h3lt : pos + 3 < data.size then
+            let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
+            let head2 := hashTable[h2]!
+            let maxLen2 := min 258 (data.size - (pos + 1))
+            have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
+            let (matchLen2, matchPos2) :=
+              lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+            if matchLen2 > matchLen then
+              if hle2 : pos + 1 + matchLen2 ≤ data.size then
+                have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
+                let (hashTable, prev) :=
+                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen2 insertCap
+                mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1 + matchLen2)
+                  (acc.push (.literal (data[pos]'(by omega))) |>.push
+                    (.reference matchLen2 (pos + 1 - matchPos2)))
+              else
+                have : data.size - (pos + matchLen) < data.size - pos := by omega
+                let (hashTable, prev) :=
+                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+                mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+                  (acc.push (.reference matchLen (pos - matchPos)))
+            else
+              have : data.size - (pos + matchLen) < data.size - pos := by omega
+              let (hashTable, prev) :=
+                lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+              mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+                (acc.push (.reference matchLen (pos - matchPos)))
+          else
+            have : data.size - (pos + matchLen) < data.size - pos := by omega
+            mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+              (acc.push (.reference matchLen (pos - matchPos)))
+        else
+          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+            (acc.push (.literal (data[pos]'(by omega))))
+      else
+        mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+          (acc.push (.literal (data[pos]'(by omega))))
+    else
+      lz77GreedyIter.trailing data pos acc
+  termination_by data.size - pos
+  decreasing_by all_goals omega
+
 /-- Emit LZ77 tokens as fixed Huffman codes into a BitWriter. -/
 def emitTokens (bw : BitWriter) (tokens : Array LZ77Token) (i : Nat) : BitWriter :=
   if h : i < tokens.size then

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -428,7 +428,7 @@ most of the ratio a single whole-file tree leaves on large/heterogeneous inputs.
 def emitChunkBlock (bw : BitWriter) (data : ByteArray) (pos j : Nat) (level : UInt8)
     (isFinal : Bool) : BitWriter :=
   let chunk := data.extract pos j
-  let toks := lz77ChainIter chunk (chainDepth level) 32768 (insertCap level)
+  let toks := lzMatch chunk level
   let f := tokenFreqs toks
   let lens := dynamicCodeLengths f.1 f.2
   emitDynBlock bw chunk toks lens.1 lens.2
@@ -470,7 +470,7 @@ def splitChunkSize : Nat := 32768
     best ratio). One shared token pass sizes the fixed and dynamic blocks and
     emits only the smaller (strict `<`, dynamic on a tie). -/
 def deflateCompressed (data : ByteArray) (level : UInt8) : ByteArray :=
-  let tokens := lz77ChainIter data (chainDepth level) 32768 (insertCap level)
+  let tokens := lzMatch data level
   let f := tokenFreqs tokens
   let lens := dynamicCodeLengths f.1 f.2
   if fixedBlockBytes f.1 f.2 < dynBlockBytes f.1 f.2 lens.1 lens.2
@@ -488,7 +488,7 @@ def deflateCompressed (data : ByteArray) (level : UInt8) : ByteArray :=
 def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   if level == 0 then deflateStoredPure data
   else
-    let tokens := lz77ChainIter data (chainDepth level) 32768 (insertCap level)
+    let tokens := lzMatch data level
     let f := tokenFreqs tokens
     let lens := dynamicCodeLengths f.1 f.2
     let fixedBytes := fixedBlockBytes f.1 f.2

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -404,6 +404,16 @@ def insertCap (level : UInt8) : Nat :=
   else if level ≤ 3 then 64
   else 1000000000
 
+/-- The per-level LZ77 matcher (zlib-faithful): levels 1–3 (`deflate_fast`) use the
+    greedy hash-chain matcher; levels ≥ 4 (`deflate_slow`) use the one-byte-lookahead
+    lazy variant, which improves ratio at equal window/chain depth. Both share the
+    same `(chainDepth, insertCap)` ladder and satisfy the same encoder contracts
+    (`lzMatch_{encodable,empty,resolves}` in `DeflateBlockSplit`), so the choice is
+    transparent to the roundtrip proof. -/
+def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
+  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level)
+  else lz77ChainIter data (chainDepth level) 32768 (insertCap level)
+
 /-! ## Self-contained block-split dynamic compression
 
 Split `data` into `chunkSize`-byte chunks, match each chunk independently (fresh

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -73,15 +73,13 @@ theorem emitChunkBlock_decode (data : ByteArray) (pos j : Nat) (level : UInt8)
   obtain ⟨litLens, distLens, headerBits, symBits, _hll, _hdl, hlv, hdv,
       hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
     emitDynBlock_spec bw hbw (data.extract pos j)
-      (lz77ChainIter (data.extract pos j) (chainDepth level) 32768 (insertCap level))
-      (lz77ChainIter_encodable (data.extract pos j) (chainDepth level) 32768 (insertCap level)
-        (by omega) (by omega))
-      (fun hz => lz77ChainIter_empty (data.extract pos j) (chainDepth level) 32768 (insertCap level) hz)
+      (lzMatch (data.extract pos j) level)
+      (lzMatch_encodable (data.extract pos j) level)
+      (fun hz => lzMatch_empty (data.extract pos j) level hz)
       isFinal
-  have hresolve := lz77ChainIter_resolves (data.extract pos j)
-    (chainDepth level) 32768 (insertCap level) (by omega)
+  have hresolve := lzMatch_resolves (data.extract pos j) level
   have hvalid := tokensToSymbols_validSymbolList
-    (lz77ChainIter (data.extract pos j) (chainDepth level) 32768 (insertCap level))
+    (lzMatch (data.extract pos j) level)
   refine ⟨[isFinal, false, true] ++ headerBits ++ symBits, ?_, ?_, ?_, ?_⟩
   · -- toBits
     simp only [emitChunkBlock]

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -1,6 +1,7 @@
 import Zip.Spec.DeflateFixedCorrect
 import Zip.Spec.DeflateDynamicCorrect
 import Zip.Spec.LZ77ChainCorrect
+import Zip.Spec.LZ77ChainLazyCorrect
 
 /-!
 # Self-contained block-splitting roundtrip
@@ -16,6 +17,41 @@ whole input. This file proves `inflate (deflateDynamicBlocksSC …) = .ok data`.
 namespace Zip.Native.Deflate
 
 open Deflate.Spec (decode)
+
+/-! ## Matcher-selector contracts
+
+The three contracts the dynamic encoder consumes, lifted to the level-dispatched
+`lzMatch` by casing on `4 ≤ level` and applying the lazy (`lz77ChainLazyIter_*`) or
+greedy (`lz77ChainIter_*`) version. Both arms are line-for-line parallel because
+the two matchers share contract signatures. Consumed here and in `DeflateRoundtrip`,
+so the `7 ≤ level`/`4 ≤ level` split lives in exactly one place. -/
+
+theorem lzMatch_encodable (data : ByteArray) (level : UInt8) :
+    ∀ t ∈ (lzMatch data level).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
+  unfold lzMatch
+  split
+  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level)
+      (by omega) (by omega)
+  · exact lz77ChainIter_encodable data (chainDepth level) 32768 (insertCap level)
+      (by omega) (by omega)
+
+theorem lzMatch_empty (data : ByteArray) (level : UInt8) (hz : data.size = 0) :
+    lzMatch data level = #[] := by
+  unfold lzMatch
+  split
+  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) hz
+  · exact lz77ChainIter_empty data (chainDepth level) 32768 (insertCap level) hz
+
+theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lzMatch data level)) [] =
+      some data.data.toList := by
+  unfold lzMatch
+  split
+  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (by omega)
+  · exact lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (by omega)
 
 set_option maxHeartbeats 800000 in
 /-- One self-contained chunk block: its bits append to `bw`, it preserves `wf`,

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -9,15 +9,18 @@ import Zip.Spec.DeflateBlockSplit
 Proves the unified roundtrip theorem for `deflateRaw`:
 `inflate (deflateRaw data level) = .ok data`.
 
-`deflateRaw` is defined in `Zip/Native/DeflateDynamic.lean` and selects the
-compression strategy based on level (0 = stored, 1 = fixed Huffman,
-2-4 = lazy LZ77 + fixed, 5+ = dynamic Huffman).
+`deflateRaw` is defined in `Zip/Native/DeflateDynamic.lean`. Level 0 is a stored
+block; every level ≥ 1 runs the hash-chain matcher via `lzMatch` (greedy at 1–3,
+lazy at ≥ 4), sizes the stored / fixed-Huffman / dynamic-Huffman candidates from
+one token pass, and emits the smallest — with the self-contained block split also
+tried at levels ≥ 7. The token stream is opaque to the proof: it is consumed only
+through the `cEnc`/`cEmpty`/`cRes` contracts (which delegate to the `lzMatch_*`
+trio), so the same composition covers both the greedy and lazy matchers.
 
-This composes the per-level roundtrip theorems:
-- `inflate_deflateStoredPure` (Level 0)
-- `inflate_deflateFixed` (Level 1)
-- `inflate_deflateLazyIter` (Levels 2-4)
-- `inflate_deflateDynamic` (Levels 5+)
+This composes the per-strategy roundtrip theorems:
+- `inflate_deflateStoredPure` (stored block, and the incompressible fallback)
+- `inflate_deflateFixedBlock` (fixed-Huffman candidate)
+- `inflate_deflateDynamicBlock` / `inflate_deflateDynamicBlocksSC` (dynamic, split)
 -/
 
 namespace Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -24,24 +24,25 @@ namespace Zip.Native.Deflate
 
 open Zip.Spec.DeflateStoredCorrect (inflate_deflateStoredPure)
 
-/-- The level-≥5 token stream: the hash-chain matcher at the level's search depth.
-    The three contracts (`cEnc`/`cEmpty`/`cRes`) are what `inflate_deflateFixedBlock`
-    / `inflate_deflateDynamicBlock` / their `_spec`s consume. -/
+/-- The level-dispatched token stream (`lzMatch`: greedy chain at levels 1–3, lazy
+    chain at ≥ 4). The three contracts (`cEnc`/`cEmpty`/`cRes`) are what
+    `inflate_deflateFixedBlock` / `inflate_deflateDynamicBlock` / their `_spec`s
+    consume; each delegates to the `lzMatch_*` trio (which cases on the level). -/
 private theorem cEnc (data : ByteArray) (level : UInt8) :
-    ∀ t ∈ (lz77ChainIter data (chainDepth level) 32768 (insertCap level)).toList,
+    ∀ t ∈ (lzMatch data level).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 :=
-  lz77ChainIter_encodable data (chainDepth level) 32768 (insertCap level) (by omega) (by omega)
+  lzMatch_encodable data level
 
 private theorem cEmpty (data : ByteArray) (level : UInt8) (hz : data.size = 0) :
-    lz77ChainIter data (chainDepth level) 32768 (insertCap level) = #[] :=
-  lz77ChainIter_empty data (chainDepth level) 32768 (insertCap level) hz
+    lzMatch data level = #[] :=
+  lzMatch_empty data level hz
 
 private theorem cRes (data : ByteArray) (level : UInt8) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainIter data (chainDepth level) 32768 (insertCap level))) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lzMatch data level)) [] =
       some data.data.toList :=
-  lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (by omega)
+  lzMatch_resolves data level
 
 set_option maxRecDepth 8000 in
 /-- `pickSmaller` of two byte arrays that both roundtrip also roundtrips. -/
@@ -65,9 +66,9 @@ theorem inflate_deflateCompressed (data : ByteArray) (level : UInt8)
   unfold deflateCompressed
   dsimp only []
   split
-  · exact inflate_deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+  · exact inflate_deflateFixedBlock data (lzMatch data level)
       (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ (by omega)
-  · exact inflate_deflateDynamicBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+  · exact inflate_deflateDynamicBlock data (lzMatch data level)
       (cEnc data level) (fun hz => cEmpty data level hz)
       (cRes data level) _ (by omega)
 
@@ -91,12 +92,12 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     dsimp only []
     split <;> split
     · exact inflate_deflateStoredPure data _ hsize
-    · exact inflate_deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+    · exact inflate_deflateFixedBlock data (lzMatch data level)
         (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
     · exact inflate_deflateStoredPure data _ hsize
     · -- Dynamic: `if 7 ≤ level then pickSmaller single split else single`.
       have hsingle := inflate_deflateDynamicBlock data
-        (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+        (lzMatch data level)
         (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
       split
       · exact inflate_pickSmaller _ _ data maxOutputSize hsingle
@@ -113,12 +114,12 @@ theorem deflateCompressed_pad (data : ByteArray) (level : UInt8) :
   split
   · -- fixed Huffman over the chain token stream
     obtain ⟨bits, _, hbytes⟩ := deflateFixedBlock_spec_of data
-      (lz77ChainIter data (chainDepth level) 32768 (insertCap level)) (cEnc data level) (fun hz => cEmpty data level hz)
+      (lzMatch data level) (cEnc data level) (fun hz => cEmpty data level hz)
     exact ⟨bits, List.replicate ((8 - bits.length % 8) % 8) false,
       hbytes, by simp only [List.length_replicate]; omega⟩
   · -- dynamic Huffman over the chain token stream
     obtain ⟨_, _, headerBits, symBits, _, _, _, _, _, _, _, _, _, _, hbytes⟩ :=
-      deflateDynamicBlock_spec data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+      deflateDynamicBlock_spec data (lzMatch data level)
         (cEnc data level) (fun hz => cEmpty data level hz)
     exact ⟨[true, false, true] ++ headerBits ++ symBits,
       List.replicate ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false,
@@ -148,17 +149,17 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
       ⟨Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data),
         [], by simp only [List.append_nil], by decide⟩
     have hfixed : ∃ (contentBits padding : List Bool),
-        Deflate.Spec.bytesToBits (deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))) =
+        Deflate.Spec.bytesToBits (deflateFixedBlock data (lzMatch data level)) =
           contentBits ++ padding ∧ padding.length < 8 := by
       obtain ⟨bits, _, hbytes⟩ := deflateFixedBlock_spec_of data
-        (lz77ChainIter data (chainDepth level) 32768 (insertCap level)) (cEnc data level) (fun hz => cEmpty data level hz)
+        (lzMatch data level) (cEnc data level) (fun hz => cEmpty data level hz)
       exact ⟨bits, List.replicate ((8 - bits.length % 8) % 8) false,
         hbytes, by simp only [List.length_replicate]; omega⟩
     have hdyn : ∃ (contentBits padding : List Bool),
-        Deflate.Spec.bytesToBits (deflateDynamicBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))) =
+        Deflate.Spec.bytesToBits (deflateDynamicBlock data (lzMatch data level)) =
           contentBits ++ padding ∧ padding.length < 8 := by
       obtain ⟨_, _, headerBits, symBits, _, _, _, _, _, _, _, _, _, _, hbytes⟩ :=
-        deflateDynamicBlock_spec data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+        deflateDynamicBlock_spec data (lzMatch data level)
           (cEnc data level) (fun hz => cEmpty data level hz)
       exact ⟨[true, false, true] ++ headerBits ++ symBits,
         List.replicate ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false,
@@ -277,10 +278,10 @@ theorem deflateCompressed_goR_pad (data : ByteArray) (level : UInt8) :
   dsimp only []
   split
   · -- fixed Huffman over the chain token stream
-    exact deflateFixedBlock_goR_pad data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+    exact deflateFixedBlock_goR_pad data (lzMatch data level)
       (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
   · -- dynamic Huffman over the chain token stream
-    exact deflateDynamicBlock_goR_pad data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+    exact deflateDynamicBlock_goR_pad data (lzMatch data level)
       (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
 
 set_option maxRecDepth 8000 in
@@ -299,16 +300,16 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
     dsimp only []
     have hfixed : ∃ remaining,
         Deflate.Spec.decode.goR
-            (Deflate.Spec.bytesToBits (deflateFixedBlock data (lz77ChainIter data (chainDepth level) 32768 (insertCap level)))) []
+            (Deflate.Spec.bytesToBits (deflateFixedBlock data (lzMatch data level))) []
           = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
-      exact deflateFixedBlock_goR_pad data (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+      exact deflateFixedBlock_goR_pad data (lzMatch data level)
         (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
     split <;> split
     · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
     · exact hfixed
     · exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
     · have hsingle := deflateDynamicBlock_goR_pad data
-        (lz77ChainIter data (chainDepth level) 32768 (insertCap level))
+        (lzMatch data level)
         (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level)
       split
       · exact pickSmaller_bytesToBits

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -1,0 +1,275 @@
+import Zip.Spec.LZ77ChainCorrect
+
+/-!
+# Correctness of the lazy hash-chain LZ77 matcher (`lz77ChainLazy`)
+
+`lz77ChainLazy` is the one-byte-lookahead (zlib `deflate_slow`-style) variant of
+`lz77Chain`: at each position it runs a second `chainWalk` at `pos+1` and, when
+that finds a longer match, emits a literal at `pos` and defers. The lookahead is
+*only a choice among valid matches* — every emitted reference is re-verified at
+emission by `chainWalk_spec` (which holds for any `prev` array), so the
+lookahead's chain state never enters the proof. This file proves the same three
+contracts the dynamic/fixed encoders consume (`ValidDecomp` → `resolveLZ77`,
+encodability, empty), mirroring `LZ77ChainCorrect`; the lookahead emission reuses
+`lazyRef_at_pos` from `LZ77NativeCorrect`.
+-/
+
+namespace Zip.Native.Deflate
+
+open Zip.Native.Deflate (lz77ChainLazy lz77Chain lz77Greedy)
+
+/-! ## Validity -/
+
+set_option backward.split false in
+/-- `lz77ChainLazy.mainLoop` produces a valid decomposition from `pos`. The
+    reference cases use `chainWalk_spec` (at `pos`, and again at `pos+1` for the
+    lookahead) exactly as `lz77Chain_mainLoop_valid` does for the single match. -/
+theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain : Nat)
+    (hashTable prev : Array Nat) (pos insertCap : Nat) (hw : windowSize > 0) :
+    ValidDecomp data pos
+      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap) := by
+  unfold lz77ChainLazy.mainLoop
+  split
+  · rename_i hlt
+    dsimp only
+    have hspec := chainWalk_spec data
+      (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
+      windowSize pos (min 258 (data.size - pos)) (by omega)
+      hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain 0 0 (Or.inl rfl)
+    split
+    · rename_i hge
+      split
+      · rename_i hle
+        obtain h0 | hQ := hspec
+        · omega
+        · split
+          · rename_i h3lt
+            have hspec2 := chainWalk_spec data
+              (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
+              windowSize (pos + 1) (min 258 (data.size - (pos + 1))) (by omega)
+              (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
+                lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
+              maxChain 0 0 (Or.inl rfl)
+            split
+            · split
+              · rename_i hle2
+                obtain h0' | hQ2 := hspec2
+                · omega
+                · exact .literal (by omega) (getElem!_pos data pos (by omega))
+                    (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
+                      (fun i hi => hQ2.2.2.2.1 i hi)
+                      (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw))
+              · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
+                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+            · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
+                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+          · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
+              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+      · exact .literal (by omega) (getElem!_pos data pos (by omega))
+          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+    · exact .literal (by omega) (getElem!_pos data pos (by omega))
+        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+  · exact trailing_valid data pos
+termination_by data.size - pos
+decreasing_by all_goals omega
+
+/-- `lz77ChainLazy` produces a valid decomposition of the input data. -/
+theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap : Nat)
+    (hw : windowSize > 0) :
+    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap).toList := by
+  simp only [lz77ChainLazy]
+  split
+  · simp only; exact trailing_valid data 0
+  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap hw
+
+/-- Resolving the LZ77 tokens produced by `lz77ChainLazy` recovers the original data. -/
+theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap : Nat)
+    (hw : windowSize > 0) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap)) [] =
+      some data.data.toList :=
+  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap hw)
+
+/-! ## Encodability -/
+
+/-- The bounds the dynamic/fixed encoders require of every token. -/
+private def Enc (t : LZ77Token) : Prop :=
+  match t with
+  | .literal _ => True
+  | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768
+
+set_option backward.split false in
+theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat)
+    (hashTable prev : Array Nat) (pos insertCap : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap, Enc t := by
+  unfold lz77ChainLazy.mainLoop
+  split
+  · rename_i hlt
+    dsimp only
+    have hspec := chainWalk_spec data
+      (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
+      windowSize pos (min 258 (data.size - pos)) (by omega)
+      hashTable[lz77Greedy.hash3 data pos hashSize hlt]! maxChain 0 0 (Or.inl rfl)
+    split
+    · rename_i hge
+      split
+      · rename_i hle
+        obtain h0 | ⟨hQ1, hQ2, _, _, hQ5⟩ := hspec
+        · omega
+        · split
+          · rename_i h3lt
+            have hspec2 := chainWalk_spec data
+              (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
+              windowSize (pos + 1) (min 258 (data.size - (pos + 1))) (by omega)
+              (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
+                lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
+              maxChain 0 0 (Or.inl rfl)
+            split
+            · split
+              · rename_i hle2
+                obtain h0' | ⟨hQ2a, hQ2b, _, _, hQ2e⟩ := hspec2
+                · omega
+                · intro t ht
+                  cases ht with
+                  | head => trivial
+                  | tail _ h =>
+                    cases h with
+                    | head => exact ⟨by omega, by omega, by omega, by omega⟩
+                    | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+              · intro t ht
+                cases ht with
+                | head => exact ⟨hge, by omega, by omega, by omega⟩
+                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+            · intro t ht
+              cases ht with
+              | head => exact ⟨hge, by omega, by omega, by omega⟩
+              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+          · intro t ht
+            cases ht with
+            | head => exact ⟨hge, by omega, by omega, by omega⟩
+            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+      · intro t ht
+        cases ht with
+        | head => trivial
+        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+    · intro t ht
+      cases ht with
+      | head => trivial
+      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+  · intro t ht
+    exact trailing_encodable data pos t ht
+termination_by data.size - pos
+decreasing_by all_goals omega
+
+/-- Every token `lz77ChainLazy` emits satisfies the encoder bounds. -/
+theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap : Nat)
+    (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
+  simp only [lz77ChainLazy]
+  split
+  · intro t ht
+    exact trailing_encodable data 0 t ht
+  · intro t ht
+    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap hw hws t ht
+
+/-! ## Iterative version: equivalence + transferred contracts -/
+
+/-- The accumulator `trailing` is the array form of the recursive one. (Local copy
+    of `LZ77ChainCorrect`'s `private trailing_eq`.) -/
+private theorem trailing_eq (data : ByteArray) (pos : Nat) (acc : Array LZ77Token) :
+    lz77GreedyIter.trailing data pos acc = acc ++ (lz77Greedy.trailing data pos).toArray := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc with
+  | _ n ih =>
+    unfold lz77GreedyIter.trailing lz77Greedy.trailing
+    by_cases hp : pos < data.size
+    · simp only [hp, ↓reduceDIte]
+      rw [ih _ (by omega) _ _ rfl, List.toArray_cons, ← Array.append_assoc, Array.push_eq_append]
+    · simp only [hp, ↓reduceDIte, List.toArray, Array.append_empty]
+
+/-- The iterative lazy chain `mainLoop` is the accumulator form of the recursive
+    one — identical branch structure, push vs. cons at each emission (two pushes in
+    the lookahead arm). -/
+private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+    (hashTable prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos acc =
+    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap).toArray := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
+  | _ n ih =>
+    unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
+    by_cases hlt : pos + 2 < data.size
+    · simp only [hlt, ↓reduceDIte]
+      -- Branch tree: hge / hle / h3lt / (matchLen2 > matchLen) / hle2
+      split
+      · -- hge : matchLen ≥ 3
+        split
+        · -- hle : pos + matchLen ≤ data.size
+          split
+          · -- h3lt : pos + 3 < data.size
+            split
+            · -- matchLen2 > matchLen
+              split
+              · -- hle2 : lookahead emits literal + reference(matchLen2), two pushes
+                rw [ih _ (by omega) _ _ _ _ rfl,
+                  Array.push_eq_append, Array.push_eq_append,
+                  Array.append_assoc, Array.append_assoc,
+                  ← List.toArray_cons, ← List.toArray_cons]
+              · -- ¬hle2 : reference(matchLen) at pos
+                rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+                  ← Array.append_assoc, Array.push_eq_append]
+            · -- matchLen2 ≤ matchLen : reference(matchLen) at pos
+              rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+                ← Array.append_assoc, Array.push_eq_append]
+          · -- ¬h3lt : reference(matchLen) at pos (near end)
+            rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+              ← Array.append_assoc, Array.push_eq_append]
+        · -- ¬hle : literal
+          rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+            ← Array.append_assoc, Array.push_eq_append]
+      · -- ¬hge : literal
+        rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+          ← Array.append_assoc, Array.push_eq_append]
+    · simp only [hlt, ↓reduceDIte]
+      exact trailing_eq data pos acc
+
+/-- `lz77ChainLazyIter` produces exactly the same tokens as `lz77ChainLazy`. -/
+theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap : Nat) :
+    lz77ChainLazyIter data maxChain windowSize insertCap =
+      lz77ChainLazy data maxChain windowSize insertCap := by
+  unfold lz77ChainLazyIter lz77ChainLazy
+  split
+  · rw [trailing_eq]; simp only [List.append_toArray, List.nil_append]
+  · rw [mainLoop_eq_chainLazy]; simp only [List.append_toArray, List.nil_append]
+
+theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap : Nat)
+    (hw : windowSize > 0) :
+    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap).toList := by
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap hw
+
+theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap : Nat)
+    (hw : windowSize > 0) :
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap)) [] =
+      some data.data.toList := by
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap hw
+
+theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap : Nat)
+    (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap).toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]
+  exact lz77ChainLazy_encodable data maxChain windowSize insertCap hw hws
+
+/-- The lazy chain matcher emits no tokens on empty input. -/
+theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap : Nat)
+    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap = #[] := by
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]
+  simp only [lz77ChainLazy, show data.size < 3 from by omega, ↓reduceIte]
+  have htrail : lz77Greedy.trailing data 0 = [] := by
+    unfold lz77Greedy.trailing
+    simp only [show ¬(0 < data.size) from by omega, ↓reduceDIte]
+  rw [htrail]
+
+end Zip.Native.Deflate

--- a/Zip/Spec/LZ77NativeCorrect.lean
+++ b/Zip/Spec/LZ77NativeCorrect.lean
@@ -451,8 +451,10 @@ termination_by data.size - pos
 The proof follows the lazy mainLoop case structure. Helper for the recurring
 "reference at pos with the first match" pattern. -/
 
-/-- Common proof step: reference at pos with a proved countMatch. -/
-private theorem lazyRef_at_pos (data : ByteArray) (pos matchPos matchLen : Nat)
+/-- Common proof step: reference at pos with a proved countMatch. Reused by the
+    chain-lazy matcher's validity proof (`LZ77ChainLazyCorrect`), sourcing the
+    match hypothesis from `chainWalk_spec` instead of `countMatch_matches`. -/
+theorem lazyRef_at_pos (data : ByteArray) (pos matchPos matchLen : Nat)
     (hmp_lt : matchPos < pos)
     (hge : matchLen ≥ 3) (hle : pos + matchLen ≤ data.size)
     (hcm : ∀ i, i < matchLen → data[pos + i]! = data[matchPos + i]!)

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -314,4 +314,35 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
   | .ok result => assert! result == largeCyclic
   | .error e => throw (IO.userError s!"deflateRaw(1) 256KB roundtrip failed: {e}")
 
+  -- Lazy chain matcher (zlib deflate_slow): levels ≥ 4 dispatch to lz77ChainLazyIter.
+  -- lz77ChainLazyIter must equal the recursive lz77ChainLazy (the Array==List bridge).
+  for (name, data) in [("empty", ByteArray.empty), ("single", singleByte),
+                        ("hello", helloBytes), ("big", big),
+                        ("constant1K", mkConstantData 1024),
+                        ("cyclic1K", mkCyclicData 1024),
+                        ("prng1K", mkPrngData 1024),
+                        ("text4K", mkTextData 4096)] do
+    let iterTokens := Zip.Native.Deflate.lz77ChainLazyIter data 64
+    let recTokens := Zip.Native.Deflate.lz77ChainLazy data 64
+    unless iterTokens == recTokens do
+      throw (IO.userError s!"lz77ChainLazyIter vs lz77ChainLazy mismatch on {name}: \
+        {iterTokens.size} vs {recTokens.size} tokens")
+
+  -- deflateRaw at every lazy level (4–9) → native inflate AND FFI decompress, on
+  -- varied shapes incl. edge cases. Exercises the lazy path end to end.
+  let lazyShapes : List (String × ByteArray) :=
+    [("empty", ByteArray.empty), ("single", singleByte), ("hello", helloBytes),
+     ("text64K", mkTextData 65536), ("cyclic128K", mkCyclicData 131072),
+     ("prng64K", mkPrngData 65536), ("const100K", mkConstantData 100000)]
+  for level in [4, 5, 6, 7, 8, 9] do
+    for (name, data) in lazyShapes do
+      let raw := Zip.Native.Deflate.deflateRaw data level.toUInt8
+      match Zip.Native.Inflate.inflate raw with
+      | .ok result => unless result == data do
+          throw (IO.userError s!"deflateRaw({level})→native inflate mismatch on {name}")
+      | .error e => throw (IO.userError s!"deflateRaw({level})→native inflate failed on {name}: {e}")
+      let ffi ← RawDeflate.decompress raw
+      unless ffi == data do
+        throw (IO.userError s!"deflateRaw({level})→FFI inflate mismatch on {name}")
+
   IO.println "  NativeDeflate tests passed."

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p3c4ab9feb4)">
+   <g clip-path="url(#p92d9436213)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAI+UlEQVR4nO3YT66kcxiG4VPdx0Gn01rQLQZCYglmDC3BTkxMbYEtSHpkAdJTdiAxMkGEpGmO4/xTp8oaWu5fXirXtYKn8uWr78672f3xaH/E/8vV+fSCdS5Ppxcssd9eT09YZnP31ekJazx/Z3rBOptb0wvW+PtyesE6B/rM9r//ND1hmcN8YgAAgwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEDs+PvNb9Mblri6OZ+esMzDl96anrDMvXsPpicssbk4nZ6wzNfn305PWOKNk9emJyyz3V1PT1ji8kB/19HR0dHp9cX0hCXeu/v29IRlXLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtjm9+mI/PWKFi+3Z9IRlXju6Nz1hne3l9II1/nwyvWCdB+9ML1jibH8+PWGZv7an0xOWeHh0f3rCMj/vf5uesMTrTw/3W+2CBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHjk9svTG/gWV1eTi9Y5/efphcssb+6mp6wzGa3nZ6wxmZ6wDovHt+dnrDEk5uz6QnL3Dm+Nz1hif3FL9MTlnHBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCIbW6++WQ/PQLgP+fWZnoBz2rnc8Z/hwsWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxI4/+vWH6Q1L/HqxnZ6wzFc//DE9YZkvP3x/esISD+68OT1hmXc/fzQ9YYkP3n55esIy3z29mJ7AM3r8+LvpCUv8+enH0xOWccECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2Ga7e7yfHrHCzW47PYF/4bmry+kJaxyfTC9Y5+zJ9IIlbu6/Pj1hmd1+Nz1hieduHe57dr07zP/Gk5vpBeu4YAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBss/vxs/30iCVuHW477i/Ppiesc/339II1drvpBcts7r8yPWGNA35mR7ePpxescX0+vWCd2yfTC5bYnz6dnrDM4VYIAMAQgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEPsHJ5OFTItsm/AAAAAASUVORK5CYII=" id="image8a05d090d1" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJG0lEQVR4nO3YPY4l5RmGYU7PmUYgNMIDI0aIwGYHSE6deQdeihNStuA1WCJ06GAWQOrACUgkYFsIzSDc0+6/6T7lNdi6P72idF0reEp16jt31eH07y+3t/bocDa9YJ3ri+kF69zs89q2h/vpCcsc3vtwesIab787vWCdvZ6Pb26mF6yz03u2/fSP6QnL7POOAQAMElgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHj94efpzcscfNwOT1hmY/e//X0hGWebM+nJyxxuL6YnrDMV9dfT09Y4vn5B9MTlrk/3U1PWOLq4XZ6wjKnbZuesMRnTz6enrCML1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQO7y++8s2PWKFqzcX0xOWefbo6fSEdW4vpxes8Z+fphes8+Gn0wuWuNyupicsc32/z+fs2VtPpics86/t5fSEJT7++WZ6wjK+YAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEDs+PjsfHrDEu8c35uesM7VxfSCdS5+mF6wxHZ7Oz1hmcPT++kJSxzO9vv++fbx3ekJS7x8uJyesMyT49PpCUtsV19PT1hmvycIAMAQgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxw8Pfv9imR8DunU7TC9Y58572i3N2mF6wxmnHf2d7PUN2fH7s98oAAIYILACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2PGPr76f3rDEq+v76QnLfPXPi+kJy/z1D7+bnrDEs3c+mZ6wzG///OX0hCV+/5tfTU9Y5ptX19MTlni0408GL158Oz1hidd/+nx6wjI7/jkCAMwQWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAscP96cU2PWKFh9P99AT+D49vb6YnrHE8n16wzuXL6QVLPLz/fHrCMqftND1hicdn+33O7k77PBvPH6YXrOMLFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMSOZ9/9bXrDEmeH/bbj9uZuesIy292b6Qn8r47H6QVLPHr94/SEZR7t9Hzcbm+nJyxzfv54esIS29X19IRl9vmUAQAMElgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALH/AlWBh479fQOqAAAAAElFTkSuQmCC" id="image2edaf35e60" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m2ef1273a8f" d="M 0 0 
+       <path id="me6ba856ea8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2ef1273a8f" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m2ef1273a8f" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6ba856ea8" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="ma39a6a402d" d="M 0 0 
+       <path id="m974a565865" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma39a6a402d" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m974a565865" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#ma39a6a402d" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m974a565865" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma39a6a402d" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m974a565865" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma39a6a402d" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m974a565865" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma39a6a402d" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m974a565865" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma39a6a402d" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m974a565865" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma39a6a402d" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m974a565865" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma39a6a402d" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m974a565865" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,39 +1303,9 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -68 -->
+    <!-- -80 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1377,29 +1347,197 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- -65 -->
+    <!-- -77 -->
     <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -82 -->
+    <!-- -87 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -93 -->
+    <!-- -94 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -96 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -87 -->
+    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -78 -->
+    <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -76 -->
+    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -87 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -79 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -96 -->
+    <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- +4 -->
+    <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- +9 -->
+    <g transform="translate(149.761237 104.25537) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +10 -->
+    <g transform="translate(186.944223 104.25537) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -23 -->
+    <g transform="translate(227.74588 104.25537) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1435,141 +1573,6 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -95 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -65 -->
-    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -67 -->
-    <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -62 -->
-    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -78 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -69 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -96 -->
-    <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- +4 -->
-    <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- +10 -->
-    <g transform="translate(147.693424 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +11 -->
-    <g transform="translate(186.944223 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -23 -->
-    <g transform="translate(227.74588 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
@@ -1583,11 +1586,11 @@ z
     </g>
    </g>
    <g id="text_36">
-    <!-- -45 -->
+    <!-- -46 -->
     <g transform="translate(306.247477 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_37">
@@ -1598,17 +1601,18 @@ z
     </g>
    </g>
    <g id="text_38">
-    <!-- +9 -->
-    <g transform="translate(385.266027 104.25537) scale(0.065 -0.065)">
+    <!-- +10 -->
+    <g transform="translate(383.198215 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- -3 -->
+    <!-- -2 -->
     <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_40">
@@ -1620,99 +1624,99 @@ z
     </g>
    </g>
    <g id="text_41">
-    <!-- -13 -->
+    <!-- -12 -->
     <g transform="translate(502.50147 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- +227 -->
+    <!-- +226 -->
     <g transform="translate(106.374813 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- +248 -->
+    <!-- +247 -->
     <g transform="translate(145.625612 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- +311 -->
+    <!-- +306 -->
     <g transform="translate(184.87641 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +78 -->
+    <!-- +75 -->
     <g transform="translate(226.195021 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- +29 -->
+    <!-- +30 -->
     <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_47">
-    <!-- +309 -->
+    <!-- +307 -->
     <g transform="translate(302.628805 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_48">
-    <!-- +236 -->
+    <!-- +234 -->
     <g transform="translate(341.879604 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +274 -->
+    <!-- +275 -->
     <g transform="translate(381.130402 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +273 -->
+    <!-- +272 -->
     <g transform="translate(420.381201 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +401 -->
+    <!-- +399 -->
     <g transform="translate(459.631999 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
@@ -1766,12 +1770,11 @@ z
     </g>
    </g>
    <g id="text_58">
-    <!-- -100 -->
-    <g transform="translate(304.179665 174.957073) scale(0.065 -0.065)">
+    <!-- -99 -->
+    <g transform="translate(306.247477 174.957073) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(163.330078 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_59">
@@ -1791,12 +1794,11 @@ z
     </g>
    </g>
    <g id="text_61">
-    <!-- -100 -->
-    <g transform="translate(421.93206 174.957073) scale(0.065 -0.065)">
+    <!-- -99 -->
+    <g transform="translate(423.999873 174.957073) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(163.330078 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_62">
@@ -1818,27 +1820,27 @@ z
     </g>
    </g>
    <g id="text_64">
-    <!-- +13 -->
+    <!-- +12 -->
     <g transform="translate(108.442626 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_65">
-    <!-- +27 -->
+    <!-- +25 -->
     <g transform="translate(147.693424 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_66">
-    <!-- -38 -->
+    <!-- -39 -->
     <g transform="translate(188.495082 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_67">
@@ -1866,123 +1868,123 @@ z
     </g>
    </g>
    <g id="text_70">
-    <!-- +25 -->
+    <!-- +24 -->
     <g transform="translate(343.947416 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
-    <!-- +31 -->
+    <!-- +29 -->
     <g transform="translate(383.198215 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_72">
-    <!-- +42 -->
+    <!-- +41 -->
     <g transform="translate(422.449013 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_73">
-    <!-- +28 -->
+    <!-- +27 -->
     <g transform="translate(461.699812 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_74">
-    <!-- -89 -->
+    <!-- -90 -->
     <g transform="translate(502.50147 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_75">
-    <!-- +26 -->
+    <!-- +24 -->
     <g transform="translate(108.442626 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_76">
-    <!-- +46 -->
+    <!-- +44 -->
     <g transform="translate(147.693424 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_77">
-    <!-- -22 -->
+    <!-- -19 -->
     <g transform="translate(188.495082 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_78">
-    <!-- -36 -->
+    <!-- -35 -->
     <g transform="translate(227.74588 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_79">
-    <!-- -66 -->
+    <!-- -63 -->
     <g transform="translate(266.996679 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_80">
-    <!-- -11 -->
+    <!-- -12 -->
     <g transform="translate(306.247477 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_81">
-    <!-- +26 -->
+    <!-- +28 -->
     <g transform="translate(343.947416 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_82">
-    <!-- +48 -->
-    <g transform="translate(383.198215 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_82">
+    <!-- +45 -->
+    <g transform="translate(383.198215 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_83">
-    <!-- -24 -->
+    <!-- -25 -->
     <g transform="translate(423.999873 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_84">
-    <!-- +53 -->
+    <!-- +54 -->
     <g transform="translate(461.699812 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_85">
@@ -1994,11 +1996,11 @@ z
     </g>
    </g>
    <g id="text_86">
-    <!-- +65 -->
+    <!-- +62 -->
     <g transform="translate(108.442626 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_87">
@@ -2010,69 +2012,68 @@ z
     </g>
    </g>
    <g id="text_88">
-    <!-- +31 -->
+    <!-- +29 -->
     <g transform="translate(186.944223 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_89">
-    <!-- -17 -->
+    <!-- -16 -->
     <g transform="translate(227.74588 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_90">
-    <!-- -39 -->
+    <!-- -40 -->
     <g transform="translate(266.996679 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_91">
-    <!-- +113 -->
+    <!-- +112 -->
     <g transform="translate(302.628805 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_92">
-    <!-- +70 -->
+    <!-- +71 -->
     <g transform="translate(343.947416 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_93">
-    <!-- +79 -->
+    <!-- +81 -->
     <g transform="translate(383.198215 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_94">
-    <!-- +94 -->
+    <!-- +97 -->
     <g transform="translate(422.449013 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
-    <!-- +113 -->
-    <g transform="translate(459.631999 281.009626) scale(0.065 -0.065)">
+    <!-- +99 -->
+    <g transform="translate(461.699812 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_96">
@@ -2084,11 +2085,11 @@ z
     </g>
    </g>
    <g id="text_97">
-    <!-- -36 -->
+    <!-- -37 -->
     <g transform="translate(109.993485 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_98">
@@ -2100,19 +2101,19 @@ z
     </g>
    </g>
    <g id="text_99">
-    <!-- -53 -->
+    <!-- -55 -->
     <g transform="translate(188.495082 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_100">
-    <!-- -74 -->
+    <!-- -75 -->
     <g transform="translate(227.74588 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_101">
@@ -2148,19 +2149,19 @@ z
     </g>
    </g>
    <g id="text_105">
-    <!-- -47 -->
+    <!-- -46 -->
     <g transform="translate(423.999873 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_106">
-    <!-- -42 -->
+    <!-- -43 -->
     <g transform="translate(463.250671 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_107">
@@ -2182,23 +2183,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image4c75b757f1" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagedb2e8c33a1" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m32c3a481aa" d="M 0 0 
+       <path id="mb5a1d13107" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m32c3a481aa" x="547.779688" y="303.632431" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a1d13107" x="547.779688" y="275.764316" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
-      <!-- −4 -->
-      <g transform="translate(554.779688 307.431649) scale(0.1 -0.1)">
+      <!-- −3 -->
+      <g transform="translate(554.779688 279.563535) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2209,118 +2210,91 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m32c3a481aa" x="547.779688" y="275.434049" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a1d13107" x="547.779688" y="247.455846" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
-      <!-- −3 -->
-      <g transform="translate(554.779688 279.233268) scale(0.1 -0.1)">
+      <!-- −2 -->
+      <g transform="translate(554.779688 251.255065) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m32c3a481aa" x="547.779688" y="247.235668" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a1d13107" x="547.779688" y="219.147375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
-      <!-- −2 -->
-      <g transform="translate(554.779688 251.034886) scale(0.1 -0.1)">
+      <!-- −1 -->
+      <g transform="translate(554.779688 222.946594) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m32c3a481aa" x="547.779688" y="219.037286" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a1d13107" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
-      <!-- −1 -->
-      <g transform="translate(554.779688 222.836505) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_13">
-     <g id="line2d_24">
-      <g>
-       <use xlink:href="#m32c3a481aa" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_112">
       <!-- 0 -->
       <g transform="translate(554.779688 194.638123) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
       </g>
      </g>
     </g>
+    <g id="ytick_13">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mb5a1d13107" x="547.779688" y="162.530434" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_112">
+      <!-- 1 -->
+      <g transform="translate(554.779688 166.329653) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m32c3a481aa" x="547.779688" y="162.640523" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a1d13107" x="547.779688" y="134.221963" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
-      <!-- 1 -->
-      <g transform="translate(554.779688 166.439742) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
+      <!-- 2 -->
+      <g transform="translate(554.779688 138.021182) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m32c3a481aa" x="547.779688" y="134.442142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a1d13107" x="547.779688" y="105.913493" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
-      <!-- 2 -->
-      <g transform="translate(554.779688 138.24136) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-32"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_16">
-     <g id="line2d_27">
-      <g>
-       <use xlink:href="#m32c3a481aa" x="547.779688" y="106.24376" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_115">
       <!-- 3 -->
-      <g transform="translate(554.779688 110.042979) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 109.712712) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
     </g>
-    <g id="ytick_17">
-     <g id="line2d_28">
-      <g>
-       <use xlink:href="#m32c3a481aa" x="547.779688" y="78.045379" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_116">
-      <!-- 4 -->
-      <g transform="translate(554.779688 81.844597) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-34"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_117">
+    <g id="text_115">
      <!-- % vs zlib (higher=faster) -->
      <g transform="translate(581.120313 253.142811) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -2426,7 +2400,7 @@ z
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
-  <g id="text_118">
+  <g id="text_116">
    <!-- Compression speed vs zlib  (canterbury, level 6, relative to zlib) -->
    <g transform="translate(80.680313 17.182125) scale(0.12 -0.12)">
     <defs>
@@ -2970,9 +2944,9 @@ z
     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3559.632812 0)"/>
    </g>
   </g>
-  <g id="text_119">
-   <!-- 2026-06-09T02:28:37Z  ·  Linux chungus x86_64  ·  commit 13e61c48  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.982969 401.184) scale(0.07 -0.07)">
+  <g id="text_117">
+   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(21.833828 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3038,17 +3012,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3087,109 +3061,108 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3442.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3506.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3538.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3570.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.429688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3693.212891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3816.015625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3879.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.734375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.916016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4102.095703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.619141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4266.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4389.009766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4452.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4516.011719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.882812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.505859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4704.292969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.916016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.539062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4863.326172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4963.033203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.896484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5120.5 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5152.287109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5184.074219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.861328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.648438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5279.435547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5382.023438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.886719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5482.068359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5545.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.923828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5672.302734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.779297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5799.158203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5838.367188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.730469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6083.142578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6208.142578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.583984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6392.371094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.470703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6569.128906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.605469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6748.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6809.265625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6882.166016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.953125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6955.066406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7016.345703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.337891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7144.519531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7176.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7204.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7256.189453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7351.453125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7452.185547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7553.072266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7650.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.267578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.646484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7769.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7821.529297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.738281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7888.521484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3c4ab9feb4">
+  <clipPath id="p92d9436213">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m33435aee63" d="M 0 0 
+       <path id="m3efce1f8e4" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m33435aee63" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efce1f8e4" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m33435aee63" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efce1f8e4" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m33435aee63" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efce1f8e4" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m33435aee63" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efce1f8e4" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m33435aee63" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efce1f8e4" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m33435aee63" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efce1f8e4" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m33435aee63" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efce1f8e4" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -852,23 +852,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 348.535435 
-L 637.2 348.535435 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 348.811562 
+L 637.2 348.811562 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m27a7ec7fb0" d="M 0 0 
+       <path id="m72d56f6285" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m27a7ec7fb0" x="49.078125" y="348.535435" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72d56f6285" x="49.078125" y="348.811562" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 352.334654) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 352.610781) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -893,18 +893,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 239.192889 
-L 637.2 239.192889 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 239.249643 
+L 637.2 239.249643 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m27a7ec7fb0" x="49.078125" y="239.192889" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72d56f6285" x="49.078125" y="239.249643" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 242.992107) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 243.048862) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -913,18 +913,18 @@ L 637.2 239.192889
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 129.850342 
-L 637.2 129.850342 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 129.687723 
+L 637.2 129.687723 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m27a7ec7fb0" x="49.078125" y="129.850342" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72d56f6285" x="49.078125" y="129.687723" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 133.649561) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 133.486942) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -933,330 +933,330 @@ L 637.2 129.850342
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 405.708329 
-L 637.2 405.708329 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 406.099161 
+L 637.2 406.099161 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="meab7384ce8" d="M 0 0 
+       <path id="m4ff49485e5" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="405.708329" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="406.099161" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 392.047209 
-L 637.2 392.047209 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 392.410633 
+L 637.2 392.410633 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="392.047209" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="392.410633" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 381.450821 
-L 637.2 381.450821 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 381.792986 
+L 637.2 381.792986 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="381.450821" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="381.792986" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 372.792942 
-L 637.2 372.792942 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 373.117737 
+L 637.2 373.117737 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="372.792942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="373.117737" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 365.47281 
-L 637.2 365.47281 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 365.782918 
+L 637.2 365.782918 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="365.47281" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="365.782918" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 359.131823 
-L 637.2 359.131823 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 359.429209 
+L 637.2 359.429209 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="359.131823" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="359.429209" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 353.538676 
-L 637.2 353.538676 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 353.824841 
+L 637.2 353.824841 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="353.538676" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="353.824841" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 315.620049 
-L 637.2 315.620049 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 315.830138 
+L 637.2 315.830138 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="315.620049" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="315.830138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 296.365782 
-L 637.2 296.365782 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 296.537242 
+L 637.2 296.537242 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="296.365782" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="296.537242" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 282.704663 
-L 637.2 282.704663 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 282.848714 
+L 637.2 282.848714 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="282.704663" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="282.848714" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 272.108275 
-L 637.2 272.108275 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 272.231067 
+L 637.2 272.231067 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="272.108275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="272.231067" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 263.450396 
-L 637.2 263.450396 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 263.555818 
+L 637.2 263.555818 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="263.450396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="263.555818" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 256.130263 
-L 637.2 256.130263 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 256.220999 
+L 637.2 256.220999 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="256.130263" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="256.220999" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 249.789276 
-L 637.2 249.789276 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.86729 
+L 637.2 249.86729 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="249.789276" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="249.86729" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 244.196129 
-L 637.2 244.196129 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 244.262921 
+L 637.2 244.262921 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="244.196129" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="244.262921" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 206.277502 
-L 637.2 206.277502 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 206.268219 
+L 637.2 206.268219 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="206.277502" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="206.268219" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 187.023236 
-L 637.2 187.023236 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 186.975322 
+L 637.2 186.975322 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="187.023236" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="186.975322" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 173.362116 
-L 637.2 173.362116 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 173.286794 
+L 637.2 173.286794 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="173.362116" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="173.286794" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 162.765729 
-L 637.2 162.765729 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 162.669147 
+L 637.2 162.669147 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="162.765729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="162.669147" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 154.10785 
-L 637.2 154.10785 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 153.993898 
+L 637.2 153.993898 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="154.10785" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="153.993898" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 146.787717 
-L 637.2 146.787717 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.659079 
+L 637.2 146.659079 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="146.787717" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="146.659079" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 140.44673 
-L 637.2 140.44673 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 140.30537 
+L 637.2 140.30537 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="140.44673" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="140.30537" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 134.853583 
-L 637.2 134.853583 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 134.701002 
+L 637.2 134.701002 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="134.853583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="134.701002" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 49.078125 96.934956 
-L 637.2 96.934956 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 96.706299 
+L 637.2 96.706299 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="96.934956" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="96.706299" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 49.078125 77.680689 
-L 637.2 77.680689 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 77.413403 
+L 637.2 77.413403 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="77.680689" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="77.413403" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 49.078125 64.01957 
-L 637.2 64.01957 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 63.724875 
+L 637.2 63.724875 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="64.01957" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="63.724875" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 49.078125 53.423182 
-L 637.2 53.423182 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 53.107228 
+L 637.2 53.107228 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#meab7384ce8" x="49.078125" y="53.423182" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4ff49485e5" x="49.078125" y="53.107228" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(298.172574 215.689001) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(298.172574 215.105703) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(214.380984 244.650339) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(166.606362 324.081206) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1739,124 +1739,124 @@ z
     </g>
    </g>
    <g id="line2d_75">
-    <path d="M 355.479835 96.018849 
-L 308.273931 102.94796 
-L 271.230161 116.627973 
-L 217.83458 121.165682 
-L 177.077692 139.620891 
-L 162.880539 158.737728 
-L 160.741445 166.155589 
-L 153.966678 184.316111 
-L 151.589614 195.432862 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 355.479835 96.221589 
+L 308.273931 103.086412 
+L 271.230161 117.04048 
+L 217.83458 120.951277 
+L 177.077692 139.538613 
+L 162.880539 158.700427 
+L 160.741445 166.116031 
+L 153.966678 184.325608 
+L 151.589614 195.420135 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf43c8ead74" d="M -2.5 2.5 
+     <path id="mc312bf3a92" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1945b93642)">
-     <use xlink:href="#mf43c8ead74" x="355.479835" y="96.018849" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf43c8ead74" x="308.273931" y="102.94796" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf43c8ead74" x="271.230161" y="116.627973" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf43c8ead74" x="217.83458" y="121.165682" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf43c8ead74" x="177.077692" y="139.620891" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf43c8ead74" x="162.880539" y="158.737728" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf43c8ead74" x="160.741445" y="166.155589" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf43c8ead74" x="153.966678" y="184.316111" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf43c8ead74" x="151.589614" y="195.432862" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1075ac3a9)">
+     <use xlink:href="#mc312bf3a92" x="355.479835" y="96.221589" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc312bf3a92" x="308.273931" y="103.086412" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc312bf3a92" x="271.230161" y="117.04048" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc312bf3a92" x="217.83458" y="120.951277" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc312bf3a92" x="177.077692" y="139.538613" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc312bf3a92" x="162.880539" y="158.700427" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc312bf3a92" x="160.741445" y="166.116031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc312bf3a92" x="153.966678" y="184.325608" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc312bf3a92" x="151.589614" y="195.420135" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
-    <path d="M 531.649087 76.196944 
-L 283.721324 99.257316 
-L 218.882044 121.315433 
-L 187.447228 127.18595 
-L 176.342474 138.569047 
-L 163.054314 161.606636 
-L 162.210539 169.08237 
-L 159.303811 176.050257 
-L 157.793928 179.831833 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 531.649087 75.715785 
+L 283.721324 98.745413 
+L 218.882044 120.970615 
+L 187.447228 126.936029 
+L 176.342474 138.381298 
+L 163.054314 161.530544 
+L 162.210539 169.028722 
+L 159.303811 176.032277 
+L 157.793928 179.841405 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m69f630f7c9" d="M 0 -2.5 
+     <path id="m7666fc7968" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1945b93642)">
-     <use xlink:href="#m69f630f7c9" x="531.649087" y="76.196944" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m69f630f7c9" x="283.721324" y="99.257316" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m69f630f7c9" x="218.882044" y="121.315433" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m69f630f7c9" x="187.447228" y="127.18595" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m69f630f7c9" x="176.342474" y="138.569047" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m69f630f7c9" x="163.054314" y="161.606636" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m69f630f7c9" x="162.210539" y="169.08237" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m69f630f7c9" x="159.303811" y="176.050257" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m69f630f7c9" x="157.793928" y="179.831833" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1075ac3a9)">
+     <use xlink:href="#m7666fc7968" x="531.649087" y="75.715785" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7666fc7968" x="283.721324" y="98.745413" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7666fc7968" x="218.882044" y="120.970615" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7666fc7968" x="187.447228" y="126.936029" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7666fc7968" x="176.342474" y="138.381298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7666fc7968" x="163.054314" y="161.530544" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7666fc7968" x="162.210539" y="169.028722" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7666fc7968" x="159.303811" y="176.032277" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7666fc7968" x="157.793928" y="179.841405" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
     <path d="M 251.559581 64.890426 
-L 203.775848 82.075995 
-L 186.982691 88.640514 
-L 179.779306 91.132127 
-L 157.610419 99.531833 
-L 148.722526 107.96569 
-L 144.388162 121.589653 
-L 127.071247 144.779457 
-L 124.491988 152.380231 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 203.775848 81.551222 
+L 186.982691 88.690505 
+L 179.779306 91.223338 
+L 157.610419 99.570775 
+L 148.722526 108.024607 
+L 144.388162 121.351751 
+L 127.071247 144.983814 
+L 124.491988 152.570158 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5c2ae7b453" d="M -0 3.535534 
+     <path id="m8b3d44b508" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1945b93642)">
-     <use xlink:href="#m5c2ae7b453" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c2ae7b453" x="203.775848" y="82.075995" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c2ae7b453" x="186.982691" y="88.640514" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c2ae7b453" x="179.779306" y="91.132127" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c2ae7b453" x="157.610419" y="99.531833" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c2ae7b453" x="148.722526" y="107.96569" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c2ae7b453" x="144.388162" y="121.589653" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c2ae7b453" x="127.071247" y="144.779457" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5c2ae7b453" x="124.491988" y="152.380231" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1075ac3a9)">
+     <use xlink:href="#m8b3d44b508" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b3d44b508" x="203.775848" y="81.551222" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b3d44b508" x="186.982691" y="88.690505" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b3d44b508" x="179.779306" y="91.223338" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b3d44b508" x="157.610419" y="99.570775" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b3d44b508" x="148.722526" y="108.024607" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b3d44b508" x="144.388162" y="121.351751" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b3d44b508" x="127.071247" y="144.983814" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b3d44b508" x="124.491988" y="152.570158" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m173dac5a8a" d="M -0 2.5 
+     <path id="ma943aa3ea2" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1945b93642)">
-     <use xlink:href="#m173dac5a8a" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1075ac3a9)">
+     <use xlink:href="#ma943aa3ea2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
-    <path d="M 362.865999 147.063538 
-L 278.798176 148.702728 
-L 251.17632 153.545591 
-L 200.806828 156.480378 
-L 169.803221 170.253487 
-L 161.916638 180.729045 
-L 158.697104 187.722528 
-L 154.26679 198.95054 
-L 153.096464 210.685867 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 362.865999 147.351516 
+L 278.798176 150.131517 
+L 251.17632 154.424374 
+L 200.806828 156.381038 
+L 169.803221 170.25855 
+L 161.916638 181.586606 
+L 158.697104 187.028572 
+L 154.26679 199.747456 
+L 153.096464 210.682045 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1d4d16fdc9" d="M -0.833333 2.5 
+     <path id="mc4ef4539f2" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,31 +1871,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1945b93642)">
-     <use xlink:href="#m1d4d16fdc9" x="362.865999" y="147.063538" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d4d16fdc9" x="278.798176" y="148.702728" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d4d16fdc9" x="251.17632" y="153.545591" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d4d16fdc9" x="200.806828" y="156.480378" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d4d16fdc9" x="169.803221" y="170.253487" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d4d16fdc9" x="161.916638" y="180.729045" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d4d16fdc9" x="158.697104" y="187.722528" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d4d16fdc9" x="154.26679" y="198.95054" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1d4d16fdc9" x="153.096464" y="210.685867" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1075ac3a9)">
+     <use xlink:href="#mc4ef4539f2" x="362.865999" y="147.351516" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc4ef4539f2" x="278.798176" y="150.131517" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc4ef4539f2" x="251.17632" y="154.424374" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc4ef4539f2" x="200.806828" y="156.381038" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc4ef4539f2" x="169.803221" y="170.25855" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc4ef4539f2" x="161.916638" y="181.586606" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc4ef4539f2" x="158.697104" y="187.028572" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc4ef4539f2" x="154.26679" y="199.747456" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc4ef4539f2" x="153.096464" y="210.682045" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
-    <path d="M 301.619021 142.178646 
-L 250.236474 148.210887 
-L 225.418659 152.863644 
-L 212.328936 156.794635 
-L 209.030149 157.664604 
-L 197.547749 165.971124 
-L 194.819287 169.155376 
-L 193.12279 175.732095 
-L 192.79794 181.388735 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 301.619021 141.435532 
+L 250.236474 148.609921 
+L 225.418659 152.913765 
+L 212.328936 156.727542 
+L 209.030149 158.033477 
+L 197.547749 165.556179 
+L 194.819287 169.087077 
+L 193.12279 175.780925 
+L 192.79794 181.258909 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me8d8264acf" d="M -1.25 2.5 
+     <path id="mc6afd3a75f" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,31 +1910,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1945b93642)">
-     <use xlink:href="#me8d8264acf" x="301.619021" y="142.178646" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8d8264acf" x="250.236474" y="148.210887" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8d8264acf" x="225.418659" y="152.863644" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8d8264acf" x="212.328936" y="156.794635" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8d8264acf" x="209.030149" y="157.664604" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8d8264acf" x="197.547749" y="165.971124" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8d8264acf" x="194.819287" y="169.155376" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8d8264acf" x="193.12279" y="175.732095" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8d8264acf" x="192.79794" y="181.388735" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1075ac3a9)">
+     <use xlink:href="#mc6afd3a75f" x="301.619021" y="141.435532" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6afd3a75f" x="250.236474" y="148.609921" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6afd3a75f" x="225.418659" y="152.913765" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6afd3a75f" x="212.328936" y="156.727542" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6afd3a75f" x="209.030149" y="158.033477" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6afd3a75f" x="197.547749" y="165.556179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6afd3a75f" x="194.819287" y="169.087077" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6afd3a75f" x="193.12279" y="175.780925" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6afd3a75f" x="192.79794" y="181.258909" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
-    <path d="M 206.45578 118.520603 
-L 206.45578 118.338281 
-L 206.45578 118.592368 
-L 206.45578 118.60434 
-L 171.767499 133.770038 
-L 163.54283 144.783142 
-L 160.174881 150.714656 
-L 154.179217 169.10155 
-L 152.4406 178.942618 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.286977 
+L 206.45578 118.608382 
+L 206.45578 117.972989 
+L 206.45578 118.15015 
+L 171.767499 133.659276 
+L 163.54283 145.068039 
+L 160.174881 150.863312 
+L 154.179217 168.922986 
+L 152.4406 178.782394 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me2e95a002a" d="M 0 -2.5 
+     <path id="mc4f9d3e6f7" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,31 +1947,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p1945b93642)">
-     <use xlink:href="#me2e95a002a" x="206.45578" y="118.520603" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me2e95a002a" x="206.45578" y="118.338281" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me2e95a002a" x="206.45578" y="118.592368" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me2e95a002a" x="206.45578" y="118.60434" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me2e95a002a" x="171.767499" y="133.770038" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me2e95a002a" x="163.54283" y="144.783142" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me2e95a002a" x="160.174881" y="150.714656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me2e95a002a" x="154.179217" y="169.10155" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me2e95a002a" x="152.4406" y="178.942618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pf1075ac3a9)">
+     <use xlink:href="#mc4f9d3e6f7" x="206.45578" y="118.286977" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4f9d3e6f7" x="206.45578" y="118.608382" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4f9d3e6f7" x="206.45578" y="117.972989" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4f9d3e6f7" x="206.45578" y="118.15015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4f9d3e6f7" x="171.767499" y="133.659276" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4f9d3e6f7" x="163.54283" y="145.068039" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4f9d3e6f7" x="160.174881" y="150.863312" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4f9d3e6f7" x="154.179217" y="168.922986" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc4f9d3e6f7" x="152.4406" y="178.782394" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
-    <path d="M 610.467188 173.553731 
-L 592.067397 174.887409 
-L 534.807821 181.405003 
-L 327.802209 176.816636 
-L 275.83761 187.569494 
-L 258.25125 199.357349 
-L 256.777056 204.517973 
-L 248.769854 218.38376 
-L 246.264594 228.332889 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467188 173.38788 
+L 592.067397 175.261277 
+L 534.807821 181.990063 
+L 327.802209 177.159819 
+L 275.83761 188.03779 
+L 258.25125 200.068916 
+L 256.777056 204.613462 
+L 248.769854 218.966816 
+L 246.264594 228.560674 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me2dac9003d" d="M 0 -2.5 
+     <path id="m2210c7b763" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1945b93642)">
-     <use xlink:href="#me2dac9003d" x="610.467188" y="173.553731" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2dac9003d" x="592.067397" y="174.887409" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2dac9003d" x="534.807821" y="181.405003" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2dac9003d" x="327.802209" y="176.816636" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2dac9003d" x="275.83761" y="187.569494" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2dac9003d" x="258.25125" y="199.357349" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2dac9003d" x="256.777056" y="204.517973" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2dac9003d" x="248.769854" y="218.38376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2dac9003d" x="246.264594" y="228.332889" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pf1075ac3a9)">
+     <use xlink:href="#m2210c7b763" x="610.467188" y="173.38788" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2210c7b763" x="592.067397" y="175.261277" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2210c7b763" x="534.807821" y="181.990063" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2210c7b763" x="327.802209" y="177.159819" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2210c7b763" x="275.83761" y="188.03779" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2210c7b763" x="258.25125" y="200.068916" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2210c7b763" x="256.777056" y="204.613462" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2210c7b763" x="248.769854" y="218.966816" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2210c7b763" x="246.264594" y="228.560674" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m5db0c66814" d="M 0 3.5 
+      <path id="m9089e5bf19" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m5db0c66814" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m9089e5bf19" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf43c8ead74" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc312bf3a92" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m69f630f7c9" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7666fc7968" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5c2ae7b453" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8b3d44b508" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m173dac5a8a" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma943aa3ea2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1d4d16fdc9" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc4ef4539f2" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me8d8264acf" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc6afd3a75f" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me2e95a002a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mc4f9d3e6f7" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me2dac9003d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2210c7b763" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 293.172574 220.689001 
-L 274.018564 224.919759 
-L 259.251152 229.354885 
-L 251.189724 232.210833 
-L 248.122312 234.175418 
-L 214.870945 238.85668 
-L 240.566957 242.326479 
-L 209.866468 245.949786 
-L 209.380984 249.650339 
-" clip-path="url(#p1945b93642)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p1945b93642)">
-     <use xlink:href="#m5db0c66814" x="293.172574" y="220.689001" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5db0c66814" x="274.018564" y="224.919759" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5db0c66814" x="259.251152" y="229.354885" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5db0c66814" x="251.189724" y="232.210833" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5db0c66814" x="248.122312" y="234.175418" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5db0c66814" x="214.870945" y="238.85668" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5db0c66814" x="240.566957" y="242.326479" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5db0c66814" x="209.866468" y="245.949786" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5db0c66814" x="209.380984" y="249.650339" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 293.172574 220.105703 
+L 274.018564 224.410269 
+L 259.251152 228.874743 
+L 234.341329 247.170554 
+L 180.806615 250.531577 
+L 175.118498 258.372877 
+L 164.013061 316.198068 
+L 162.146409 322.605174 
+L 161.606362 329.081206 
+" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pf1075ac3a9)">
+     <use xlink:href="#m9089e5bf19" x="293.172574" y="220.105703" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9089e5bf19" x="274.018564" y="224.410269" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9089e5bf19" x="259.251152" y="228.874743" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9089e5bf19" x="234.341329" y="247.170554" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9089e5bf19" x="180.806615" y="250.531577" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9089e5bf19" x="175.118498" y="258.372877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9089e5bf19" x="164.013061" y="316.198068" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9089e5bf19" x="162.146409" y="322.605174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9089e5bf19" x="161.606362" y="329.081206" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,39 +2891,9 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-09T02:28:37Z  ·  Linux chungus x86_64  ·  commit 13e61c48  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.982969 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(48.833828 465.66) scale(0.07 -0.07)">
     <defs>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2948,14 +2918,29 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -3052,17 +3037,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3101,109 +3086,108 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3442.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3506.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3538.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3570.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.429688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3693.212891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3816.015625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3879.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.734375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.916016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4102.095703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.619141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4266.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4389.009766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4452.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4516.011719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.882812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.505859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4704.292969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.916016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.539062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4863.326172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4963.033203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.896484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5120.5 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5152.287109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5184.074219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.861328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.648438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5279.435547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5382.023438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.886719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5482.068359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5545.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.923828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5672.302734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.779297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5799.158203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5838.367188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.730469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6083.142578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6208.142578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.583984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6392.371094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.470703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6569.128906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.605469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6748.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6809.265625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6882.166016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.953125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6955.066406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7016.345703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.337891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7144.519531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7176.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7204.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7256.189453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7351.453125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7452.185547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7553.072266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7650.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.267578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.646484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7769.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7821.529297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.738281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7888.521484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1945b93642">
+  <clipPath id="pf1075ac3a9">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p72c3415c01)">
+   <g clip-path="url(#p1198597a54)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3YP46dVx3H4XvtmdE4BEdBJolSItGhiCJN3FBnCdlBVkDHnz7rINlApAghaBCIhgbRIbooiqLEOMa2ZsZ33ssSHKSDfuh+nmcF37d4z/no7Ld//ea4OzVPv55esNTxm9P6nt1ut/v8559OT1jqn397Nj1huZ99/P70hOX2P313esJa+zvTC9Z78uX0gvUu708vWOqTNz+anrDcCf5JAADfnRgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbXx8+O06PWO2426YnLLU/wWY9v3MxPWGpm+1qesJy53//y/SE5Q4/eTg9YanDdjM9YblnhyfTE5Z7cGLHw4v7D6YnLHd6tywAwH9BDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ2dP3s8vWG96+fTC9Y6btML1rt3f3rBUhfTA/4Hjk+eTU9Y7vzfj6YnLHW+HaYnLHfvFM+7q6fTC5Y6Pzu9E8/LEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANL2h+13x+kRqx2P2/SEpbYT+57dbrc7v3MxPWGp2+NhesJyd58+mp6w3vffmF6w1IvtZnrCct9cfTE9Ybm3rs+mJyy1vf729ITlvAwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGlnf/3qT9Mblruz209PWOqHrzyYnrDc7XaYnrDUxd3L6QnLffiHP05PWO7X7/14esJSh+M2PWG5X/75H9MTlnv49vemJyz14TsPpycs52UIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAafsXt789To9Y7eb2anrCUvf2l9MTeImb/WF6wnLfXn89PWG5H1y+NT1hqe24TU9Y7vH1V9MTlnt0/eX0hKV+dP+d6QnLeRkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2n7bfn+cHgH8HzrcTC9Y7+xiegEvcXX7fHrCcpd3X5mewEt4GQIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa2e7xF9Mb1rt5Pr1grf0JNuvlq9MLeIlPXvvV9ITlPnj0i+kJa22H6QXLXW7b9IT1rp9OL1jr1QfTC5Y7wVsWAOC7E0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn/AfLCiQgt1012AAAAAElFTkSuQmCC" id="image703ef369df" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+UlEQVR4nO3YwYqkVx2H4aqe7rYnwUFlEsMshewkuHDjbLL2TnIFWYp7r8PkBgQRMZugZONG3IkbEQkhmSSTmaG7p/orL2ESOPKXep/nCn5nUafe7+y3L3973J2aZ59PL1jq+MVpnWe32+3+/f7vpics9c+/PZ+esNy7H/xyesJy+5/9fHrCWvuz6QXrPf10esF6Vw+mFyz14Y9/Mz1huRP8JQEAfHtiCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbX9z+P1xesRqx902PWGp/Qk268XZ5fSEpW636+kJy138/ZPpCcsdfvp4esJSh+12esJyzw9Ppycs9/DEroeXDx5OT1ju9P5lAQC+AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvH8q+kN6928mF6w1nGbXrDe/QfTC5a6nB7wP3B8+nx6wnIX3zyZnrDUxXaYnrDc/VO8766fTS9Y6uL89G48L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2Px6nR6x2PG7TE5baTuw8u91ud3F2OT1hqbvjYXrCcveePZmesN7335xesNTL7XZ6wnJfXP9nesJyb92cT09Yavvho+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSzv/62Z+nNyx3tttPT1jqjdceTk9Y7m47TE9Y6vLe1fSE5d776OPpCcv9+hdvT09Y6nDcpics96u//GN6wnKPH70+PWGp9955PD1hOS9DAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASNu/vPvDcXrEard319MTlrq/v5qewCvc7g/TE5b7+ubz6QnL/ejqrekJS23HbXrCcl/dfDY9YbknN59OT1jqJw/emZ6wnJchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO237U/H6RHA/6HD7fSC9c4vpxfwCtd3L6YnLHd177XpCbyClyEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkne9uX0xvWO9wO71grXvn0wvWOzuxM+1P8Lviyb+mF6z3g0fTC9Y6tbtut9vtvnc5vWC94za9YK0T7IYTvMEBAL49MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfwb+IB8PIhC4AAAAASUVORK5CYII=" id="image6408d19398" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="md094bfc117" d="M 0 0 
+       <path id="mc27b46c688" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md094bfc117" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#md094bfc117" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#md094bfc117" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md094bfc117" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#md094bfc117" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md094bfc117" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#md094bfc117" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#md094bfc117" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#md094bfc117" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md094bfc117" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#md094bfc117" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc27b46c688" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mdb9ff816cb" d="M 0 0 
+       <path id="m1334f2885b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdb9ff816cb" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1334f2885b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mdb9ff816cb" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1334f2885b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdb9ff816cb" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1334f2885b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mdb9ff816cb" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1334f2885b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdb9ff816cb" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1334f2885b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mdb9ff816cb" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1334f2885b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdb9ff816cb" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1334f2885b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mdb9ff816cb" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1334f2885b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 512.247548 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +2 -->
+    <!-- +1 -->
     <g transform="translate(109.820098 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1323,12 +1323,40 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +3 -->
+    <!-- +1 -->
     <g transform="translate(147.690216 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- +1 -->
+    <g transform="translate(185.560334 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +1 -->
+    <g transform="translate(223.430452 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- +1 -->
+    <g transform="translate(261.30057 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +3 -->
+    <g transform="translate(299.170688 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1367,89 +1395,39 @@ z
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_22">
-    <!-- +3 -->
-    <g transform="translate(185.560334 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +2 -->
-    <g transform="translate(223.430452 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- +2 -->
-    <g transform="translate(261.30057 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +20 -->
-    <g transform="translate(297.102876 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
    <g id="text_26">
-    <!-- +2 -->
+    <!-- +1 -->
     <g transform="translate(337.040806 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +3 -->
+    <!-- +1 -->
     <g transform="translate(374.910924 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- +3 -->
-    <g transform="translate(412.781042 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    <!-- -1 -->
+    <g transform="translate(414.331902 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- +4 -->
+    <!-- +0 -->
     <g transform="translate(450.65116 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- +2 -->
+    <!-- +1 -->
     <g transform="translate(488.521278 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1595,6 +1573,27 @@ z
    <g id="text_51">
     <!-- -4 -->
     <g transform="translate(452.20202 139.606222) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
@@ -2093,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image6b46925a6b" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagefaa2c31e1e" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="ma30a4da7ad" d="M 0 0 
+       <path id="m94cedb4080" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma30a4da7ad" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94cedb4080" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#ma30a4da7ad" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94cedb4080" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma30a4da7ad" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94cedb4080" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma30a4da7ad" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94cedb4080" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma30a4da7ad" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94cedb4080" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma30a4da7ad" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94cedb4080" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma30a4da7ad" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94cedb4080" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma30a4da7ad" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94cedb4080" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma30a4da7ad" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94cedb4080" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-09T02:28:37Z  ·  Linux chungus x86_64  ·  commit 13e61c48  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.982969 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(21.833828 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,17 +2949,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2998,108 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3442.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3506.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3538.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3570.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.429688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3693.212891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3816.015625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3879.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.734375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.916016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4102.095703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.619141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4266.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4389.009766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4452.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4516.011719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.882812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.505859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4704.292969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.916016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.539062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4863.326172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4963.033203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.896484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5120.5 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5152.287109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5184.074219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.861328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.648438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5279.435547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5382.023438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.886719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5482.068359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5545.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.923828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5672.302734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.779297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5799.158203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5838.367188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.730469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6083.142578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6208.142578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.583984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6392.371094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.470703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6569.128906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.605469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6748.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6809.265625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6882.166016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.953125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6955.066406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7016.345703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.337891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7144.519531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7176.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7204.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7256.189453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7351.453125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7452.185547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7553.072266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7650.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.267578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.646484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7769.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7821.529297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.738281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7888.521484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p72c3415c01">
+  <clipPath id="p1198597a54">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.434062pt" height="386.202469pt" viewBox="0 0 570.434062 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.732344pt" height="386.202469pt" viewBox="0 0 564.732344 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.434062 386.202469 
-L 570.434062 0 
+L 564.732344 386.202469 
+L 564.732344 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.342031 104.1264 
-L 291.967031 104.1264 
-L 291.967031 74.7432 
-L 187.342031 74.7432 
+    <path d="M 184.491172 104.1264 
+L 289.116172 104.1264 
+L 289.116172 74.7432 
+L 184.491172 74.7432 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.967031 104.1264 
-L 396.592031 104.1264 
-L 396.592031 74.7432 
-L 291.967031 74.7432 
+    <path d="M 289.116172 104.1264 
+L 393.741172 104.1264 
+L 393.741172 74.7432 
+L 289.116172 74.7432 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.592031 104.1264 
-L 501.217031 104.1264 
-L 501.217031 74.7432 
-L 396.592031 74.7432 
+    <path d="M 393.741172 104.1264 
+L 498.366172 104.1264 
+L 498.366172 74.7432 
+L 393.741172 74.7432 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.342031 133.5096 
-L 291.967031 133.5096 
-L 291.967031 104.1264 
-L 187.342031 104.1264 
+    <path d="M 184.491172 133.5096 
+L 289.116172 133.5096 
+L 289.116172 104.1264 
+L 184.491172 104.1264 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.967031 133.5096 
-L 396.592031 133.5096 
-L 396.592031 104.1264 
-L 291.967031 104.1264 
+    <path d="M 289.116172 133.5096 
+L 393.741172 133.5096 
+L 393.741172 104.1264 
+L 289.116172 104.1264 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.592031 133.5096 
-L 501.217031 133.5096 
-L 501.217031 104.1264 
-L 396.592031 104.1264 
+    <path d="M 393.741172 133.5096 
+L 498.366172 133.5096 
+L 498.366172 104.1264 
+L 393.741172 104.1264 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fdaf62; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #fdaf62; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.342031 162.8928 
-L 291.967031 162.8928 
-L 291.967031 133.5096 
-L 187.342031 133.5096 
+    <path d="M 184.491172 162.8928 
+L 289.116172 162.8928 
+L 289.116172 133.5096 
+L 184.491172 133.5096 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.967031 162.8928 
-L 396.592031 162.8928 
-L 396.592031 133.5096 
-L 291.967031 133.5096 
+    <path d="M 289.116172 162.8928 
+L 393.741172 162.8928 
+L 393.741172 133.5096 
+L 289.116172 133.5096 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #feda86; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #feda86; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.592031 162.8928 
-L 501.217031 162.8928 
-L 501.217031 133.5096 
-L 396.592031 133.5096 
+    <path d="M 393.741172 162.8928 
+L 498.366172 162.8928 
+L 498.366172 133.5096 
+L 393.741172 133.5096 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #c5e67e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #c5e67e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.342031 192.276 
-L 291.967031 192.276 
-L 291.967031 162.8928 
-L 187.342031 162.8928 
+    <path d="M 184.491172 192.276 
+L 289.116172 192.276 
+L 289.116172 162.8928 
+L 184.491172 162.8928 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.967031 192.276 
-L 396.592031 192.276 
-L 396.592031 162.8928 
-L 291.967031 162.8928 
+    <path d="M 289.116172 192.276 
+L 393.741172 192.276 
+L 393.741172 162.8928 
+L 289.116172 162.8928 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.592031 192.276 
-L 501.217031 192.276 
-L 501.217031 162.8928 
-L 396.592031 162.8928 
+    <path d="M 393.741172 192.276 
+L 498.366172 192.276 
+L 498.366172 162.8928 
+L 393.741172 162.8928 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #b7e075; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #b7e075; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.342031 221.6592 
-L 291.967031 221.6592 
-L 291.967031 192.276 
-L 187.342031 192.276 
+    <path d="M 184.491172 221.6592 
+L 289.116172 221.6592 
+L 289.116172 192.276 
+L 184.491172 192.276 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.967031 221.6592 
-L 396.592031 221.6592 
-L 396.592031 192.276 
-L 291.967031 192.276 
+    <path d="M 289.116172 221.6592 
+L 393.741172 221.6592 
+L 393.741172 192.276 
+L 289.116172 192.276 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.592031 221.6592 
-L 501.217031 221.6592 
-L 501.217031 192.276 
-L 396.592031 192.276 
+    <path d="M 393.741172 221.6592 
+L 498.366172 221.6592 
+L 498.366172 192.276 
+L 393.741172 192.276 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.342031 251.0424 
-L 291.967031 251.0424 
-L 291.967031 221.6592 
-L 187.342031 221.6592 
+    <path d="M 184.491172 251.0424 
+L 289.116172 251.0424 
+L 289.116172 221.6592 
+L 184.491172 221.6592 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.967031 251.0424 
-L 396.592031 251.0424 
-L 396.592031 221.6592 
-L 291.967031 221.6592 
+    <path d="M 289.116172 251.0424 
+L 393.741172 251.0424 
+L 393.741172 221.6592 
+L 289.116172 221.6592 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fdad60; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #fdad60; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.592031 251.0424 
-L 501.217031 251.0424 
-L 501.217031 221.6592 
-L 396.592031 221.6592 
+    <path d="M 393.741172 251.0424 
+L 498.366172 251.0424 
+L 498.366172 221.6592 
+L 393.741172 221.6592 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fa9656; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.342031 280.4256 
-L 291.967031 280.4256 
-L 291.967031 251.0424 
-L 187.342031 251.0424 
+    <path d="M 184.491172 280.4256 
+L 289.116172 280.4256 
+L 289.116172 251.0424 
+L 184.491172 251.0424 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.967031 280.4256 
-L 396.592031 280.4256 
-L 396.592031 251.0424 
-L 291.967031 251.0424 
+    <path d="M 289.116172 280.4256 
+L 393.741172 280.4256 
+L 393.741172 251.0424 
+L 289.116172 251.0424 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.592031 280.4256 
-L 501.217031 280.4256 
-L 501.217031 251.0424 
-L 396.592031 251.0424 
+    <path d="M 393.741172 280.4256 
+L 498.366172 280.4256 
+L 498.366172 251.0424 
+L 393.741172 251.0424 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.342031 309.8088 
-L 291.967031 309.8088 
-L 291.967031 280.4256 
-L 187.342031 280.4256 
+    <path d="M 184.491172 309.8088 
+L 289.116172 309.8088 
+L 289.116172 280.4256 
+L 184.491172 280.4256 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.967031 309.8088 
-L 396.592031 309.8088 
-L 396.592031 280.4256 
-L 291.967031 280.4256 
+    <path d="M 289.116172 309.8088 
+L 393.741172 309.8088 
+L 393.741172 280.4256 
+L 289.116172 280.4256 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #f26841; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #ed5f3c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.592031 309.8088 
-L 501.217031 309.8088 
-L 501.217031 280.4256 
-L 396.592031 280.4256 
+    <path d="M 393.741172 309.8088 
+L 498.366172 309.8088 
+L 498.366172 280.4256 
+L 393.741172 280.4256 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.342031 339.192 
-L 291.967031 339.192 
-L 291.967031 309.8088 
-L 187.342031 309.8088 
+    <path d="M 184.491172 339.192 
+L 289.116172 339.192 
+L 289.116172 309.8088 
+L 184.491172 309.8088 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.967031 339.192 
-L 396.592031 339.192 
-L 396.592031 309.8088 
-L 291.967031 309.8088 
+    <path d="M 289.116172 339.192 
+L 393.741172 339.192 
+L 393.741172 309.8088 
+L 289.116172 309.8088 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.592031 339.192 
-L 501.217031 339.192 
-L 501.217031 309.8088 
-L 396.592031 309.8088 
+    <path d="M 393.741172 339.192 
+L 498.366172 339.192 
+L 498.366172 309.8088 
+L 393.741172 309.8088 
 z
-" clip-path="url(#p8510d300a8)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6a1a8887d1)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.329297 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(117.478438 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.613516 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(224.762656 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.185625 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(303.334766 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.537344 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(401.686484 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.267031 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(113.416172 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.203281 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -945,8 +945,8 @@ z
     </g>
    </g>
    <g id="text_7">
-    <!-- 159 -->
-    <g transform="translate(336.644531 91.6423) scale(0.08 -0.08)">
+    <!-- 158 -->
+    <g transform="translate(333.793672 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -987,23 +987,62 @@ Q 953 2441 691 2322
 L 691 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_8">
-    <!-- 962 -->
-    <g transform="translate(441.269531 91.6423) scale(0.08 -0.08)">
+    <!-- 958 -->
+    <g transform="translate(438.418672 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.905156 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(108.054297 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1102,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.203281 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1111,8 +1150,8 @@ z
     </g>
    </g>
    <g id="text_11">
-    <!-- 73 -->
-    <g transform="translate(339.189531 121.0255) scale(0.08 -0.08)">
+    <!-- 72 -->
+    <g transform="translate(336.338672 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1124,87 +1163,14 @@ L 525 4134
 L 525 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_12">
     <!-- 282 -->
-    <g transform="translate(441.269531 121.0255) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(438.418672 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1212,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.168281 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(125.317422 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1236,7 +1202,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.203281 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1246,7 +1212,7 @@ z
    </g>
    <g id="text_15">
     <!-- 54 -->
-    <g transform="translate(339.189531 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(336.338672 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1273,16 +1239,16 @@ z
     </g>
    </g>
    <g id="text_16">
-    <!-- 698 -->
-    <g transform="translate(441.269531 150.4087) scale(0.08 -0.08)">
+    <!-- 697 -->
+    <g transform="translate(438.418672 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.474531 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(108.623672 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1392,7 +1358,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.203281 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1402,22 +1368,22 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.189531 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(336.338672 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 736 -->
-    <g transform="translate(441.269531 179.7919) scale(0.08 -0.08)">
+    <!-- 729 -->
+    <g transform="translate(438.418672 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.630781 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(116.779922 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1477,7 +1443,41 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.203281 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 209.1751) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1487,22 +1487,22 @@ z
    </g>
    <g id="text_23">
     <!-- 47 -->
-    <g transform="translate(339.189531 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(336.338672 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 151 -->
-    <g transform="translate(441.269531 209.1751) scale(0.08 -0.08)">
+    <!-- 154 -->
+    <g transform="translate(438.418672 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- Go compress/flate -->
-    <g transform="translate(98.598281 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(95.747422 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1622,7 +1622,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.299 -->
-    <g transform="translate(228.203281 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1632,22 +1632,22 @@ z
    </g>
    <g id="text_27">
     <!-- 34 -->
-    <g transform="translate(339.189531 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(336.338672 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 235 -->
-    <g transform="translate(441.269531 238.5583) scale(0.08 -0.08)">
+    <!-- 227 -->
+    <g transform="translate(438.418672 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.091406 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(93.240547 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1712,7 +1712,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(228.203281 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1722,22 +1722,22 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(339.189531 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(336.338672 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 117 -->
-    <g transform="translate(441.269531 267.9415) scale(0.08 -0.08)">
+    <!-- 116 -->
+    <g transform="translate(438.418672 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.976406 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.125547 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1845,8 +1845,8 @@ z
     </g>
    </g>
    <g id="text_34">
-    <!-- 0.311 -->
-    <g transform="translate(227.002656 297.3247) scale(0.08 -0.08)">
+    <!-- 0.302 -->
+    <g transform="translate(224.151797 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1908,38 +1908,57 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-30"/>
      <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(246.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(246.728516 0)"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 10 -->
-    <g transform="translate(338.713281 297.3247) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+    <!-- 7 -->
+    <g transform="translate(338.645547 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-37"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 92 -->
-    <g transform="translate(443.338281 297.3247) scale(0.08 -0.08)">
+    <!-- 93 -->
+    <g transform="translate(440.487422 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1971,36 +1990,14 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-32" d="M 1844 884 
-L 3897 884 
-L 3897 0 
-L 506 0 
-L 506 884 
-L 2209 2388 
-Q 2438 2594 2547 2791 
-Q 2656 2988 2656 3200 
-Q 2656 3528 2436 3728 
-Q 2216 3928 1850 3928 
-Q 1569 3928 1234 3808 
-Q 900 3688 519 3450 
-L 519 4475 
-Q 925 4609 1322 4679 
-Q 1719 4750 2100 4750 
-Q 2938 4750 3402 4381 
-Q 3866 4013 3866 3353 
-Q 3866 2972 3669 2642 
-Q 3472 2313 2841 1759 
-L 1844 884 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-39"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.312656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(121.461797 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2011,7 +2008,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.203281 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2021,13 +2018,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.734531 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(338.883672 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.904531 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(442.053672 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2043,7 +2040,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.725781 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(131.874922 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2256,7 +2253,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-09T02:28:37Z  ·  Linux chungus x86_64  ·  commit 13e61c48  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2394,17 +2391,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2443,110 +2440,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3442.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3506.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3538.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3570.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.429688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3693.212891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3816.015625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3879.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.734375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.916016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4102.095703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.619141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4266.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4389.009766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4452.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4516.011719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.882812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.505859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4704.292969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.916016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.539062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4863.326172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4963.033203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.896484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5120.5 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5152.287109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5184.074219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.861328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.648438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5279.435547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5382.023438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.886719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5482.068359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5545.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.923828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5672.302734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.779297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5799.158203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5838.367188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.730469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6083.142578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6208.142578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.583984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6392.371094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.470703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6569.128906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.605469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6748.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6809.265625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6882.166016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.953125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6955.066406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7016.345703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.337891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7144.519531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7176.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7204.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7256.189453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7351.453125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7452.185547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7553.072266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7650.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.267578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.646484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7769.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7821.529297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.738281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7888.521484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8510d300a8">
-   <rect x="82.717031" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p6a1a8887d1">
+   <rect x="79.866172" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 47.90175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pe0b99b2bb8)">
+   <g clip-path="url(#p13ee7ccf25)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAFrCAYAAAAO+zsvAAAJAklEQVR4nO3YTYql5R2HYavq1FdT9BfxAxociQ4yCuLUqVO34QrcQAZuwAW4BEFw7sCJAyXTIN2ahARjg3Y63dWnyjouQp773xyuawU/eL/u9zm4efzZ7pV9tn02vWCtg8PpBWvdXE8vWGvfr9/1dnrBWrfuTi9Y68XT6QX8EUcn0wvW2vf78/hsesFSe/71AwDgZSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFKbb64eTm9Y6vbp+fSEpZ5sn09PWOqNi9enJyz14//+NT1hqcOj/f7Hfevs7vSEpa5OT6YnLPXDk39MT1jqwfl+vz//v3kxPWGpzeH19ISl9vvrAADAS0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQ2Dy4eTG9Y6vXzN6cnLPWfZ4+mJyz14PlmesJSF/f/PD1hqZOjs+kJS+12N9MTlnr18GJ6wlLHd06mJyx19/S16QlLPf/t6fSEpW7f7Pf96QQUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBIbU4Oz6Y3LPXr9ufpCUudby6mJyx1df/+9ISlfnryt+kJSz3ZPp+esNR7996bnrDU5Svb6QlL/fPpj9MTlrpz+qfpCUt9+9O30xOWeve1d6cnLOUEFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASB3c++SD3fSIlY6Oj6YnLPXz3x9PT1jq04/+Mj1hqb9+/e/pCUu9/+bd6QlLff7Vw+kJS3384TvTE5b64vtfpycs9da98+kJSz385XJ6wlIfvn1nesJSTkABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgcvrr/cTY9Y6fj6enrCWsdn0wvW2j6bXrDWya3pBWsd7Pk/7u5mesFaV5fTC9ba9/vzcDO9YKntwX5/30+u9/v9sudPHwAALxsBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDabB59N71hqd3NbnrCUgenp9MTltr99/H0hLXu35lesNbNzfSCta5/m16w1vZqesFaF7emF6x1+WJ6wVLHh/t9hrbb8+dvv68eAAAvHQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkPodtQ5yOMaK1JEAAAAASUVORK5CYII=" id="image98ddf4be0e" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="483.84" height="261.36"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAFrCAYAAAAO+zsvAAAI8klEQVR4nO3YPY5k5RmGYXdP9Y97EMNPC1tAAoETJCMW4JDAkTdCzhII2IEzS96DSYjtzJYtWSIACYMsI4ZgrKaZqampZhGj735HR9e1gufonDrnru/k+MOf7n6xZfvb6QVrnZxOL1jreJhewPN4tvH7d/XK9IK1ntxML+B5nO6mF6y19e/72eX0gqU2Xi8AALxoBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAavev47fTG5Y6v9hNT1jqZv94esJSb7389vSEpb65+WZ6wlKPj0+nJyz13tX19ISlHl+cT09Y6uv/b/v399bVr6YnLLW/OE5PWGp3epiesJQTUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILV74+rN6Q1LXV9u+/r+++NX0xOW+vXt9IK1rl59b3rCUvdOdtMTlnp2d5iesNSb916bnrDU2YPz6QlLPbi4np6w1NPjfnrCUvefbfuMcNtXBwDAC0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKR290520xuWerR/OD1hqftnL09PWOr40hvTE5b67tE/picsdfv0yfSEpd5/8MH0hKX2p8fpCUt9e/Of6QlLPbi4np6w1D8f/n16wlK/vd72+8UJKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkDp5/dPf302PWOl0t+3G/v6Lh9MTlvrjRx9MT1jqk79+Nz1hqQ/ffW16wlJ//vzL6QlLffyH30xPWOqzrx5NT1jqnVd+OT1hqf/d7KcnLPW7t+9PT1hq23UGAMALR4ACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJA6eXL4y930iJXODofpCWudXU4vWGt/O71grfOr6QVrnWz8P+7dcXrBWof99IK1tv58bvz69ifb/r6fH7b9ftn20wkAwAtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkdrt//216w1J3h2fTE9ba3ZtesNbt4+kFa11dTi/geWz9/XI8Ti9Y6/JiesFa+6fTC5Y6Oz+bnrDU3e1P0xOWcgIKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkfgYqq3IH+y5bzAAAAABJRU5ErkJggg==" id="image5e6c7ce4ae" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="483.84" height="261.36"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m43a3197e14" d="M 0 0 
+       <path id="m5fd7607b96" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m43a3197e14" x="115.814949" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="115.814949" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m43a3197e14" x="156.092348" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="156.092348" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m43a3197e14" x="196.369746" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="196.369746" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m43a3197e14" x="236.647145" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="236.647145" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m43a3197e14" x="276.924544" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="276.924544" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m43a3197e14" x="317.201942" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="317.201942" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m43a3197e14" x="357.479341" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="357.479341" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m43a3197e14" x="397.756739" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="397.756739" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m43a3197e14" x="438.034138" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="438.034138" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m43a3197e14" x="478.311536" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="478.311536" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m43a3197e14" x="518.588935" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="518.588935" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m43a3197e14" x="558.866334" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5fd7607b96" x="558.866334" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="md1faeaec36" d="M 0 0 
+       <path id="m8f260b4034" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md1faeaec36" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f260b4034" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md1faeaec36" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f260b4034" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md1faeaec36" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f260b4034" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md1faeaec36" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f260b4034" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -881,7 +881,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md1faeaec36" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f260b4034" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -948,7 +948,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md1faeaec36" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f260b4034" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1029,7 +1029,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md1faeaec36" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f260b4034" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1120,82 +1120,19 @@ L 579.005033 47.90175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -65 -->
+    <!-- -78 -->
     <g transform="translate(110.506785 68.352934) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- -66 -->
-    <g transform="translate(150.784184 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -58 -->
-    <g transform="translate(191.061582 68.352934) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1237,13 +1174,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_23">
+   <g id="text_21">
     <!-- -82 -->
-    <g transform="translate(231.338981 68.352934) scale(0.065 -0.065)">
+    <g transform="translate(150.784184 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1275,25 +1212,17 @@ z
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- -62 -->
-    <g transform="translate(271.616379 68.352934) scale(0.065 -0.065)">
+   <g id="text_22">
+    <!-- -78 -->
+    <g transform="translate(191.061582 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- -65 -->
-    <g transform="translate(311.893778 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -69 -->
-    <g transform="translate(352.171177 68.352934) scale(0.065 -0.065)">
+   <g id="text_23">
+    <!-- -90 -->
+    <g transform="translate(231.338981 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1325,43 +1254,84 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- -75 -->
-    <g transform="translate(392.448575 68.352934) scale(0.065 -0.065)">
+   <g id="text_24">
+    <!-- -76 -->
+    <g transform="translate(271.616379 68.352934) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- -62 -->
-    <g transform="translate(432.725974 68.352934) scale(0.065 -0.065)">
+   <g id="text_25">
+    <!-- -76 -->
+    <g transform="translate(311.893778 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- -73 -->
-    <g transform="translate(473.003372 68.352934) scale(0.065 -0.065)">
+   <g id="text_26">
+    <!-- -83 -->
+    <g transform="translate(352.171177 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1397,46 +1367,74 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- -70 -->
-    <g transform="translate(513.280771 68.352934) scale(0.065 -0.065)">
+   <g id="text_27">
+    <!-- -85 -->
+    <g transform="translate(392.448575 68.352934) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -75 -->
+    <g transform="translate(432.725974 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -83 -->
+    <g transform="translate(473.003372 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -75 -->
+    <g transform="translate(513.280771 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- -77 -->
+    <!-- -87 -->
     <g transform="translate(553.558169 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
@@ -1465,7 +1463,7 @@ z
     </g>
    </g>
    <g id="text_33">
-    <!-- -14 -->
+    <!-- -13 -->
     <g transform="translate(150.784184 105.668114) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
@@ -1482,6 +1480,31 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -5 -->
+    <g transform="translate(193.129395 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -16 -->
+    <g transform="translate(231.338981 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -4 -->
+    <g transform="translate(273.684192 105.668114) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
 L 2419 1625 
@@ -1503,29 +1526,6 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -4 -->
-    <g transform="translate(193.129395 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -15 -->
-    <g transform="translate(231.338981 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -4 -->
-    <g transform="translate(273.684192 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
@@ -1537,10 +1537,10 @@ z
     </g>
    </g>
    <g id="text_38">
-    <!-- -4 -->
+    <!-- -3 -->
     <g transform="translate(354.238989 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_39">
@@ -1559,18 +1559,18 @@ z
     </g>
    </g>
    <g id="text_41">
-    <!-- -6 -->
+    <!-- -5 -->
     <g transform="translate(475.071185 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- +11 -->
+    <!-- +10 -->
     <g transform="translate(511.729912 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_43">
@@ -1591,66 +1591,66 @@ z
     </g>
    </g>
    <g id="text_45">
-    <!-- +251 -->
+    <!-- +253 -->
     <g transform="translate(147.165512 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- +300 -->
+    <!-- +304 -->
     <g transform="translate(187.44291 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_47">
-    <!-- +135 -->
+    <!-- +132 -->
     <g transform="translate(227.720309 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_48">
-    <!-- +239 -->
+    <!-- +236 -->
     <g transform="translate(267.997708 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +190 -->
+    <!-- +182 -->
     <g transform="translate(308.275106 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +279 -->
+    <!-- +280 -->
     <g transform="translate(348.552505 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +156 -->
+    <!-- +155 -->
     <g transform="translate(388.829903 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
@@ -1672,29 +1672,29 @@ z
     </g>
    </g>
    <g id="text_54">
-    <!-- +216 -->
+    <!-- +210 -->
     <g transform="translate(509.662099 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_55">
-    <!-- +148 -->
+    <!-- +159 -->
     <g transform="translate(549.939498 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_56">
-    <!-- +32 -->
+    <!-- +33 -->
     <g transform="translate(108.955926 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_57">
@@ -1706,34 +1706,34 @@ z
     </g>
    </g>
    <g id="text_58">
-    <!-- +28 -->
+    <!-- +29 -->
     <g transform="translate(189.510723 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_59">
-    <!-- +9 -->
+    <!-- +5 -->
     <g transform="translate(231.855934 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_60">
-    <!-- +62 -->
+    <!-- +60 -->
     <g transform="translate(270.06552 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_61">
-    <!-- +78 -->
+    <!-- +72 -->
     <g transform="translate(310.342919 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_62">
@@ -1745,51 +1745,51 @@ z
     </g>
    </g>
    <g id="text_63">
-    <!-- +12 -->
+    <!-- +11 -->
     <g transform="translate(390.897716 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_64">
-    <!-- +73 -->
+    <!-- +75 -->
     <g transform="translate(431.175114 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_65">
-    <!-- +11 -->
+    <!-- +10 -->
     <g transform="translate(471.452513 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_66">
-    <!-- +90 -->
-    <g transform="translate(511.729912 180.298474) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_66">
+    <!-- +85 -->
+    <g transform="translate(511.729912 180.298474) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_67">
-    <!-- +19 -->
+    <!-- +17 -->
     <g transform="translate(552.00731 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_68">
-    <!-- +41 -->
+    <!-- +37 -->
     <g transform="translate(108.955926 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_69">
@@ -1800,11 +1800,11 @@ z
     </g>
    </g>
    <g id="text_70">
-    <!-- +43 -->
+    <!-- +46 -->
     <g transform="translate(189.510723 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
@@ -1816,11 +1816,11 @@ z
     </g>
    </g>
    <g id="text_72">
-    <!-- +26 -->
+    <!-- +23 -->
     <g transform="translate(270.06552 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_73">
@@ -1832,18 +1832,18 @@ z
     </g>
    </g>
    <g id="text_74">
-    <!-- +20 -->
+    <!-- +22 -->
     <g transform="translate(350.620317 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_75">
-    <!-- -5 -->
+    <!-- -9 -->
     <g transform="translate(394.516388 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_76">
@@ -1855,34 +1855,35 @@ z
     </g>
    </g>
    <g id="text_77">
-    <!-- +9 -->
-    <g transform="translate(473.520325 217.613655) scale(0.065 -0.065)">
+    <!-- +11 -->
+    <g transform="translate(471.452513 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_78">
-    <!-- +22 -->
+    <!-- +19 -->
     <g transform="translate(511.729912 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_79">
-    <!-- -15 -->
+    <!-- -16 -->
     <g transform="translate(553.558169 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_80">
-    <!-- +78 -->
+    <!-- +71 -->
     <g transform="translate(108.955926 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_81">
@@ -1902,35 +1903,35 @@ z
     </g>
    </g>
    <g id="text_83">
-    <!-- +45 -->
+    <!-- +40 -->
     <g transform="translate(229.788122 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_84">
-    <!-- +86 -->
+    <!-- +80 -->
     <g transform="translate(270.06552 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_85">
-    <!-- +84 -->
+    <!-- +89 -->
     <g transform="translate(310.342919 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_86">
-    <!-- +34 -->
+    <!-- +31 -->
     <g transform="translate(350.620317 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_87">
@@ -1942,43 +1943,43 @@ z
     </g>
    </g>
    <g id="text_88">
-    <!-- +82 -->
+    <!-- +84 -->
     <g transform="translate(431.175114 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_89">
-    <!-- +48 -->
-    <g transform="translate(471.452513 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_90">
-    <!-- +64 -->
-    <g transform="translate(511.729912 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_91">
+   <g id="text_89">
+    <!-- +49 -->
+    <g transform="translate(471.452513 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_90">
     <!-- +59 -->
-    <g transform="translate(552.00731 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(511.729912 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_91">
+    <!-- +51 -->
+    <g transform="translate(552.00731 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_92">
-    <!-- -33 -->
+    <!-- -35 -->
     <g transform="translate(110.506785 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_93">
@@ -2006,27 +2007,27 @@ z
     </g>
    </g>
    <g id="text_96">
-    <!-- -47 -->
+    <!-- -48 -->
     <g transform="translate(271.616379 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_97">
-    <!-- -53 -->
+    <!-- -54 -->
     <g transform="translate(311.893778 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_98">
-    <!-- -34 -->
+    <!-- -33 -->
     <g transform="translate(352.171177 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_99">
@@ -2046,27 +2047,27 @@ z
     </g>
    </g>
    <g id="text_101">
-    <!-- -41 -->
+    <!-- -43 -->
     <g transform="translate(473.003372 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_102">
-    <!-- -55 -->
+    <!-- -56 -->
     <g transform="translate(513.280771 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_103">
-    <!-- -45 -->
+    <!-- -46 -->
     <g transform="translate(553.558169 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2080,23 +2081,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB10lEQVR4nO2b223EMAwEKVu1pPOUeVZKoD8GwRyxLGDhHXIp3cPrt35OAXURIlVV+4KkfEJGRosRMlqzCYVRX0JGazEZEVrTCYVRX4MZgdagc200I84aQ3uv27ZqF2YNEgKtQbBBRrr2c5M9l9GC9ojSWtrfVCLSl88aFlohoyvt74V0t5GyWdt12yJStjkSWtPNERkR6qJlgz14jQit1dwLe9ZIW9wa8aVft9iwgRR+7YOtER8j0NrYO2QYvREKo17IZ426H0G/HE9mNHqOBltL+5sKo752LYoRJGRs/2BGmDUbbCMjm5Awa2vdiFDa35ew/ZMZ2Vat0ZpNSMjoUH+sPOdBhDhGD/RE+1SsdULUE3GMqIHcD8UoEWlLae3DCCUivVAi0tZga4nICyFjRJBXjo3t56wVxogREq4RcI7CqCnQGjfZcxnZJnv0quV2dhg1pbSWNfJvQh9Gx8jIaA0S+nBzhOiAjKiu+WCDc8QsyETkjdDoiGTVdkJCa5A336pNRPoiGVHWoONIaQ1rv+0SQXXNB1s5R4iO0trk9lNCk9fI3APS1jVl+ymhyWuE+ihKwT46RtQTGa1R7Z/MyGYtjPoyWrNlzcjIJjSYkdFaIvJ9QhijP3Z3X2u76gsSAAAAAElFTkSuQmCC" id="imaged01f69c3e7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-51.12" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB10lEQVR4nO2b223EMAwEKVu1pPOUeVZKoD8GwRyxLGDhHXIp3cPrt35OAXURIlVV+4KkfEJGRosRMlqzCYVRX0JGazEZEVrTCYVRX4MZgdagc200I84aQ3uv27ZqF2YNEgKtQbBBRrr2c5M9l9GC9ojSWtrfVCLSl88aFlohoyvt74V0t5GyWdt12yJStjkSWtPNERkR6qJlgz14jQit1dwLe9ZIW9wa8aVft9iwgRR+7YOtER8j0NrYO2QYvREKo17IZ426H0G/HE9mNHqOBltL+5sKo752LYoRJGRs/2BGmDUbbCMjm5Awa2vdiFDa35ew/ZMZ2Vat0ZpNSMjoUH+sPOdBhDhGD/RE+1SsdULUE3GMqIHcD8UoEWlLae3DCCUivVAi0tZga4nICyFjRJBXjo3t56wVxogREq4RcI7CqCnQGjfZcxnZJnv0quV2dhg1pbSWNfJvQh9Gx8jIaA0S+nBzhOiAjKiu+WCDc8QsyETkjdDoiGTVdkJCa5A336pNRPoiGVHWoONIaQ1rv+0SQXXNB1s5R4iO0trk9lNCk9fI3APS1jVl+ymhyWuE+ihKwT46RtQTGa1R7Z/MyGYtjPoyWrNlzcjIJjSYkdFaIvJ9QhijP3Z3X2u76gsSAAAAAElFTkSuQmCC" id="imagecda760947f" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-51.12" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_20">
       <defs>
-       <path id="mee03510140" d="M 0 0 
+       <path id="m40b64c4be4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mee03510140" x="601.779688" y="262.99477" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40b64c4be4" x="601.779688" y="303.401516" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_104">
-      <!-- −2 -->
-      <g transform="translate(608.779688 266.793989) scale(0.1 -0.1)">
+      <!-- −3 -->
+      <g transform="translate(608.779688 307.200735) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2107,64 +2108,91 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mee03510140" x="601.779688" y="220.749825" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40b64c4be4" x="601.779688" y="261.769304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_105">
-      <!-- −1 -->
-      <g transform="translate(608.779688 224.549044) scale(0.1 -0.1)">
+      <!-- −2 -->
+      <g transform="translate(608.779688 265.568523) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mee03510140" x="601.779688" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40b64c4be4" x="601.779688" y="220.137093" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_106">
-      <!-- 0 -->
-      <g transform="translate(608.779688 182.304099) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
+      <!-- −1 -->
+      <g transform="translate(608.779688 223.936311) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mee03510140" x="601.779688" y="136.259936" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40b64c4be4" x="601.779688" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_107">
-      <!-- 1 -->
-      <g transform="translate(608.779688 140.059155) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-31"/>
+      <!-- 0 -->
+      <g transform="translate(608.779688 182.304099) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mee03510140" x="601.779688" y="94.014992" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m40b64c4be4" x="601.779688" y="136.872669" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
+      <!-- 1 -->
+      <g transform="translate(608.779688 140.671888) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m40b64c4be4" x="601.779688" y="95.240457" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_109">
       <!-- 2 -->
-      <g transform="translate(608.779688 97.81421) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 99.039676) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
     </g>
-    <g id="text_109">
+    <g id="ytick_14">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m40b64c4be4" x="601.779688" y="53.608245" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_110">
+      <!-- 3 -->
+      <g transform="translate(608.779688 57.407464) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_111">
      <!-- % vs zlib (higher=faster) -->
      <g transform="translate(635.120313 240.808787) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -2289,7 +2317,7 @@ z
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
-  <g id="text_110">
+  <g id="text_112">
    <!-- Compression speed vs zlib  (silesia, level 6, relative to zlib) -->
    <g transform="translate(122.993437 16.462125) scale(0.12 -0.12)">
     <defs>
@@ -2769,9 +2797,9 @@ z
     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3304.394531 0)"/>
    </g>
   </g>
-  <g id="text_111">
-   <!-- 2026-06-09T02:28:37Z  ·  Linux chungus x86_64  ·  commit 13e61c48  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.982969 365.364) scale(0.07 -0.07)">
+  <g id="text_113">
+   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(48.833828 365.364) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2859,17 +2887,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2908,109 +2936,108 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3442.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3506.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3538.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3570.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.429688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3693.212891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3816.015625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3879.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.734375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.916016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4102.095703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.619141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4266.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4389.009766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4452.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4516.011719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.882812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.505859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4704.292969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.916016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.539062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4863.326172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4963.033203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.896484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5120.5 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5152.287109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5184.074219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.861328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.648438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5279.435547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5382.023438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.886719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5482.068359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5545.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.923828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5672.302734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.779297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5799.158203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5838.367188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.730469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6083.142578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6208.142578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.583984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6392.371094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.470703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6569.128906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.605469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6748.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6809.265625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6882.166016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.953125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6955.066406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7016.345703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.337891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7144.519531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7176.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7204.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7256.189453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7351.453125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7452.185547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7553.072266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7650.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.267578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.646484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7769.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7821.529297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.738281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7888.521484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe0b99b2bb8">
+  <clipPath id="p13ee7ccf25">
    <rect x="95.67625" y="47.90175" width="483.328783" height="261.206261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 100.798569 412.80375 
 L 100.798569 48.323125 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m5378db4873" d="M 0 0 
+       <path id="m2dc11e37be" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5378db4873" x="100.798569" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2dc11e37be" x="100.798569" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -154,11 +154,11 @@ z
      <g id="line2d_3">
       <path d="M 193.031172 412.80375 
 L 193.031172 48.323125 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5378db4873" x="193.031172" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2dc11e37be" x="193.031172" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -196,11 +196,11 @@ z
      <g id="line2d_5">
       <path d="M 285.263775 412.80375 
 L 285.263775 48.323125 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5378db4873" x="285.263775" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2dc11e37be" x="285.263775" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -249,11 +249,11 @@ z
      <g id="line2d_7">
       <path d="M 377.496378 412.80375 
 L 377.496378 48.323125 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5378db4873" x="377.496378" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2dc11e37be" x="377.496378" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -311,11 +311,11 @@ z
      <g id="line2d_9">
       <path d="M 469.72898 412.80375 
 L 469.72898 48.323125 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5378db4873" x="469.72898" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2dc11e37be" x="469.72898" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ L 469.72898 48.323125
      <g id="line2d_11">
       <path d="M 561.961583 412.80375 
 L 561.961583 48.323125 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5378db4873" x="561.961583" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2dc11e37be" x="561.961583" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -831,23 +831,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_13">
-      <path d="M 49.078125 383.731944 
-L 637.2 383.731944 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 275.17508 
+L 637.2 275.17508 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <defs>
-       <path id="m8f72930ae0" d="M 0 0 
+       <path id="mdfdb3c54cb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8f72930ae0" x="49.078125" y="383.731944" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfdb3c54cb" x="49.078125" y="275.17508" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 387.531163) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 278.974298) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -872,18 +872,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_15">
-      <path d="M 49.078125 161.329109 
-L 637.2 161.329109 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 128.33751 
+L 637.2 128.33751 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m8f72930ae0" x="49.078125" y="161.329109" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfdb3c54cb" x="49.078125" y="128.33751" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 165.128328) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 132.136729) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -892,150 +892,222 @@ L 637.2 161.329109
     </g>
     <g id="ytick_3">
      <g id="line2d_17">
-      <path d="M 49.078125 405.285006 
-L 637.2 405.285006 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 377.810136 
+L 637.2 377.810136 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <defs>
-       <path id="m078b80addc" d="M 0 0 
+       <path id="m809a69971e" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="405.285006" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="377.810136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_19">
-      <path d="M 49.078125 393.90854 
-L 637.2 393.90854 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 351.953324 
+L 637.2 351.953324 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="393.90854" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="351.953324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_21">
-      <path d="M 49.078125 316.78202 
-L 637.2 316.78202 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 333.607623 
+L 637.2 333.607623 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="316.78202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="333.607623" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_23">
-      <path d="M 49.078125 277.618825 
-L 637.2 277.618825 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 319.377593 
+L 637.2 319.377593 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="277.618825" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="319.377593" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_25">
-      <path d="M 49.078125 249.832095 
-L 637.2 249.832095 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 307.750811 
+L 637.2 307.750811 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="249.832095" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="307.750811" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_27">
-      <path d="M 49.078125 228.279034 
-L 637.2 228.279034 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 297.920507 
+L 637.2 297.920507 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="228.279034" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="297.920507" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_29">
-      <path d="M 49.078125 210.6689 
-L 637.2 210.6689 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 289.405111 
+L 637.2 289.405111 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="210.6689" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="289.405111" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_31">
-      <path d="M 49.078125 195.779744 
-L 637.2 195.779744 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 281.893998 
+L 637.2 281.893998 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="195.779744" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="281.893998" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_33">
-      <path d="M 49.078125 182.882171 
-L 637.2 182.882171 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 230.972567 
+L 637.2 230.972567 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="182.882171" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="230.972567" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_35">
-      <path d="M 49.078125 171.505705 
-L 637.2 171.505705 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.115754 
+L 637.2 205.115754 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="171.505705" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="205.115754" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_37">
-      <path d="M 49.078125 94.379185 
-L 637.2 94.379185 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 186.770054 
+L 637.2 186.770054 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="94.379185" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="186.770054" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_39">
-      <path d="M 49.078125 55.215989 
-L 637.2 55.215989 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 172.540023 
+L 637.2 172.540023 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m078b80addc" x="49.078125" y="55.215989" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m809a69971e" x="49.078125" y="172.540023" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_41">
+      <path d="M 49.078125 160.913241 
+L 637.2 160.913241 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m809a69971e" x="49.078125" y="160.913241" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_43">
+      <path d="M 49.078125 151.082938 
+L 637.2 151.082938 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m809a69971e" x="49.078125" y="151.082938" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_45">
+      <path d="M 49.078125 142.567541 
+L 637.2 142.567541 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m809a69971e" x="49.078125" y="142.567541" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_47">
+      <path d="M 49.078125 135.056429 
+L 637.2 135.056429 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m809a69971e" x="49.078125" y="135.056429" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_49">
+      <path d="M 49.078125 84.134997 
+L 637.2 84.134997 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m809a69971e" x="49.078125" y="84.134997" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_51">
+      <path d="M 49.078125 58.278185 
+L 637.2 58.278185 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m809a69971e" x="49.078125" y="58.278185" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1157,7 +1229,7 @@ L 637.2 48.323125
    </g>
    <g id="text_11">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(472.789269 318.933816) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(472.789269 230.426768) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1189,7 +1261,7 @@ z
    </g>
    <g id="text_12">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(323.19509 391.236449) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(121.602636 391.236449) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1517,111 +1589,111 @@ z
      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1145.849609 0)"/>
     </g>
    </g>
-   <g id="line2d_41">
-    <path d="M 354.801917 135.6841 
-L 296.396877 145.820388 
-L 240.372732 174.410861 
-L 199.2912 178.416925 
-L 145.672036 216.419317 
-L 115.077361 255.748648 
-L 105.421184 274.809337 
-L 95.641458 310.838082 
-L 93.912266 323.138705 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_53">
+    <path d="M 354.801917 111.776119 
+L 296.396877 118.38239 
+L 240.372732 137.302009 
+L 199.2912 139.4363 
+L 145.672036 164.396936 
+L 115.077361 190.555326 
+L 105.421184 203.209875 
+L 95.641458 227.103078 
+L 93.912266 235.121278 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m3831108429" d="M -2.5 2.5 
+     <path id="m766ca61a5c" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7eb8dc9edd)">
-     <use xlink:href="#m3831108429" x="354.801917" y="135.6841" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3831108429" x="296.396877" y="145.820388" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3831108429" x="240.372732" y="174.410861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3831108429" x="199.2912" y="178.416925" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3831108429" x="145.672036" y="216.419317" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3831108429" x="115.077361" y="255.748648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3831108429" x="105.421184" y="274.809337" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3831108429" x="95.641458" y="310.838082" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3831108429" x="93.912266" y="323.138705" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9d887ab682)">
+     <use xlink:href="#m766ca61a5c" x="354.801917" y="111.776119" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766ca61a5c" x="296.396877" y="118.38239" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766ca61a5c" x="240.372732" y="137.302009" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766ca61a5c" x="199.2912" y="139.4363" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766ca61a5c" x="145.672036" y="164.396936" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766ca61a5c" x="115.077361" y="190.555326" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766ca61a5c" x="105.421184" y="203.209875" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766ca61a5c" x="95.641458" y="227.103078" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m766ca61a5c" x="93.912266" y="235.121278" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_42">
-    <path d="M 610.467187 79.374455 
-L 292.101608 130.349276 
-L 172.024432 180.432315 
-L 156.692445 187.402827 
-L 134.525595 212.062313 
-L 108.348473 261.072209 
-L 102.387102 282.237893 
-L 99.4003 299.540072 
-L 97.945363 306.394618 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_54">
+    <path d="M 610.467187 73.587747 
+L 292.101608 107.421391 
+L 172.024432 140.7311 
+L 156.692445 145.272459 
+L 134.525595 161.569513 
+L 108.348473 194.034785 
+L 102.387102 208.080833 
+L 99.4003 219.556513 
+L 97.945363 224.106407 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m81198bef74" d="M 0 -2.5 
+     <path id="m321fec97a4" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7eb8dc9edd)">
-     <use xlink:href="#m81198bef74" x="610.467187" y="79.374455" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81198bef74" x="292.101608" y="130.349276" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81198bef74" x="172.024432" y="180.432315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81198bef74" x="156.692445" y="187.402827" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81198bef74" x="134.525595" y="212.062313" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81198bef74" x="108.348473" y="261.072209" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81198bef74" x="102.387102" y="282.237893" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81198bef74" x="99.4003" y="299.540072" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m81198bef74" x="97.945363" y="306.394618" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9d887ab682)">
+     <use xlink:href="#m321fec97a4" x="610.467187" y="73.587747" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m321fec97a4" x="292.101608" y="107.421391" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m321fec97a4" x="172.024432" y="140.7311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m321fec97a4" x="156.692445" y="145.272459" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m321fec97a4" x="134.525595" y="161.569513" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m321fec97a4" x="108.348473" y="194.034785" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m321fec97a4" x="102.387102" y="208.080833" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m321fec97a4" x="99.4003" y="219.556513" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m321fec97a4" x="97.945363" y="224.106407" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_43">
+   <g id="line2d_55">
     <path d="M 261.591835 64.890426 
-L 207.694789 92.947767 
-L 180.75628 102.69287 
-L 158.366417 109.69335 
-L 123.924526 125.376533 
-L 101.412222 146.15975 
-L 89.106563 173.562616 
-L 77.579551 214.980933 
-L 75.810938 229.510881 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 207.694789 83.472682 
+L 180.75628 89.86461 
+L 158.366417 94.727656 
+L 123.924526 105.030385 
+L 101.412222 118.289132 
+L 89.106563 136.68356 
+L 77.579551 164.162689 
+L 75.810938 173.8635 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5880a72423" d="M -0 3.535534 
+     <path id="mf78ccb86eb" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7eb8dc9edd)">
-     <use xlink:href="#m5880a72423" x="261.591835" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5880a72423" x="207.694789" y="92.947767" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5880a72423" x="180.75628" y="102.69287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5880a72423" x="158.366417" y="109.69335" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5880a72423" x="123.924526" y="125.376533" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5880a72423" x="101.412222" y="146.15975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5880a72423" x="89.106563" y="173.562616" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5880a72423" x="77.579551" y="214.980933" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5880a72423" x="75.810938" y="229.510881" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9d887ab682)">
+     <use xlink:href="#mf78ccb86eb" x="261.591835" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf78ccb86eb" x="207.694789" y="83.472682" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf78ccb86eb" x="180.75628" y="89.86461" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf78ccb86eb" x="158.366417" y="94.727656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf78ccb86eb" x="123.924526" y="105.030385" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf78ccb86eb" x="101.412222" y="118.289132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf78ccb86eb" x="89.106563" y="136.68356" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf78ccb86eb" x="77.579551" y="164.162689" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf78ccb86eb" x="75.810938" y="173.8635" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_44">
-    <path d="M 415.481577 121.706367 
-L 271.002054 152.41924 
-L 234.129884 166.887301 
-L 189.290714 169.218728 
-L 139.928317 204.766817 
-L 121.802872 228.457477 
-L 114.483714 245.176008 
-L 107.370838 269.08136 
-L 106.338791 280.810463 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_56">
+    <path d="M 415.481577 102.520757 
+L 271.002054 122.79617 
+L 234.129884 132.37151 
+L 189.290714 133.833688 
+L 139.928317 156.903538 
+L 121.802872 173.16502 
+L 114.483714 183.899882 
+L 107.370838 199.718544 
+L 106.338791 207.421577 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m8be4b600de" d="M -0.833333 2.5 
+     <path id="ma4d347ce34" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1636,31 +1708,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7eb8dc9edd)">
-     <use xlink:href="#m8be4b600de" x="415.481577" y="121.706367" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8be4b600de" x="271.002054" y="152.41924" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8be4b600de" x="234.129884" y="166.887301" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8be4b600de" x="189.290714" y="169.218728" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8be4b600de" x="139.928317" y="204.766817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8be4b600de" x="121.802872" y="228.457477" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8be4b600de" x="114.483714" y="245.176008" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8be4b600de" x="107.370838" y="269.08136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8be4b600de" x="106.338791" y="280.810463" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9d887ab682)">
+     <use xlink:href="#ma4d347ce34" x="415.481577" y="102.520757" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma4d347ce34" x="271.002054" y="122.79617" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma4d347ce34" x="234.129884" y="132.37151" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma4d347ce34" x="189.290714" y="133.833688" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma4d347ce34" x="139.928317" y="156.903538" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma4d347ce34" x="121.802872" y="173.16502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma4d347ce34" x="114.483714" y="183.899882" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma4d347ce34" x="107.370838" y="199.718544" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma4d347ce34" x="106.338791" y="207.421577" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_45">
-    <path d="M 319.655788 189.86411 
-L 241.138751 202.775345 
-L 205.372997 213.100579 
-L 184.155683 222.472725 
-L 168.571516 226.476263 
-L 140.014958 245.991679 
-L 138.061909 252.440556 
-L 136.349672 262.360711 
-L 136.267068 271.95307 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_57">
+    <path d="M 319.655788 147.083464 
+L 241.138751 155.60659 
+L 205.372997 162.276322 
+L 184.155683 169.100406 
+L 168.571516 171.586622 
+L 140.014958 184.606525 
+L 138.061909 188.001389 
+L 136.349672 195.436076 
+L 136.267068 201.851274 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m148a0884f6" d="M -1.25 2.5 
+     <path id="mc6a459cc91" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1675,31 +1747,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7eb8dc9edd)">
-     <use xlink:href="#m148a0884f6" x="319.655788" y="189.86411" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m148a0884f6" x="241.138751" y="202.775345" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m148a0884f6" x="205.372997" y="213.100579" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m148a0884f6" x="184.155683" y="222.472725" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m148a0884f6" x="168.571516" y="226.476263" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m148a0884f6" x="140.014958" y="245.991679" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m148a0884f6" x="138.061909" y="252.440556" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m148a0884f6" x="136.349672" y="262.360711" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m148a0884f6" x="136.267068" y="271.95307" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9d887ab682)">
+     <use xlink:href="#mc6a459cc91" x="319.655788" y="147.083464" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6a459cc91" x="241.138751" y="155.60659" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6a459cc91" x="205.372997" y="162.276322" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6a459cc91" x="184.155683" y="169.100406" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6a459cc91" x="168.571516" y="171.586622" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6a459cc91" x="140.014958" y="184.606525" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6a459cc91" x="138.061909" y="188.001389" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6a459cc91" x="136.349672" y="195.436076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc6a459cc91" x="136.267068" y="201.851274" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_46">
-    <path d="M 190.200149 151.421131 
-L 190.200149 151.366163 
-L 190.200149 151.316177 
-L 190.200149 152.077937 
-L 136.403453 184.873104 
-L 117.347293 208.80847 
-L 110.358201 221.516077 
-L 102.810747 248.786881 
-L 101.457483 261.177735 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_58">
+    <path d="M 190.200149 122.027753 
+L 190.200149 122.569211 
+L 190.200149 121.713741 
+L 190.200149 121.458056 
+L 136.403453 144.935929 
+L 117.347293 160.509091 
+L 110.358201 168.098667 
+L 102.810747 186.030199 
+L 101.457483 194.986364 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb0fc043d6c" d="M 0 -2.5 
+     <path id="md888c81323" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1712,31 +1784,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p7eb8dc9edd)">
-     <use xlink:href="#mb0fc043d6c" x="190.200149" y="151.421131" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0fc043d6c" x="190.200149" y="151.366163" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0fc043d6c" x="190.200149" y="151.316177" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0fc043d6c" x="190.200149" y="152.077937" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0fc043d6c" x="136.403453" y="184.873104" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0fc043d6c" x="117.347293" y="208.80847" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0fc043d6c" x="110.358201" y="221.516077" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0fc043d6c" x="102.810747" y="248.786881" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0fc043d6c" x="101.457483" y="261.177735" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p9d887ab682)">
+     <use xlink:href="#md888c81323" x="190.200149" y="122.027753" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md888c81323" x="190.200149" y="122.569211" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md888c81323" x="190.200149" y="121.713741" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md888c81323" x="190.200149" y="121.458056" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md888c81323" x="136.403453" y="144.935929" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md888c81323" x="117.347293" y="160.509091" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md888c81323" x="110.358201" y="168.098667" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md888c81323" x="102.810747" y="186.030199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md888c81323" x="101.457483" y="194.986364" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
-   <g id="line2d_47">
-    <path d="M 583.298166 260.143441 
-L 519.179151 263.977104 
-L 442.700778 278.818549 
-L 261.692068 268.272349 
-L 208.012723 289.449098 
-L 175.596233 314.401054 
-L 165.747429 328.30334 
-L 156.224637 357.477932 
-L 154.208481 367.41971 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_59">
+    <path d="M 583.298166 193.951199 
+L 519.179151 196.566985 
+L 442.700778 206.25977 
+L 261.692068 199.557248 
+L 208.012723 213.429972 
+L 175.596233 229.929448 
+L 165.747429 238.98927 
+L 156.224637 258.199348 
+L 154.208481 264.671077 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m050cb177c0" d="M 0 -2.5 
+     <path id="m4a5b9e5fd3" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1745,16 +1817,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7eb8dc9edd)">
-     <use xlink:href="#m050cb177c0" x="583.298166" y="260.143441" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m050cb177c0" x="519.179151" y="263.977104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m050cb177c0" x="442.700778" y="278.818549" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m050cb177c0" x="261.692068" y="268.272349" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m050cb177c0" x="208.012723" y="289.449098" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m050cb177c0" x="175.596233" y="314.401054" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m050cb177c0" x="165.747429" y="328.30334" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m050cb177c0" x="156.224637" y="357.477932" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m050cb177c0" x="154.208481" y="367.41971" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p9d887ab682)">
+     <use xlink:href="#m4a5b9e5fd3" x="583.298166" y="193.951199" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a5b9e5fd3" x="519.179151" y="196.566985" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a5b9e5fd3" x="442.700778" y="206.25977" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a5b9e5fd3" x="261.692068" y="199.557248" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a5b9e5fd3" x="208.012723" y="213.429972" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a5b9e5fd3" x="175.596233" y="229.929448" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a5b9e5fd3" x="165.747429" y="238.98927" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a5b9e5fd3" x="156.224637" y="258.199348" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a5b9e5fd3" x="154.208481" y="264.671077" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1771,13 +1843,13 @@ Q 422.84625 408.80375 424.44625 408.80375
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_48">
+    <g id="line2d_60">
      <path d="M 426.04625 365.69 
 L 434.04625 365.69 
 L 442.04625 365.69 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m2e426034c0" d="M 0 3.5 
+      <path id="m260cccae68" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1790,7 +1862,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m2e426034c0" x="434.04625" y="365.69" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m260cccae68" x="434.04625" y="365.69" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_14">
@@ -1847,13 +1919,13 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
      </g>
     </g>
-    <g id="line2d_49">
+    <g id="line2d_61">
      <path d="M 426.04625 377.4325 
 L 434.04625 377.4325 
 L 442.04625 377.4325 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m3831108429" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m766ca61a5c" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_15">
@@ -1865,13 +1937,13 @@ L 442.04625 377.4325
       <use xlink:href="#DejaVuSans-62" transform="translate(108.056641 0)"/>
      </g>
     </g>
-    <g id="line2d_50">
+    <g id="line2d_62">
      <path d="M 426.04625 389.175 
 L 434.04625 389.175 
 L 442.04625 389.175 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m81198bef74" x="434.04625" y="389.175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m321fec97a4" x="434.04625" y="389.175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -1914,13 +1986,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
      </g>
     </g>
-    <g id="line2d_51">
+    <g id="line2d_63">
      <path d="M 426.04625 401.14 
 L 434.04625 401.14 
 L 442.04625 401.14 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5880a72423" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf78ccb86eb" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -1961,13 +2033,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
      </g>
     </g>
-    <g id="line2d_52">
+    <g id="line2d_64">
      <path d="M 529.72375 365.69 
 L 537.72375 365.69 
 L 545.72375 365.69 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m8be4b600de" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma4d347ce34" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2019,13 +2091,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
      </g>
     </g>
-    <g id="line2d_53">
+    <g id="line2d_65">
      <path d="M 529.72375 377.4325 
 L 537.72375 377.4325 
 L 545.72375 377.4325 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m148a0884f6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc6a459cc91" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2088,13 +2160,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
      </g>
     </g>
-    <g id="line2d_54">
+    <g id="line2d_66">
      <path d="M 529.72375 389.175 
 L 537.72375 389.175 
 L 545.72375 389.175 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb0fc043d6c" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#md888c81323" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_20">
@@ -2130,13 +2202,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(541.601562 0)"/>
      </g>
     </g>
-    <g id="line2d_55">
+    <g id="line2d_67">
      <path d="M 529.72375 400.9175 
 L 537.72375 400.9175 
 L 545.72375 400.9175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m050cb177c0" x="537.72375" y="400.9175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4a5b9e5fd3" x="537.72375" y="400.9175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2205,27 +2277,27 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_56">
-    <path d="M 467.789269 323.933816 
-L 418.340522 334.13398 
-L 358.158195 345.099695 
-L 343.779411 357.234363 
-L 337.314948 358.582768 
-L 327.078946 370.461208 
-L 321.740855 381.134768 
-L 319.283185 389.45506 
-L 318.19509 396.236449 
-" clip-path="url(#p7eb8dc9edd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p7eb8dc9edd)">
-     <use xlink:href="#m2e426034c0" x="467.789269" y="323.933816" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2e426034c0" x="418.340522" y="334.13398" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2e426034c0" x="358.158195" y="345.099695" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2e426034c0" x="343.779411" y="357.234363" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2e426034c0" x="337.314948" y="358.582768" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2e426034c0" x="327.078946" y="370.461208" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2e426034c0" x="321.740855" y="381.134768" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2e426034c0" x="319.283185" y="389.45506" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2e426034c0" x="318.19509" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+   <g id="line2d_68">
+    <path d="M 467.789269 235.426768 
+L 418.340522 242.330896 
+L 358.158195 249.618552 
+L 302.416526 278.723991 
+L 296.217965 284.329677 
+L 286.657165 297.51306 
+L 119.684757 381.191793 
+L 117.697993 389.814346 
+L 116.602636 396.236449 
+" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p9d887ab682)">
+     <use xlink:href="#m260cccae68" x="467.789269" y="235.426768" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m260cccae68" x="418.340522" y="242.330896" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m260cccae68" x="358.158195" y="249.618552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m260cccae68" x="302.416526" y="278.723991" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m260cccae68" x="296.217965" y="284.329677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m260cccae68" x="286.657165" y="297.51306" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m260cccae68" x="119.684757" y="381.191793" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m260cccae68" x="117.697993" y="389.814346" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m260cccae68" x="116.602636" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2594,39 +2666,9 @@ z
    </g>
   </g>
   <g id="text_23">
-   <!-- 2026-06-09T02:28:37Z  ·  Linux chungus x86_64  ·  commit 13e61c48  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.982969 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(48.833828 465.66) scale(0.07 -0.07)">
     <defs>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2651,14 +2693,29 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2755,17 +2812,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2804,109 +2861,108 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3442.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3506.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3538.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3570.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.429688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3693.212891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3816.015625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3879.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.734375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.916016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4102.095703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.619141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4266.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4389.009766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4452.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4516.011719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.882812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.505859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4704.292969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.916016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.539062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4863.326172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4963.033203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.896484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5120.5 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5152.287109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5184.074219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.861328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.648438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5279.435547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5382.023438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.886719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5482.068359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5545.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.923828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5672.302734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.779297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5799.158203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5838.367188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.730469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6083.142578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6208.142578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.583984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6392.371094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.470703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6569.128906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.605469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6748.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6809.265625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6882.166016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.953125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6955.066406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7016.345703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.337891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7144.519531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7176.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7204.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7256.189453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7351.453125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7452.185547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7553.072266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7650.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.267578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.646484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7769.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7821.529297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.738281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7888.521484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7eb8dc9edd">
+  <clipPath id="p9d887ab682">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 47.90175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc7063069b6)">
+   <g clip-path="url(#p54edbd7140)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAApMAAAFrCAYAAACNPwIUAAAI2ElEQVR4nO3YwaqdVx2H4X22p/vshJCGtEItJThSKA4U7MCCV1A6V3DiFTiUgr0Eb0JoJ44ddV6QQge2OCoIIYNS1MY0PTnmnOztNfjC4o/b57mC38fHWryss8M3fzxuTtTxb59PT1jm7LUH0xPWuXV3esE6Xz+aXrDOvdenF6xxfTW9YJnjJ3+enrDM2U/fmp6wzsWd6QXrHG6mFyxz/MfD6QnLbKcHAADwv0tMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAALKzq5s/HadHrLJ7djk9YZlnF7vpCcs8P1xNT1jm5X8fpicsc3X7zvQE/kv77X56wjqXj6cXLPP81u3pCcvsHn81PWGd+w+mFyzjZRIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAALLz3eXT6Q3r7G5PL1jmsLmZnrDMy18+nJ6wzvfenF6wzP7yyfSENQ6H6QXr7E73Htmc76YXLLP79kTP2mazeXb3/vSEZW7968vpCct4mQQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgOzs5vDRcXrEKtun/5yesMzTi/PpCcs8P1xNT1jm/pPL6QnLvHj1wfSEJa4Pz6cnLLPf7qcnrPP1o+kFy1zfe216wjIv/f3h9IRlXnz3+9MTlvEyCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAA2fn0gJWe7ffTE5a52O6mJyzz9Prx9IRlrl95Y3rCMsfjzfSEJfbH070mn9w8np6wzN37D6YnLLM90bO22Ww216+e8H+bHrDQKX8bAACLiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAALLz7Qn35K2z/fSEdbbn0wuWufjO7ekJy7y03U1PWOawOUxPWGN7unfknc296Qnwf+PqxeX0hGVO95YEAGA5MQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIzj7Y/OA4PWKVX3zx6+kJy3zxyz9MT1jms7+8mJ6wzDu/++H0hGUufvOr6QlLfPyj96cnLPOzD9+dnrDM2Y/fnp6wzKc/eW96wjJv/vX30xOWefTz305PWMbLJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZP8BASFygyYpsQ0AAAAASUVORK5CYII=" id="image65bb743719" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="474.48" height="261.36"/>
+iVBORw0KGgoAAAANSUhEUgAAApMAAAFrCAYAAACNPwIUAAAI4ElEQVR4nO3YPY5kVx2H4arudqm6DcaWPwJkeWQHpJMQQeDImWMkAhIkQidO2AAZYgdOHbAAImdOHZA6wgNMYOGRP8Y9nmamu4o18KKjvyg9zwp+V/fq3Fdne3j85+PmRB0//+v0hGW2b709PWGdq5enFyxzfPRgesIy21ffmp6wxvOb6QXLHD/9dHrCMttf/mJ6wjqXL00vWOf22fSCZY5ffjE9YZmz6QEAAPz/EpMAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCAbHtz+5fj9IhVdj9cT09Y5sl+Nz1hmWd3N9MTlnnl5jA9YZmbH700PWGJ4/F039nl+dX0hHWefD29YJmby9N9b/uvv5yesM7r70wvWMbNJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZBe7J4+nN6yzu5pesMzxeDs9YZmX//nF9IR17t2fXrDM/vrb6QlrHA/TC9bZne45sjnfTS9YZn99uv/tp6+8MT1hmctvHk5PWMbNJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZNvbwyfH6RGrnH3/aHrCMo/3F9MTlvn37Q/TE5Z5/fHpPtvdG+9MT1ji2d3N9IRlLs+vpies8+jB9IJlnr/65vSEZV7419+mJyzz/ETPyM3GzSQAAP8DMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDItreHT47TI1Z5ens9PWGZ3dl+esIyX908nJ6wzGv7n05P4L+0u5tesM53x9M9I3+ye216wjLPD8+mJyxz3BymJyxzvr2YnrCMm0kAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAdnF2wj354vZqesI6ZxfTC5bZn5/ue9ud7acnLHPYHKYnrHF2umfkjze76QkEZ9vT/Sbvjid6jmw2m6e319MTljndLxIAgOXEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACDbfrz52XF6xCq/fvjB9IRl/v6bj6YnLPPVP55OT1jm/of3pycs88Lvfjs9YYkH7/1+esIy9/70/vSEZbb3352esMznPz/df9u9z/44PWGZ7371h+kJy7iZBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCA7D9fMX3Yj4e/igAAAABJRU5ErkJggg==" id="image3d9f99833f" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="474.48" height="261.36"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mfb9ca9cced" d="M 0 0 
+       <path id="m609212f498" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfb9ca9cced" x="115.435312" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="115.435312" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="154.953436" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="154.953436" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="194.47156" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="194.47156" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="233.989683" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="233.989683" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="273.507807" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="273.507807" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="313.025931" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="313.025931" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="352.544055" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="352.544055" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="392.062179" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="392.062179" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="431.580303" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="431.580303" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="471.098426" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="471.098426" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="510.61655" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="510.61655" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mfb9ca9cced" x="550.134674" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m609212f498" x="550.134674" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m9dc2dddc5d" d="M 0 0 
+       <path id="m2aab4d4024" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9dc2dddc5d" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2aab4d4024" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9dc2dddc5d" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2aab4d4024" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m9dc2dddc5d" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2aab4d4024" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m9dc2dddc5d" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2aab4d4024" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -881,7 +881,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m9dc2dddc5d" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2aab4d4024" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -948,7 +948,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m9dc2dddc5d" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2aab4d4024" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1029,7 +1029,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m9dc2dddc5d" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2aab4d4024" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1120,7 +1120,7 @@ L 569.893736 47.90175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +28 -->
+    <!-- +25 -->
     <g transform="translate(108.576288 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1160,6 +1160,83 @@ Q 3406 3131 3298 2873
 Q 3191 2616 2906 2266 
 Q 2828 2175 2409 1742 
 Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- +4 -->
+    <g transform="translate(150.162225 68.352934) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- +18 -->
+    <g transform="translate(187.612536 68.352934) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1203,167 +1280,36 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_21">
-    <!-- +6 -->
-    <g transform="translate(150.162225 68.352934) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
+   <g id="text_23">
     <!-- +21 -->
-    <g transform="translate(187.612536 68.352934) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(227.13066 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- +27 -->
-    <g transform="translate(227.13066 68.352934) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
    <g id="text_24">
-    <!-- +15 -->
+    <!-- +12 -->
     <g transform="translate(266.648784 68.352934) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +2 -->
+    <!-- +1 -->
     <g transform="translate(308.23472 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +24 -->
+    <!-- +19 -->
     <g transform="translate(345.685031 68.352934) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +9 -->
-    <g transform="translate(387.270968 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1397,76 +1343,39 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- +2 -->
-    <g transform="translate(426.789092 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +23 -->
-    <g transform="translate(464.239403 68.352934) scale(0.065 -0.065)">
+   <g id="text_27">
+    <!-- +7 -->
+    <g transform="translate(387.270968 68.352934) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- -1 -->
-    <g transform="translate(507.376199 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- +21 -->
-    <g transform="translate(543.275651 68.352934) scale(0.065 -0.065)">
+   <g id="text_28">
+    <!-- +1 -->
+    <g transform="translate(426.789092 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_32">
-    <!-- +0 -->
-    <g transform="translate(110.644101 105.668114) scale(0.065 -0.065)">
+   <g id="text_29">
+    <!-- +20 -->
+    <g transform="translate(464.239403 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -1490,6 +1399,29 @@ Q 1250 4750 2034 4750
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -1 -->
+    <g transform="translate(507.376199 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- +17 -->
+    <g transform="translate(543.275651 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- +0 -->
+    <g transform="translate(110.644101 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
@@ -1595,6 +1527,40 @@ z
    <g id="text_47">
     <!-- -3 -->
     <g transform="translate(230.749332 142.983294) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -1763,6 +1729,38 @@ z
    <g id="text_71">
     <!-- +6 -->
     <g transform="translate(229.198472 217.613655) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
@@ -2003,23 +2001,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFYCAYAAABeeqzpAAAB0klEQVR4nO2b0Y0DIQwFYZeerqXr/3+XlOB8jNDEehQwwoOfIUoyx//fHsBa85oEhwNdCGUYS1tzxtEpUBzVy+goETkGiqN6tXaUrB0DcY4uCLVu6PjXrXMEloZwuB0pHVEghkM64kqTySb7iAIJS/MdP8JROrJljRwjFMgmW9lHCEfZR9SovbjBhnDI5zF2HWGyhVmDQDrZZB8lIhUIm9nUjowR6Xsd6dKv7CNZRJTzSDZqsR0JHYEgprrejnR9BLGMpdk6u7cjmWwyInFUrPRRvcDSbA1JOpKN2jV9fURd2VRpwqxN7llDyYZ2JMxaIlKDjBG5GVAiUoO4PtI50kWkdR/Z7jVhH03knxBjrLFfBMQ5onbkA4GO3r6l2U4Nk93aka6P9n4YULL2g6DGo9boyDZq4+grEPOINGYtjo6ByNIY2Tn+k6C946gGxVENiqMaFEc1qK2j/WAXpM4RVdruW9p4qD5q7Ih6Q1JZE46RZO0gyOhINkYw2cKPoq2v7PRRsbjSsD7yzaO3b2lb9/IXOrKVtt44OgZSOpKFVngdURHp7EgX2s6OfDMbmiIcyFga9TPGzo5soDiql9AR9T1tZ0c6UBzVC3Rku46MjmylfQB5PCuHsIxBxQAAAABJRU5ErkJggg==" id="image0643c565de" transform="scale(1 -1) translate(0 -247.68)" x="579.6" y="-54" width="12.96" height="247.68"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFYCAYAAABeeqzpAAAB0klEQVR4nO2b0Y0DIQwFYZeerqXr/3+XlOB8jNDEehQwwoOfIUoyx//fHsBa85oEhwNdCGUYS1tzxtEpUBzVy+goETkGiqN6tXaUrB0DcY4uCLVu6PjXrXMEloZwuB0pHVEghkM64kqTySb7iAIJS/MdP8JROrJljRwjFMgmW9lHCEfZR9SovbjBhnDI5zF2HWGyhVmDQDrZZB8lIhUIm9nUjowR6Xsd6dKv7CNZRJTzSDZqsR0JHYEgprrejnR9BLGMpdk6u7cjmWwyInFUrPRRvcDSbA1JOpKN2jV9fURd2VRpwqxN7llDyYZ2JMxaIlKDjBG5GVAiUoO4PtI50kWkdR/Z7jVhH03knxBjrLFfBMQ5onbkA4GO3r6l2U4Nk93aka6P9n4YULL2g6DGo9boyDZq4+grEPOINGYtjo6ByNIY2Tn+k6C946gGxVENiqMaFEc1qK2j/WAXpM4RVdruW9p4qD5q7Ih6Q1JZE46RZO0gyOhINkYw2cKPoq2v7PRRsbjSsD7yzaO3b2lb9/IXOrKVtt44OgZSOpKFVngdURHp7EgX2s6OfDMbmiIcyFga9TPGzo5soDiql9AR9T1tZ0c6UBzVC3Rku46MjmylfQB5PCuHsIxBxQAAAABJRU5ErkJggg==" id="image2f5b70a509" transform="scale(1 -1) translate(0 -247.68)" x="579.6" y="-54" width="12.96" height="247.68"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_20">
       <defs>
-       <path id="m3700c3f4e6" d="M 0 0 
+       <path id="m3b8090dfb4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3700c3f4e6" x="592.239063" y="268.249987" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b8090dfb4" x="592.239063" y="278.634505" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_104">
       <!-- −0.2 -->
-      <g transform="translate(599.239063 272.049205) scale(0.1 -0.1)">
+      <g transform="translate(599.239063 282.433724) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2039,12 +2037,12 @@ z
     <g id="ytick_9">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m3700c3f4e6" x="592.239063" y="223.377434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b8090dfb4" x="592.239063" y="228.569693" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_105">
       <!-- −0.1 -->
-      <g transform="translate(599.239063 227.176652) scale(0.1 -0.1)">
+      <g transform="translate(599.239063 232.368912) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
@@ -2055,7 +2053,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3700c3f4e6" x="592.239063" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b8090dfb4" x="592.239063" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_106">
@@ -2070,12 +2068,12 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3700c3f4e6" x="592.239063" y="133.632328" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b8090dfb4" x="592.239063" y="128.440069" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_107">
       <!-- 0.1 -->
-      <g transform="translate(599.239063 137.431547) scale(0.1 -0.1)">
+      <g transform="translate(599.239063 132.239287) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
@@ -2085,12 +2083,12 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3700c3f4e6" x="592.239063" y="88.759775" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b8090dfb4" x="592.239063" y="78.375256" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
       <!-- 0.2 -->
-      <g transform="translate(599.239063 92.558994) scale(0.1 -0.1)">
+      <g transform="translate(599.239063 82.174475) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2677,8 +2675,8 @@ z
    </g>
   </g>
   <g id="text_111">
-   <!-- 2026-06-09T02:28:37Z  ·  Linux chungus x86_64  ·  commit 13e61c48  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.982969 365.364) scale(0.07 -0.07)">
+   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(48.833828 365.364) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2766,17 +2764,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2815,109 +2813,108 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3442.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3506.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3538.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3570.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.429688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3693.212891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3816.015625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3879.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.734375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.916016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4102.095703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.619141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4266.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4389.009766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4452.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4516.011719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.882812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.505859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4704.292969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.916016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.539062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4863.326172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4963.033203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.896484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5120.5 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5152.287109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5184.074219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.861328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.648438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5279.435547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5382.023438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.886719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5482.068359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5545.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.923828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5672.302734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.779297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5799.158203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5838.367188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.730469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6083.142578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6208.142578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.583984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6392.371094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.470703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6569.128906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.605469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6748.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6809.265625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6882.166016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.953125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6955.066406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7016.345703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.337891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7144.519531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7176.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7204.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7256.189453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7351.453125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7452.185547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7553.072266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7650.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.267578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.646484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7769.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7821.529297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.738281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7888.521484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc7063069b6">
+  <clipPath id="p54edbd7140">
    <rect x="95.67625" y="47.90175" width="474.217486" height="261.206261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.434062pt" height="354.774469pt" viewBox="0 0 570.434062 354.774469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.732344pt" height="354.774469pt" viewBox="0 0 564.732344 354.774469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,208 +22,208 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 354.774469 
-L 570.434062 354.774469 
-L 570.434062 0 
+L 564.732344 354.774469 
+L 564.732344 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.342031 101.872 
-L 291.967031 101.872 
-L 291.967031 71.996 
-L 187.342031 71.996 
+    <path d="M 184.491172 101.872 
+L 289.116172 101.872 
+L 289.116172 71.996 
+L 184.491172 71.996 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.967031 101.872 
-L 396.592031 101.872 
-L 396.592031 71.996 
-L 291.967031 71.996 
+    <path d="M 289.116172 101.872 
+L 393.741172 101.872 
+L 393.741172 71.996 
+L 289.116172 71.996 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.592031 101.872 
-L 501.217031 101.872 
-L 501.217031 71.996 
-L 396.592031 71.996 
+    <path d="M 393.741172 101.872 
+L 498.366172 101.872 
+L 498.366172 71.996 
+L 393.741172 71.996 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.342031 131.748 
-L 291.967031 131.748 
-L 291.967031 101.872 
-L 187.342031 101.872 
+    <path d="M 184.491172 131.748 
+L 289.116172 131.748 
+L 289.116172 101.872 
+L 184.491172 101.872 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #66bd63; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #6bbf64; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.967031 131.748 
-L 396.592031 131.748 
-L 396.592031 101.872 
-L 291.967031 101.872 
+    <path d="M 289.116172 131.748 
+L 393.741172 131.748 
+L 393.741172 101.872 
+L 289.116172 101.872 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #fff8b4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.592031 131.748 
-L 501.217031 131.748 
-L 501.217031 101.872 
-L 396.592031 101.872 
+    <path d="M 393.741172 131.748 
+L 498.366172 131.748 
+L 498.366172 101.872 
+L 393.741172 101.872 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.342031 161.624 
-L 291.967031 161.624 
-L 291.967031 131.748 
-L 187.342031 131.748 
+    <path d="M 184.491172 161.624 
+L 289.116172 161.624 
+L 289.116172 131.748 
+L 184.491172 131.748 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #6ec064; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #78c565; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.967031 161.624 
-L 396.592031 161.624 
-L 396.592031 131.748 
-L 291.967031 131.748 
+    <path d="M 289.116172 161.624 
+L 393.741172 161.624 
+L 393.741172 131.748 
+L 289.116172 131.748 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #fee18d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.592031 161.624 
-L 501.217031 161.624 
-L 501.217031 131.748 
-L 396.592031 131.748 
+    <path d="M 393.741172 161.624 
+L 498.366172 161.624 
+L 498.366172 131.748 
+L 393.741172 131.748 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #fdbb6c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.342031 191.5 
-L 291.967031 191.5 
-L 291.967031 161.624 
-L 187.342031 161.624 
+    <path d="M 184.491172 191.5 
+L 289.116172 191.5 
+L 289.116172 161.624 
+L 184.491172 161.624 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #93d168; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #a2d76a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.967031 191.5 
-L 396.592031 191.5 
-L 396.592031 161.624 
-L 291.967031 161.624 
+    <path d="M 289.116172 191.5 
+L 393.741172 191.5 
+L 393.741172 161.624 
+L 289.116172 161.624 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.592031 191.5 
-L 501.217031 191.5 
-L 501.217031 161.624 
-L 396.592031 161.624 
+    <path d="M 393.741172 191.5 
+L 498.366172 191.5 
+L 498.366172 161.624 
+L 393.741172 161.624 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #fba35c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.342031 221.376 
-L 291.967031 221.376 
-L 291.967031 191.5 
-L 187.342031 191.5 
+    <path d="M 184.491172 221.376 
+L 289.116172 221.376 
+L 289.116172 191.5 
+L 184.491172 191.5 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #60ba62; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #66bd63; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.967031 221.376 
-L 396.592031 221.376 
-L 396.592031 191.5 
-L 291.967031 191.5 
+    <path d="M 289.116172 221.376 
+L 393.741172 221.376 
+L 393.741172 191.5 
+L 289.116172 191.5 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #fdb96a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.592031 221.376 
-L 501.217031 221.376 
-L 501.217031 191.5 
-L 396.592031 191.5 
+    <path d="M 393.741172 221.376 
+L 498.366172 221.376 
+L 498.366172 191.5 
+L 393.741172 191.5 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #fff5ae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.342031 251.252 
-L 291.967031 251.252 
-L 291.967031 221.376 
-L 187.342031 221.376 
+    <path d="M 184.491172 251.252 
+L 289.116172 251.252 
+L 289.116172 221.376 
+L 184.491172 221.376 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #4eb15d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #54b45f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.967031 251.252 
-L 396.592031 251.252 
-L 396.592031 221.376 
-L 291.967031 221.376 
+    <path d="M 289.116172 251.252 
+L 393.741172 251.252 
+L 393.741172 221.376 
+L 289.116172 221.376 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.592031 251.252 
-L 501.217031 251.252 
-L 501.217031 221.376 
-L 396.592031 221.376 
+    <path d="M 393.741172 251.252 
+L 498.366172 251.252 
+L 498.366172 221.376 
+L 393.741172 221.376 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #ecf7a6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #eef8a8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.342031 281.128 
-L 291.967031 281.128 
-L 291.967031 251.252 
-L 187.342031 251.252 
+    <path d="M 184.491172 281.128 
+L 289.116172 281.128 
+L 289.116172 251.252 
+L 184.491172 251.252 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #cfeb85; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.967031 281.128 
-L 396.592031 281.128 
-L 396.592031 251.252 
-L 291.967031 251.252 
+    <path d="M 289.116172 281.128 
+L 393.741172 281.128 
+L 393.741172 251.252 
+L 289.116172 251.252 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #f57245; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.592031 281.128 
-L 501.217031 281.128 
-L 501.217031 251.252 
-L 396.592031 251.252 
+    <path d="M 393.741172 281.128 
+L 498.366172 281.128 
+L 498.366172 251.252 
+L 393.741172 251.252 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.342031 311.004 
-L 291.967031 311.004 
-L 291.967031 281.128 
-L 187.342031 281.128 
+    <path d="M 184.491172 311.004 
+L 289.116172 311.004 
+L 289.116172 281.128 
+L 184.491172 281.128 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.967031 311.004 
-L 396.592031 311.004 
-L 396.592031 281.128 
-L 291.967031 281.128 
+    <path d="M 289.116172 311.004 
+L 393.741172 311.004 
+L 393.741172 281.128 
+L 289.116172 281.128 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.592031 311.004 
-L 501.217031 311.004 
-L 501.217031 281.128 
-L 396.592031 281.128 
+    <path d="M 393.741172 311.004 
+L 498.366172 311.004 
+L 498.366172 281.128 
+L 393.741172 281.128 
 z
-" clip-path="url(#pe4f7441183)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p96f300d071)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.329297 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(117.478438 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -328,7 +328,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.613516 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(224.762656 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -424,7 +424,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.185625 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(303.334766 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -589,7 +589,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.537344 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(401.686484 59.541437) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -609,7 +609,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.267031 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(113.416172 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -798,7 +798,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.203281 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -894,7 +894,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.644531 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(333.793672 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -927,76 +927,73 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 874 -->
-    <g transform="translate(441.269531 89.1415) scale(0.08 -0.08)">
+    <!-- 905 -->
+    <g transform="translate(438.418672 89.1415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
 z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-39"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.905156 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(108.054297 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1095,7 +1092,28 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.203281 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 119.0175) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1104,8 +1122,8 @@ z
     </g>
    </g>
    <g id="text_11">
-    <!-- 61 -->
-    <g transform="translate(339.189531 119.0175) scale(0.08 -0.08)">
+    <!-- 60 -->
+    <g transform="translate(336.338672 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1139,20 +1157,20 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_12">
-    <!-- 311 -->
-    <g transform="translate(441.269531 119.0175) scale(0.08 -0.08)">
+    <!-- 310 -->
+    <g transform="translate(438.418672 119.0175) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.598281 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(95.747422 148.8935) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1323,34 +1341,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.203281 148.8935) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(225.352422 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1360,22 +1351,22 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(339.189531 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(336.338672 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 273 -->
-    <g transform="translate(441.269531 148.8935) scale(0.08 -0.08)">
+    <!-- 272 -->
+    <g transform="translate(438.418672 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.630781 178.7695) scale(0.08 -0.08)">
+    <g transform="translate(116.779922 178.7695) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1435,39 +1426,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.203281 178.7695) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(225.352422 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1476,23 +1435,64 @@ z
     </g>
    </g>
    <g id="text_19">
-    <!-- 42 -->
-    <g transform="translate(339.189531 178.7695) scale(0.08 -0.08)">
+    <!-- 41 -->
+    <g transform="translate(336.338672 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 226 -->
-    <g transform="translate(441.269531 178.7695) scale(0.08 -0.08)">
+    <!-- 228 -->
+    <g transform="translate(438.418672 178.7695) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.168281 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(125.317422 208.6455) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.203281 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1526,22 +1526,22 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(339.189531 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(336.338672 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 450 -->
-    <g transform="translate(441.269531 208.6455) scale(0.08 -0.08)">
+    <!-- 447 -->
+    <g transform="translate(438.418672 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.474531 238.41025) scale(0.08 -0.08)">
+    <g transform="translate(108.623672 238.41025) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1600,7 +1600,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.203281 238.5215) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1610,22 +1610,22 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(339.189531 238.5215) scale(0.08 -0.08)">
+    <g transform="translate(336.338672 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 528 -->
-    <g transform="translate(441.269531 238.5215) scale(0.08 -0.08)">
+    <!-- 539 -->
+    <g transform="translate(438.418672 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.091406 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(93.240547 268.3975) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1690,7 +1690,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.336 -->
-    <g transform="translate(228.203281 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(225.352422 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1700,21 +1700,21 @@ z
    </g>
    <g id="text_31">
     <!-- 20 -->
-    <g transform="translate(339.189531 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(336.338672 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 69 -->
-    <g transform="translate(443.814531 268.3975) scale(0.08 -0.08)">
+    <!-- 68 -->
+    <g transform="translate(440.963672 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.976406 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(95.125547 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1822,8 +1822,8 @@ z
     </g>
    </g>
    <g id="text_34">
-    <!-- 0.369 -->
-    <g transform="translate(227.002656 298.2735) scale(0.08 -0.08)">
+    <!-- 0.360 -->
+    <g transform="translate(224.151797 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1915,47 +1915,35 @@ Q 2900 4744 3203 4694
 Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
-z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-30"/>
      <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
      <use xlink:href="#DejaVuSans-Bold-36" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(246.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(246.728516 0)"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 11 -->
-    <g transform="translate(338.713281 298.2735) scale(0.08 -0.08)">
+    <!-- 7 -->
+    <g transform="translate(338.645547 298.2735) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-37"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 105 -->
+    <g transform="translate(437.704297 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1971,15 +1959,6 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 105 -->
-    <g transform="translate(440.555156 298.2735) scale(0.08 -0.08)">
-     <defs>
       <path id="DejaVuSans-Bold-35" d="M 678 4666 
 L 3669 4666 
 L 3669 3781 
@@ -2014,7 +1993,7 @@ z
   </g>
   <g id="text_37">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.81875 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(148.967891 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2128,7 +2107,7 @@ z
    </g>
   </g>
   <g id="text_38">
-   <!-- 2026-06-09T02:28:37Z  ·  Linux chungus x86_64  ·  commit 13e61c48  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 345.924) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2266,17 +2245,17 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2315,110 +2294,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3379.248047 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3442.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3506.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3538.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3570.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3601.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3633.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3665.429688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3693.212891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3754.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3816.015625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3879.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3942.871094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.734375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4042.916016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4102.095703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4163.619141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4238.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4266.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4327.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4389.009766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4452.388672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4516.011719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4549.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4608.882812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4672.505859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4704.292969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4767.916016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.539062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4863.326172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4963.033203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5001.896484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5056.876953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5120.5 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5152.287109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5184.074219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5215.861328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5247.648438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5279.435547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5318.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5382.023438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.886719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5482.068359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5545.447266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5608.923828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5672.302734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5735.779297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5799.158203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5838.367188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5870.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5953.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.730469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6083.142578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6144.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6208.142578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6235.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6297.205078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6360.583984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6392.371094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6444.470703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6507.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6569.128906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6632.605469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6684.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6748.083984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6809.265625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6848.474609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6882.166016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6913.953125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6955.066406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7016.345703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7055.554688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7083.337891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7144.519531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7176.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7204.089844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7256.189453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7287.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7351.453125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7412.976562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7452.185547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7513.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7553.072266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7650.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7678.267578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7741.646484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7769.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7821.529297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7860.738281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7888.521484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe4f7441183">
-   <rect x="82.717031" y="42.12" width="418.5" height="268.884"/>
+  <clipPath id="p96f300d071">
+   <rect x="79.866172" y="42.12" width="418.5" height="268.884"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
 "meta": {
-"date": "2026-06-09T02:28:37Z",
+"date": "2026-06-10T02:01:55Z",
 "machine": "Linux chungus x86_64",
-"git_commit": "13e61c48",
+"git_commit": "52df143",
 "toolchain": "leanprover/lean4:v4.30.0-rc2",
 "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
 },
@@ -14,8 +14,8 @@
 "level": 1,
 "out_size": 59545,
 "ratio": 0.3915,
-"compress_mbps": 14.07,
-"decompress_mbps": 85.95
+"compress_mbps": 14.04,
+"decompress_mbps": 85.77
 },
 {
 "compressor": "native",
@@ -24,8 +24,8 @@
 "level": 2,
 "out_size": 57936,
 "ratio": 0.3809,
-"compress_mbps": 12.41,
-"decompress_mbps": 93.75
+"compress_mbps": 12.39,
+"decompress_mbps": 92.41
 },
 {
 "compressor": "native",
@@ -34,68 +34,68 @@
 "level": 3,
 "out_size": 56891,
 "ratio": 0.3741,
-"compress_mbps": 10.89,
-"decompress_mbps": 103.03
+"compress_mbps": 10.82,
+"decompress_mbps": 101.69
 },
 {
 "compressor": "native",
 "pattern": "canterbury/alice29.txt",
 "size": 152089,
 "level": 4,
-"out_size": 56299,
-"ratio": 0.3702,
-"compress_mbps": 9.98,
-"decompress_mbps": 103.36
+"out_size": 55541,
+"ratio": 0.3652,
+"compress_mbps": 6.63,
+"decompress_mbps": 102.17
 },
 {
 "compressor": "native",
 "pattern": "canterbury/alice29.txt",
 "size": 152089,
 "level": 5,
-"out_size": 56019,
-"ratio": 0.3683,
-"compress_mbps": 9.32,
-"decompress_mbps": 104.03
+"out_size": 55282,
+"ratio": 0.3635,
+"compress_mbps": 6.1,
+"decompress_mbps": 104.39
 },
 {
 "compressor": "native",
 "pattern": "canterbury/alice29.txt",
 "size": 152089,
 "level": 6,
-"out_size": 55608,
-"ratio": 0.3656,
-"compress_mbps": 8.11,
-"decompress_mbps": 108.69
+"out_size": 54902,
+"ratio": 0.361,
+"compress_mbps": 5.13,
+"decompress_mbps": 108.64
 },
 {
 "compressor": "native",
 "pattern": "canterbury/alice29.txt",
 "size": 152089,
 "level": 7,
-"out_size": 55476,
-"ratio": 0.3648,
-"compress_mbps": 7.41,
-"decompress_mbps": 108.09
+"out_size": 54758,
+"ratio": 0.36,
+"compress_mbps": 1.63,
+"decompress_mbps": 109.07
 },
 {
 "compressor": "native",
 "pattern": "canterbury/alice29.txt",
 "size": 152089,
 "level": 8,
-"out_size": 55411,
-"ratio": 0.3643,
-"compress_mbps": 6.87,
-"decompress_mbps": 108.86
+"out_size": 54717,
+"ratio": 0.3598,
+"compress_mbps": 1.54,
+"decompress_mbps": 109.85
 },
 {
 "compressor": "native",
 "pattern": "canterbury/alice29.txt",
 "size": 152089,
 "level": 9,
-"out_size": 55408,
-"ratio": 0.3643,
-"compress_mbps": 6.79,
-"decompress_mbps": 109.19
+"out_size": 54716,
+"ratio": 0.3598,
+"compress_mbps": 1.51,
+"decompress_mbps": 109.61
 },
 {
 "compressor": "native",
@@ -104,8 +104,8 @@
 "level": 1,
 "out_size": 52768,
 "ratio": 0.4215,
-"compress_mbps": 12.96,
-"decompress_mbps": 81.06
+"compress_mbps": 13.23,
+"decompress_mbps": 81.32
 },
 {
 "compressor": "native",
@@ -114,8 +114,8 @@
 "level": 2,
 "out_size": 51760,
 "ratio": 0.4135,
-"compress_mbps": 11.72,
-"decompress_mbps": 85.13
+"compress_mbps": 11.75,
+"decompress_mbps": 85.47
 },
 {
 "compressor": "native",
@@ -124,68 +124,68 @@
 "level": 3,
 "out_size": 51056,
 "ratio": 0.4079,
-"compress_mbps": 10.24,
-"decompress_mbps": 90.76
+"compress_mbps": 10.35,
+"decompress_mbps": 91.98
 },
 {
 "compressor": "native",
 "pattern": "canterbury/asyoulik.txt",
 "size": 125179,
 "level": 4,
-"out_size": 50724,
-"ratio": 0.4052,
-"compress_mbps": 9.46,
-"decompress_mbps": 92.46
+"out_size": 49963,
+"ratio": 0.3991,
+"compress_mbps": 6.5,
+"decompress_mbps": 93.95
 },
 {
 "compressor": "native",
 "pattern": "canterbury/asyoulik.txt",
 "size": 125179,
 "level": 5,
-"out_size": 50548,
-"ratio": 0.4038,
-"compress_mbps": 9.05,
-"decompress_mbps": 96.02
+"out_size": 49779,
+"ratio": 0.3977,
+"compress_mbps": 5.96,
+"decompress_mbps": 97.38
 },
 {
 "compressor": "native",
 "pattern": "canterbury/asyoulik.txt",
 "size": 125179,
 "level": 6,
-"out_size": 50313,
-"ratio": 0.4019,
-"compress_mbps": 7.95,
-"decompress_mbps": 97.58
+"out_size": 49540,
+"ratio": 0.3958,
+"compress_mbps": 5.19,
+"decompress_mbps": 97.79
 },
 {
 "compressor": "native",
 "pattern": "canterbury/asyoulik.txt",
 "size": 125179,
 "level": 7,
-"out_size": 50231,
-"ratio": 0.4013,
-"compress_mbps": 7.44,
-"decompress_mbps": 98.06
+"out_size": 49419,
+"ratio": 0.3948,
+"compress_mbps": 1.71,
+"decompress_mbps": 98.31
 },
 {
 "compressor": "native",
 "pattern": "canterbury/asyoulik.txt",
 "size": 125179,
 "level": 8,
-"out_size": 50220,
-"ratio": 0.4012,
-"compress_mbps": 7.25,
-"decompress_mbps": 98.07
+"out_size": 49409,
+"ratio": 0.3947,
+"compress_mbps": 1.67,
+"decompress_mbps": 99.72
 },
 {
 "compressor": "native",
 "pattern": "canterbury/asyoulik.txt",
 "size": 125179,
 "level": 9,
-"out_size": 50220,
-"ratio": 0.4012,
-"compress_mbps": 7.24,
-"decompress_mbps": 98.27
+"out_size": 49409,
+"ratio": 0.3947,
+"compress_mbps": 1.67,
+"decompress_mbps": 99.02
 },
 {
 "compressor": "native",
@@ -194,8 +194,8 @@
 "level": 1,
 "out_size": 8430,
 "ratio": 0.3426,
-"compress_mbps": 15.76,
-"decompress_mbps": 84.4
+"compress_mbps": 15.9,
+"decompress_mbps": 85.33
 },
 {
 "compressor": "native",
@@ -204,8 +204,8 @@
 "level": 2,
 "out_size": 8297,
 "ratio": 0.3372,
-"compress_mbps": 14.85,
-"decompress_mbps": 88.42
+"compress_mbps": 14.97,
+"decompress_mbps": 89.11
 },
 {
 "compressor": "native",
@@ -214,68 +214,68 @@
 "level": 3,
 "out_size": 8218,
 "ratio": 0.334,
-"compress_mbps": 13.87,
-"decompress_mbps": 90.22
+"compress_mbps": 14.01,
+"decompress_mbps": 90.67
 },
 {
 "compressor": "native",
 "pattern": "canterbury/cp.html",
 "size": 24603,
 "level": 4,
-"out_size": 8192,
-"ratio": 0.333,
-"compress_mbps": 13.23,
-"decompress_mbps": 89.2
+"out_size": 8055,
+"ratio": 0.3274,
+"compress_mbps": 10.22,
+"decompress_mbps": 90.61
 },
 {
 "compressor": "native",
 "pattern": "canterbury/cp.html",
 "size": 24603,
 "level": 5,
-"out_size": 8186,
-"ratio": 0.3327,
-"compress_mbps": 12.77,
-"decompress_mbps": 91.23
+"out_size": 8049,
+"ratio": 0.3272,
+"compress_mbps": 9.66,
+"decompress_mbps": 92.63
 },
 {
 "compressor": "native",
 "pattern": "canterbury/cp.html",
 "size": 24603,
 "level": 6,
-"out_size": 8179,
-"ratio": 0.3324,
-"compress_mbps": 12.03,
-"decompress_mbps": 90.9
+"out_size": 8043,
+"ratio": 0.3269,
+"compress_mbps": 8.71,
+"decompress_mbps": 92.27
 },
 {
 "compressor": "native",
 "pattern": "canterbury/cp.html",
 "size": 24603,
 "level": 7,
-"out_size": 8173,
-"ratio": 0.3322,
-"compress_mbps": 11.93,
-"decompress_mbps": 92.07
+"out_size": 8038,
+"ratio": 0.3267,
+"compress_mbps": 2.85,
+"decompress_mbps": 93.84
 },
 {
 "compressor": "native",
 "pattern": "canterbury/cp.html",
 "size": 24603,
 "level": 8,
-"out_size": 8173,
-"ratio": 0.3322,
-"compress_mbps": 11.94,
-"decompress_mbps": 92.08
+"out_size": 8038,
+"ratio": 0.3267,
+"compress_mbps": 2.83,
+"decompress_mbps": 93.52
 },
 {
 "compressor": "native",
 "pattern": "canterbury/cp.html",
 "size": 24603,
 "level": 9,
-"out_size": 8173,
-"ratio": 0.3322,
-"compress_mbps": 11.93,
-"decompress_mbps": 91.84
+"out_size": 8038,
+"ratio": 0.3267,
+"compress_mbps": 2.83,
+"decompress_mbps": 92.89
 },
 {
 "compressor": "native",
@@ -284,8 +284,8 @@
 "level": 1,
 "out_size": 3325,
 "ratio": 0.2982,
-"compress_mbps": 13.03,
-"decompress_mbps": 73.96
+"compress_mbps": 13.42,
+"decompress_mbps": 75.15
 },
 {
 "compressor": "native",
@@ -294,8 +294,8 @@
 "level": 2,
 "out_size": 3251,
 "ratio": 0.2916,
-"compress_mbps": 12.45,
-"decompress_mbps": 76.12
+"compress_mbps": 12.85,
+"decompress_mbps": 77.53
 },
 {
 "compressor": "native",
@@ -304,68 +304,68 @@
 "level": 3,
 "out_size": 3202,
 "ratio": 0.2872,
-"compress_mbps": 11.94,
-"decompress_mbps": 78.51
+"compress_mbps": 12.19,
+"decompress_mbps": 77.89
 },
 {
 "compressor": "native",
 "pattern": "canterbury/fields.c",
 "size": 11150,
 "level": 4,
-"out_size": 3189,
-"ratio": 0.286,
-"compress_mbps": 11.54,
-"decompress_mbps": 80.06
+"out_size": 3150,
+"ratio": 0.2825,
+"compress_mbps": 9.4,
+"decompress_mbps": 81.05
 },
 {
 "compressor": "native",
 "pattern": "canterbury/fields.c",
 "size": 11150,
 "level": 5,
-"out_size": 3178,
-"ratio": 0.285,
-"compress_mbps": 11.36,
-"decompress_mbps": 81.04
+"out_size": 3141,
+"ratio": 0.2817,
+"compress_mbps": 9.1,
+"decompress_mbps": 82.36
 },
 {
 "compressor": "native",
 "pattern": "canterbury/fields.c",
 "size": 11150,
 "level": 6,
-"out_size": 3173,
-"ratio": 0.2846,
-"compress_mbps": 10.94,
-"decompress_mbps": 81.77
+"out_size": 3136,
+"ratio": 0.2813,
+"compress_mbps": 8.48,
+"decompress_mbps": 82.49
 },
 {
 "compressor": "native",
 "pattern": "canterbury/fields.c",
 "size": 11150,
 "level": 7,
-"out_size": 3172,
-"ratio": 0.2845,
-"compress_mbps": 10.75,
-"decompress_mbps": 81.88
+"out_size": 3134,
+"ratio": 0.2811,
+"compress_mbps": 2.76,
+"decompress_mbps": 82.59
 },
 {
 "compressor": "native",
 "pattern": "canterbury/fields.c",
 "size": 11150,
 "level": 8,
-"out_size": 3172,
-"ratio": 0.2845,
-"compress_mbps": 10.73,
-"decompress_mbps": 82.01
+"out_size": 3134,
+"ratio": 0.2811,
+"compress_mbps": 2.73,
+"decompress_mbps": 82.99
 },
 {
 "compressor": "native",
 "pattern": "canterbury/fields.c",
 "size": 11150,
 "level": 9,
-"out_size": 3172,
-"ratio": 0.2845,
-"compress_mbps": 10.71,
-"decompress_mbps": 82.07
+"out_size": 3134,
+"ratio": 0.2811,
+"compress_mbps": 2.72,
+"decompress_mbps": 82.93
 },
 {
 "compressor": "native",
@@ -374,8 +374,8 @@
 "level": 1,
 "out_size": 1251,
 "ratio": 0.3362,
-"compress_mbps": 8.34,
-"decompress_mbps": 41.41
+"compress_mbps": 8.51,
+"decompress_mbps": 42.05
 },
 {
 "compressor": "native",
@@ -384,8 +384,8 @@
 "level": 2,
 "out_size": 1241,
 "ratio": 0.3335,
-"compress_mbps": 8.17,
-"decompress_mbps": 41.85
+"compress_mbps": 8.32,
+"decompress_mbps": 42.59
 },
 {
 "compressor": "native",
@@ -394,68 +394,68 @@
 "level": 3,
 "out_size": 1241,
 "ratio": 0.3335,
-"compress_mbps": 7.96,
-"decompress_mbps": 42.02
+"compress_mbps": 8.11,
+"decompress_mbps": 42.85
 },
 {
 "compressor": "native",
 "pattern": "canterbury/grammar.lsp",
 "size": 3721,
 "level": 4,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 7.9,
-"decompress_mbps": 42.8
+"out_size": 1225,
+"ratio": 0.3292,
+"compress_mbps": 7.23,
+"decompress_mbps": 43.33
 },
 {
 "compressor": "native",
 "pattern": "canterbury/grammar.lsp",
 "size": 3721,
 "level": 5,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 7.91,
-"decompress_mbps": 42.96
+"out_size": 1224,
+"ratio": 0.3289,
+"compress_mbps": 7.16,
+"decompress_mbps": 43.55
 },
 {
 "compressor": "native",
 "pattern": "canterbury/grammar.lsp",
 "size": 3721,
 "level": 6,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 7.91,
-"decompress_mbps": 43.0
+"out_size": 1224,
+"ratio": 0.3289,
+"compress_mbps": 7.11,
+"decompress_mbps": 43.49
 },
 {
 "compressor": "native",
 "pattern": "canterbury/grammar.lsp",
 "size": 3721,
 "level": 7,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 7.87,
-"decompress_mbps": 43.07
+"out_size": 1224,
+"ratio": 0.3289,
+"compress_mbps": 2.47,
+"decompress_mbps": 43.51
 },
 {
 "compressor": "native",
 "pattern": "canterbury/grammar.lsp",
 "size": 3721,
 "level": 8,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 7.87,
-"decompress_mbps": 43.02
+"out_size": 1224,
+"ratio": 0.3289,
+"compress_mbps": 2.47,
+"decompress_mbps": 43.68
 },
 {
 "compressor": "native",
 "pattern": "canterbury/grammar.lsp",
 "size": 3721,
 "level": 9,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 7.87,
-"decompress_mbps": 42.96
+"out_size": 1224,
+"ratio": 0.3289,
+"compress_mbps": 2.47,
+"decompress_mbps": 43.67
 },
 {
 "compressor": "native",
@@ -464,8 +464,8 @@
 "level": 1,
 "out_size": 248840,
 "ratio": 0.2417,
-"compress_mbps": 24.33,
-"decompress_mbps": 129.54
+"compress_mbps": 24.55,
+"decompress_mbps": 128.32
 },
 {
 "compressor": "native",
@@ -474,8 +474,8 @@
 "level": 2,
 "out_size": 247429,
 "ratio": 0.2403,
-"compress_mbps": 21.53,
-"decompress_mbps": 150.01
+"compress_mbps": 21.97,
+"decompress_mbps": 149.77
 },
 {
 "compressor": "native",
@@ -484,68 +484,68 @@
 "level": 3,
 "out_size": 246442,
 "ratio": 0.2393,
-"compress_mbps": 20.59,
-"decompress_mbps": 156.93
+"compress_mbps": 20.63,
+"decompress_mbps": 157.98
 },
 {
 "compressor": "native",
 "pattern": "canterbury/kennedy.xls",
 "size": 1029744,
 "level": 4,
-"out_size": 246157,
-"ratio": 0.239,
-"compress_mbps": 20.07,
-"decompress_mbps": 162.34
+"out_size": 213851,
+"ratio": 0.2077,
+"compress_mbps": 10.64,
+"decompress_mbps": 163.82
 },
 {
 "compressor": "native",
 "pattern": "canterbury/kennedy.xls",
 "size": 1029744,
 "level": 5,
-"out_size": 245857,
-"ratio": 0.2388,
-"compress_mbps": 19.33,
-"decompress_mbps": 130.75
+"out_size": 212782,
+"ratio": 0.2066,
+"compress_mbps": 9.33,
+"decompress_mbps": 131.2
 },
 {
 "compressor": "native",
 "pattern": "canterbury/kennedy.xls",
 "size": 1029744,
 "level": 6,
-"out_size": 245653,
-"ratio": 0.2386,
-"compress_mbps": 17.45,
-"decompress_mbps": 131.46
+"out_size": 210061,
+"ratio": 0.204,
+"compress_mbps": 6.27,
+"decompress_mbps": 131.16
 },
 {
 "compressor": "native",
 "pattern": "canterbury/kennedy.xls",
 "size": 1029744,
 "level": 7,
-"out_size": 244234,
-"ratio": 0.2372,
-"compress_mbps": 16.55,
-"decompress_mbps": 125.22
+"out_size": 199322,
+"ratio": 0.1936,
+"compress_mbps": 1.3,
+"decompress_mbps": 121.13
 },
 {
 "compressor": "native",
 "pattern": "canterbury/kennedy.xls",
 "size": 1029744,
 "level": 8,
-"out_size": 244051,
-"ratio": 0.237,
-"compress_mbps": 14.74,
-"decompress_mbps": 121.99
+"out_size": 199462,
+"ratio": 0.1937,
+"compress_mbps": 0.8,
+"decompress_mbps": 119.84
 },
 {
 "compressor": "native",
 "pattern": "canterbury/kennedy.xls",
 "size": 1029744,
 "level": 9,
-"out_size": 243952,
-"ratio": 0.2369,
-"compress_mbps": 13.22,
-"decompress_mbps": 122.13
+"out_size": 199644,
+"ratio": 0.1939,
+"compress_mbps": 0.48,
+"decompress_mbps": 118.9
 },
 {
 "compressor": "native",
@@ -554,8 +554,8 @@
 "level": 1,
 "out_size": 194388,
 "ratio": 0.4555,
-"compress_mbps": 15.11,
-"decompress_mbps": 89.81
+"compress_mbps": 15.29,
+"decompress_mbps": 90.57
 },
 {
 "compressor": "native",
@@ -564,8 +564,8 @@
 "level": 2,
 "out_size": 153708,
 "ratio": 0.3602,
-"compress_mbps": 13.31,
-"decompress_mbps": 96.05
+"compress_mbps": 13.21,
+"decompress_mbps": 96.67
 },
 {
 "compressor": "native",
@@ -574,68 +574,68 @@
 "level": 3,
 "out_size": 150718,
 "ratio": 0.3532,
-"compress_mbps": 11.42,
-"decompress_mbps": 106.18
+"compress_mbps": 11.52,
+"decompress_mbps": 106.59
 },
 {
 "compressor": "native",
 "pattern": "canterbury/lcet10.txt",
 "size": 426754,
 "level": 4,
-"out_size": 149578,
-"ratio": 0.3505,
-"compress_mbps": 10.56,
-"decompress_mbps": 107.21
+"out_size": 177586,
+"ratio": 0.4161,
+"compress_mbps": 7.18,
+"decompress_mbps": 107.71
 },
 {
 "compressor": "native",
 "pattern": "canterbury/lcet10.txt",
 "size": 426754,
 "level": 5,
-"out_size": 148968,
-"ratio": 0.3491,
-"compress_mbps": 9.91,
-"decompress_mbps": 110.72
+"out_size": 146857,
+"ratio": 0.3441,
+"compress_mbps": 6.61,
+"decompress_mbps": 111.83
 },
 {
 "compressor": "native",
 "pattern": "canterbury/lcet10.txt",
 "size": 426754,
 "level": 6,
-"out_size": 148124,
-"ratio": 0.3471,
-"compress_mbps": 8.66,
-"decompress_mbps": 113.06
+"out_size": 146118,
+"ratio": 0.3424,
+"compress_mbps": 5.63,
+"decompress_mbps": 113.71
 },
 {
 "compressor": "native",
 "pattern": "canterbury/lcet10.txt",
 "size": 426754,
 "level": 7,
-"out_size": 147805,
-"ratio": 0.3463,
-"compress_mbps": 7.97,
-"decompress_mbps": 112.51
+"out_size": 145876,
+"ratio": 0.3418,
+"compress_mbps": 1.81,
+"decompress_mbps": 113.96
 },
 {
 "compressor": "native",
 "pattern": "canterbury/lcet10.txt",
 "size": 426754,
 "level": 8,
-"out_size": 147704,
-"ratio": 0.3461,
-"compress_mbps": 7.62,
-"decompress_mbps": 113.39
+"out_size": 145803,
+"ratio": 0.3417,
+"compress_mbps": 1.73,
+"decompress_mbps": 113.8
 },
 {
 "compressor": "native",
 "pattern": "canterbury/lcet10.txt",
 "size": 426754,
 "level": 9,
-"out_size": 147693,
-"ratio": 0.3461,
-"compress_mbps": 7.48,
-"decompress_mbps": 113.33
+"out_size": 145799,
+"ratio": 0.3416,
+"compress_mbps": 1.71,
+"decompress_mbps": 114.36
 },
 {
 "compressor": "native",
@@ -644,8 +644,8 @@
 "level": 1,
 "out_size": 212305,
 "ratio": 0.4406,
-"compress_mbps": 12.74,
-"decompress_mbps": 77.62
+"compress_mbps": 12.71,
+"decompress_mbps": 79.05
 },
 {
 "compressor": "native",
@@ -655,7 +655,7 @@
 "out_size": 263152,
 "ratio": 0.5461,
 "compress_mbps": 11.23,
-"decompress_mbps": 84.71
+"decompress_mbps": 85.54
 },
 {
 "compressor": "native",
@@ -664,68 +664,68 @@
 "level": 3,
 "out_size": 257812,
 "ratio": 0.535,
-"compress_mbps": 9.8,
-"decompress_mbps": 89.98
+"compress_mbps": 9.78,
+"decompress_mbps": 90.97
 },
 {
 "compressor": "native",
 "pattern": "canterbury/plrabn12.txt",
 "size": 481861,
 "level": 4,
-"out_size": 255742,
-"ratio": 0.5307,
-"compress_mbps": 8.91,
-"decompress_mbps": 90.62
+"out_size": 249343,
+"ratio": 0.5175,
+"compress_mbps": 5.97,
+"decompress_mbps": 91.41
 },
 {
 "compressor": "native",
 "pattern": "canterbury/plrabn12.txt",
 "size": 481861,
 "level": 5,
-"out_size": 254639,
-"ratio": 0.5284,
-"compress_mbps": 8.35,
-"decompress_mbps": 93.73
+"out_size": 199229,
+"ratio": 0.4135,
+"compress_mbps": 5.5,
+"decompress_mbps": 94.63
 },
 {
 "compressor": "native",
 "pattern": "canterbury/plrabn12.txt",
 "size": 481861,
 "level": 6,
-"out_size": 200186,
-"ratio": 0.4154,
-"compress_mbps": 7.29,
-"decompress_mbps": 96.17
+"out_size": 198023,
+"ratio": 0.411,
+"compress_mbps": 4.62,
+"decompress_mbps": 97.21
 },
 {
 "compressor": "native",
 "pattern": "canterbury/plrabn12.txt",
 "size": 481861,
 "level": 7,
-"out_size": 252262,
-"ratio": 0.5235,
-"compress_mbps": 6.68,
-"decompress_mbps": 96.49
+"out_size": 197532,
+"ratio": 0.4099,
+"compress_mbps": 1.46,
+"decompress_mbps": 97.34
 },
 {
 "compressor": "native",
 "pattern": "canterbury/plrabn12.txt",
 "size": 481861,
 "level": 8,
-"out_size": 199503,
-"ratio": 0.414,
-"compress_mbps": 6.32,
-"decompress_mbps": 96.74
+"out_size": 197364,
+"ratio": 0.4096,
+"compress_mbps": 1.32,
+"decompress_mbps": 97.35
 },
 {
 "compressor": "native",
 "pattern": "canterbury/plrabn12.txt",
 "size": 481861,
 "level": 9,
-"out_size": 199461,
-"ratio": 0.4139,
-"compress_mbps": 6.12,
-"decompress_mbps": 96.54
+"out_size": 197347,
+"ratio": 0.4096,
+"compress_mbps": 1.27,
+"decompress_mbps": 97.24
 },
 {
 "compressor": "native",
@@ -734,8 +734,8 @@
 "level": 1,
 "out_size": 60352,
 "ratio": 0.1176,
-"compress_mbps": 42.45,
-"decompress_mbps": 240.98
+"compress_mbps": 42.65,
+"decompress_mbps": 242.28
 },
 {
 "compressor": "native",
@@ -744,8 +744,8 @@
 "level": 2,
 "out_size": 59696,
 "ratio": 0.1163,
-"compress_mbps": 35.28,
-"decompress_mbps": 251.12
+"compress_mbps": 35.44,
+"decompress_mbps": 256.01
 },
 {
 "compressor": "native",
@@ -754,68 +754,68 @@
 "level": 3,
 "out_size": 59069,
 "ratio": 0.1151,
-"compress_mbps": 28.03,
-"decompress_mbps": 266.21
+"compress_mbps": 28.44,
+"decompress_mbps": 270.46
 },
 {
 "compressor": "native",
 "pattern": "canterbury/ptt5",
 "size": 513216,
 "level": 4,
-"out_size": 58170,
-"ratio": 0.1133,
-"compress_mbps": 23.97,
-"decompress_mbps": 243.72
+"out_size": 56435,
+"ratio": 0.11,
+"compress_mbps": 16.14,
+"decompress_mbps": 247.79
 },
 {
 "compressor": "native",
 "pattern": "canterbury/ptt5",
 "size": 513216,
 "level": 5,
-"out_size": 58107,
-"ratio": 0.1132,
-"compress_mbps": 21.88,
-"decompress_mbps": 255.79
+"out_size": 56350,
+"ratio": 0.1098,
+"compress_mbps": 14.04,
+"decompress_mbps": 261.24
 },
 {
 "compressor": "native",
 "pattern": "canterbury/ptt5",
 "size": 513216,
 "level": 6,
-"out_size": 57926,
-"ratio": 0.1129,
-"compress_mbps": 17.0,
-"decompress_mbps": 271.36
+"out_size": 56014,
+"ratio": 0.1091,
+"compress_mbps": 9.58,
+"decompress_mbps": 275.92
 },
 {
 "compressor": "native",
 "pattern": "canterbury/ptt5",
 "size": 513216,
 "level": 7,
-"out_size": 57344,
-"ratio": 0.1117,
-"compress_mbps": 12.97,
-"decompress_mbps": 281.82
+"out_size": 54781,
+"ratio": 0.1067,
+"compress_mbps": 2.17,
+"decompress_mbps": 282.72
 },
 {
 "compressor": "native",
 "pattern": "canterbury/ptt5",
 "size": 513216,
 "level": 8,
-"out_size": 56856,
-"ratio": 0.1108,
-"compress_mbps": 9.09,
-"decompress_mbps": 292.48
+"out_size": 54031,
+"ratio": 0.1053,
+"compress_mbps": 1.39,
+"decompress_mbps": 296.66
 },
 {
 "compressor": "native",
 "pattern": "canterbury/ptt5",
 "size": 513216,
 "level": 9,
-"out_size": 56706,
-"ratio": 0.1105,
-"compress_mbps": 5.77,
-"decompress_mbps": 297.82
+"out_size": 53850,
+"ratio": 0.1049,
+"compress_mbps": 0.82,
+"decompress_mbps": 301.07
 },
 {
 "compressor": "native",
@@ -824,8 +824,8 @@
 "level": 1,
 "out_size": 13725,
 "ratio": 0.3589,
-"compress_mbps": 13.71,
-"decompress_mbps": 65.87
+"compress_mbps": 13.9,
+"decompress_mbps": 66.21
 },
 {
 "compressor": "native",
@@ -834,8 +834,8 @@
 "level": 2,
 "out_size": 13615,
 "ratio": 0.356,
-"compress_mbps": 12.96,
-"decompress_mbps": 68.67
+"compress_mbps": 13.24,
+"decompress_mbps": 69.77
 },
 {
 "compressor": "native",
@@ -844,68 +844,68 @@
 "level": 3,
 "out_size": 13548,
 "ratio": 0.3543,
-"compress_mbps": 12.23,
-"decompress_mbps": 71.97
+"compress_mbps": 12.41,
+"decompress_mbps": 72.39
 },
 {
 "compressor": "native",
 "pattern": "canterbury/sum",
 "size": 38240,
 "level": 4,
-"out_size": 13483,
-"ratio": 0.3526,
-"compress_mbps": 11.64,
-"decompress_mbps": 70.39
+"out_size": 13080,
+"ratio": 0.3421,
+"compress_mbps": 9.09,
+"decompress_mbps": 70.36
 },
 {
 "compressor": "native",
 "pattern": "canterbury/sum",
 "size": 38240,
 "level": 5,
-"out_size": 13469,
-"ratio": 0.3522,
-"compress_mbps": 11.25,
-"decompress_mbps": 72.67
+"out_size": 13060,
+"ratio": 0.3415,
+"compress_mbps": 8.44,
+"decompress_mbps": 74.15
 },
 {
 "compressor": "native",
 "pattern": "canterbury/sum",
 "size": 38240,
 "level": 6,
-"out_size": 13446,
-"ratio": 0.3516,
-"compress_mbps": 10.25,
-"decompress_mbps": 74.74
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13421,
-"ratio": 0.351,
-"compress_mbps": 9.07,
+"out_size": 13015,
+"ratio": 0.3404,
+"compress_mbps": 6.88,
 "decompress_mbps": 74.8
 },
 {
 "compressor": "native",
 "pattern": "canterbury/sum",
 "size": 38240,
+"level": 7,
+"out_size": 12923,
+"ratio": 0.3379,
+"compress_mbps": 1.67,
+"decompress_mbps": 75.41
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
 "level": 8,
-"out_size": 13412,
-"ratio": 0.3507,
-"compress_mbps": 7.68,
-"decompress_mbps": 77.55
+"out_size": 12905,
+"ratio": 0.3375,
+"compress_mbps": 1.23,
+"decompress_mbps": 77.96
 },
 {
 "compressor": "native",
 "pattern": "canterbury/sum",
 "size": 38240,
 "level": 9,
-"out_size": 13404,
-"ratio": 0.3505,
-"compress_mbps": 6.14,
-"decompress_mbps": 76.8
+"out_size": 12887,
+"ratio": 0.337,
+"compress_mbps": 0.84,
+"decompress_mbps": 77.69
 },
 {
 "compressor": "native",
@@ -914,8 +914,8 @@
 "level": 1,
 "out_size": 1781,
 "ratio": 0.4213,
-"compress_mbps": 8.54,
-"decompress_mbps": 40.98
+"compress_mbps": 8.76,
+"decompress_mbps": 41.75
 },
 {
 "compressor": "native",
@@ -924,8 +924,8 @@
 "level": 2,
 "out_size": 1764,
 "ratio": 0.4173,
-"compress_mbps": 8.44,
-"decompress_mbps": 41.9
+"compress_mbps": 8.67,
+"decompress_mbps": 42.78
 },
 {
 "compressor": "native",
@@ -934,68 +934,68 @@
 "level": 3,
 "out_size": 1765,
 "ratio": 0.4176,
-"compress_mbps": 8.41,
-"decompress_mbps": 41.93
+"compress_mbps": 8.65,
+"decompress_mbps": 42.71
 },
 {
 "compressor": "native",
 "pattern": "canterbury/xargs.1",
 "size": 4227,
 "level": 4,
-"out_size": 1765,
-"ratio": 0.4176,
-"compress_mbps": 8.4,
-"decompress_mbps": 42.77
+"out_size": 1747,
+"ratio": 0.4133,
+"compress_mbps": 8.0,
+"decompress_mbps": 43.74
 },
 {
 "compressor": "native",
 "pattern": "canterbury/xargs.1",
 "size": 4227,
 "level": 5,
-"out_size": 1765,
-"ratio": 0.4176,
-"compress_mbps": 8.39,
-"decompress_mbps": 42.7
+"out_size": 1747,
+"ratio": 0.4133,
+"compress_mbps": 8.01,
+"decompress_mbps": 43.73
 },
 {
 "compressor": "native",
 "pattern": "canterbury/xargs.1",
 "size": 4227,
 "level": 6,
-"out_size": 1765,
-"ratio": 0.4176,
-"compress_mbps": 8.39,
-"decompress_mbps": 42.62
+"out_size": 1747,
+"ratio": 0.4133,
+"compress_mbps": 8.0,
+"decompress_mbps": 43.69
 },
 {
 "compressor": "native",
 "pattern": "canterbury/xargs.1",
 "size": 4227,
 "level": 7,
-"out_size": 1765,
-"ratio": 0.4176,
-"compress_mbps": 8.39,
-"decompress_mbps": 42.59
+"out_size": 1747,
+"ratio": 0.4133,
+"compress_mbps": 2.79,
+"decompress_mbps": 43.65
 },
 {
 "compressor": "native",
 "pattern": "canterbury/xargs.1",
 "size": 4227,
 "level": 8,
-"out_size": 1765,
-"ratio": 0.4176,
-"compress_mbps": 8.4,
-"decompress_mbps": 42.46
+"out_size": 1747,
+"ratio": 0.4133,
+"compress_mbps": 2.79,
+"decompress_mbps": 43.59
 },
 {
 "compressor": "native",
 "pattern": "canterbury/xargs.1",
 "size": 4227,
 "level": 9,
-"out_size": 1765,
-"ratio": 0.4176,
-"compress_mbps": 8.37,
-"decompress_mbps": 42.58
+"out_size": 1747,
+"ratio": 0.4133,
+"compress_mbps": 2.78,
+"decompress_mbps": 43.56
 },
 {
 "compressor": "zlib",
@@ -1004,8 +1004,8 @@
 "level": 1,
 "out_size": 65130,
 "ratio": 0.4282,
-"compress_mbps": 118.79,
-"decompress_mbps": 399.08
+"compress_mbps": 117.93,
+"decompress_mbps": 409.61
 },
 {
 "compressor": "zlib",
@@ -1014,8 +1014,8 @@
 "level": 2,
 "out_size": 62270,
 "ratio": 0.4094,
-"compress_mbps": 103.06,
-"decompress_mbps": 417.73
+"compress_mbps": 102.2,
+"decompress_mbps": 427.14
 },
 {
 "compressor": "zlib",
@@ -1024,8 +1024,8 @@
 "level": 3,
 "out_size": 59488,
 "ratio": 0.3911,
-"compress_mbps": 67.71,
-"decompress_mbps": 430.9
+"compress_mbps": 67.17,
+"decompress_mbps": 441.45
 },
 {
 "compressor": "zlib",
@@ -1034,8 +1034,8 @@
 "level": 4,
 "out_size": 57679,
 "ratio": 0.3792,
-"compress_mbps": 71.05,
-"decompress_mbps": 411.36
+"compress_mbps": 71.3,
+"decompress_mbps": 419.65
 },
 {
 "compressor": "zlib",
@@ -1044,8 +1044,8 @@
 "level": 5,
 "out_size": 55616,
 "ratio": 0.3657,
-"compress_mbps": 41.79,
-"decompress_mbps": 404.55
+"compress_mbps": 41.75,
+"decompress_mbps": 411.55
 },
 {
 "compressor": "zlib",
@@ -1055,7 +1055,7 @@
 "out_size": 54398,
 "ratio": 0.3577,
 "compress_mbps": 25.53,
-"decompress_mbps": 416.95
+"decompress_mbps": 426.15
 },
 {
 "compressor": "zlib",
@@ -1064,8 +1064,8 @@
 "level": 7,
 "out_size": 54253,
 "ratio": 0.3567,
-"compress_mbps": 21.44,
-"decompress_mbps": 419.55
+"compress_mbps": 21.46,
+"decompress_mbps": 425.45
 },
 {
 "compressor": "zlib",
@@ -1074,8 +1074,8 @@
 "level": 8,
 "out_size": 54164,
 "ratio": 0.3561,
-"compress_mbps": 17.02,
-"decompress_mbps": 419.18
+"compress_mbps": 17.04,
+"decompress_mbps": 427.29
 },
 {
 "compressor": "zlib",
@@ -1084,8 +1084,8 @@
 "level": 9,
 "out_size": 54164,
 "ratio": 0.3561,
-"compress_mbps": 16.98,
-"decompress_mbps": 419.68
+"compress_mbps": 17.02,
+"decompress_mbps": 425.23
 },
 {
 "compressor": "zlib",
@@ -1094,8 +1094,8 @@
 "level": 1,
 "out_size": 56791,
 "ratio": 0.4537,
-"compress_mbps": 116.25,
-"decompress_mbps": 394.1
+"compress_mbps": 115.56,
+"decompress_mbps": 398.4
 },
 {
 "compressor": "zlib",
@@ -1104,8 +1104,8 @@
 "level": 2,
 "out_size": 54652,
 "ratio": 0.4366,
-"compress_mbps": 98.96,
-"decompress_mbps": 405.25
+"compress_mbps": 98.47,
+"decompress_mbps": 412.81
 },
 {
 "compressor": "zlib",
@@ -1114,8 +1114,8 @@
 "level": 3,
 "out_size": 52663,
 "ratio": 0.4207,
-"compress_mbps": 63.05,
-"decompress_mbps": 428.56
+"compress_mbps": 62.64,
+"decompress_mbps": 436.38
 },
 {
 "compressor": "zlib",
@@ -1124,8 +1124,8 @@
 "level": 4,
 "out_size": 51266,
 "ratio": 0.4095,
-"compress_mbps": 66.62,
-"decompress_mbps": 395.18
+"compress_mbps": 67.0,
+"decompress_mbps": 406.84
 },
 {
 "compressor": "zlib",
@@ -1134,8 +1134,8 @@
 "level": 5,
 "out_size": 49622,
 "ratio": 0.3964,
-"compress_mbps": 37.31,
-"decompress_mbps": 384.46
+"compress_mbps": 37.32,
+"decompress_mbps": 393.59
 },
 {
 "compressor": "zlib",
@@ -1144,8 +1144,8 @@
 "level": 6,
 "out_size": 48891,
 "ratio": 0.3906,
-"compress_mbps": 22.82,
-"decompress_mbps": 392.82
+"compress_mbps": 22.84,
+"decompress_mbps": 402.28
 },
 {
 "compressor": "zlib",
@@ -1155,7 +1155,7 @@
 "out_size": 48801,
 "ratio": 0.3898,
 "compress_mbps": 20.04,
-"decompress_mbps": 393.21
+"decompress_mbps": 402.51
 },
 {
 "compressor": "zlib",
@@ -1164,8 +1164,8 @@
 "level": 8,
 "out_size": 48772,
 "ratio": 0.3896,
-"compress_mbps": 18.16,
-"decompress_mbps": 391.04
+"compress_mbps": 18.17,
+"decompress_mbps": 401.32
 },
 {
 "compressor": "zlib",
@@ -1174,8 +1174,8 @@
 "level": 9,
 "out_size": 48772,
 "ratio": 0.3896,
-"compress_mbps": 18.13,
-"decompress_mbps": 394.61
+"compress_mbps": 18.17,
+"decompress_mbps": 404.13
 },
 {
 "compressor": "zlib",
@@ -1184,8 +1184,8 @@
 "level": 1,
 "out_size": 9028,
 "ratio": 0.3669,
-"compress_mbps": 402.28,
-"decompress_mbps": 1050.56
+"compress_mbps": 398.57,
+"decompress_mbps": 1056.86
 },
 {
 "compressor": "zlib",
@@ -1194,8 +1194,8 @@
 "level": 2,
 "out_size": 8811,
 "ratio": 0.3581,
-"compress_mbps": 220.39,
-"decompress_mbps": 1081.6
+"compress_mbps": 224.34,
+"decompress_mbps": 1068.65
 },
 {
 "compressor": "zlib",
@@ -1204,8 +1204,8 @@
 "level": 3,
 "out_size": 8616,
 "ratio": 0.3502,
-"compress_mbps": 159.03,
-"decompress_mbps": 1091.92
+"compress_mbps": 153.67,
+"decompress_mbps": 1101.25
 },
 {
 "compressor": "zlib",
@@ -1214,8 +1214,8 @@
 "level": 4,
 "out_size": 8219,
 "ratio": 0.3341,
-"compress_mbps": 114.35,
-"decompress_mbps": 1125.17
+"compress_mbps": 115.6,
+"decompress_mbps": 1122.05
 },
 {
 "compressor": "zlib",
@@ -1224,8 +1224,8 @@
 "level": 5,
 "out_size": 8001,
 "ratio": 0.3252,
-"compress_mbps": 83.65,
-"decompress_mbps": 1149.93
+"compress_mbps": 83.8,
+"decompress_mbps": 1147.85
 },
 {
 "compressor": "zlib",
@@ -1234,8 +1234,8 @@
 "level": 6,
 "out_size": 7955,
 "ratio": 0.3233,
-"compress_mbps": 67.91,
-"decompress_mbps": 1156.62
+"compress_mbps": 68.29,
+"decompress_mbps": 1152.25
 },
 {
 "compressor": "zlib",
@@ -1244,8 +1244,8 @@
 "level": 7,
 "out_size": 7933,
 "ratio": 0.3224,
-"compress_mbps": 62.11,
-"decompress_mbps": 1162.7
+"compress_mbps": 62.39,
+"decompress_mbps": 1155.6
 },
 {
 "compressor": "zlib",
@@ -1254,8 +1254,8 @@
 "level": 8,
 "out_size": 7934,
 "ratio": 0.3225,
-"compress_mbps": 57.44,
-"decompress_mbps": 1157.42
+"compress_mbps": 57.63,
+"decompress_mbps": 1149.03
 },
 {
 "compressor": "zlib",
@@ -1264,8 +1264,8 @@
 "level": 9,
 "out_size": 7934,
 "ratio": 0.3225,
-"compress_mbps": 57.21,
-"decompress_mbps": 1160.86
+"compress_mbps": 57.65,
+"decompress_mbps": 1155.26
 },
 {
 "compressor": "zlib",
@@ -1274,8 +1274,8 @@
 "level": 1,
 "out_size": 3647,
 "ratio": 0.3271,
-"compress_mbps": 415.43,
-"decompress_mbps": 1070.3
+"compress_mbps": 413.46,
+"decompress_mbps": 1069.34
 },
 {
 "compressor": "zlib",
@@ -1284,8 +1284,8 @@
 "level": 2,
 "out_size": 3501,
 "ratio": 0.314,
-"compress_mbps": 400.54,
-"decompress_mbps": 1120.73
+"compress_mbps": 398.75,
+"decompress_mbps": 1111.82
 },
 {
 "compressor": "zlib",
@@ -1294,8 +1294,8 @@
 "level": 3,
 "out_size": 3393,
 "ratio": 0.3043,
-"compress_mbps": 333.1,
-"decompress_mbps": 1140.32
+"compress_mbps": 332.56,
+"decompress_mbps": 1137.03
 },
 {
 "compressor": "zlib",
@@ -1304,8 +1304,8 @@
 "level": 4,
 "out_size": 3215,
 "ratio": 0.2883,
-"compress_mbps": 264.64,
-"decompress_mbps": 1173.41
+"compress_mbps": 267.89,
+"decompress_mbps": 1172.12
 },
 {
 "compressor": "zlib",
@@ -1314,8 +1314,8 @@
 "level": 5,
 "out_size": 3140,
 "ratio": 0.2816,
-"compress_mbps": 197.81,
-"decompress_mbps": 1206.16
+"compress_mbps": 200.05,
+"decompress_mbps": 1198.27
 },
 {
 "compressor": "zlib",
@@ -1324,8 +1324,8 @@
 "level": 6,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 150.59,
-"decompress_mbps": 1218.6
+"compress_mbps": 151.03,
+"decompress_mbps": 1212.76
 },
 {
 "compressor": "zlib",
@@ -1334,8 +1334,8 @@
 "level": 7,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 129.0,
-"decompress_mbps": 1224.91
+"compress_mbps": 129.48,
+"decompress_mbps": 1216.92
 },
 {
 "compressor": "zlib",
@@ -1344,8 +1344,8 @@
 "level": 8,
 "out_size": 3109,
 "ratio": 0.2788,
-"compress_mbps": 109.41,
-"decompress_mbps": 1223.22
+"compress_mbps": 109.5,
+"decompress_mbps": 1216.23
 },
 {
 "compressor": "zlib",
@@ -1354,8 +1354,8 @@
 "level": 9,
 "out_size": 3109,
 "ratio": 0.2788,
-"compress_mbps": 109.02,
-"decompress_mbps": 1219.43
+"compress_mbps": 109.01,
+"decompress_mbps": 1216.09
 },
 {
 "compressor": "zlib",
@@ -1364,8 +1364,8 @@
 "level": 1,
 "out_size": 1326,
 "ratio": 0.3564,
-"compress_mbps": 311.56,
-"decompress_mbps": 787.18
+"compress_mbps": 308.12,
+"decompress_mbps": 772.78
 },
 {
 "compressor": "zlib",
@@ -1374,8 +1374,8 @@
 "level": 2,
 "out_size": 1306,
 "ratio": 0.351,
-"compress_mbps": 305.94,
-"decompress_mbps": 784.92
+"compress_mbps": 303.02,
+"decompress_mbps": 777.01
 },
 {
 "compressor": "zlib",
@@ -1384,8 +1384,8 @@
 "level": 3,
 "out_size": 1301,
 "ratio": 0.3496,
-"compress_mbps": 288.48,
-"decompress_mbps": 783.53
+"compress_mbps": 285.95,
+"decompress_mbps": 782.5
 },
 {
 "compressor": "zlib",
@@ -1394,8 +1394,8 @@
 "level": 4,
 "out_size": 1228,
 "ratio": 0.33,
-"compress_mbps": 225.65,
-"decompress_mbps": 809.08
+"compress_mbps": 227.16,
+"decompress_mbps": 806.51
 },
 {
 "compressor": "zlib",
@@ -1404,8 +1404,8 @@
 "level": 5,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 190.21,
-"decompress_mbps": 814.46
+"compress_mbps": 191.07,
+"decompress_mbps": 812.97
 },
 {
 "compressor": "zlib",
@@ -1414,8 +1414,8 @@
 "level": 6,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 171.35,
-"decompress_mbps": 817.47
+"compress_mbps": 171.75,
+"decompress_mbps": 811.86
 },
 {
 "compressor": "zlib",
@@ -1424,8 +1424,8 @@
 "level": 7,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 164.3,
-"decompress_mbps": 814.84
+"compress_mbps": 164.88,
+"decompress_mbps": 811.67
 },
 {
 "compressor": "zlib",
@@ -1434,8 +1434,8 @@
 "level": 8,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 162.12,
-"decompress_mbps": 816.34
+"compress_mbps": 162.17,
+"decompress_mbps": 811.3
 },
 {
 "compressor": "zlib",
@@ -1444,8 +1444,8 @@
 "level": 9,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 161.92,
-"decompress_mbps": 817.65
+"compress_mbps": 162.56,
+"decompress_mbps": 810.93
 },
 {
 "compressor": "zlib",
@@ -1454,8 +1454,8 @@
 "level": 1,
 "out_size": 242293,
 "ratio": 0.2353,
-"compress_mbps": 259.39,
-"decompress_mbps": 844.32
+"compress_mbps": 258.39,
+"decompress_mbps": 843.91
 },
 {
 "compressor": "zlib",
@@ -1464,8 +1464,8 @@
 "level": 2,
 "out_size": 233553,
 "ratio": 0.2268,
-"compress_mbps": 248.4,
-"decompress_mbps": 1001.05
+"compress_mbps": 247.81,
+"decompress_mbps": 997.79
 },
 {
 "compressor": "zlib",
@@ -1474,8 +1474,8 @@
 "level": 3,
 "out_size": 228222,
 "ratio": 0.2216,
-"compress_mbps": 196.91,
-"decompress_mbps": 1059.21
+"compress_mbps": 196.18,
+"decompress_mbps": 1058.35
 },
 {
 "compressor": "zlib",
@@ -1484,8 +1484,8 @@
 "level": 4,
 "out_size": 223668,
 "ratio": 0.2172,
-"compress_mbps": 176.47,
-"decompress_mbps": 1088.12
+"compress_mbps": 176.7,
+"decompress_mbps": 1087.34
 },
 {
 "compressor": "zlib",
@@ -1494,8 +1494,8 @@
 "level": 5,
 "out_size": 205994,
 "ratio": 0.2,
-"compress_mbps": 109.94,
-"decompress_mbps": 1050.38
+"compress_mbps": 109.6,
+"decompress_mbps": 1043.08
 },
 {
 "compressor": "zlib",
@@ -1504,8 +1504,8 @@
 "level": 6,
 "out_size": 203986,
 "ratio": 0.1981,
-"compress_mbps": 50.03,
-"decompress_mbps": 1053.18
+"compress_mbps": 49.98,
+"decompress_mbps": 1044.15
 },
 {
 "compressor": "zlib",
@@ -1514,8 +1514,8 @@
 "level": 7,
 "out_size": 207681,
 "ratio": 0.2017,
-"compress_mbps": 37.01,
-"decompress_mbps": 1042.54
+"compress_mbps": 36.94,
+"decompress_mbps": 1035.1
 },
 {
 "compressor": "zlib",
@@ -1524,8 +1524,8 @@
 "level": 8,
 "out_size": 206827,
 "ratio": 0.2009,
-"compress_mbps": 7.29,
-"decompress_mbps": 1017.67
+"compress_mbps": 7.28,
+"decompress_mbps": 1010.23
 },
 {
 "compressor": "zlib",
@@ -1534,8 +1534,8 @@
 "level": 9,
 "out_size": 207023,
 "ratio": 0.201,
-"compress_mbps": 3.43,
-"decompress_mbps": 1016.47
+"compress_mbps": 3.42,
+"decompress_mbps": 1006.36
 },
 {
 "compressor": "zlib",
@@ -1544,8 +1544,8 @@
 "level": 1,
 "out_size": 174124,
 "ratio": 0.408,
-"compress_mbps": 124.3,
-"decompress_mbps": 398.24
+"compress_mbps": 122.72,
+"decompress_mbps": 394.72
 },
 {
 "compressor": "zlib",
@@ -1554,8 +1554,8 @@
 "level": 2,
 "out_size": 166150,
 "ratio": 0.3893,
-"compress_mbps": 105.8,
-"decompress_mbps": 407.6
+"compress_mbps": 104.19,
+"decompress_mbps": 403.73
 },
 {
 "compressor": "zlib",
@@ -1564,8 +1564,8 @@
 "level": 3,
 "out_size": 158784,
 "ratio": 0.3721,
-"compress_mbps": 70.8,
-"decompress_mbps": 423.56
+"compress_mbps": 69.75,
+"decompress_mbps": 423.34
 },
 {
 "compressor": "zlib",
@@ -1574,8 +1574,8 @@
 "level": 4,
 "out_size": 152782,
 "ratio": 0.358,
-"compress_mbps": 73.05,
-"decompress_mbps": 411.51
+"compress_mbps": 72.52,
+"decompress_mbps": 410.75
 },
 {
 "compressor": "zlib",
@@ -1584,8 +1584,8 @@
 "level": 5,
 "out_size": 147196,
 "ratio": 0.3449,
-"compress_mbps": 43.18,
-"decompress_mbps": 408.76
+"compress_mbps": 42.79,
+"decompress_mbps": 404.52
 },
 {
 "compressor": "zlib",
@@ -1594,8 +1594,8 @@
 "level": 6,
 "out_size": 144898,
 "ratio": 0.3395,
-"compress_mbps": 26.31,
-"decompress_mbps": 418.05
+"compress_mbps": 26.12,
+"decompress_mbps": 414.24
 },
 {
 "compressor": "zlib",
@@ -1604,8 +1604,8 @@
 "level": 7,
 "out_size": 144589,
 "ratio": 0.3388,
-"compress_mbps": 22.82,
-"decompress_mbps": 421.5
+"compress_mbps": 22.68,
+"decompress_mbps": 416.65
 },
 {
 "compressor": "zlib",
@@ -1614,8 +1614,8 @@
 "level": 8,
 "out_size": 144436,
 "ratio": 0.3385,
-"compress_mbps": 19.61,
-"decompress_mbps": 420.24
+"compress_mbps": 19.51,
+"decompress_mbps": 415.99
 },
 {
 "compressor": "zlib",
@@ -1624,8 +1624,8 @@
 "level": 9,
 "out_size": 144433,
 "ratio": 0.3384,
-"compress_mbps": 19.53,
-"decompress_mbps": 420.4
+"compress_mbps": 19.45,
+"decompress_mbps": 417.23
 },
 {
 "compressor": "zlib",
@@ -1634,8 +1634,8 @@
 "level": 1,
 "out_size": 228883,
 "ratio": 0.475,
-"compress_mbps": 108.41,
-"decompress_mbps": 373.9
+"compress_mbps": 107.18,
+"decompress_mbps": 367.93
 },
 {
 "compressor": "zlib",
@@ -1644,8 +1644,8 @@
 "level": 2,
 "out_size": 219047,
 "ratio": 0.4546,
-"compress_mbps": 91.35,
-"decompress_mbps": 393.0
+"compress_mbps": 90.23,
+"decompress_mbps": 388.32
 },
 {
 "compressor": "zlib",
@@ -1654,8 +1654,8 @@
 "level": 3,
 "out_size": 209408,
 "ratio": 0.4346,
-"compress_mbps": 55.78,
-"decompress_mbps": 405.83
+"compress_mbps": 55.01,
+"decompress_mbps": 402.18
 },
 {
 "compressor": "zlib",
@@ -1664,8 +1664,8 @@
 "level": 4,
 "out_size": 205916,
 "ratio": 0.4273,
-"compress_mbps": 61.5,
-"decompress_mbps": 381.05
+"compress_mbps": 61.06,
+"decompress_mbps": 378.11
 },
 {
 "compressor": "zlib",
@@ -1674,8 +1674,8 @@
 "level": 5,
 "out_size": 199188,
 "ratio": 0.4134,
-"compress_mbps": 32.85,
-"decompress_mbps": 362.35
+"compress_mbps": 32.51,
+"decompress_mbps": 357.49
 },
 {
 "compressor": "zlib",
@@ -1684,8 +1684,8 @@
 "level": 6,
 "out_size": 195255,
 "ratio": 0.4052,
-"compress_mbps": 19.35,
-"decompress_mbps": 372.42
+"compress_mbps": 19.19,
+"decompress_mbps": 365.87
 },
 {
 "compressor": "zlib",
@@ -1694,8 +1694,8 @@
 "level": 7,
 "out_size": 194657,
 "ratio": 0.404,
-"compress_mbps": 16.37,
-"decompress_mbps": 373.58
+"compress_mbps": 16.26,
+"decompress_mbps": 370.27
 },
 {
 "compressor": "zlib",
@@ -1704,8 +1704,8 @@
 "level": 8,
 "out_size": 194326,
 "ratio": 0.4033,
-"compress_mbps": 12.97,
-"decompress_mbps": 368.28
+"compress_mbps": 12.87,
+"decompress_mbps": 369.51
 },
 {
 "compressor": "zlib",
@@ -1714,8 +1714,8 @@
 "level": 9,
 "out_size": 194326,
 "ratio": 0.4033,
-"compress_mbps": 12.95,
-"decompress_mbps": 374.4
+"compress_mbps": 12.86,
+"decompress_mbps": 368.77
 },
 {
 "compressor": "zlib",
@@ -1724,8 +1724,8 @@
 "level": 1,
 "out_size": 65553,
 "ratio": 0.1277,
-"compress_mbps": 275.69,
-"decompress_mbps": 899.15
+"compress_mbps": 270.76,
+"decompress_mbps": 887.65
 },
 {
 "compressor": "zlib",
@@ -1734,8 +1734,8 @@
 "level": 2,
 "out_size": 63891,
 "ratio": 0.1245,
-"compress_mbps": 249.54,
-"decompress_mbps": 932.29
+"compress_mbps": 244.47,
+"decompress_mbps": 914.86
 },
 {
 "compressor": "zlib",
@@ -1744,8 +1744,8 @@
 "level": 3,
 "out_size": 62515,
 "ratio": 0.1218,
-"compress_mbps": 196.07,
-"decompress_mbps": 997.69
+"compress_mbps": 192.65,
+"decompress_mbps": 975.16
 },
 {
 "compressor": "zlib",
@@ -1754,8 +1754,8 @@
 "level": 4,
 "out_size": 58451,
 "ratio": 0.1139,
-"compress_mbps": 166.99,
-"decompress_mbps": 702.93
+"compress_mbps": 165.93,
+"decompress_mbps": 700.13
 },
 {
 "compressor": "zlib",
@@ -1764,8 +1764,8 @@
 "level": 5,
 "out_size": 57410,
 "ratio": 0.1119,
-"compress_mbps": 128.84,
-"decompress_mbps": 735.39
+"compress_mbps": 127.99,
+"decompress_mbps": 729.11
 },
 {
 "compressor": "zlib",
@@ -1774,8 +1774,8 @@
 "level": 6,
 "out_size": 56459,
 "ratio": 0.11,
-"compress_mbps": 76.65,
-"decompress_mbps": 780.02
+"compress_mbps": 76.24,
+"decompress_mbps": 776.91
 },
 {
 "compressor": "zlib",
@@ -1784,8 +1784,8 @@
 "level": 7,
 "out_size": 55358,
 "ratio": 0.1079,
-"compress_mbps": 60.09,
-"decompress_mbps": 819.25
+"compress_mbps": 59.79,
+"decompress_mbps": 811.68
 },
 {
 "compressor": "zlib",
@@ -1794,8 +1794,8 @@
 "level": 8,
 "out_size": 52991,
 "ratio": 0.1033,
-"compress_mbps": 27.46,
-"decompress_mbps": 872.77
+"compress_mbps": 27.34,
+"decompress_mbps": 869.38
 },
 {
 "compressor": "zlib",
@@ -1804,8 +1804,8 @@
 "level": 9,
 "out_size": 52215,
 "ratio": 0.1017,
-"compress_mbps": 9.81,
-"decompress_mbps": 886.21
+"compress_mbps": 9.78,
+"decompress_mbps": 885.29
 },
 {
 "compressor": "zlib",
@@ -1814,8 +1814,8 @@
 "level": 1,
 "out_size": 14112,
 "ratio": 0.369,
-"compress_mbps": 127.97,
-"decompress_mbps": 886.32
+"compress_mbps": 126.86,
+"decompress_mbps": 938.48
 },
 {
 "compressor": "zlib",
@@ -1824,8 +1824,8 @@
 "level": 2,
 "out_size": 13815,
 "ratio": 0.3613,
-"compress_mbps": 110.5,
-"decompress_mbps": 978.52
+"compress_mbps": 108.59,
+"decompress_mbps": 972.73
 },
 {
 "compressor": "zlib",
@@ -1834,8 +1834,8 @@
 "level": 3,
 "out_size": 13795,
 "ratio": 0.3607,
-"compress_mbps": 80.06,
-"decompress_mbps": 1017.74
+"compress_mbps": 78.26,
+"decompress_mbps": 1006.69
 },
 {
 "compressor": "zlib",
@@ -1844,8 +1844,8 @@
 "level": 4,
 "out_size": 13375,
 "ratio": 0.3498,
-"compress_mbps": 79.5,
-"decompress_mbps": 1014.03
+"compress_mbps": 78.79,
+"decompress_mbps": 1002.93
 },
 {
 "compressor": "zlib",
@@ -1854,8 +1854,8 @@
 "level": 5,
 "out_size": 13062,
 "ratio": 0.3416,
-"compress_mbps": 54.97,
-"decompress_mbps": 1045.33
+"compress_mbps": 54.73,
+"decompress_mbps": 1036.92
 },
 {
 "compressor": "zlib",
@@ -1864,8 +1864,8 @@
 "level": 6,
 "out_size": 12984,
 "ratio": 0.3395,
-"compress_mbps": 32.77,
-"decompress_mbps": 1062.08
+"compress_mbps": 32.66,
+"decompress_mbps": 1055.99
 },
 {
 "compressor": "zlib",
@@ -1874,8 +1874,8 @@
 "level": 7,
 "out_size": 12949,
 "ratio": 0.3386,
-"compress_mbps": 25.29,
-"decompress_mbps": 1063.87
+"compress_mbps": 25.15,
+"decompress_mbps": 1058.41
 },
 {
 "compressor": "zlib",
@@ -1884,8 +1884,8 @@
 "level": 8,
 "out_size": 12894,
 "ratio": 0.3372,
-"compress_mbps": 11.05,
-"decompress_mbps": 1078.63
+"compress_mbps": 11.0,
+"decompress_mbps": 1075.8
 },
 {
 "compressor": "zlib",
@@ -1894,8 +1894,8 @@
 "level": 9,
 "out_size": 12832,
 "ratio": 0.3356,
-"compress_mbps": 5.09,
-"decompress_mbps": 1086.76
+"compress_mbps": 5.07,
+"decompress_mbps": 1079.24
 },
 {
 "compressor": "zlib",
@@ -1904,8 +1904,8 @@
 "level": 1,
 "out_size": 1846,
 "ratio": 0.4367,
-"compress_mbps": 285.58,
-"decompress_mbps": 711.97
+"compress_mbps": 283.59,
+"decompress_mbps": 702.3
 },
 {
 "compressor": "zlib",
@@ -1914,8 +1914,8 @@
 "level": 2,
 "out_size": 1820,
 "ratio": 0.4306,
-"compress_mbps": 278.96,
-"decompress_mbps": 727.26
+"compress_mbps": 277.73,
+"decompress_mbps": 715.13
 },
 {
 "compressor": "zlib",
@@ -1924,8 +1924,8 @@
 "level": 3,
 "out_size": 1808,
 "ratio": 0.4277,
-"compress_mbps": 268.58,
-"decompress_mbps": 734.54
+"compress_mbps": 266.72,
+"decompress_mbps": 727.13
 },
 {
 "compressor": "zlib",
@@ -1934,8 +1934,8 @@
 "level": 4,
 "out_size": 1749,
 "ratio": 0.4138,
-"compress_mbps": 219.77,
-"decompress_mbps": 746.1
+"compress_mbps": 219.22,
+"decompress_mbps": 738.04
 },
 {
 "compressor": "zlib",
@@ -1944,8 +1944,8 @@
 "level": 5,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 191.9,
-"decompress_mbps": 749.15
+"compress_mbps": 192.41,
+"decompress_mbps": 738.99
 },
 {
 "compressor": "zlib",
@@ -1954,8 +1954,8 @@
 "level": 6,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 190.06,
-"decompress_mbps": 747.9
+"compress_mbps": 189.68,
+"decompress_mbps": 742.8
 },
 {
 "compressor": "zlib",
@@ -1964,8 +1964,8 @@
 "level": 7,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 187.37,
-"decompress_mbps": 752.09
+"compress_mbps": 187.57,
+"decompress_mbps": 744.31
 },
 {
 "compressor": "zlib",
@@ -1974,8 +1974,8 @@
 "level": 8,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 187.19,
-"decompress_mbps": 755.33
+"compress_mbps": 187.65,
+"decompress_mbps": 743.49
 },
 {
 "compressor": "zlib",
@@ -1984,8 +1984,8 @@
 "level": 9,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 187.52,
-"decompress_mbps": 754.34
+"compress_mbps": 187.65,
+"decompress_mbps": 743.35
 },
 {
 "compressor": "miniz_oxide",
@@ -1994,8 +1994,8 @@
 "level": 1,
 "out_size": 76470,
 "ratio": 0.5028,
-"compress_mbps": 154.67,
-"decompress_mbps": 459.95
+"compress_mbps": 158.4,
+"decompress_mbps": 441.68
 },
 {
 "compressor": "miniz_oxide",
@@ -2004,8 +2004,8 @@
 "level": 2,
 "out_size": 62765,
 "ratio": 0.4127,
-"compress_mbps": 131.77,
-"decompress_mbps": 507.5
+"compress_mbps": 134.17,
+"decompress_mbps": 493.24
 },
 {
 "compressor": "miniz_oxide",
@@ -2014,8 +2014,8 @@
 "level": 3,
 "out_size": 57162,
 "ratio": 0.3758,
-"compress_mbps": 72.08,
-"decompress_mbps": 563.37
+"compress_mbps": 72.41,
+"decompress_mbps": 551.41
 },
 {
 "compressor": "miniz_oxide",
@@ -2024,8 +2024,8 @@
 "level": 4,
 "out_size": 56826,
 "ratio": 0.3736,
-"compress_mbps": 64.3,
-"decompress_mbps": 550.81
+"compress_mbps": 64.46,
+"decompress_mbps": 541.64
 },
 {
 "compressor": "miniz_oxide",
@@ -2034,8 +2034,8 @@
 "level": 5,
 "out_size": 55696,
 "ratio": 0.3662,
-"compress_mbps": 46.94,
-"decompress_mbps": 536.12
+"compress_mbps": 46.93,
+"decompress_mbps": 530.39
 },
 {
 "compressor": "miniz_oxide",
@@ -2044,8 +2044,8 @@
 "level": 6,
 "out_size": 54440,
 "ratio": 0.3579,
-"compress_mbps": 26.63,
-"decompress_mbps": 553.95
+"compress_mbps": 26.6,
+"decompress_mbps": 545.29
 },
 {
 "compressor": "miniz_oxide",
@@ -2054,8 +2054,8 @@
 "level": 7,
 "out_size": 54283,
 "ratio": 0.3569,
-"compress_mbps": 22.47,
-"decompress_mbps": 550.83
+"compress_mbps": 22.45,
+"decompress_mbps": 543.55
 },
 {
 "compressor": "miniz_oxide",
@@ -2064,8 +2064,8 @@
 "level": 8,
 "out_size": 54221,
 "ratio": 0.3565,
-"compress_mbps": 19.78,
-"decompress_mbps": 555.22
+"compress_mbps": 19.76,
+"decompress_mbps": 543.67
 },
 {
 "compressor": "miniz_oxide",
@@ -2074,8 +2074,8 @@
 "level": 9,
 "out_size": 54217,
 "ratio": 0.3565,
-"compress_mbps": 19.55,
-"decompress_mbps": 549.67
+"compress_mbps": 19.53,
+"decompress_mbps": 544.05
 },
 {
 "compressor": "miniz_oxide",
@@ -2084,8 +2084,8 @@
 "level": 1,
 "out_size": 64926,
 "ratio": 0.5187,
-"compress_mbps": 148.78,
-"decompress_mbps": 434.83
+"compress_mbps": 152.25,
+"decompress_mbps": 420.44
 },
 {
 "compressor": "miniz_oxide",
@@ -2094,8 +2094,8 @@
 "level": 2,
 "out_size": 54985,
 "ratio": 0.4393,
-"compress_mbps": 124.27,
-"decompress_mbps": 483.78
+"compress_mbps": 125.92,
+"decompress_mbps": 469.17
 },
 {
 "compressor": "miniz_oxide",
@@ -2104,8 +2104,8 @@
 "level": 3,
 "out_size": 51148,
 "ratio": 0.4086,
-"compress_mbps": 67.12,
-"decompress_mbps": 550.03
+"compress_mbps": 67.29,
+"decompress_mbps": 535.86
 },
 {
 "compressor": "miniz_oxide",
@@ -2114,8 +2114,8 @@
 "level": 4,
 "out_size": 50599,
 "ratio": 0.4042,
-"compress_mbps": 59.1,
-"decompress_mbps": 533.93
+"compress_mbps": 59.25,
+"decompress_mbps": 522.61
 },
 {
 "compressor": "miniz_oxide",
@@ -2124,8 +2124,8 @@
 "level": 5,
 "out_size": 49775,
 "ratio": 0.3976,
-"compress_mbps": 42.69,
-"decompress_mbps": 521.19
+"compress_mbps": 42.72,
+"decompress_mbps": 511.1
 },
 {
 "compressor": "miniz_oxide",
@@ -2134,8 +2134,8 @@
 "level": 6,
 "out_size": 48967,
 "ratio": 0.3912,
-"compress_mbps": 25.04,
-"decompress_mbps": 532.88
+"compress_mbps": 25.0,
+"decompress_mbps": 524.91
 },
 {
 "compressor": "miniz_oxide",
@@ -2144,8 +2144,8 @@
 "level": 7,
 "out_size": 48870,
 "ratio": 0.3904,
-"compress_mbps": 22.2,
-"decompress_mbps": 532.01
+"compress_mbps": 22.19,
+"decompress_mbps": 521.5
 },
 {
 "compressor": "miniz_oxide",
@@ -2154,8 +2154,8 @@
 "level": 8,
 "out_size": 48845,
 "ratio": 0.3902,
-"compress_mbps": 20.95,
-"decompress_mbps": 533.1
+"compress_mbps": 20.94,
+"decompress_mbps": 523.67
 },
 {
 "compressor": "miniz_oxide",
@@ -2164,8 +2164,8 @@
 "level": 9,
 "out_size": 48845,
 "ratio": 0.3902,
-"compress_mbps": 20.95,
-"decompress_mbps": 536.33
+"compress_mbps": 20.94,
+"decompress_mbps": 521.37
 },
 {
 "compressor": "miniz_oxide",
@@ -2174,8 +2174,8 @@
 "level": 1,
 "out_size": 10024,
 "ratio": 0.4074,
-"compress_mbps": 571.7,
-"decompress_mbps": 904.31
+"compress_mbps": 568.12,
+"decompress_mbps": 903.58
 },
 {
 "compressor": "miniz_oxide",
@@ -2184,8 +2184,8 @@
 "level": 2,
 "out_size": 8577,
 "ratio": 0.3486,
-"compress_mbps": 259.13,
-"decompress_mbps": 928.94
+"compress_mbps": 258.71,
+"decompress_mbps": 925.17
 },
 {
 "compressor": "miniz_oxide",
@@ -2194,8 +2194,8 @@
 "level": 3,
 "out_size": 8168,
 "ratio": 0.332,
-"compress_mbps": 154.41,
-"decompress_mbps": 946.82
+"compress_mbps": 156.4,
+"decompress_mbps": 944.88
 },
 {
 "compressor": "miniz_oxide",
@@ -2204,8 +2204,8 @@
 "level": 4,
 "out_size": 8069,
 "ratio": 0.328,
-"compress_mbps": 116.11,
-"decompress_mbps": 968.96
+"compress_mbps": 115.51,
+"decompress_mbps": 964.26
 },
 {
 "compressor": "miniz_oxide",
@@ -2214,8 +2214,8 @@
 "level": 5,
 "out_size": 7997,
 "ratio": 0.325,
-"compress_mbps": 100.41,
-"decompress_mbps": 997.88
+"compress_mbps": 100.83,
+"decompress_mbps": 996.36
 },
 {
 "compressor": "miniz_oxide",
@@ -2224,8 +2224,8 @@
 "level": 6,
 "out_size": 7952,
 "ratio": 0.3232,
-"compress_mbps": 75.25,
-"decompress_mbps": 1004.98
+"compress_mbps": 75.23,
+"decompress_mbps": 1002.32
 },
 {
 "compressor": "miniz_oxide",
@@ -2234,8 +2234,8 @@
 "level": 7,
 "out_size": 7947,
 "ratio": 0.323,
-"compress_mbps": 72.84,
-"decompress_mbps": 1010.08
+"compress_mbps": 72.08,
+"decompress_mbps": 1006.79
 },
 {
 "compressor": "miniz_oxide",
@@ -2244,8 +2244,8 @@
 "level": 8,
 "out_size": 7947,
 "ratio": 0.323,
-"compress_mbps": 71.68,
-"decompress_mbps": 1009.0
+"compress_mbps": 71.45,
+"decompress_mbps": 1004.89
 },
 {
 "compressor": "miniz_oxide",
@@ -2254,8 +2254,8 @@
 "level": 9,
 "out_size": 7947,
 "ratio": 0.323,
-"compress_mbps": 71.56,
-"decompress_mbps": 1011.22
+"compress_mbps": 71.03,
+"decompress_mbps": 1007.74
 },
 {
 "compressor": "miniz_oxide",
@@ -2264,8 +2264,8 @@
 "level": 1,
 "out_size": 4061,
 "ratio": 0.3642,
-"compress_mbps": 508.95,
-"decompress_mbps": 862.41
+"compress_mbps": 504.75,
+"decompress_mbps": 855.19
 },
 {
 "compressor": "miniz_oxide",
@@ -2274,8 +2274,8 @@
 "level": 2,
 "out_size": 3446,
 "ratio": 0.3091,
-"compress_mbps": 303.52,
-"decompress_mbps": 898.17
+"compress_mbps": 305.07,
+"decompress_mbps": 896.2
 },
 {
 "compressor": "miniz_oxide",
@@ -2284,8 +2284,8 @@
 "level": 3,
 "out_size": 3201,
 "ratio": 0.2871,
-"compress_mbps": 232.24,
-"decompress_mbps": 928.44
+"compress_mbps": 231.97,
+"decompress_mbps": 926.66
 },
 {
 "compressor": "miniz_oxide",
@@ -2294,8 +2294,8 @@
 "level": 4,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 195.33,
-"decompress_mbps": 951.97
+"compress_mbps": 194.23,
+"decompress_mbps": 954.53
 },
 {
 "compressor": "miniz_oxide",
@@ -2304,8 +2304,8 @@
 "level": 5,
 "out_size": 3139,
 "ratio": 0.2815,
-"compress_mbps": 162.28,
-"decompress_mbps": 973.76
+"compress_mbps": 162.92,
+"decompress_mbps": 966.15
 },
 {
 "compressor": "miniz_oxide",
@@ -2314,8 +2314,8 @@
 "level": 6,
 "out_size": 3115,
 "ratio": 0.2794,
-"compress_mbps": 116.31,
-"decompress_mbps": 982.49
+"compress_mbps": 115.76,
+"decompress_mbps": 981.58
 },
 {
 "compressor": "miniz_oxide",
@@ -2324,8 +2324,8 @@
 "level": 7,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 106.29,
-"decompress_mbps": 985.77
+"compress_mbps": 106.21,
+"decompress_mbps": 982.58
 },
 {
 "compressor": "miniz_oxide",
@@ -2334,8 +2334,8 @@
 "level": 8,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 103.84,
-"decompress_mbps": 984.4
+"compress_mbps": 103.08,
+"decompress_mbps": 982.13
 },
 {
 "compressor": "miniz_oxide",
@@ -2344,8 +2344,8 @@
 "level": 9,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 103.0,
-"decompress_mbps": 983.85
+"compress_mbps": 102.7,
+"decompress_mbps": 984.12
 },
 {
 "compressor": "miniz_oxide",
@@ -2354,8 +2354,8 @@
 "level": 1,
 "out_size": 1410,
 "ratio": 0.3789,
-"compress_mbps": 368.92,
-"decompress_mbps": 592.52
+"compress_mbps": 365.54,
+"decompress_mbps": 589.18
 },
 {
 "compressor": "miniz_oxide",
@@ -2364,8 +2364,8 @@
 "level": 2,
 "out_size": 1262,
 "ratio": 0.3392,
-"compress_mbps": 234.7,
-"decompress_mbps": 597.01
+"compress_mbps": 232.57,
+"decompress_mbps": 596.51
 },
 {
 "compressor": "miniz_oxide",
@@ -2374,8 +2374,8 @@
 "level": 3,
 "out_size": 1238,
 "ratio": 0.3327,
-"compress_mbps": 206.74,
-"decompress_mbps": 599.73
+"compress_mbps": 207.41,
+"decompress_mbps": 598.02
 },
 {
 "compressor": "miniz_oxide",
@@ -2384,8 +2384,8 @@
 "level": 4,
 "out_size": 1219,
 "ratio": 0.3276,
-"compress_mbps": 176.0,
-"decompress_mbps": 614.37
+"compress_mbps": 177.25,
+"decompress_mbps": 615.87
 },
 {
 "compressor": "miniz_oxide",
@@ -2394,8 +2394,8 @@
 "level": 5,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 161.43,
-"decompress_mbps": 620.61
+"compress_mbps": 162.53,
+"decompress_mbps": 619.52
 },
 {
 "compressor": "miniz_oxide",
@@ -2404,8 +2404,8 @@
 "level": 6,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 147.18,
-"decompress_mbps": 623.77
+"compress_mbps": 147.56,
+"decompress_mbps": 626.41
 },
 {
 "compressor": "miniz_oxide",
@@ -2414,8 +2414,8 @@
 "level": 7,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 146.23,
-"decompress_mbps": 624.98
+"compress_mbps": 147.05,
+"decompress_mbps": 628.3
 },
 {
 "compressor": "miniz_oxide",
@@ -2424,8 +2424,8 @@
 "level": 8,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 146.37,
-"decompress_mbps": 616.08
+"compress_mbps": 146.41,
+"decompress_mbps": 623.33
 },
 {
 "compressor": "miniz_oxide",
@@ -2434,8 +2434,8 @@
 "level": 9,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 146.26,
-"decompress_mbps": 622.89
+"compress_mbps": 146.72,
+"decompress_mbps": 626.08
 },
 {
 "compressor": "miniz_oxide",
@@ -2444,8 +2444,8 @@
 "level": 1,
 "out_size": 274412,
 "ratio": 0.2665,
-"compress_mbps": 448.55,
-"decompress_mbps": 799.54
+"compress_mbps": 451.96,
+"decompress_mbps": 792.76
 },
 {
 "compressor": "miniz_oxide",
@@ -2454,8 +2454,8 @@
 "level": 2,
 "out_size": 213239,
 "ratio": 0.2071,
-"compress_mbps": 276.24,
-"decompress_mbps": 906.33
+"compress_mbps": 276.99,
+"decompress_mbps": 896.16
 },
 {
 "compressor": "miniz_oxide",
@@ -2464,8 +2464,8 @@
 "level": 3,
 "out_size": 232107,
 "ratio": 0.2254,
-"compress_mbps": 137.38,
-"decompress_mbps": 949.23
+"compress_mbps": 137.1,
+"decompress_mbps": 940.9
 },
 {
 "compressor": "miniz_oxide",
@@ -2474,8 +2474,8 @@
 "level": 4,
 "out_size": 202733,
 "ratio": 0.1969,
-"compress_mbps": 130.45,
-"decompress_mbps": 960.8
+"compress_mbps": 129.88,
+"decompress_mbps": 947.59
 },
 {
 "compressor": "miniz_oxide",
@@ -2484,8 +2484,8 @@
 "level": 5,
 "out_size": 207803,
 "ratio": 0.2018,
-"compress_mbps": 84.42,
-"decompress_mbps": 969.76
+"compress_mbps": 84.12,
+"decompress_mbps": 955.44
 },
 {
 "compressor": "miniz_oxide",
@@ -2494,8 +2494,8 @@
 "level": 6,
 "out_size": 205270,
 "ratio": 0.1993,
-"compress_mbps": 27.3,
-"decompress_mbps": 992.46
+"compress_mbps": 27.21,
+"decompress_mbps": 983.18
 },
 {
 "compressor": "miniz_oxide",
@@ -2504,8 +2504,8 @@
 "level": 7,
 "out_size": 209951,
 "ratio": 0.2039,
-"compress_mbps": 19.31,
-"decompress_mbps": 1008.71
+"compress_mbps": 19.28,
+"decompress_mbps": 995.62
 },
 {
 "compressor": "miniz_oxide",
@@ -2514,8 +2514,8 @@
 "level": 8,
 "out_size": 209656,
 "ratio": 0.2036,
-"compress_mbps": 12.24,
-"decompress_mbps": 1015.92
+"compress_mbps": 12.21,
+"decompress_mbps": 1007.05
 },
 {
 "compressor": "miniz_oxide",
@@ -2524,8 +2524,8 @@
 "level": 9,
 "out_size": 209189,
 "ratio": 0.2031,
-"compress_mbps": 8.96,
-"decompress_mbps": 1020.06
+"compress_mbps": 8.94,
+"decompress_mbps": 1011.41
 },
 {
 "compressor": "miniz_oxide",
@@ -2534,8 +2534,8 @@
 "level": 1,
 "out_size": 208640,
 "ratio": 0.4889,
-"compress_mbps": 155.72,
-"decompress_mbps": 442.72
+"compress_mbps": 155.63,
+"decompress_mbps": 425.97
 },
 {
 "compressor": "miniz_oxide",
@@ -2544,8 +2544,8 @@
 "level": 2,
 "out_size": 167329,
 "ratio": 0.3921,
-"compress_mbps": 137.61,
-"decompress_mbps": 482.97
+"compress_mbps": 139.25,
+"decompress_mbps": 466.78
 },
 {
 "compressor": "miniz_oxide",
@@ -2554,8 +2554,8 @@
 "level": 3,
 "out_size": 151097,
 "ratio": 0.3541,
-"compress_mbps": 73.51,
-"decompress_mbps": 527.02
+"compress_mbps": 73.66,
+"decompress_mbps": 512.97
 },
 {
 "compressor": "miniz_oxide",
@@ -2564,8 +2564,8 @@
 "level": 4,
 "out_size": 150035,
 "ratio": 0.3516,
-"compress_mbps": 66.58,
-"decompress_mbps": 519.88
+"compress_mbps": 66.53,
+"decompress_mbps": 512.15
 },
 {
 "compressor": "miniz_oxide",
@@ -2575,7 +2575,7 @@
 "out_size": 147375,
 "ratio": 0.3453,
 "compress_mbps": 48.17,
-"decompress_mbps": 519.68
+"decompress_mbps": 508.36
 },
 {
 "compressor": "miniz_oxide",
@@ -2584,8 +2584,8 @@
 "level": 6,
 "out_size": 144908,
 "ratio": 0.3396,
-"compress_mbps": 28.08,
-"decompress_mbps": 529.34
+"compress_mbps": 28.07,
+"decompress_mbps": 519.9
 },
 {
 "compressor": "miniz_oxide",
@@ -2594,8 +2594,8 @@
 "level": 7,
 "out_size": 144562,
 "ratio": 0.3387,
-"compress_mbps": 24.65,
-"decompress_mbps": 530.13
+"compress_mbps": 24.64,
+"decompress_mbps": 519.53
 },
 {
 "compressor": "miniz_oxide",
@@ -2604,8 +2604,8 @@
 "level": 8,
 "out_size": 144449,
 "ratio": 0.3385,
-"compress_mbps": 22.4,
-"decompress_mbps": 530.95
+"compress_mbps": 22.41,
+"decompress_mbps": 518.91
 },
 {
 "compressor": "miniz_oxide",
@@ -2614,8 +2614,8 @@
 "level": 9,
 "out_size": 144438,
 "ratio": 0.3385,
-"compress_mbps": 22.32,
-"decompress_mbps": 531.06
+"compress_mbps": 22.31,
+"decompress_mbps": 520.13
 },
 {
 "compressor": "miniz_oxide",
@@ -2624,8 +2624,8 @@
 "level": 1,
 "out_size": 264549,
 "ratio": 0.549,
-"compress_mbps": 133.92,
-"decompress_mbps": 392.37
+"compress_mbps": 134.75,
+"decompress_mbps": 378.48
 },
 {
 "compressor": "miniz_oxide",
@@ -2634,8 +2634,8 @@
 "level": 2,
 "out_size": 223724,
 "ratio": 0.4643,
-"compress_mbps": 118.46,
-"decompress_mbps": 438.9
+"compress_mbps": 119.83,
+"decompress_mbps": 423.57
 },
 {
 "compressor": "miniz_oxide",
@@ -2644,8 +2644,8 @@
 "level": 3,
 "out_size": 204825,
 "ratio": 0.4251,
-"compress_mbps": 60.6,
-"decompress_mbps": 491.91
+"compress_mbps": 60.68,
+"decompress_mbps": 479.4
 },
 {
 "compressor": "miniz_oxide",
@@ -2654,8 +2654,8 @@
 "level": 4,
 "out_size": 203945,
 "ratio": 0.4232,
-"compress_mbps": 53.99,
-"decompress_mbps": 482.0
+"compress_mbps": 54.03,
+"decompress_mbps": 473.58
 },
 {
 "compressor": "miniz_oxide",
@@ -2664,8 +2664,8 @@
 "level": 5,
 "out_size": 199780,
 "ratio": 0.4146,
-"compress_mbps": 37.89,
-"decompress_mbps": 465.53
+"compress_mbps": 37.91,
+"decompress_mbps": 457.2
 },
 {
 "compressor": "miniz_oxide",
@@ -2674,8 +2674,8 @@
 "level": 6,
 "out_size": 195417,
 "ratio": 0.4055,
-"compress_mbps": 21.18,
-"decompress_mbps": 476.91
+"compress_mbps": 21.17,
+"decompress_mbps": 468.52
 },
 {
 "compressor": "miniz_oxide",
@@ -2684,8 +2684,8 @@
 "level": 7,
 "out_size": 194796,
 "ratio": 0.4043,
-"compress_mbps": 17.91,
-"decompress_mbps": 475.37
+"compress_mbps": 17.87,
+"decompress_mbps": 468.56
 },
 {
 "compressor": "miniz_oxide",
@@ -2694,8 +2694,8 @@
 "level": 8,
 "out_size": 194543,
 "ratio": 0.4037,
-"compress_mbps": 15.72,
-"decompress_mbps": 476.29
+"compress_mbps": 15.69,
+"decompress_mbps": 466.49
 },
 {
 "compressor": "miniz_oxide",
@@ -2704,8 +2704,8 @@
 "level": 9,
 "out_size": 194460,
 "ratio": 0.4036,
-"compress_mbps": 15.05,
-"decompress_mbps": 475.14
+"compress_mbps": 15.02,
+"decompress_mbps": 468.43
 },
 {
 "compressor": "miniz_oxide",
@@ -2714,8 +2714,8 @@
 "level": 1,
 "out_size": 67436,
 "ratio": 0.1314,
-"compress_mbps": 622.44,
-"decompress_mbps": 1039.05
+"compress_mbps": 624.79,
+"decompress_mbps": 1014.95
 },
 {
 "compressor": "miniz_oxide",
@@ -2724,8 +2724,8 @@
 "level": 2,
 "out_size": 59257,
 "ratio": 0.1155,
-"compress_mbps": 278.53,
-"decompress_mbps": 1099.86
+"compress_mbps": 280.41,
+"decompress_mbps": 1070.32
 },
 {
 "compressor": "miniz_oxide",
@@ -2734,8 +2734,8 @@
 "level": 3,
 "out_size": 58316,
 "ratio": 0.1136,
-"compress_mbps": 181.33,
-"decompress_mbps": 1180.86
+"compress_mbps": 181.54,
+"decompress_mbps": 1155.66
 },
 {
 "compressor": "miniz_oxide",
@@ -2744,8 +2744,8 @@
 "level": 4,
 "out_size": 56291,
 "ratio": 0.1097,
-"compress_mbps": 184.61,
-"decompress_mbps": 1193.15
+"compress_mbps": 185.33,
+"decompress_mbps": 1156.45
 },
 {
 "compressor": "miniz_oxide",
@@ -2754,8 +2754,8 @@
 "level": 5,
 "out_size": 56220,
 "ratio": 0.1095,
-"compress_mbps": 146.19,
-"decompress_mbps": 1251.77
+"compress_mbps": 146.23,
+"decompress_mbps": 1221.77
 },
 {
 "compressor": "miniz_oxide",
@@ -2764,8 +2764,8 @@
 "level": 6,
 "out_size": 55972,
 "ratio": 0.1091,
-"compress_mbps": 74.59,
-"decompress_mbps": 1314.79
+"compress_mbps": 74.43,
+"decompress_mbps": 1279.83
 },
 {
 "compressor": "miniz_oxide",
@@ -2774,8 +2774,8 @@
 "level": 7,
 "out_size": 55121,
 "ratio": 0.1074,
-"compress_mbps": 52.13,
-"decompress_mbps": 1351.91
+"compress_mbps": 52.02,
+"decompress_mbps": 1313.02
 },
 {
 "compressor": "miniz_oxide",
@@ -2784,8 +2784,8 @@
 "level": 8,
 "out_size": 54124,
 "ratio": 0.1055,
-"compress_mbps": 36.74,
-"decompress_mbps": 1417.65
+"compress_mbps": 36.63,
+"decompress_mbps": 1384.59
 },
 {
 "compressor": "miniz_oxide",
@@ -2794,8 +2794,8 @@
 "level": 9,
 "out_size": 53699,
 "ratio": 0.1046,
-"compress_mbps": 28.69,
-"decompress_mbps": 1448.27
+"compress_mbps": 28.6,
+"decompress_mbps": 1419.91
 },
 {
 "compressor": "miniz_oxide",
@@ -2804,8 +2804,8 @@
 "level": 1,
 "out_size": 15612,
 "ratio": 0.4083,
-"compress_mbps": 509.76,
-"decompress_mbps": 854.52
+"compress_mbps": 513.22,
+"decompress_mbps": 851.77
 },
 {
 "compressor": "miniz_oxide",
@@ -2814,8 +2814,8 @@
 "level": 2,
 "out_size": 14133,
 "ratio": 0.3696,
-"compress_mbps": 146.24,
-"decompress_mbps": 891.52
+"compress_mbps": 147.1,
+"decompress_mbps": 887.42
 },
 {
 "compressor": "miniz_oxide",
@@ -2824,8 +2824,8 @@
 "level": 3,
 "out_size": 13341,
 "ratio": 0.3489,
-"compress_mbps": 89.01,
-"decompress_mbps": 916.89
+"compress_mbps": 89.31,
+"decompress_mbps": 908.8
 },
 {
 "compressor": "miniz_oxide",
@@ -2834,8 +2834,8 @@
 "level": 4,
 "out_size": 13289,
 "ratio": 0.3475,
-"compress_mbps": 83.27,
-"decompress_mbps": 940.98
+"compress_mbps": 84.3,
+"decompress_mbps": 936.07
 },
 {
 "compressor": "miniz_oxide",
@@ -2844,8 +2844,8 @@
 "level": 5,
 "out_size": 13052,
 "ratio": 0.3413,
-"compress_mbps": 67.19,
-"decompress_mbps": 978.44
+"compress_mbps": 67.06,
+"decompress_mbps": 977.29
 },
 {
 "compressor": "miniz_oxide",
@@ -2854,8 +2854,8 @@
 "level": 6,
 "out_size": 12996,
 "ratio": 0.3399,
-"compress_mbps": 37.27,
-"decompress_mbps": 987.56
+"compress_mbps": 37.22,
+"decompress_mbps": 989.22
 },
 {
 "compressor": "miniz_oxide",
@@ -2864,8 +2864,8 @@
 "level": 7,
 "out_size": 12972,
 "ratio": 0.3392,
-"compress_mbps": 27.33,
-"decompress_mbps": 994.15
+"compress_mbps": 27.24,
+"decompress_mbps": 991.21
 },
 {
 "compressor": "miniz_oxide",
@@ -2874,8 +2874,8 @@
 "level": 8,
 "out_size": 12951,
 "ratio": 0.3387,
-"compress_mbps": 19.08,
-"decompress_mbps": 997.28
+"compress_mbps": 19.02,
+"decompress_mbps": 997.52
 },
 {
 "compressor": "miniz_oxide",
@@ -2884,8 +2884,8 @@
 "level": 9,
 "out_size": 12933,
 "ratio": 0.3382,
-"compress_mbps": 14.9,
-"decompress_mbps": 1002.07
+"compress_mbps": 14.85,
+"decompress_mbps": 995.65
 },
 {
 "compressor": "miniz_oxide",
@@ -2894,8 +2894,8 @@
 "level": 1,
 "out_size": 1988,
 "ratio": 0.4703,
-"compress_mbps": 340.73,
-"decompress_mbps": 539.94
+"compress_mbps": 341.39,
+"decompress_mbps": 537.63
 },
 {
 "compressor": "miniz_oxide",
@@ -2904,8 +2904,8 @@
 "level": 2,
 "out_size": 1802,
 "ratio": 0.4263,
-"compress_mbps": 215.7,
-"decompress_mbps": 544.98
+"compress_mbps": 216.2,
+"decompress_mbps": 543.43
 },
 {
 "compressor": "miniz_oxide",
@@ -2914,8 +2914,8 @@
 "level": 3,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 203.83,
-"decompress_mbps": 551.46
+"compress_mbps": 205.95,
+"decompress_mbps": 551.08
 },
 {
 "compressor": "miniz_oxide",
@@ -2924,8 +2924,8 @@
 "level": 4,
 "out_size": 1732,
 "ratio": 0.4097,
-"compress_mbps": 169.53,
-"decompress_mbps": 569.3
+"compress_mbps": 170.53,
+"decompress_mbps": 569.13
 },
 {
 "compressor": "miniz_oxide",
@@ -2934,8 +2934,8 @@
 "level": 5,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 166.35,
-"decompress_mbps": 578.03
+"compress_mbps": 166.21,
+"decompress_mbps": 575.64
 },
 {
 "compressor": "miniz_oxide",
@@ -2944,8 +2944,8 @@
 "level": 6,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 164.73,
-"decompress_mbps": 578.03
+"compress_mbps": 165.97,
+"decompress_mbps": 573.59
 },
 {
 "compressor": "miniz_oxide",
@@ -2954,8 +2954,8 @@
 "level": 7,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 164.79,
-"decompress_mbps": 577.7
+"compress_mbps": 166.38,
+"decompress_mbps": 573.43
 },
 {
 "compressor": "miniz_oxide",
@@ -2964,8 +2964,8 @@
 "level": 8,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 164.97,
-"decompress_mbps": 577.2
+"compress_mbps": 166.6,
+"decompress_mbps": 574.98
 },
 {
 "compressor": "miniz_oxide",
@@ -2974,8 +2974,8 @@
 "level": 9,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 164.96,
-"decompress_mbps": 578.11
+"compress_mbps": 165.5,
+"decompress_mbps": 573.92
 },
 {
 "compressor": "libdeflate",
@@ -2984,8 +2984,8 @@
 "level": 1,
 "out_size": 59790,
 "ratio": 0.3931,
-"compress_mbps": 261.88,
-"decompress_mbps": 1003.4
+"compress_mbps": 262.44,
+"decompress_mbps": 995.75
 },
 {
 "compressor": "libdeflate",
@@ -2994,8 +2994,8 @@
 "level": 2,
 "out_size": 57173,
 "ratio": 0.3759,
-"compress_mbps": 181.24,
-"decompress_mbps": 1088.87
+"compress_mbps": 180.16,
+"decompress_mbps": 1085.4
 },
 {
 "compressor": "libdeflate",
@@ -3004,8 +3004,8 @@
 "level": 3,
 "out_size": 56189,
 "ratio": 0.3694,
-"compress_mbps": 151.4,
-"decompress_mbps": 1161.16
+"compress_mbps": 150.25,
+"decompress_mbps": 1161.44
 },
 {
 "compressor": "libdeflate",
@@ -3014,8 +3014,8 @@
 "level": 4,
 "out_size": 55816,
 "ratio": 0.367,
-"compress_mbps": 138.49,
-"decompress_mbps": 1207.76
+"compress_mbps": 137.76,
+"decompress_mbps": 1193.82
 },
 {
 "compressor": "libdeflate",
@@ -3024,8 +3024,8 @@
 "level": 5,
 "out_size": 54758,
 "ratio": 0.36,
-"compress_mbps": 108.67,
-"decompress_mbps": 1256.29
+"compress_mbps": 108.39,
+"decompress_mbps": 1248.74
 },
 {
 "compressor": "libdeflate",
@@ -3034,8 +3034,8 @@
 "level": 6,
 "out_size": 54220,
 "ratio": 0.3565,
-"compress_mbps": 83.61,
-"decompress_mbps": 1300.07
+"compress_mbps": 83.3,
+"decompress_mbps": 1295.46
 },
 {
 "compressor": "libdeflate",
@@ -3044,8 +3044,8 @@
 "level": 7,
 "out_size": 53801,
 "ratio": 0.3537,
-"compress_mbps": 59.99,
-"decompress_mbps": 1295.76
+"compress_mbps": 60.28,
+"decompress_mbps": 1295.93
 },
 {
 "compressor": "libdeflate",
@@ -3054,8 +3054,8 @@
 "level": 8,
 "out_size": 53573,
 "ratio": 0.3522,
-"compress_mbps": 39.01,
-"decompress_mbps": 1307.79
+"compress_mbps": 39.0,
+"decompress_mbps": 1301.62
 },
 {
 "compressor": "libdeflate",
@@ -3064,8 +3064,8 @@
 "level": 9,
 "out_size": 53546,
 "ratio": 0.3521,
-"compress_mbps": 34.53,
-"decompress_mbps": 1308.41
+"compress_mbps": 34.47,
+"decompress_mbps": 1304.07
 },
 {
 "compressor": "libdeflate",
@@ -3074,8 +3074,8 @@
 "level": 1,
 "out_size": 52276,
 "ratio": 0.4176,
-"compress_mbps": 243.49,
-"decompress_mbps": 956.23
+"compress_mbps": 243.11,
+"decompress_mbps": 954.22
 },
 {
 "compressor": "libdeflate",
@@ -3084,8 +3084,8 @@
 "level": 2,
 "out_size": 50534,
 "ratio": 0.4037,
-"compress_mbps": 168.73,
-"decompress_mbps": 1009.1
+"compress_mbps": 167.92,
+"decompress_mbps": 1003.32
 },
 {
 "compressor": "libdeflate",
@@ -3094,8 +3094,8 @@
 "level": 3,
 "out_size": 49919,
 "ratio": 0.3988,
-"compress_mbps": 141.6,
-"decompress_mbps": 1075.75
+"compress_mbps": 141.26,
+"decompress_mbps": 1069.89
 },
 {
 "compressor": "libdeflate",
@@ -3104,8 +3104,8 @@
 "level": 4,
 "out_size": 49715,
 "ratio": 0.3972,
-"compress_mbps": 131.52,
-"decompress_mbps": 1112.73
+"compress_mbps": 131.37,
+"decompress_mbps": 1107.75
 },
 {
 "compressor": "libdeflate",
@@ -3114,8 +3114,8 @@
 "level": 5,
 "out_size": 48735,
 "ratio": 0.3893,
-"compress_mbps": 100.31,
-"decompress_mbps": 1151.03
+"compress_mbps": 100.57,
+"decompress_mbps": 1154.14
 },
 {
 "compressor": "libdeflate",
@@ -3124,8 +3124,8 @@
 "level": 6,
 "out_size": 48422,
 "ratio": 0.3868,
-"compress_mbps": 79.45,
-"decompress_mbps": 1187.54
+"compress_mbps": 79.35,
+"decompress_mbps": 1182.43
 },
 {
 "compressor": "libdeflate",
@@ -3134,8 +3134,8 @@
 "level": 7,
 "out_size": 48249,
 "ratio": 0.3854,
-"compress_mbps": 61.04,
-"decompress_mbps": 1179.39
+"compress_mbps": 61.02,
+"decompress_mbps": 1185.24
 },
 {
 "compressor": "libdeflate",
@@ -3144,8 +3144,8 @@
 "level": 8,
 "out_size": 47977,
 "ratio": 0.3833,
-"compress_mbps": 43.04,
-"decompress_mbps": 1189.65
+"compress_mbps": 42.89,
+"decompress_mbps": 1178.17
 },
 {
 "compressor": "libdeflate",
@@ -3154,8 +3154,8 @@
 "level": 9,
 "out_size": 47971,
 "ratio": 0.3832,
-"compress_mbps": 41.1,
-"decompress_mbps": 1188.5
+"compress_mbps": 41.02,
+"decompress_mbps": 1176.31
 },
 {
 "compressor": "libdeflate",
@@ -3164,8 +3164,8 @@
 "level": 1,
 "out_size": 8385,
 "ratio": 0.3408,
-"compress_mbps": 691.5,
-"decompress_mbps": 948.16
+"compress_mbps": 688.37,
+"decompress_mbps": 933.56
 },
 {
 "compressor": "libdeflate",
@@ -3174,8 +3174,8 @@
 "level": 2,
 "out_size": 8380,
 "ratio": 0.3406,
-"compress_mbps": 438.54,
-"decompress_mbps": 969.04
+"compress_mbps": 436.65,
+"decompress_mbps": 968.92
 },
 {
 "compressor": "libdeflate",
@@ -3184,8 +3184,8 @@
 "level": 3,
 "out_size": 8286,
 "ratio": 0.3368,
-"compress_mbps": 407.73,
-"decompress_mbps": 997.63
+"compress_mbps": 402.96,
+"decompress_mbps": 1002.87
 },
 {
 "compressor": "libdeflate",
@@ -3194,8 +3194,8 @@
 "level": 4,
 "out_size": 8163,
 "ratio": 0.3318,
-"compress_mbps": 376.45,
-"decompress_mbps": 1027.15
+"compress_mbps": 374.46,
+"decompress_mbps": 1038.24
 },
 {
 "compressor": "libdeflate",
@@ -3204,8 +3204,8 @@
 "level": 5,
 "out_size": 8053,
 "ratio": 0.3273,
-"compress_mbps": 339.22,
-"decompress_mbps": 1063.9
+"compress_mbps": 333.9,
+"decompress_mbps": 1053.39
 },
 {
 "compressor": "libdeflate",
@@ -3214,8 +3214,8 @@
 "level": 6,
 "out_size": 7986,
 "ratio": 0.3246,
-"compress_mbps": 279.27,
-"decompress_mbps": 1056.14
+"compress_mbps": 277.12,
+"decompress_mbps": 1062.21
 },
 {
 "compressor": "libdeflate",
@@ -3224,8 +3224,8 @@
 "level": 7,
 "out_size": 7954,
 "ratio": 0.3233,
-"compress_mbps": 186.98,
-"decompress_mbps": 1068.45
+"compress_mbps": 190.83,
+"decompress_mbps": 1075.41
 },
 {
 "compressor": "libdeflate",
@@ -3234,8 +3234,8 @@
 "level": 8,
 "out_size": 7916,
 "ratio": 0.3217,
-"compress_mbps": 129.63,
-"decompress_mbps": 1076.59
+"compress_mbps": 128.54,
+"decompress_mbps": 1081.8
 },
 {
 "compressor": "libdeflate",
@@ -3244,8 +3244,8 @@
 "level": 9,
 "out_size": 7916,
 "ratio": 0.3217,
-"compress_mbps": 125.92,
-"decompress_mbps": 1072.75
+"compress_mbps": 124.64,
+"decompress_mbps": 1081.41
 },
 {
 "compressor": "libdeflate",
@@ -3254,8 +3254,8 @@
 "level": 1,
 "out_size": 3401,
 "ratio": 0.305,
-"compress_mbps": 586.77,
-"decompress_mbps": 823.73
+"compress_mbps": 584.35,
+"decompress_mbps": 759.48
 },
 {
 "compressor": "libdeflate",
@@ -3264,8 +3264,8 @@
 "level": 2,
 "out_size": 3307,
 "ratio": 0.2966,
-"compress_mbps": 396.92,
-"decompress_mbps": 805.44
+"compress_mbps": 397.36,
+"decompress_mbps": 835.64
 },
 {
 "compressor": "libdeflate",
@@ -3274,8 +3274,8 @@
 "level": 3,
 "out_size": 3242,
 "ratio": 0.2908,
-"compress_mbps": 369.03,
-"decompress_mbps": 869.6
+"compress_mbps": 368.54,
+"decompress_mbps": 856.36
 },
 {
 "compressor": "libdeflate",
@@ -3284,8 +3284,8 @@
 "level": 4,
 "out_size": 3205,
 "ratio": 0.2874,
-"compress_mbps": 349.29,
-"decompress_mbps": 863.53
+"compress_mbps": 350.5,
+"decompress_mbps": 885.53
 },
 {
 "compressor": "libdeflate",
@@ -3294,8 +3294,8 @@
 "level": 5,
 "out_size": 3150,
 "ratio": 0.2825,
-"compress_mbps": 313.05,
-"decompress_mbps": 860.73
+"compress_mbps": 312.13,
+"decompress_mbps": 895.9
 },
 {
 "compressor": "libdeflate",
@@ -3304,8 +3304,8 @@
 "level": 6,
 "out_size": 3126,
 "ratio": 0.2804,
-"compress_mbps": 267.45,
-"decompress_mbps": 894.25
+"compress_mbps": 263.64,
+"decompress_mbps": 898.4
 },
 {
 "compressor": "libdeflate",
@@ -3314,8 +3314,8 @@
 "level": 7,
 "out_size": 3106,
 "ratio": 0.2786,
-"compress_mbps": 207.68,
-"decompress_mbps": 899.31
+"compress_mbps": 207.09,
+"decompress_mbps": 903.44
 },
 {
 "compressor": "libdeflate",
@@ -3324,8 +3324,8 @@
 "level": 8,
 "out_size": 3102,
 "ratio": 0.2782,
-"compress_mbps": 148.38,
-"decompress_mbps": 895.83
+"compress_mbps": 146.67,
+"decompress_mbps": 910.87
 },
 {
 "compressor": "libdeflate",
@@ -3334,8 +3334,8 @@
 "level": 9,
 "out_size": 3102,
 "ratio": 0.2782,
-"compress_mbps": 141.36,
-"decompress_mbps": 899.77
+"compress_mbps": 139.8,
+"decompress_mbps": 893.34
 },
 {
 "compressor": "libdeflate",
@@ -3344,8 +3344,8 @@
 "level": 1,
 "out_size": 1251,
 "ratio": 0.3362,
-"compress_mbps": 382.85,
-"decompress_mbps": 463.51
+"compress_mbps": 380.55,
+"decompress_mbps": 458.72
 },
 {
 "compressor": "libdeflate",
@@ -3354,8 +3354,8 @@
 "level": 2,
 "out_size": 1228,
 "ratio": 0.33,
-"compress_mbps": 269.43,
-"decompress_mbps": 457.3
+"compress_mbps": 267.03,
+"decompress_mbps": 427.44
 },
 {
 "compressor": "libdeflate",
@@ -3364,8 +3364,8 @@
 "level": 3,
 "out_size": 1219,
 "ratio": 0.3276,
-"compress_mbps": 262.53,
-"decompress_mbps": 483.79
+"compress_mbps": 260.16,
+"decompress_mbps": 492.8
 },
 {
 "compressor": "libdeflate",
@@ -3374,8 +3374,8 @@
 "level": 4,
 "out_size": 1220,
 "ratio": 0.3279,
-"compress_mbps": 255.02,
-"decompress_mbps": 491.91
+"compress_mbps": 254.05,
+"decompress_mbps": 442.25
 },
 {
 "compressor": "libdeflate",
@@ -3384,8 +3384,8 @@
 "level": 5,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 240.7,
-"decompress_mbps": 483.6
+"compress_mbps": 240.05,
+"decompress_mbps": 485.85
 },
 {
 "compressor": "libdeflate",
@@ -3394,8 +3394,8 @@
 "level": 6,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 221.87,
-"decompress_mbps": 504.85
+"compress_mbps": 222.61,
+"decompress_mbps": 475.43
 },
 {
 "compressor": "libdeflate",
@@ -3404,8 +3404,8 @@
 "level": 7,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 203.62,
-"decompress_mbps": 502.64
+"compress_mbps": 202.79,
+"decompress_mbps": 485.98
 },
 {
 "compressor": "libdeflate",
@@ -3414,8 +3414,8 @@
 "level": 8,
 "out_size": 1204,
 "ratio": 0.3236,
-"compress_mbps": 169.26,
-"decompress_mbps": 480.78
+"compress_mbps": 166.06,
+"decompress_mbps": 487.78
 },
 {
 "compressor": "libdeflate",
@@ -3424,8 +3424,8 @@
 "level": 9,
 "out_size": 1204,
 "ratio": 0.3236,
-"compress_mbps": 169.01,
-"decompress_mbps": 510.08
+"compress_mbps": 165.63,
+"decompress_mbps": 485.85
 },
 {
 "compressor": "libdeflate",
@@ -3434,8 +3434,8 @@
 "level": 1,
 "out_size": 221813,
 "ratio": 0.2154,
-"compress_mbps": 596.36,
-"decompress_mbps": 1016.43
+"compress_mbps": 588.25,
+"decompress_mbps": 1014.19
 },
 {
 "compressor": "libdeflate",
@@ -3444,8 +3444,8 @@
 "level": 2,
 "out_size": 199825,
 "ratio": 0.1941,
-"compress_mbps": 406.68,
-"decompress_mbps": 1484.63
+"compress_mbps": 409.13,
+"decompress_mbps": 1475.95
 },
 {
 "compressor": "libdeflate",
@@ -3454,8 +3454,8 @@
 "level": 3,
 "out_size": 195675,
 "ratio": 0.19,
-"compress_mbps": 282.28,
-"decompress_mbps": 1547.98
+"compress_mbps": 282.82,
+"decompress_mbps": 1547.08
 },
 {
 "compressor": "libdeflate",
@@ -3464,8 +3464,8 @@
 "level": 4,
 "out_size": 195664,
 "ratio": 0.19,
-"compress_mbps": 279.42,
-"decompress_mbps": 1562.62
+"compress_mbps": 279.93,
+"decompress_mbps": 1557.2
 },
 {
 "compressor": "libdeflate",
@@ -3474,8 +3474,8 @@
 "level": 5,
 "out_size": 198900,
 "ratio": 0.1932,
-"compress_mbps": 239.84,
-"decompress_mbps": 1140.23
+"compress_mbps": 238.25,
+"decompress_mbps": 1138.61
 },
 {
 "compressor": "libdeflate",
@@ -3484,8 +3484,8 @@
 "level": 6,
 "out_size": 199347,
 "ratio": 0.1936,
-"compress_mbps": 204.57,
-"decompress_mbps": 1134.71
+"compress_mbps": 203.38,
+"decompress_mbps": 1137.58
 },
 {
 "compressor": "libdeflate",
@@ -3494,8 +3494,8 @@
 "level": 7,
 "out_size": 199777,
 "ratio": 0.194,
-"compress_mbps": 123.52,
-"decompress_mbps": 1196.81
+"compress_mbps": 123.06,
+"decompress_mbps": 1199.93
 },
 {
 "compressor": "libdeflate",
@@ -3504,8 +3504,8 @@
 "level": 8,
 "out_size": 182094,
 "ratio": 0.1768,
-"compress_mbps": 25.7,
-"decompress_mbps": 1184.36
+"compress_mbps": 25.58,
+"decompress_mbps": 1183.03
 },
 {
 "compressor": "libdeflate",
@@ -3514,8 +3514,8 @@
 "level": 9,
 "out_size": 181451,
 "ratio": 0.1762,
-"compress_mbps": 13.63,
-"decompress_mbps": 1185.12
+"compress_mbps": 13.6,
+"decompress_mbps": 1190.57
 },
 {
 "compressor": "libdeflate",
@@ -3524,8 +3524,8 @@
 "level": 1,
 "out_size": 159063,
 "ratio": 0.3727,
-"compress_mbps": 266.75,
-"decompress_mbps": 1037.65
+"compress_mbps": 263.48,
+"decompress_mbps": 1034.75
 },
 {
 "compressor": "libdeflate",
@@ -3534,8 +3534,8 @@
 "level": 2,
 "out_size": 152115,
 "ratio": 0.3564,
-"compress_mbps": 188.06,
-"decompress_mbps": 1116.38
+"compress_mbps": 186.89,
+"decompress_mbps": 1118.79
 },
 {
 "compressor": "libdeflate",
@@ -3544,8 +3544,8 @@
 "level": 3,
 "out_size": 149162,
 "ratio": 0.3495,
-"compress_mbps": 157.23,
-"decompress_mbps": 1207.36
+"compress_mbps": 156.66,
+"decompress_mbps": 1200.34
 },
 {
 "compressor": "libdeflate",
@@ -3554,8 +3554,8 @@
 "level": 4,
 "out_size": 148359,
 "ratio": 0.3476,
-"compress_mbps": 143.36,
-"decompress_mbps": 1051.13
+"compress_mbps": 142.85,
+"decompress_mbps": 1057.83
 },
 {
 "compressor": "libdeflate",
@@ -3564,8 +3564,8 @@
 "level": 5,
 "out_size": 145353,
 "ratio": 0.3406,
-"compress_mbps": 114.18,
-"decompress_mbps": 1035.17
+"compress_mbps": 112.92,
+"decompress_mbps": 1024.09
 },
 {
 "compressor": "libdeflate",
@@ -3574,8 +3574,8 @@
 "level": 6,
 "out_size": 144209,
 "ratio": 0.3379,
-"compress_mbps": 88.46,
-"decompress_mbps": 1072.72
+"compress_mbps": 87.37,
+"decompress_mbps": 1060.35
 },
 {
 "compressor": "libdeflate",
@@ -3584,8 +3584,8 @@
 "level": 7,
 "out_size": 143604,
 "ratio": 0.3365,
-"compress_mbps": 66.9,
-"decompress_mbps": 1074.29
+"compress_mbps": 66.48,
+"decompress_mbps": 1068.87
 },
 {
 "compressor": "libdeflate",
@@ -3594,8 +3594,8 @@
 "level": 8,
 "out_size": 142086,
 "ratio": 0.3329,
-"compress_mbps": 44.16,
-"decompress_mbps": 1072.76
+"compress_mbps": 44.17,
+"decompress_mbps": 1056.99
 },
 {
 "compressor": "libdeflate",
@@ -3604,8 +3604,8 @@
 "level": 9,
 "out_size": 142027,
 "ratio": 0.3328,
-"compress_mbps": 40.29,
-"decompress_mbps": 1070.38
+"compress_mbps": 40.43,
+"decompress_mbps": 1069.75
 },
 {
 "compressor": "libdeflate",
@@ -3614,8 +3614,8 @@
 "level": 1,
 "out_size": 210662,
 "ratio": 0.4372,
-"compress_mbps": 232.43,
-"decompress_mbps": 874.46
+"compress_mbps": 229.19,
+"decompress_mbps": 879.78
 },
 {
 "compressor": "libdeflate",
@@ -3624,8 +3624,8 @@
 "level": 2,
 "out_size": 202881,
 "ratio": 0.421,
-"compress_mbps": 159.07,
-"decompress_mbps": 944.0
+"compress_mbps": 158.88,
+"decompress_mbps": 948.93
 },
 {
 "compressor": "libdeflate",
@@ -3634,8 +3634,8 @@
 "level": 3,
 "out_size": 200409,
 "ratio": 0.4159,
-"compress_mbps": 133.34,
-"decompress_mbps": 1029.07
+"compress_mbps": 133.25,
+"decompress_mbps": 1027.43
 },
 {
 "compressor": "libdeflate",
@@ -3644,8 +3644,8 @@
 "level": 4,
 "out_size": 199678,
 "ratio": 0.4144,
-"compress_mbps": 123.03,
-"decompress_mbps": 855.87
+"compress_mbps": 123.52,
+"decompress_mbps": 863.69
 },
 {
 "compressor": "libdeflate",
@@ -3654,8 +3654,8 @@
 "level": 5,
 "out_size": 195798,
 "ratio": 0.4063,
-"compress_mbps": 93.84,
-"decompress_mbps": 809.86
+"compress_mbps": 93.63,
+"decompress_mbps": 814.09
 },
 {
 "compressor": "libdeflate",
@@ -3664,8 +3664,8 @@
 "level": 6,
 "out_size": 194029,
 "ratio": 0.4027,
-"compress_mbps": 72.38,
-"decompress_mbps": 836.25
+"compress_mbps": 71.92,
+"decompress_mbps": 839.22
 },
 {
 "compressor": "libdeflate",
@@ -3674,8 +3674,8 @@
 "level": 7,
 "out_size": 192773,
 "ratio": 0.4001,
-"compress_mbps": 50.81,
-"decompress_mbps": 836.67
+"compress_mbps": 51.4,
+"decompress_mbps": 844.46
 },
 {
 "compressor": "libdeflate",
@@ -3684,8 +3684,8 @@
 "level": 8,
 "out_size": 191739,
 "ratio": 0.3979,
-"compress_mbps": 33.67,
-"decompress_mbps": 839.55
+"compress_mbps": 33.65,
+"decompress_mbps": 833.43
 },
 {
 "compressor": "libdeflate",
@@ -3694,8 +3694,8 @@
 "level": 9,
 "out_size": 191676,
 "ratio": 0.3978,
-"compress_mbps": 31.1,
-"decompress_mbps": 842.23
+"compress_mbps": 31.03,
+"decompress_mbps": 842.91
 },
 {
 "compressor": "libdeflate",
@@ -3704,8 +3704,8 @@
 "level": 1,
 "out_size": 58079,
 "ratio": 0.1132,
-"compress_mbps": 374.11,
-"decompress_mbps": 1715.87
+"compress_mbps": 373.41,
+"decompress_mbps": 1709.49
 },
 {
 "compressor": "libdeflate",
@@ -3714,8 +3714,8 @@
 "level": 2,
 "out_size": 57838,
 "ratio": 0.1127,
-"compress_mbps": 413.4,
-"decompress_mbps": 1815.91
+"compress_mbps": 414.45,
+"decompress_mbps": 1817.42
 },
 {
 "compressor": "libdeflate",
@@ -3724,8 +3724,8 @@
 "level": 3,
 "out_size": 57554,
 "ratio": 0.1121,
-"compress_mbps": 395.02,
-"decompress_mbps": 1928.2
+"compress_mbps": 393.38,
+"decompress_mbps": 1908.59
 },
 {
 "compressor": "libdeflate",
@@ -3734,8 +3734,8 @@
 "level": 4,
 "out_size": 57064,
 "ratio": 0.1112,
-"compress_mbps": 375.5,
-"decompress_mbps": 1758.6
+"compress_mbps": 373.3,
+"decompress_mbps": 1753.82
 },
 {
 "compressor": "libdeflate",
@@ -3744,8 +3744,8 @@
 "level": 5,
 "out_size": 55743,
 "ratio": 0.1086,
-"compress_mbps": 345.05,
-"decompress_mbps": 1823.11
+"compress_mbps": 342.67,
+"decompress_mbps": 1804.91
 },
 {
 "compressor": "libdeflate",
@@ -3754,8 +3754,8 @@
 "level": 6,
 "out_size": 55102,
 "ratio": 0.1074,
-"compress_mbps": 286.19,
-"decompress_mbps": 1898.51
+"compress_mbps": 283.74,
+"decompress_mbps": 1901.37
 },
 {
 "compressor": "libdeflate",
@@ -3764,8 +3764,8 @@
 "level": 7,
 "out_size": 54742,
 "ratio": 0.1067,
-"compress_mbps": 193.27,
-"decompress_mbps": 1967.29
+"compress_mbps": 191.84,
+"decompress_mbps": 1927.62
 },
 {
 "compressor": "libdeflate",
@@ -3774,8 +3774,8 @@
 "level": 8,
 "out_size": 53133,
 "ratio": 0.1035,
-"compress_mbps": 102.91,
-"decompress_mbps": 2036.66
+"compress_mbps": 102.41,
+"decompress_mbps": 2011.92
 },
 {
 "compressor": "libdeflate",
@@ -3784,8 +3784,8 @@
 "level": 9,
 "out_size": 52186,
 "ratio": 0.1017,
-"compress_mbps": 72.25,
-"decompress_mbps": 2057.31
+"compress_mbps": 72.07,
+"decompress_mbps": 2064.93
 },
 {
 "compressor": "libdeflate",
@@ -3794,8 +3794,8 @@
 "level": 1,
 "out_size": 14122,
 "ratio": 0.3693,
-"compress_mbps": 649.26,
-"decompress_mbps": 830.11
+"compress_mbps": 644.49,
+"decompress_mbps": 829.0
 },
 {
 "compressor": "libdeflate",
@@ -3804,8 +3804,8 @@
 "level": 2,
 "out_size": 13374,
 "ratio": 0.3497,
-"compress_mbps": 341.83,
-"decompress_mbps": 893.31
+"compress_mbps": 376.73,
+"decompress_mbps": 889.98
 },
 {
 "compressor": "libdeflate",
@@ -3814,8 +3814,8 @@
 "level": 3,
 "out_size": 13293,
 "ratio": 0.3476,
-"compress_mbps": 275.45,
-"decompress_mbps": 986.89
+"compress_mbps": 269.35,
+"decompress_mbps": 978.68
 },
 {
 "compressor": "libdeflate",
@@ -3824,8 +3824,8 @@
 "level": 4,
 "out_size": 13259,
 "ratio": 0.3467,
-"compress_mbps": 272.86,
-"decompress_mbps": 990.29
+"compress_mbps": 259.3,
+"decompress_mbps": 977.58
 },
 {
 "compressor": "libdeflate",
@@ -3834,8 +3834,8 @@
 "level": 5,
 "out_size": 12641,
 "ratio": 0.3306,
-"compress_mbps": 190.46,
-"decompress_mbps": 1029.89
+"compress_mbps": 187.51,
+"decompress_mbps": 1014.71
 },
 {
 "compressor": "libdeflate",
@@ -3844,8 +3844,8 @@
 "level": 6,
 "out_size": 12432,
 "ratio": 0.3251,
-"compress_mbps": 164.12,
-"decompress_mbps": 1032.75
+"compress_mbps": 163.06,
+"decompress_mbps": 1033.86
 },
 {
 "compressor": "libdeflate",
@@ -3854,8 +3854,8 @@
 "level": 7,
 "out_size": 12439,
 "ratio": 0.3253,
-"compress_mbps": 123.55,
-"decompress_mbps": 1050.27
+"compress_mbps": 123.56,
+"decompress_mbps": 1039.91
 },
 {
 "compressor": "libdeflate",
@@ -3864,8 +3864,8 @@
 "level": 8,
 "out_size": 12579,
 "ratio": 0.3289,
-"compress_mbps": 67.7,
-"decompress_mbps": 1064.59
+"compress_mbps": 67.21,
+"decompress_mbps": 1052.88
 },
 {
 "compressor": "libdeflate",
@@ -3874,8 +3874,8 @@
 "level": 9,
 "out_size": 12574,
 "ratio": 0.3288,
-"compress_mbps": 47.3,
-"decompress_mbps": 1073.93
+"compress_mbps": 47.27,
+"decompress_mbps": 1058.65
 },
 {
 "compressor": "libdeflate",
@@ -3884,8 +3884,8 @@
 "level": 1,
 "out_size": 1777,
 "ratio": 0.4204,
-"compress_mbps": 385.35,
-"decompress_mbps": 401.23
+"compress_mbps": 383.7,
+"decompress_mbps": 407.97
 },
 {
 "compressor": "libdeflate",
@@ -3894,8 +3894,8 @@
 "level": 2,
 "out_size": 1756,
 "ratio": 0.4154,
-"compress_mbps": 259.56,
-"decompress_mbps": 409.3
+"compress_mbps": 256.0,
+"decompress_mbps": 398.65
 },
 {
 "compressor": "libdeflate",
@@ -3904,8 +3904,8 @@
 "level": 3,
 "out_size": 1746,
 "ratio": 0.4131,
-"compress_mbps": 256.52,
-"decompress_mbps": 409.88
+"compress_mbps": 254.7,
+"decompress_mbps": 434.86
 },
 {
 "compressor": "libdeflate",
@@ -3914,8 +3914,8 @@
 "level": 4,
 "out_size": 1740,
 "ratio": 0.4116,
-"compress_mbps": 254.67,
-"decompress_mbps": 410.63
+"compress_mbps": 252.15,
+"decompress_mbps": 439.56
 },
 {
 "compressor": "libdeflate",
@@ -3924,8 +3924,8 @@
 "level": 5,
 "out_size": 1722,
 "ratio": 0.4074,
-"compress_mbps": 238.49,
-"decompress_mbps": 437.27
+"compress_mbps": 239.28,
+"decompress_mbps": 452.69
 },
 {
 "compressor": "libdeflate",
@@ -3934,8 +3934,8 @@
 "level": 6,
 "out_size": 1721,
 "ratio": 0.4071,
-"compress_mbps": 234.9,
-"decompress_mbps": 444.84
+"compress_mbps": 235.38,
+"decompress_mbps": 450.46
 },
 {
 "compressor": "libdeflate",
@@ -3944,8 +3944,8 @@
 "level": 7,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 233.46,
-"decompress_mbps": 446.47
+"compress_mbps": 233.8,
+"decompress_mbps": 448.86
 },
 {
 "compressor": "libdeflate",
@@ -3954,8 +3954,8 @@
 "level": 8,
 "out_size": 1717,
 "ratio": 0.4062,
-"compress_mbps": 216.36,
-"decompress_mbps": 454.17
+"compress_mbps": 212.53,
+"decompress_mbps": 448.66
 },
 {
 "compressor": "libdeflate",
@@ -3964,8 +3964,8 @@
 "level": 9,
 "out_size": 1717,
 "ratio": 0.4062,
-"compress_mbps": 217.24,
-"decompress_mbps": 464.96
+"compress_mbps": 212.57,
+"decompress_mbps": 455.96
 },
 {
 "compressor": "zopfli",
@@ -3994,7 +3994,7 @@
 "level": 6,
 "out_size": 7697,
 "ratio": 0.3128,
-"compress_mbps": 0.66,
+"compress_mbps": 0.68,
 "decompress_mbps": null
 },
 {
@@ -4004,7 +4004,7 @@
 "level": 6,
 "out_size": 3002,
 "ratio": 0.2692,
-"compress_mbps": 0.57,
+"compress_mbps": 0.58,
 "decompress_mbps": null
 },
 {
@@ -4034,7 +4034,7 @@
 "level": 6,
 "out_size": 137229,
 "ratio": 0.3216,
-"compress_mbps": 0.78,
+"compress_mbps": 0.79,
 "decompress_mbps": null
 },
 {
@@ -4054,7 +4054,7 @@
 "level": 6,
 "out_size": 48558,
 "ratio": 0.0946,
-"compress_mbps": 0.38,
+"compress_mbps": 0.39,
 "decompress_mbps": null
 },
 {
@@ -4084,8 +4084,8 @@
 "level": 1,
 "out_size": 5364132,
 "ratio": 0.5263,
-"compress_mbps": 12.83,
-"decompress_mbps": 81.85
+"compress_mbps": 12.9,
+"decompress_mbps": 81.52
 },
 {
 "compressor": "native",
@@ -4094,8 +4094,8 @@
 "level": 2,
 "out_size": 5165701,
 "ratio": 0.5068,
-"compress_mbps": 11.37,
-"decompress_mbps": 88.98
+"compress_mbps": 11.35,
+"decompress_mbps": 88.58
 },
 {
 "compressor": "native",
@@ -4104,68 +4104,68 @@
 "level": 3,
 "out_size": 5046240,
 "ratio": 0.4951,
-"compress_mbps": 9.87,
-"decompress_mbps": 96.8
+"compress_mbps": 9.91,
+"decompress_mbps": 96.97
 },
 {
 "compressor": "native",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 4,
-"out_size": 5003437,
-"ratio": 0.4909,
-"compress_mbps": 9.03,
-"decompress_mbps": 96.17
+"out_size": 4889382,
+"ratio": 0.4797,
+"compress_mbps": 6.05,
+"decompress_mbps": 96.44
 },
 {
 "compressor": "native",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 5,
-"out_size": 4980160,
-"ratio": 0.4886,
-"compress_mbps": 8.45,
-"decompress_mbps": 97.33
+"out_size": 4867273,
+"ratio": 0.4775,
+"compress_mbps": 5.57,
+"decompress_mbps": 98.93
 },
 {
 "compressor": "native",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 6,
-"out_size": 4943357,
-"ratio": 0.485,
-"compress_mbps": 7.29,
-"decompress_mbps": 102.25
+"out_size": 4832420,
+"ratio": 0.4741,
+"compress_mbps": 4.71,
+"decompress_mbps": 101.78
 },
 {
 "compressor": "native",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 7,
-"out_size": 4927320,
-"ratio": 0.4834,
-"compress_mbps": 6.65,
-"decompress_mbps": 102.77
+"out_size": 3922973,
+"ratio": 0.3849,
+"compress_mbps": 1.51,
+"decompress_mbps": 100.71
 },
 {
 "compressor": "native",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 8,
-"out_size": 4922659,
-"ratio": 0.483,
-"compress_mbps": 6.34,
-"decompress_mbps": 102.92
+"out_size": 3919702,
+"ratio": 0.3846,
+"compress_mbps": 1.44,
+"decompress_mbps": 100.56
 },
 {
 "compressor": "native",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 9,
-"out_size": 4922557,
-"ratio": 0.483,
-"compress_mbps": 6.27,
-"decompress_mbps": 102.16
+"out_size": 3919665,
+"ratio": 0.3846,
+"compress_mbps": 1.44,
+"decompress_mbps": 100.1
 },
 {
 "compressor": "native",
@@ -4174,8 +4174,8 @@
 "level": 1,
 "out_size": 20729473,
 "ratio": 0.4047,
-"compress_mbps": 18.54,
-"decompress_mbps": 73.93
+"compress_mbps": 18.65,
+"decompress_mbps": 72.82
 },
 {
 "compressor": "native",
@@ -4184,8 +4184,8 @@
 "level": 2,
 "out_size": 20500337,
 "ratio": 0.4002,
-"compress_mbps": 17.15,
-"decompress_mbps": 76.22
+"compress_mbps": 17.1,
+"decompress_mbps": 74.71
 },
 {
 "compressor": "native",
@@ -4194,68 +4194,68 @@
 "level": 3,
 "out_size": 20349978,
 "ratio": 0.3973,
-"compress_mbps": 15.38,
-"decompress_mbps": 78.7
+"compress_mbps": 15.3,
+"decompress_mbps": 77.73
 },
 {
 "compressor": "native",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 4,
-"out_size": 20283389,
-"ratio": 0.396,
-"compress_mbps": 14.19,
-"decompress_mbps": 80.08
+"out_size": 19952001,
+"ratio": 0.3895,
+"compress_mbps": 9.01,
+"decompress_mbps": 78.92
 },
 {
 "compressor": "native",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 5,
-"out_size": 20256373,
-"ratio": 0.3955,
-"compress_mbps": 13.42,
-"decompress_mbps": 83.02
+"out_size": 19925043,
+"ratio": 0.389,
+"compress_mbps": 8.08,
+"decompress_mbps": 82.86
 },
 {
 "compressor": "native",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 6,
-"out_size": 20212646,
-"ratio": 0.3946,
-"compress_mbps": 11.68,
-"decompress_mbps": 86.19
+"out_size": 19882104,
+"ratio": 0.3882,
+"compress_mbps": 6.13,
+"decompress_mbps": 85.11
 },
 {
 "compressor": "native",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 7,
-"out_size": 20193173,
-"ratio": 0.3942,
-"compress_mbps": 10.12,
-"decompress_mbps": 84.83
+"out_size": 19004928,
+"ratio": 0.371,
+"compress_mbps": 1.47,
+"decompress_mbps": 83.44
 },
 {
 "compressor": "native",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 8,
-"out_size": 20183399,
-"ratio": 0.394,
-"compress_mbps": 8.94,
-"decompress_mbps": 85.52
+"out_size": 19002295,
+"ratio": 0.371,
+"compress_mbps": 1.16,
+"decompress_mbps": 85.22
 },
 {
 "compressor": "native",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 9,
-"out_size": 20179045,
-"ratio": 0.394,
-"compress_mbps": 7.63,
-"decompress_mbps": 85.62
+"out_size": 19000618,
+"ratio": 0.371,
+"compress_mbps": 0.9,
+"decompress_mbps": 85.01
 },
 {
 "compressor": "native",
@@ -4264,8 +4264,8 @@
 "level": 1,
 "out_size": 4668650,
 "ratio": 0.4682,
-"compress_mbps": 18.16,
-"decompress_mbps": 74.46
+"compress_mbps": 18.08,
+"decompress_mbps": 74.92
 },
 {
 "compressor": "native",
@@ -4274,8 +4274,8 @@
 "level": 2,
 "out_size": 4570500,
 "ratio": 0.4584,
-"compress_mbps": 16.19,
-"decompress_mbps": 79.35
+"compress_mbps": 16.25,
+"decompress_mbps": 77.46
 },
 {
 "compressor": "native",
@@ -4284,68 +4284,68 @@
 "level": 3,
 "out_size": 4510300,
 "ratio": 0.4524,
-"compress_mbps": 14.4,
-"decompress_mbps": 79.46
+"compress_mbps": 14.35,
+"decompress_mbps": 80.38
 },
 {
 "compressor": "native",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 4,
-"out_size": 4482499,
-"ratio": 0.4496,
-"compress_mbps": 13.15,
-"decompress_mbps": 73.83
+"out_size": 4369955,
+"ratio": 0.4383,
+"compress_mbps": 8.56,
+"decompress_mbps": 74.15
 },
 {
 "compressor": "native",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 5,
-"out_size": 4473067,
-"ratio": 0.4486,
-"compress_mbps": 12.4,
-"decompress_mbps": 76.87
+"out_size": 4360147,
+"ratio": 0.4373,
+"compress_mbps": 7.71,
+"decompress_mbps": 76.92
 },
 {
 "compressor": "native",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 6,
-"out_size": 4462756,
-"ratio": 0.4476,
-"compress_mbps": 11.07,
-"decompress_mbps": 78.41
+"out_size": 4349427,
+"ratio": 0.4362,
+"compress_mbps": 5.72,
+"decompress_mbps": 77.61
 },
 {
 "compressor": "native",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 7,
-"out_size": 4460935,
-"ratio": 0.4474,
-"compress_mbps": 10.29,
-"decompress_mbps": 80.0
+"out_size": 3678637,
+"ratio": 0.3689,
+"compress_mbps": 1.37,
+"decompress_mbps": 78.57
 },
 {
 "compressor": "native",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 8,
-"out_size": 4459787,
-"ratio": 0.4473,
-"compress_mbps": 9.32,
-"decompress_mbps": 78.78
+"out_size": 3680111,
+"ratio": 0.3691,
+"compress_mbps": 1.05,
+"decompress_mbps": 78.32
 },
 {
 "compressor": "native",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 9,
-"out_size": 4459581,
-"ratio": 0.4473,
-"compress_mbps": 8.12,
-"decompress_mbps": 79.97
+"out_size": 3679584,
+"ratio": 0.369,
+"compress_mbps": 0.83,
+"decompress_mbps": 78.03
 },
 {
 "compressor": "native",
@@ -4354,8 +4354,8 @@
 "level": 1,
 "out_size": 4705330,
 "ratio": 0.1402,
-"compress_mbps": 40.68,
-"decompress_mbps": 269.95
+"compress_mbps": 40.71,
+"decompress_mbps": 263.83
 },
 {
 "compressor": "native",
@@ -4364,8 +4364,8 @@
 "level": 2,
 "out_size": 4457802,
 "ratio": 0.1329,
-"compress_mbps": 34.5,
-"decompress_mbps": 301.52
+"compress_mbps": 35.39,
+"decompress_mbps": 306.73
 },
 {
 "compressor": "native",
@@ -4374,68 +4374,68 @@
 "level": 3,
 "out_size": 4241801,
 "ratio": 0.1264,
-"compress_mbps": 30.08,
-"decompress_mbps": 329.95
+"compress_mbps": 29.91,
+"decompress_mbps": 332.06
 },
 {
 "compressor": "native",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 4,
-"out_size": 4148538,
-"ratio": 0.1236,
-"compress_mbps": 26.72,
-"decompress_mbps": 331.5
+"out_size": 3946147,
+"ratio": 0.1176,
+"compress_mbps": 17.27,
+"decompress_mbps": 337.23
 },
 {
 "compressor": "native",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 5,
-"out_size": 4113607,
-"ratio": 0.1226,
-"compress_mbps": 24.59,
-"decompress_mbps": 363.7
+"out_size": 3917350,
+"ratio": 0.1167,
+"compress_mbps": 15.45,
+"decompress_mbps": 365.97
 },
 {
 "compressor": "native",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 6,
-"out_size": 4056012,
-"ratio": 0.1209,
-"compress_mbps": 20.02,
-"decompress_mbps": 384.43
+"out_size": 3871740,
+"ratio": 0.1154,
+"compress_mbps": 11.61,
+"decompress_mbps": 387.03
 },
 {
 "compressor": "native",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 7,
-"out_size": 4021022,
-"ratio": 0.1198,
-"compress_mbps": 16.48,
-"decompress_mbps": 389.64
+"out_size": 3256646,
+"ratio": 0.0971,
+"compress_mbps": 2.89,
+"decompress_mbps": 352.8
 },
 {
 "compressor": "native",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 8,
-"out_size": 3990327,
-"ratio": 0.1189,
-"compress_mbps": 13.23,
-"decompress_mbps": 390.95
+"out_size": 3232193,
+"ratio": 0.0963,
+"compress_mbps": 2.13,
+"decompress_mbps": 371.13
 },
 {
 "compressor": "native",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 9,
-"out_size": 3969131,
-"ratio": 0.1183,
-"compress_mbps": 10.98,
-"decompress_mbps": 370.79
+"out_size": 3211270,
+"ratio": 0.0957,
+"compress_mbps": 1.63,
+"decompress_mbps": 367.4
 },
 {
 "compressor": "native",
@@ -4444,8 +4444,8 @@
 "level": 1,
 "out_size": 3632401,
 "ratio": 0.5904,
-"compress_mbps": 13.86,
-"decompress_mbps": 50.13
+"compress_mbps": 13.63,
+"decompress_mbps": 49.99
 },
 {
 "compressor": "native",
@@ -4454,8 +4454,8 @@
 "level": 2,
 "out_size": 3594843,
 "ratio": 0.5843,
-"compress_mbps": 12.87,
-"decompress_mbps": 50.87
+"compress_mbps": 12.78,
+"decompress_mbps": 51.1
 },
 {
 "compressor": "native",
@@ -4464,68 +4464,68 @@
 "level": 3,
 "out_size": 3570380,
 "ratio": 0.5803,
-"compress_mbps": 11.91,
-"decompress_mbps": 54.89
+"compress_mbps": 11.74,
+"decompress_mbps": 54.22
 },
 {
 "compressor": "native",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 4,
-"out_size": 3560166,
-"ratio": 0.5787,
-"compress_mbps": 11.26,
-"decompress_mbps": 54.64
+"out_size": 3475962,
+"ratio": 0.565,
+"compress_mbps": 8.02,
+"decompress_mbps": 53.96
 },
 {
 "compressor": "native",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 5,
-"out_size": 3555532,
-"ratio": 0.5779,
-"compress_mbps": 10.82,
-"decompress_mbps": 55.74
+"out_size": 3470919,
+"ratio": 0.5642,
+"compress_mbps": 7.42,
+"decompress_mbps": 55.6
 },
 {
 "compressor": "native",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 6,
-"out_size": 3548173,
-"ratio": 0.5767,
-"compress_mbps": 9.96,
-"decompress_mbps": 57.58
+"out_size": 3462594,
+"ratio": 0.5628,
+"compress_mbps": 6.26,
+"decompress_mbps": 56.71
 },
 {
 "compressor": "native",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 7,
-"out_size": 3544886,
-"ratio": 0.5762,
-"compress_mbps": 9.04,
-"decompress_mbps": 57.36
+"out_size": 3100878,
+"ratio": 0.504,
+"compress_mbps": 1.68,
+"decompress_mbps": 57.97
 },
 {
 "compressor": "native",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 8,
-"out_size": 3543369,
-"ratio": 0.576,
-"compress_mbps": 8.4,
-"decompress_mbps": 58.43
+"out_size": 3099704,
+"ratio": 0.5038,
+"compress_mbps": 1.49,
+"decompress_mbps": 57.87
 },
 {
 "compressor": "native",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 9,
-"out_size": 3542757,
-"ratio": 0.5759,
-"compress_mbps": 8.02,
-"decompress_mbps": 58.63
+"out_size": 3098139,
+"ratio": 0.5036,
+"compress_mbps": 1.38,
+"decompress_mbps": 57.79
 },
 {
 "compressor": "native",
@@ -4534,8 +4534,8 @@
 "level": 1,
 "out_size": 3889230,
 "ratio": 0.3856,
-"compress_mbps": 20.33,
-"decompress_mbps": 70.07
+"compress_mbps": 20.75,
+"decompress_mbps": 69.69
 },
 {
 "compressor": "native",
@@ -4544,8 +4544,8 @@
 "level": 2,
 "out_size": 3811489,
 "ratio": 0.3779,
-"compress_mbps": 18.78,
-"decompress_mbps": 72.21
+"compress_mbps": 19.03,
+"decompress_mbps": 70.75
 },
 {
 "compressor": "native",
@@ -4554,68 +4554,68 @@
 "level": 3,
 "out_size": 3789217,
 "ratio": 0.3757,
-"compress_mbps": 18.05,
-"decompress_mbps": 73.36
+"compress_mbps": 18.39,
+"decompress_mbps": 72.73
 },
 {
 "compressor": "native",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 4,
-"out_size": 3781245,
-"ratio": 0.3749,
-"compress_mbps": 17.91,
-"decompress_mbps": 73.84
+"out_size": 3742155,
+"ratio": 0.371,
+"compress_mbps": 13.9,
+"decompress_mbps": 71.82
 },
 {
 "compressor": "native",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 5,
-"out_size": 3778561,
-"ratio": 0.3746,
-"compress_mbps": 17.25,
-"decompress_mbps": 73.25
+"out_size": 3734147,
+"ratio": 0.3702,
+"compress_mbps": 13.23,
+"decompress_mbps": 71.04
 },
 {
 "compressor": "native",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 6,
-"out_size": 3775697,
-"ratio": 0.3744,
-"compress_mbps": 17.25,
-"decompress_mbps": 71.96
+"out_size": 3723457,
+"ratio": 0.3692,
+"compress_mbps": 11.72,
+"decompress_mbps": 71.35
 },
 {
 "compressor": "native",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 7,
-"out_size": 3775075,
-"ratio": 0.3743,
-"compress_mbps": 16.94,
-"decompress_mbps": 72.14
+"out_size": 3723087,
+"ratio": 0.3691,
+"compress_mbps": 2.9,
+"decompress_mbps": 71.7
 },
 {
 "compressor": "native",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 8,
-"out_size": 3774951,
-"ratio": 0.3743,
-"compress_mbps": 16.95,
-"decompress_mbps": 73.47
+"out_size": 3723909,
+"ratio": 0.3692,
+"compress_mbps": 2.73,
+"decompress_mbps": 70.43
 },
 {
 "compressor": "native",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 9,
-"out_size": 3774951,
-"ratio": 0.3743,
-"compress_mbps": 16.94,
-"decompress_mbps": 75.36
+"out_size": 3723909,
+"ratio": 0.3692,
+"compress_mbps": 2.74,
+"decompress_mbps": 70.53
 },
 {
 "compressor": "native",
@@ -4624,8 +4624,8 @@
 "level": 1,
 "out_size": 2592263,
 "ratio": 0.3912,
-"compress_mbps": 16.09,
-"decompress_mbps": 100.31
+"compress_mbps": 16.15,
+"decompress_mbps": 98.15
 },
 {
 "compressor": "native",
@@ -4634,8 +4634,8 @@
 "level": 2,
 "out_size": 2479835,
 "ratio": 0.3742,
-"compress_mbps": 14.04,
-"decompress_mbps": 109.19
+"compress_mbps": 13.84,
+"decompress_mbps": 107.71
 },
 {
 "compressor": "native",
@@ -4644,68 +4644,68 @@
 "level": 3,
 "out_size": 2405060,
 "ratio": 0.3629,
-"compress_mbps": 11.66,
-"decompress_mbps": 120.63
+"compress_mbps": 11.6,
+"decompress_mbps": 119.06
 },
 {
 "compressor": "native",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 4,
-"out_size": 2369716,
-"ratio": 0.3576,
-"compress_mbps": 5.93,
-"decompress_mbps": 120.71
+"out_size": 2257758,
+"ratio": 0.3407,
+"compress_mbps": 6.51,
+"decompress_mbps": 118.75
 },
 {
 "compressor": "native",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 5,
-"out_size": 2349190,
-"ratio": 0.3545,
-"compress_mbps": 9.16,
-"decompress_mbps": 126.05
+"out_size": 2239545,
+"ratio": 0.3379,
+"compress_mbps": 5.57,
+"decompress_mbps": 126.46
 },
 {
 "compressor": "native",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 6,
-"out_size": 2309940,
-"ratio": 0.3486,
-"compress_mbps": 7.14,
-"decompress_mbps": 129.45
+"out_size": 2207053,
+"ratio": 0.333,
+"compress_mbps": 3.92,
+"decompress_mbps": 128.96
 },
 {
 "compressor": "native",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 7,
-"out_size": 2288793,
-"ratio": 0.3454,
-"compress_mbps": 5.86,
-"decompress_mbps": 134.8
+"out_size": 1865730,
+"ratio": 0.2815,
+"compress_mbps": 1.06,
+"decompress_mbps": 134.67
 },
 {
 "compressor": "native",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 8,
-"out_size": 2280775,
-"ratio": 0.3442,
-"compress_mbps": 5.11,
-"decompress_mbps": 134.85
+"out_size": 1860184,
+"ratio": 0.2807,
+"compress_mbps": 0.86,
+"decompress_mbps": 132.22
 },
 {
 "compressor": "native",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 9,
-"out_size": 2277374,
-"ratio": 0.3436,
-"compress_mbps": 4.69,
-"decompress_mbps": 134.87
+"out_size": 1858631,
+"ratio": 0.2805,
+"compress_mbps": 0.74,
+"decompress_mbps": 131.95
 },
 {
 "compressor": "native",
@@ -4714,8 +4714,8 @@
 "level": 1,
 "out_size": 6185865,
 "ratio": 0.2863,
-"compress_mbps": 24.43,
-"decompress_mbps": 129.02
+"compress_mbps": 24.72,
+"decompress_mbps": 132.01
 },
 {
 "compressor": "native",
@@ -4724,8 +4724,8 @@
 "level": 2,
 "out_size": 6066146,
 "ratio": 0.2808,
-"compress_mbps": 21.76,
-"decompress_mbps": 136.51
+"compress_mbps": 21.83,
+"decompress_mbps": 138.84
 },
 {
 "compressor": "native",
@@ -4734,68 +4734,68 @@
 "level": 3,
 "out_size": 5993070,
 "ratio": 0.2774,
-"compress_mbps": 18.83,
-"decompress_mbps": 141.79
+"compress_mbps": 18.74,
+"decompress_mbps": 142.95
 },
 {
 "compressor": "native",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 4,
-"out_size": 5943715,
-"ratio": 0.2751,
-"compress_mbps": 16.85,
-"decompress_mbps": 146.23
+"out_size": 5847650,
+"ratio": 0.2706,
+"compress_mbps": 11.33,
+"decompress_mbps": 146.4
 },
 {
 "compressor": "native",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 5,
-"out_size": 5931927,
-"ratio": 0.2745,
-"compress_mbps": 15.97,
-"decompress_mbps": 150.86
+"out_size": 5837234,
+"ratio": 0.2702,
+"compress_mbps": 10.42,
+"decompress_mbps": 149.45
 },
 {
 "compressor": "native",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 6,
-"out_size": 5915116,
-"ratio": 0.2738,
-"compress_mbps": 13.82,
-"decompress_mbps": 151.94
+"out_size": 5823141,
+"ratio": 0.2695,
+"compress_mbps": 8.6,
+"decompress_mbps": 153.32
 },
 {
 "compressor": "native",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 7,
-"out_size": 5907662,
-"ratio": 0.2734,
-"compress_mbps": 11.91,
-"decompress_mbps": 154.31
+"out_size": 5455440,
+"ratio": 0.2525,
+"compress_mbps": 2.35,
+"decompress_mbps": 153.6
 },
 {
 "compressor": "native",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 8,
-"out_size": 5904235,
-"ratio": 0.2733,
-"compress_mbps": 10.11,
-"decompress_mbps": 153.74
+"out_size": 5450250,
+"ratio": 0.2523,
+"compress_mbps": 1.94,
+"decompress_mbps": 151.46
 },
 {
 "compressor": "native",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 9,
-"out_size": 5899870,
-"ratio": 0.2731,
-"compress_mbps": 8.56,
-"decompress_mbps": 154.05
+"out_size": 5449052,
+"ratio": 0.2522,
+"compress_mbps": 1.61,
+"decompress_mbps": 154.04
 },
 {
 "compressor": "native",
@@ -4804,8 +4804,8 @@
 "level": 1,
 "out_size": 5514279,
 "ratio": 0.7604,
-"compress_mbps": 12.82,
-"decompress_mbps": 53.01
+"compress_mbps": 12.95,
+"decompress_mbps": 52.18
 },
 {
 "compressor": "native",
@@ -4814,8 +4814,8 @@
 "level": 2,
 "out_size": 5472540,
 "ratio": 0.7546,
-"compress_mbps": 11.85,
-"decompress_mbps": 50.93
+"compress_mbps": 12.07,
+"decompress_mbps": 55.43
 },
 {
 "compressor": "native",
@@ -4824,68 +4824,68 @@
 "level": 3,
 "out_size": 5448811,
 "ratio": 0.7514,
-"compress_mbps": 10.85,
-"decompress_mbps": 52.04
+"compress_mbps": 11.0,
+"decompress_mbps": 54.42
 },
 {
 "compressor": "native",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 4,
-"out_size": 5439111,
-"ratio": 0.75,
-"compress_mbps": 10.21,
-"decompress_mbps": 55.11
+"out_size": 5375802,
+"ratio": 0.7413,
+"compress_mbps": 7.24,
+"decompress_mbps": 57.25
 },
 {
 "compressor": "native",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 5,
-"out_size": 5433854,
-"ratio": 0.7493,
-"compress_mbps": 9.62,
-"decompress_mbps": 57.56
+"out_size": 5370794,
+"ratio": 0.7406,
+"compress_mbps": 6.67,
+"decompress_mbps": 55.17
 },
 {
 "compressor": "native",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 6,
-"out_size": 5425061,
-"ratio": 0.7481,
-"compress_mbps": 8.83,
-"decompress_mbps": 57.08
+"out_size": 5362339,
+"ratio": 0.7394,
+"compress_mbps": 5.67,
+"decompress_mbps": 57.57
 },
 {
 "compressor": "native",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 7,
-"out_size": 5421299,
-"ratio": 0.7476,
-"compress_mbps": 8.2,
-"decompress_mbps": 53.23
+"out_size": 5358816,
+"ratio": 0.7389,
+"compress_mbps": 1.54,
+"decompress_mbps": 58.43
 },
 {
 "compressor": "native",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 8,
-"out_size": 5421106,
-"ratio": 0.7475,
-"compress_mbps": 8.23,
-"decompress_mbps": 57.93
+"out_size": 5358607,
+"ratio": 0.7389,
+"compress_mbps": 1.52,
+"decompress_mbps": 54.57
 },
 {
 "compressor": "native",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 9,
-"out_size": 5421103,
-"ratio": 0.7475,
-"compress_mbps": 8.12,
-"decompress_mbps": 53.22
+"out_size": 5358607,
+"ratio": 0.7389,
+"compress_mbps": 1.53,
+"decompress_mbps": 57.21
 },
 {
 "compressor": "native",
@@ -4894,8 +4894,8 @@
 "level": 1,
 "out_size": 16232235,
 "ratio": 0.3915,
-"compress_mbps": 16.81,
-"decompress_mbps": 104.86
+"compress_mbps": 16.92,
+"decompress_mbps": 104.82
 },
 {
 "compressor": "native",
@@ -4904,8 +4904,8 @@
 "level": 2,
 "out_size": 15659043,
 "ratio": 0.3777,
-"compress_mbps": 15.27,
-"decompress_mbps": 111.33
+"compress_mbps": 15.37,
+"decompress_mbps": 112.48
 },
 {
 "compressor": "native",
@@ -4914,68 +4914,68 @@
 "level": 3,
 "out_size": 15341951,
 "ratio": 0.3701,
-"compress_mbps": 13.46,
-"decompress_mbps": 118.83
+"compress_mbps": 13.58,
+"decompress_mbps": 119.87
 },
 {
 "compressor": "native",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 4,
-"out_size": 15229374,
-"ratio": 0.3673,
-"compress_mbps": 12.51,
-"decompress_mbps": 121.82
+"out_size": 14794018,
+"ratio": 0.3568,
+"compress_mbps": 8.42,
+"decompress_mbps": 119.37
 },
 {
 "compressor": "native",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 5,
-"out_size": 15166979,
-"ratio": 0.3658,
-"compress_mbps": 11.67,
-"decompress_mbps": 122.19
+"out_size": 14735437,
+"ratio": 0.3554,
+"compress_mbps": 7.63,
+"decompress_mbps": 123.74
 },
 {
 "compressor": "native",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 6,
-"out_size": 15058449,
-"ratio": 0.3632,
-"compress_mbps": 10.01,
-"decompress_mbps": 126.05
+"out_size": 14635001,
+"ratio": 0.353,
+"compress_mbps": 6.16,
+"decompress_mbps": 126.59
 },
 {
 "compressor": "native",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 7,
-"out_size": 15004235,
-"ratio": 0.3619,
-"compress_mbps": 8.64,
-"decompress_mbps": 125.95
+"out_size": 12345372,
+"ratio": 0.2978,
+"compress_mbps": 1.85,
+"decompress_mbps": 125.4
 },
 {
 "compressor": "native",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 8,
-"out_size": 14981819,
-"ratio": 0.3614,
-"compress_mbps": 7.83,
-"decompress_mbps": 126.44
+"out_size": 12327847,
+"ratio": 0.2974,
+"compress_mbps": 1.74,
+"decompress_mbps": 127.7
 },
 {
 "compressor": "native",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 9,
-"out_size": 14981770,
-"ratio": 0.3614,
-"compress_mbps": 7.86,
-"decompress_mbps": 122.46
+"out_size": 12327819,
+"ratio": 0.2974,
+"compress_mbps": 1.73,
+"decompress_mbps": 127.43
 },
 {
 "compressor": "native",
@@ -4984,8 +4984,8 @@
 "level": 1,
 "out_size": 7300743,
 "ratio": 0.8615,
-"compress_mbps": 11.84,
-"decompress_mbps": 40.42
+"compress_mbps": 11.96,
+"decompress_mbps": 40.7
 },
 {
 "compressor": "native",
@@ -4994,8 +4994,8 @@
 "level": 2,
 "out_size": 7258514,
 "ratio": 0.8565,
-"compress_mbps": 10.92,
-"decompress_mbps": 43.28
+"compress_mbps": 10.65,
+"decompress_mbps": 43.59
 },
 {
 "compressor": "native",
@@ -5004,68 +5004,68 @@
 "level": 3,
 "out_size": 5983501,
 "ratio": 0.7061,
-"compress_mbps": 10.58,
-"decompress_mbps": 46.04
+"compress_mbps": 10.56,
+"decompress_mbps": 46.77
 },
 {
 "compressor": "native",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 4,
-"out_size": 5979868,
-"ratio": 0.7057,
-"compress_mbps": 10.33,
-"decompress_mbps": 43.08
+"out_size": 5965382,
+"ratio": 0.7039,
+"compress_mbps": 8.75,
+"decompress_mbps": 42.45
 },
 {
 "compressor": "native",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 5,
-"out_size": 5979028,
-"ratio": 0.7056,
-"compress_mbps": 10.25,
-"decompress_mbps": 43.48
+"out_size": 5964821,
+"ratio": 0.7039,
+"compress_mbps": 8.75,
+"decompress_mbps": 43.47
 },
 {
 "compressor": "native",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 6,
-"out_size": 5978765,
-"ratio": 0.7055,
-"compress_mbps": 10.24,
-"decompress_mbps": 43.6
+"out_size": 5964654,
+"ratio": 0.7039,
+"compress_mbps": 8.56,
+"decompress_mbps": 44.2
 },
 {
 "compressor": "native",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 7,
-"out_size": 5978761,
-"ratio": 0.7055,
-"compress_mbps": 10.21,
-"decompress_mbps": 44.25
+"out_size": 5964649,
+"ratio": 0.7039,
+"compress_mbps": 2.37,
+"decompress_mbps": 43.35
 },
 {
 "compressor": "native",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 8,
-"out_size": 5978761,
-"ratio": 0.7055,
-"compress_mbps": 10.31,
-"decompress_mbps": 44.23
+"out_size": 5964649,
+"ratio": 0.7039,
+"compress_mbps": 2.39,
+"decompress_mbps": 44.18
 },
 {
 "compressor": "native",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 9,
-"out_size": 5978761,
-"ratio": 0.7055,
-"compress_mbps": 10.16,
-"decompress_mbps": 44.71
+"out_size": 5964649,
+"ratio": 0.7039,
+"compress_mbps": 2.36,
+"decompress_mbps": 43.66
 },
 {
 "compressor": "native",
@@ -5074,8 +5074,8 @@
 "level": 1,
 "out_size": 968373,
 "ratio": 0.1812,
-"compress_mbps": 33.92,
-"decompress_mbps": 198.84
+"compress_mbps": 33.81,
+"decompress_mbps": 200.17
 },
 {
 "compressor": "native",
@@ -5084,8 +5084,8 @@
 "level": 2,
 "out_size": 912756,
 "ratio": 0.1708,
-"compress_mbps": 29.85,
-"decompress_mbps": 217.36
+"compress_mbps": 29.82,
+"decompress_mbps": 217.6
 },
 {
 "compressor": "native",
@@ -5094,68 +5094,68 @@
 "level": 3,
 "out_size": 875269,
 "ratio": 0.1637,
-"compress_mbps": 25.33,
-"decompress_mbps": 242.28
+"compress_mbps": 25.45,
+"decompress_mbps": 240.65
 },
 {
 "compressor": "native",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 4,
-"out_size": 856342,
-"ratio": 0.1602,
-"compress_mbps": 22.47,
-"decompress_mbps": 232.14
+"out_size": 826760,
+"ratio": 0.1547,
+"compress_mbps": 14.51,
+"decompress_mbps": 235.48
 },
 {
 "compressor": "native",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 5,
-"out_size": 847366,
-"ratio": 0.1585,
-"compress_mbps": 20.94,
-"decompress_mbps": 252.82
+"out_size": 818408,
+"ratio": 0.1531,
+"compress_mbps": 13.13,
+"decompress_mbps": 262.55
 },
 {
 "compressor": "native",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 6,
-"out_size": 834340,
-"ratio": 0.1561,
-"compress_mbps": 17.96,
-"decompress_mbps": 275.27
+"out_size": 805917,
+"ratio": 0.1508,
+"compress_mbps": 10.54,
+"decompress_mbps": 273.88
 },
 {
 "compressor": "native",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 7,
-"out_size": 828114,
-"ratio": 0.1549,
-"compress_mbps": 15.65,
-"decompress_mbps": 272.82
+"out_size": 685265,
+"ratio": 0.1282,
+"compress_mbps": 3.01,
+"decompress_mbps": 286.06
 },
 {
 "compressor": "native",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 8,
-"out_size": 826043,
-"ratio": 0.1545,
-"compress_mbps": 14.38,
-"decompress_mbps": 263.41
+"out_size": 683484,
+"ratio": 0.1279,
+"compress_mbps": 2.67,
+"decompress_mbps": 270.99
 },
 {
 "compressor": "native",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 9,
-"out_size": 825718,
-"ratio": 0.1545,
-"compress_mbps": 14.02,
-"decompress_mbps": 281.98
+"out_size": 683122,
+"ratio": 0.1278,
+"compress_mbps": 2.59,
+"decompress_mbps": 274.85
 },
 {
 "compressor": "zlib",
@@ -5164,8 +5164,8 @@
 "level": 1,
 "out_size": 4585612,
 "ratio": 0.4499,
-"compress_mbps": 113.74,
-"decompress_mbps": 351.83
+"compress_mbps": 113.41,
+"decompress_mbps": 342.19
 },
 {
 "compressor": "zlib",
@@ -5174,8 +5174,8 @@
 "level": 2,
 "out_size": 4389474,
 "ratio": 0.4307,
-"compress_mbps": 96.14,
-"decompress_mbps": 389.61
+"compress_mbps": 95.63,
+"decompress_mbps": 363.71
 },
 {
 "compressor": "zlib",
@@ -5184,8 +5184,8 @@
 "level": 3,
 "out_size": 4192079,
 "ratio": 0.4113,
-"compress_mbps": 59.18,
-"decompress_mbps": 394.75
+"compress_mbps": 59.33,
+"decompress_mbps": 389.49
 },
 {
 "compressor": "zlib",
@@ -5194,8 +5194,8 @@
 "level": 4,
 "out_size": 4095021,
 "ratio": 0.4018,
-"compress_mbps": 65.3,
-"decompress_mbps": 382.48
+"compress_mbps": 65.35,
+"decompress_mbps": 369.61
 },
 {
 "compressor": "zlib",
@@ -5204,8 +5204,8 @@
 "level": 5,
 "out_size": 3949169,
 "ratio": 0.3875,
-"compress_mbps": 35.74,
-"decompress_mbps": 371.06
+"compress_mbps": 35.84,
+"decompress_mbps": 359.21
 },
 {
 "compressor": "zlib",
@@ -5214,8 +5214,8 @@
 "level": 6,
 "out_size": 3871628,
 "ratio": 0.3799,
-"compress_mbps": 21.09,
-"decompress_mbps": 381.37
+"compress_mbps": 21.1,
+"decompress_mbps": 366.43
 },
 {
 "compressor": "zlib",
@@ -5224,8 +5224,8 @@
 "level": 7,
 "out_size": 3858876,
 "ratio": 0.3786,
-"compress_mbps": 17.61,
-"decompress_mbps": 383.95
+"compress_mbps": 17.63,
+"decompress_mbps": 367.24
 },
 {
 "compressor": "zlib",
@@ -5234,8 +5234,8 @@
 "level": 8,
 "out_size": 3854729,
 "ratio": 0.3782,
-"compress_mbps": 15.06,
-"decompress_mbps": 382.6
+"compress_mbps": 15.05,
+"decompress_mbps": 368.36
 },
 {
 "compressor": "zlib",
@@ -5244,8 +5244,8 @@
 "level": 9,
 "out_size": 3854729,
 "ratio": 0.3782,
-"compress_mbps": 15.0,
-"decompress_mbps": 382.41
+"compress_mbps": 15.1,
+"decompress_mbps": 370.27
 },
 {
 "compressor": "zlib",
@@ -5254,8 +5254,8 @@
 "level": 1,
 "out_size": 20577220,
 "ratio": 0.4017,
-"compress_mbps": 112.67,
-"decompress_mbps": 357.17
+"compress_mbps": 112.93,
+"decompress_mbps": 374.1
 },
 {
 "compressor": "zlib",
@@ -5264,8 +5264,8 @@
 "level": 2,
 "out_size": 20247697,
 "ratio": 0.3953,
-"compress_mbps": 100.87,
-"decompress_mbps": 367.51
+"compress_mbps": 101.22,
+"decompress_mbps": 381.64
 },
 {
 "compressor": "zlib",
@@ -5274,8 +5274,8 @@
 "level": 3,
 "out_size": 19987880,
 "ratio": 0.3902,
-"compress_mbps": 76.53,
-"decompress_mbps": 376.29
+"compress_mbps": 76.6,
+"decompress_mbps": 389.78
 },
 {
 "compressor": "zlib",
@@ -5284,8 +5284,8 @@
 "level": 4,
 "out_size": 19512665,
 "ratio": 0.381,
-"compress_mbps": 74.5,
-"decompress_mbps": 367.92
+"compress_mbps": 75.6,
+"decompress_mbps": 378.5
 },
 {
 "compressor": "zlib",
@@ -5294,8 +5294,8 @@
 "level": 5,
 "out_size": 19213507,
 "ratio": 0.3751,
-"compress_mbps": 52.86,
-"decompress_mbps": 372.06
+"compress_mbps": 52.78,
+"decompress_mbps": 380.28
 },
 {
 "compressor": "zlib",
@@ -5304,8 +5304,8 @@
 "level": 6,
 "out_size": 19089118,
 "ratio": 0.3727,
-"compress_mbps": 34.4,
-"decompress_mbps": 382.61
+"compress_mbps": 34.11,
+"decompress_mbps": 385.45
 },
 {
 "compressor": "zlib",
@@ -5314,8 +5314,8 @@
 "level": 7,
 "out_size": 19061204,
 "ratio": 0.3721,
-"compress_mbps": 27.32,
-"decompress_mbps": 381.18
+"compress_mbps": 27.13,
+"decompress_mbps": 386.32
 },
 {
 "compressor": "zlib",
@@ -5324,8 +5324,8 @@
 "level": 8,
 "out_size": 19040998,
 "ratio": 0.3717,
-"compress_mbps": 15.39,
-"decompress_mbps": 385.98
+"compress_mbps": 15.38,
+"decompress_mbps": 395.23
 },
 {
 "compressor": "zlib",
@@ -5334,8 +5334,8 @@
 "level": 9,
 "out_size": 19044390,
 "ratio": 0.3718,
-"compress_mbps": 9.53,
-"decompress_mbps": 382.51
+"compress_mbps": 9.51,
+"decompress_mbps": 383.17
 },
 {
 "compressor": "zlib",
@@ -5344,8 +5344,8 @@
 "level": 1,
 "out_size": 3828360,
 "ratio": 0.384,
-"compress_mbps": 144.87,
-"decompress_mbps": 476.7
+"compress_mbps": 140.36,
+"decompress_mbps": 449.21
 },
 {
 "compressor": "zlib",
@@ -5354,8 +5354,8 @@
 "level": 2,
 "out_size": 3798539,
 "ratio": 0.381,
-"compress_mbps": 127.87,
-"decompress_mbps": 486.35
+"compress_mbps": 124.68,
+"decompress_mbps": 459.56
 },
 {
 "compressor": "zlib",
@@ -5364,8 +5364,8 @@
 "level": 3,
 "out_size": 3674568,
 "ratio": 0.3685,
-"compress_mbps": 80.45,
-"decompress_mbps": 507.37
+"compress_mbps": 77.52,
+"decompress_mbps": 477.52
 },
 {
 "compressor": "zlib",
@@ -5374,8 +5374,8 @@
 "level": 4,
 "out_size": 3680923,
 "ratio": 0.3692,
-"compress_mbps": 89.08,
-"decompress_mbps": 449.63
+"compress_mbps": 85.77,
+"decompress_mbps": 421.01
 },
 {
 "compressor": "zlib",
@@ -5384,8 +5384,8 @@
 "level": 5,
 "out_size": 3698707,
 "ratio": 0.371,
-"compress_mbps": 47.44,
-"decompress_mbps": 424.31
+"compress_mbps": 47.74,
+"decompress_mbps": 401.07
 },
 {
 "compressor": "zlib",
@@ -5394,8 +5394,8 @@
 "level": 6,
 "out_size": 3675935,
 "ratio": 0.3687,
-"compress_mbps": 26.28,
-"decompress_mbps": 438.75
+"compress_mbps": 26.32,
+"decompress_mbps": 415.88
 },
 {
 "compressor": "zlib",
@@ -5404,8 +5404,8 @@
 "level": 7,
 "out_size": 3670281,
 "ratio": 0.3681,
-"compress_mbps": 20.72,
-"decompress_mbps": 442.45
+"compress_mbps": 20.69,
+"decompress_mbps": 420.52
 },
 {
 "compressor": "zlib",
@@ -5414,8 +5414,8 @@
 "level": 8,
 "out_size": 3661103,
 "ratio": 0.3672,
-"compress_mbps": 10.98,
-"decompress_mbps": 452.43
+"compress_mbps": 10.87,
+"decompress_mbps": 420.94
 },
 {
 "compressor": "zlib",
@@ -5424,8 +5424,8 @@
 "level": 9,
 "out_size": 3660788,
 "ratio": 0.3672,
-"compress_mbps": 9.48,
-"decompress_mbps": 457.25
+"compress_mbps": 9.43,
+"decompress_mbps": 424.42
 },
 {
 "compressor": "zlib",
@@ -5434,8 +5434,8 @@
 "level": 1,
 "out_size": 4624591,
 "ratio": 0.1378,
-"compress_mbps": 331.89,
-"decompress_mbps": 809.53
+"compress_mbps": 332.2,
+"decompress_mbps": 843.43
 },
 {
 "compressor": "zlib",
@@ -5444,8 +5444,8 @@
 "level": 2,
 "out_size": 4303176,
 "ratio": 0.1282,
-"compress_mbps": 308.52,
-"decompress_mbps": 848.1
+"compress_mbps": 308.07,
+"decompress_mbps": 872.53
 },
 {
 "compressor": "zlib",
@@ -5454,8 +5454,8 @@
 "level": 3,
 "out_size": 4010156,
 "ratio": 0.1195,
-"compress_mbps": 257.81,
-"decompress_mbps": 922.79
+"compress_mbps": 257.27,
+"decompress_mbps": 954.87
 },
 {
 "compressor": "zlib",
@@ -5464,8 +5464,8 @@
 "level": 4,
 "out_size": 3713866,
 "ratio": 0.1107,
-"compress_mbps": 210.81,
-"decompress_mbps": 905.21
+"compress_mbps": 211.05,
+"decompress_mbps": 941.74
 },
 {
 "compressor": "zlib",
@@ -5474,8 +5474,8 @@
 "level": 5,
 "out_size": 3378136,
 "ratio": 0.1007,
-"compress_mbps": 164.66,
-"decompress_mbps": 962.59
+"compress_mbps": 165.24,
+"decompress_mbps": 1024.55
 },
 {
 "compressor": "zlib",
@@ -5484,8 +5484,8 @@
 "level": 6,
 "out_size": 3200182,
 "ratio": 0.0954,
-"compress_mbps": 112.73,
-"decompress_mbps": 1004.77
+"compress_mbps": 113.59,
+"decompress_mbps": 1057.12
 },
 {
 "compressor": "zlib",
@@ -5494,8 +5494,8 @@
 "level": 7,
 "out_size": 3141278,
 "ratio": 0.0936,
-"compress_mbps": 89.7,
-"decompress_mbps": 1010.74
+"compress_mbps": 89.98,
+"decompress_mbps": 1066.05
 },
 {
 "compressor": "zlib",
@@ -5504,8 +5504,8 @@
 "level": 8,
 "out_size": 3031199,
 "ratio": 0.0903,
-"compress_mbps": 39.19,
-"decompress_mbps": 1023.3
+"compress_mbps": 39.2,
+"decompress_mbps": 1010.46
 },
 {
 "compressor": "zlib",
@@ -5514,8 +5514,8 @@
 "level": 9,
 "out_size": 2987995,
 "ratio": 0.0891,
-"compress_mbps": 21.33,
-"decompress_mbps": 1032.82
+"compress_mbps": 21.45,
+"decompress_mbps": 1064.31
 },
 {
 "compressor": "zlib",
@@ -5524,8 +5524,8 @@
 "level": 1,
 "out_size": 3290526,
 "ratio": 0.5349,
-"compress_mbps": 78.91,
-"decompress_mbps": 254.06
+"compress_mbps": 78.95,
+"decompress_mbps": 257.91
 },
 {
 "compressor": "zlib",
@@ -5534,8 +5534,8 @@
 "level": 2,
 "out_size": 3238282,
 "ratio": 0.5264,
-"compress_mbps": 71.97,
-"decompress_mbps": 257.94
+"compress_mbps": 72.25,
+"decompress_mbps": 262.31
 },
 {
 "compressor": "zlib",
@@ -5544,8 +5544,8 @@
 "level": 3,
 "out_size": 3193366,
 "ratio": 0.5191,
-"compress_mbps": 56.93,
-"decompress_mbps": 264.94
+"compress_mbps": 56.47,
+"decompress_mbps": 263.36
 },
 {
 "compressor": "zlib",
@@ -5554,8 +5554,8 @@
 "level": 4,
 "out_size": 3158012,
 "ratio": 0.5133,
-"compress_mbps": 54.54,
-"decompress_mbps": 266.04
+"compress_mbps": 54.73,
+"decompress_mbps": 262.21
 },
 {
 "compressor": "zlib",
@@ -5564,8 +5564,8 @@
 "level": 5,
 "out_size": 3115309,
 "ratio": 0.5064,
-"compress_mbps": 38.55,
-"decompress_mbps": 268.26
+"compress_mbps": 38.65,
+"decompress_mbps": 266.08
 },
 {
 "compressor": "zlib",
@@ -5574,8 +5574,8 @@
 "level": 6,
 "out_size": 3097288,
 "ratio": 0.5034,
-"compress_mbps": 26.19,
-"decompress_mbps": 270.83
+"compress_mbps": 26.18,
+"decompress_mbps": 270.71
 },
 {
 "compressor": "zlib",
@@ -5585,7 +5585,7 @@
 "out_size": 3094363,
 "ratio": 0.503,
 "compress_mbps": 21.83,
-"decompress_mbps": 271.65
+"decompress_mbps": 271.16
 },
 {
 "compressor": "zlib",
@@ -5594,8 +5594,8 @@
 "level": 8,
 "out_size": 3093026,
 "ratio": 0.5028,
-"compress_mbps": 17.07,
-"decompress_mbps": 270.67
+"compress_mbps": 17.05,
+"decompress_mbps": 272.13
 },
 {
 "compressor": "zlib",
@@ -5604,8 +5604,8 @@
 "level": 9,
 "out_size": 3092920,
 "ratio": 0.5027,
-"compress_mbps": 15.51,
-"decompress_mbps": 272.51
+"compress_mbps": 15.35,
+"decompress_mbps": 270.99
 },
 {
 "compressor": "zlib",
@@ -5614,8 +5614,8 @@
 "level": 1,
 "out_size": 4076385,
 "ratio": 0.4042,
-"compress_mbps": 127.5,
-"decompress_mbps": 476.07
+"compress_mbps": 126.61,
+"decompress_mbps": 451.9
 },
 {
 "compressor": "zlib",
@@ -5624,8 +5624,8 @@
 "level": 2,
 "out_size": 3991014,
 "ratio": 0.3957,
-"compress_mbps": 118.57,
-"decompress_mbps": 496.02
+"compress_mbps": 118.41,
+"decompress_mbps": 469.22
 },
 {
 "compressor": "zlib",
@@ -5634,8 +5634,8 @@
 "level": 3,
 "out_size": 3934055,
 "ratio": 0.3901,
-"compress_mbps": 93.6,
-"decompress_mbps": 511.05
+"compress_mbps": 94.45,
+"decompress_mbps": 486.82
 },
 {
 "compressor": "zlib",
@@ -5644,8 +5644,8 @@
 "level": 4,
 "out_size": 3825092,
 "ratio": 0.3793,
-"compress_mbps": 84.64,
-"decompress_mbps": 510.75
+"compress_mbps": 85.05,
+"decompress_mbps": 474.79
 },
 {
 "compressor": "zlib",
@@ -5654,8 +5654,8 @@
 "level": 5,
 "out_size": 3752932,
 "ratio": 0.3721,
-"compress_mbps": 64.76,
-"decompress_mbps": 501.22
+"compress_mbps": 65.15,
+"decompress_mbps": 473.72
 },
 {
 "compressor": "zlib",
@@ -5664,8 +5664,8 @@
 "level": 6,
 "out_size": 3695164,
 "ratio": 0.3664,
-"compress_mbps": 49.24,
-"decompress_mbps": 512.21
+"compress_mbps": 49.41,
+"decompress_mbps": 466.07
 },
 {
 "compressor": "zlib",
@@ -5674,8 +5674,8 @@
 "level": 7,
 "out_size": 3676881,
 "ratio": 0.3646,
-"compress_mbps": 38.05,
-"decompress_mbps": 524.15
+"compress_mbps": 38.08,
+"decompress_mbps": 480.03
 },
 {
 "compressor": "zlib",
@@ -5684,8 +5684,8 @@
 "level": 8,
 "out_size": 3673171,
 "ratio": 0.3642,
-"compress_mbps": 32.01,
-"decompress_mbps": 520.56
+"compress_mbps": 31.89,
+"decompress_mbps": 486.62
 },
 {
 "compressor": "zlib",
@@ -5694,8 +5694,8 @@
 "level": 9,
 "out_size": 3673171,
 "ratio": 0.3642,
-"compress_mbps": 31.88,
-"decompress_mbps": 524.23
+"compress_mbps": 31.9,
+"decompress_mbps": 484.76
 },
 {
 "compressor": "zlib",
@@ -5704,8 +5704,8 @@
 "level": 1,
 "out_size": 2376424,
 "ratio": 0.3586,
-"compress_mbps": 130.57,
-"decompress_mbps": 391.34
+"compress_mbps": 129.63,
+"decompress_mbps": 395.09
 },
 {
 "compressor": "zlib",
@@ -5714,8 +5714,8 @@
 "level": 2,
 "out_size": 2259060,
 "ratio": 0.3409,
-"compress_mbps": 113.01,
-"decompress_mbps": 413.44
+"compress_mbps": 112.09,
+"decompress_mbps": 412.6
 },
 {
 "compressor": "zlib",
@@ -5724,8 +5724,8 @@
 "level": 3,
 "out_size": 2135664,
 "ratio": 0.3223,
-"compress_mbps": 72.85,
-"decompress_mbps": 428.76
+"compress_mbps": 72.41,
+"decompress_mbps": 429.97
 },
 {
 "compressor": "zlib",
@@ -5734,8 +5734,8 @@
 "level": 4,
 "out_size": 2052793,
 "ratio": 0.3098,
-"compress_mbps": 81.31,
-"decompress_mbps": 417.75
+"compress_mbps": 81.72,
+"decompress_mbps": 427.88
 },
 {
 "compressor": "zlib",
@@ -5744,8 +5744,8 @@
 "level": 5,
 "out_size": 1932127,
 "ratio": 0.2915,
-"compress_mbps": 45.26,
-"decompress_mbps": 430.23
+"compress_mbps": 45.23,
+"decompress_mbps": 423.42
 },
 {
 "compressor": "zlib",
@@ -5754,8 +5754,8 @@
 "level": 6,
 "out_size": 1860865,
 "ratio": 0.2808,
-"compress_mbps": 22.91,
-"decompress_mbps": 427.13
+"compress_mbps": 22.78,
+"decompress_mbps": 433.0
 },
 {
 "compressor": "zlib",
@@ -5764,8 +5764,8 @@
 "level": 7,
 "out_size": 1838671,
 "ratio": 0.2774,
-"compress_mbps": 15.89,
-"decompress_mbps": 438.25
+"compress_mbps": 15.9,
+"decompress_mbps": 428.78
 },
 {
 "compressor": "zlib",
@@ -5774,8 +5774,8 @@
 "level": 8,
 "out_size": 1823235,
 "ratio": 0.2751,
-"compress_mbps": 8.17,
-"decompress_mbps": 429.75
+"compress_mbps": 8.11,
+"decompress_mbps": 435.32
 },
 {
 "compressor": "zlib",
@@ -5784,8 +5784,8 @@
 "level": 9,
 "out_size": 1823190,
 "ratio": 0.2751,
-"compress_mbps": 8.13,
-"decompress_mbps": 435.94
+"compress_mbps": 8.07,
+"decompress_mbps": 432.7
 },
 {
 "compressor": "zlib",
@@ -5794,8 +5794,8 @@
 "level": 1,
 "out_size": 6329449,
 "ratio": 0.2929,
-"compress_mbps": 170.5,
-"decompress_mbps": 483.71
+"compress_mbps": 168.61,
+"decompress_mbps": 459.83
 },
 {
 "compressor": "zlib",
@@ -5804,8 +5804,8 @@
 "level": 2,
 "out_size": 6128866,
 "ratio": 0.2837,
-"compress_mbps": 156.98,
-"decompress_mbps": 553.71
+"compress_mbps": 155.37,
+"decompress_mbps": 548.7
 },
 {
 "compressor": "zlib",
@@ -5814,8 +5814,8 @@
 "level": 3,
 "out_size": 5982546,
 "ratio": 0.2769,
-"compress_mbps": 125.79,
-"decompress_mbps": 576.47
+"compress_mbps": 124.41,
+"decompress_mbps": 573.03
 },
 {
 "compressor": "zlib",
@@ -5824,8 +5824,8 @@
 "level": 4,
 "out_size": 5656400,
 "ratio": 0.2618,
-"compress_mbps": 115.68,
-"decompress_mbps": 568.51
+"compress_mbps": 115.83,
+"decompress_mbps": 570.76
 },
 {
 "compressor": "zlib",
@@ -5834,8 +5834,8 @@
 "level": 5,
 "out_size": 5511352,
 "ratio": 0.2551,
-"compress_mbps": 81.43,
-"decompress_mbps": 575.72
+"compress_mbps": 81.64,
+"decompress_mbps": 577.51
 },
 {
 "compressor": "zlib",
@@ -5844,8 +5844,8 @@
 "level": 6,
 "out_size": 5451399,
 "ratio": 0.2523,
-"compress_mbps": 56.07,
-"decompress_mbps": 588.35
+"compress_mbps": 56.23,
+"decompress_mbps": 591.12
 },
 {
 "compressor": "zlib",
@@ -5854,8 +5854,8 @@
 "level": 7,
 "out_size": 5417123,
 "ratio": 0.2507,
-"compress_mbps": 46.29,
-"decompress_mbps": 593.36
+"compress_mbps": 46.39,
+"decompress_mbps": 591.26
 },
 {
 "compressor": "zlib",
@@ -5864,8 +5864,8 @@
 "level": 8,
 "out_size": 5404364,
 "ratio": 0.2501,
-"compress_mbps": 32.49,
-"decompress_mbps": 598.11
+"compress_mbps": 32.56,
+"decompress_mbps": 600.38
 },
 {
 "compressor": "zlib",
@@ -5874,8 +5874,8 @@
 "level": 9,
 "out_size": 5402704,
 "ratio": 0.2501,
-"compress_mbps": 29.68,
-"decompress_mbps": 607.36
+"compress_mbps": 29.69,
+"decompress_mbps": 602.34
 },
 {
 "compressor": "zlib",
@@ -5884,8 +5884,8 @@
 "level": 1,
 "out_size": 5567768,
 "ratio": 0.7678,
-"compress_mbps": 65.14,
-"decompress_mbps": 318.13
+"compress_mbps": 64.12,
+"decompress_mbps": 315.55
 },
 {
 "compressor": "zlib",
@@ -5894,8 +5894,8 @@
 "level": 2,
 "out_size": 5504009,
 "ratio": 0.759,
-"compress_mbps": 59.04,
-"decompress_mbps": 326.33
+"compress_mbps": 58.18,
+"decompress_mbps": 327.78
 },
 {
 "compressor": "zlib",
@@ -5904,8 +5904,8 @@
 "level": 3,
 "out_size": 5439339,
 "ratio": 0.7501,
-"compress_mbps": 46.86,
-"decompress_mbps": 333.52
+"compress_mbps": 46.11,
+"decompress_mbps": 332.34
 },
 {
 "compressor": "zlib",
@@ -5914,8 +5914,8 @@
 "level": 4,
 "out_size": 5394604,
 "ratio": 0.7439,
-"compress_mbps": 47.86,
-"decompress_mbps": 343.81
+"compress_mbps": 47.79,
+"decompress_mbps": 346.26
 },
 {
 "compressor": "zlib",
@@ -5924,8 +5924,8 @@
 "level": 5,
 "out_size": 5370116,
 "ratio": 0.7405,
-"compress_mbps": 32.9,
-"decompress_mbps": 330.28
+"compress_mbps": 32.98,
+"decompress_mbps": 333.52
 },
 {
 "compressor": "zlib",
@@ -5934,8 +5934,8 @@
 "level": 6,
 "out_size": 5331793,
 "ratio": 0.7352,
-"compress_mbps": 22.98,
-"decompress_mbps": 344.08
+"compress_mbps": 22.95,
+"decompress_mbps": 334.24
 },
 {
 "compressor": "zlib",
@@ -5944,8 +5944,8 @@
 "level": 7,
 "out_size": 5327677,
 "ratio": 0.7347,
-"compress_mbps": 21.07,
-"decompress_mbps": 345.75
+"compress_mbps": 21.0,
+"decompress_mbps": 347.1
 },
 {
 "compressor": "zlib",
@@ -5954,8 +5954,8 @@
 "level": 8,
 "out_size": 5325914,
 "ratio": 0.7344,
-"compress_mbps": 18.85,
-"decompress_mbps": 346.28
+"compress_mbps": 19.0,
+"decompress_mbps": 347.35
 },
 {
 "compressor": "zlib",
@@ -5964,8 +5964,8 @@
 "level": 9,
 "out_size": 5325914,
 "ratio": 0.7344,
-"compress_mbps": 18.7,
-"decompress_mbps": 344.08
+"compress_mbps": 18.99,
+"decompress_mbps": 345.95
 },
 {
 "compressor": "zlib",
@@ -5974,8 +5974,8 @@
 "level": 1,
 "out_size": 14991236,
 "ratio": 0.3616,
-"compress_mbps": 137.95,
-"decompress_mbps": 385.5
+"compress_mbps": 137.68,
+"decompress_mbps": 374.4
 },
 {
 "compressor": "zlib",
@@ -5984,8 +5984,8 @@
 "level": 2,
 "out_size": 14249692,
 "ratio": 0.3437,
-"compress_mbps": 121.2,
-"decompress_mbps": 391.5
+"compress_mbps": 121.15,
+"decompress_mbps": 407.23
 },
 {
 "compressor": "zlib",
@@ -5994,8 +5994,8 @@
 "level": 3,
 "out_size": 13627761,
 "ratio": 0.3287,
-"compress_mbps": 87.74,
-"decompress_mbps": 410.98
+"compress_mbps": 87.82,
+"decompress_mbps": 423.08
 },
 {
 "compressor": "zlib",
@@ -6004,8 +6004,8 @@
 "level": 4,
 "out_size": 13001990,
 "ratio": 0.3136,
-"compress_mbps": 83.9,
-"decompress_mbps": 393.65
+"compress_mbps": 85.1,
+"decompress_mbps": 400.11
 },
 {
 "compressor": "zlib",
@@ -6014,8 +6014,8 @@
 "level": 5,
 "out_size": 12445991,
 "ratio": 0.3002,
-"compress_mbps": 54.41,
-"decompress_mbps": 389.03
+"compress_mbps": 54.74,
+"decompress_mbps": 397.69
 },
 {
 "compressor": "zlib",
@@ -6024,8 +6024,8 @@
 "level": 6,
 "out_size": 12213941,
 "ratio": 0.2946,
-"compress_mbps": 36.44,
-"decompress_mbps": 396.85
+"compress_mbps": 36.35,
+"decompress_mbps": 403.76
 },
 {
 "compressor": "zlib",
@@ -6034,8 +6034,8 @@
 "level": 7,
 "out_size": 12130416,
 "ratio": 0.2926,
-"compress_mbps": 29.5,
-"decompress_mbps": 396.26
+"compress_mbps": 29.39,
+"decompress_mbps": 404.99
 },
 {
 "compressor": "zlib",
@@ -6044,8 +6044,8 @@
 "level": 8,
 "out_size": 12073697,
 "ratio": 0.2912,
-"compress_mbps": 21.36,
-"decompress_mbps": 396.44
+"compress_mbps": 21.33,
+"decompress_mbps": 405.63
 },
 {
 "compressor": "zlib",
@@ -6054,8 +6054,8 @@
 "level": 9,
 "out_size": 12073469,
 "ratio": 0.2912,
-"compress_mbps": 21.25,
-"decompress_mbps": 400.75
+"compress_mbps": 21.16,
+"decompress_mbps": 406.12
 },
 {
 "compressor": "zlib",
@@ -6064,8 +6064,8 @@
 "level": 1,
 "out_size": 6033926,
 "ratio": 0.712,
-"compress_mbps": 74.87,
-"decompress_mbps": 278.83
+"compress_mbps": 74.68,
+"decompress_mbps": 278.85
 },
 {
 "compressor": "zlib",
@@ -6074,8 +6074,8 @@
 "level": 2,
 "out_size": 5997474,
 "ratio": 0.7077,
-"compress_mbps": 67.99,
-"decompress_mbps": 285.69
+"compress_mbps": 67.62,
+"decompress_mbps": 288.14
 },
 {
 "compressor": "zlib",
@@ -6084,8 +6084,8 @@
 "level": 3,
 "out_size": 5966621,
 "ratio": 0.7041,
-"compress_mbps": 55.18,
-"decompress_mbps": 292.75
+"compress_mbps": 54.89,
+"decompress_mbps": 294.82
 },
 {
 "compressor": "zlib",
@@ -6094,8 +6094,8 @@
 "level": 4,
 "out_size": 6091108,
 "ratio": 0.7188,
-"compress_mbps": 45.05,
-"decompress_mbps": 252.85
+"compress_mbps": 45.82,
+"decompress_mbps": 257.47
 },
 {
 "compressor": "zlib",
@@ -6104,8 +6104,8 @@
 "level": 5,
 "out_size": 6053566,
 "ratio": 0.7143,
-"compress_mbps": 36.49,
-"decompress_mbps": 259.82
+"compress_mbps": 37.09,
+"decompress_mbps": 265.93
 },
 {
 "compressor": "zlib",
@@ -6114,8 +6114,8 @@
 "level": 6,
 "out_size": 6045111,
 "ratio": 0.7134,
-"compress_mbps": 34.3,
-"decompress_mbps": 263.88
+"compress_mbps": 34.83,
+"decompress_mbps": 268.83
 },
 {
 "compressor": "zlib",
@@ -6124,8 +6124,8 @@
 "level": 7,
 "out_size": 6045034,
 "ratio": 0.7133,
-"compress_mbps": 34.23,
-"decompress_mbps": 264.3
+"compress_mbps": 34.74,
+"decompress_mbps": 265.43
 },
 {
 "compressor": "zlib",
@@ -6134,8 +6134,8 @@
 "level": 8,
 "out_size": 6045032,
 "ratio": 0.7133,
-"compress_mbps": 34.29,
-"decompress_mbps": 263.46
+"compress_mbps": 34.41,
+"decompress_mbps": 265.75
 },
 {
 "compressor": "zlib",
@@ -6144,8 +6144,8 @@
 "level": 9,
 "out_size": 6045032,
 "ratio": 0.7133,
-"compress_mbps": 34.15,
-"decompress_mbps": 263.38
+"compress_mbps": 34.48,
+"decompress_mbps": 268.71
 },
 {
 "compressor": "zlib",
@@ -6154,8 +6154,8 @@
 "level": 1,
 "out_size": 965242,
 "ratio": 0.1806,
-"compress_mbps": 260.57,
-"decompress_mbps": 678.28
+"compress_mbps": 262.34,
+"decompress_mbps": 685.7
 },
 {
 "compressor": "zlib",
@@ -6164,8 +6164,8 @@
 "level": 2,
 "out_size": 887265,
 "ratio": 0.166,
-"compress_mbps": 243.72,
-"decompress_mbps": 732.83
+"compress_mbps": 246.56,
+"decompress_mbps": 744.15
 },
 {
 "compressor": "zlib",
@@ -6174,8 +6174,8 @@
 "level": 3,
 "out_size": 822167,
 "ratio": 0.1538,
-"compress_mbps": 189.17,
-"decompress_mbps": 786.54
+"compress_mbps": 191.22,
+"decompress_mbps": 789.44
 },
 {
 "compressor": "zlib",
@@ -6184,8 +6184,8 @@
 "level": 4,
 "out_size": 807518,
 "ratio": 0.1511,
-"compress_mbps": 166.78,
-"decompress_mbps": 759.04
+"compress_mbps": 168.7,
+"decompress_mbps": 764.43
 },
 {
 "compressor": "zlib",
@@ -6194,8 +6194,8 @@
 "level": 5,
 "out_size": 730574,
 "ratio": 0.1367,
-"compress_mbps": 120.13,
-"decompress_mbps": 805.91
+"compress_mbps": 121.64,
+"decompress_mbps": 814.91
 },
 {
 "compressor": "zlib",
@@ -6204,8 +6204,8 @@
 "level": 6,
 "out_size": 687991,
 "ratio": 0.1287,
-"compress_mbps": 78.66,
-"decompress_mbps": 859.93
+"compress_mbps": 79.44,
+"decompress_mbps": 873.7
 },
 {
 "compressor": "zlib",
@@ -6214,8 +6214,8 @@
 "level": 7,
 "out_size": 673933,
 "ratio": 0.1261,
-"compress_mbps": 64.82,
-"decompress_mbps": 807.8
+"compress_mbps": 64.98,
+"decompress_mbps": 884.66
 },
 {
 "compressor": "zlib",
@@ -6224,8 +6224,8 @@
 "level": 8,
 "out_size": 659518,
 "ratio": 0.1234,
-"compress_mbps": 42.92,
-"decompress_mbps": 860.48
+"compress_mbps": 42.96,
+"decompress_mbps": 884.85
 },
 {
 "compressor": "zlib",
@@ -6234,8 +6234,8 @@
 "level": 9,
 "out_size": 658899,
 "ratio": 0.1233,
-"compress_mbps": 39.73,
-"decompress_mbps": 880.59
+"compress_mbps": 39.74,
+"decompress_mbps": 897.62
 },
 {
 "compressor": "miniz_oxide",
@@ -6244,8 +6244,8 @@
 "level": 1,
 "out_size": 5363862,
 "ratio": 0.5263,
-"compress_mbps": 140.64,
-"decompress_mbps": 398.47
+"compress_mbps": 140.67,
+"decompress_mbps": 358.75
 },
 {
 "compressor": "miniz_oxide",
@@ -6254,8 +6254,8 @@
 "level": 2,
 "out_size": 4438205,
 "ratio": 0.4354,
-"compress_mbps": 127.0,
-"decompress_mbps": 425.97
+"compress_mbps": 129.76,
+"decompress_mbps": 430.34
 },
 {
 "compressor": "miniz_oxide",
@@ -6264,8 +6264,8 @@
 "level": 3,
 "out_size": 4054333,
 "ratio": 0.3978,
-"compress_mbps": 63.64,
-"decompress_mbps": 485.98
+"compress_mbps": 63.93,
+"decompress_mbps": 478.59
 },
 {
 "compressor": "miniz_oxide",
@@ -6274,8 +6274,8 @@
 "level": 4,
 "out_size": 4038550,
 "ratio": 0.3962,
-"compress_mbps": 57.34,
-"decompress_mbps": 473.48
+"compress_mbps": 58.02,
+"decompress_mbps": 472.16
 },
 {
 "compressor": "miniz_oxide",
@@ -6284,8 +6284,8 @@
 "level": 5,
 "out_size": 3954920,
 "ratio": 0.388,
-"compress_mbps": 40.33,
-"decompress_mbps": 466.78
+"compress_mbps": 40.43,
+"decompress_mbps": 463.56
 },
 {
 "compressor": "miniz_oxide",
@@ -6294,8 +6294,8 @@
 "level": 6,
 "out_size": 3872874,
 "ratio": 0.38,
-"compress_mbps": 22.62,
-"decompress_mbps": 467.99
+"compress_mbps": 22.64,
+"decompress_mbps": 472.02
 },
 {
 "compressor": "miniz_oxide",
@@ -6304,8 +6304,8 @@
 "level": 7,
 "out_size": 3859937,
 "ratio": 0.3787,
-"compress_mbps": 18.84,
-"decompress_mbps": 474.22
+"compress_mbps": 18.89,
+"decompress_mbps": 470.26
 },
 {
 "compressor": "miniz_oxide",
@@ -6314,8 +6314,8 @@
 "level": 8,
 "out_size": 3855935,
 "ratio": 0.3783,
-"compress_mbps": 17.01,
-"decompress_mbps": 476.12
+"compress_mbps": 17.09,
+"decompress_mbps": 469.5
 },
 {
 "compressor": "miniz_oxide",
@@ -6325,7 +6325,7 @@
 "out_size": 3855791,
 "ratio": 0.3783,
 "compress_mbps": 17.04,
-"decompress_mbps": 475.17
+"decompress_mbps": 469.08
 },
 {
 "compressor": "miniz_oxide",
@@ -6334,8 +6334,8 @@
 "level": 1,
 "out_size": 22334882,
 "ratio": 0.4361,
-"compress_mbps": 230.69,
-"decompress_mbps": 377.75
+"compress_mbps": 232.88,
+"decompress_mbps": 374.84
 },
 {
 "compressor": "miniz_oxide",
@@ -6344,8 +6344,8 @@
 "level": 2,
 "out_size": 20150366,
 "ratio": 0.3934,
-"compress_mbps": 119.66,
-"decompress_mbps": 382.47
+"compress_mbps": 121.92,
+"decompress_mbps": 387.83
 },
 {
 "compressor": "miniz_oxide",
@@ -6354,8 +6354,8 @@
 "level": 3,
 "out_size": 19495014,
 "ratio": 0.3806,
-"compress_mbps": 69.98,
-"decompress_mbps": 392.3
+"compress_mbps": 70.69,
+"decompress_mbps": 398.43
 },
 {
 "compressor": "miniz_oxide",
@@ -6364,8 +6364,8 @@
 "level": 4,
 "out_size": 19424978,
 "ratio": 0.3792,
-"compress_mbps": 70.79,
-"decompress_mbps": 406.21
+"compress_mbps": 71.94,
+"decompress_mbps": 412.53
 },
 {
 "compressor": "miniz_oxide",
@@ -6374,8 +6374,8 @@
 "level": 5,
 "out_size": 19298736,
 "ratio": 0.3768,
-"compress_mbps": 53.87,
-"decompress_mbps": 420.74
+"compress_mbps": 54.47,
+"decompress_mbps": 428.4
 },
 {
 "compressor": "miniz_oxide",
@@ -6384,8 +6384,8 @@
 "level": 6,
 "out_size": 19179167,
 "ratio": 0.3744,
-"compress_mbps": 29.61,
-"decompress_mbps": 426.98
+"compress_mbps": 29.8,
+"decompress_mbps": 431.82
 },
 {
 "compressor": "miniz_oxide",
@@ -6394,8 +6394,8 @@
 "level": 7,
 "out_size": 19151324,
 "ratio": 0.3739,
-"compress_mbps": 21.91,
-"decompress_mbps": 430.4
+"compress_mbps": 21.96,
+"decompress_mbps": 432.82
 },
 {
 "compressor": "miniz_oxide",
@@ -6405,7 +6405,7 @@
 "out_size": 19144373,
 "ratio": 0.3738,
 "compress_mbps": 16.6,
-"decompress_mbps": 432.05
+"decompress_mbps": 429.55
 },
 {
 "compressor": "miniz_oxide",
@@ -6414,8 +6414,8 @@
 "level": 9,
 "out_size": 19141383,
 "ratio": 0.3737,
-"compress_mbps": 14.21,
-"decompress_mbps": 431.81
+"compress_mbps": 14.13,
+"decompress_mbps": 409.33
 },
 {
 "compressor": "miniz_oxide",
@@ -6424,8 +6424,8 @@
 "level": 1,
 "out_size": 4249731,
 "ratio": 0.4262,
-"compress_mbps": 309.63,
-"decompress_mbps": 537.16
+"compress_mbps": 309.29,
+"decompress_mbps": 473.63
 },
 {
 "compressor": "miniz_oxide",
@@ -6434,8 +6434,8 @@
 "level": 2,
 "out_size": 3775479,
 "ratio": 0.3787,
-"compress_mbps": 160.2,
-"decompress_mbps": 563.61
+"compress_mbps": 159.95,
+"decompress_mbps": 556.15
 },
 {
 "compressor": "miniz_oxide",
@@ -6444,8 +6444,8 @@
 "level": 3,
 "out_size": 3656966,
 "ratio": 0.3668,
-"compress_mbps": 81.36,
-"decompress_mbps": 584.97
+"compress_mbps": 81.2,
+"decompress_mbps": 578.25
 },
 {
 "compressor": "miniz_oxide",
@@ -6454,8 +6454,8 @@
 "level": 4,
 "out_size": 3740378,
 "ratio": 0.3751,
-"compress_mbps": 68.21,
-"decompress_mbps": 543.41
+"compress_mbps": 68.39,
+"decompress_mbps": 539.54
 },
 {
 "compressor": "miniz_oxide",
@@ -6464,8 +6464,8 @@
 "level": 5,
 "out_size": 3713604,
 "ratio": 0.3725,
-"compress_mbps": 49.19,
-"decompress_mbps": 506.86
+"compress_mbps": 49.2,
+"decompress_mbps": 504.09
 },
 {
 "compressor": "miniz_oxide",
@@ -6475,7 +6475,7 @@
 "out_size": 3683556,
 "ratio": 0.3694,
 "compress_mbps": 25.11,
-"decompress_mbps": 523.0
+"decompress_mbps": 522.94
 },
 {
 "compressor": "miniz_oxide",
@@ -6484,8 +6484,8 @@
 "level": 7,
 "out_size": 3683797,
 "ratio": 0.3695,
-"compress_mbps": 19.04,
-"decompress_mbps": 532.96
+"compress_mbps": 18.99,
+"decompress_mbps": 532.57
 },
 {
 "compressor": "miniz_oxide",
@@ -6494,8 +6494,8 @@
 "level": 8,
 "out_size": 3684477,
 "ratio": 0.3695,
-"compress_mbps": 14.38,
-"decompress_mbps": 537.21
+"compress_mbps": 14.33,
+"decompress_mbps": 538.96
 },
 {
 "compressor": "miniz_oxide",
@@ -6504,8 +6504,8 @@
 "level": 9,
 "out_size": 3679414,
 "ratio": 0.369,
-"compress_mbps": 12.38,
-"decompress_mbps": 543.87
+"compress_mbps": 12.34,
+"decompress_mbps": 541.79
 },
 {
 "compressor": "miniz_oxide",
@@ -6514,8 +6514,8 @@
 "level": 1,
 "out_size": 5594622,
 "ratio": 0.1667,
-"compress_mbps": 427.67,
-"decompress_mbps": 878.48
+"compress_mbps": 417.27,
+"decompress_mbps": 869.58
 },
 {
 "compressor": "miniz_oxide",
@@ -6524,8 +6524,8 @@
 "level": 2,
 "out_size": 4179532,
 "ratio": 0.1246,
-"compress_mbps": 325.65,
-"decompress_mbps": 960.13
+"compress_mbps": 326.86,
+"decompress_mbps": 959.26
 },
 {
 "compressor": "miniz_oxide",
@@ -6534,8 +6534,8 @@
 "level": 3,
 "out_size": 3542329,
 "ratio": 0.1056,
-"compress_mbps": 210.28,
-"decompress_mbps": 868.23
+"compress_mbps": 212.82,
+"decompress_mbps": 906.25
 },
 {
 "compressor": "miniz_oxide",
@@ -6544,8 +6544,8 @@
 "level": 4,
 "out_size": 3323363,
 "ratio": 0.099,
-"compress_mbps": 195.97,
-"decompress_mbps": 898.52
+"compress_mbps": 196.37,
+"decompress_mbps": 850.27
 },
 {
 "compressor": "miniz_oxide",
@@ -6554,8 +6554,8 @@
 "level": 5,
 "out_size": 3230343,
 "ratio": 0.0963,
-"compress_mbps": 162.45,
-"decompress_mbps": 989.11
+"compress_mbps": 163.31,
+"decompress_mbps": 1027.44
 },
 {
 "compressor": "miniz_oxide",
@@ -6564,8 +6564,8 @@
 "level": 6,
 "out_size": 3123421,
 "ratio": 0.0931,
-"compress_mbps": 95.98,
-"decompress_mbps": 1015.8
+"compress_mbps": 95.87,
+"decompress_mbps": 1070.3
 },
 {
 "compressor": "miniz_oxide",
@@ -6574,8 +6574,8 @@
 "level": 7,
 "out_size": 3093778,
 "ratio": 0.0922,
-"compress_mbps": 69.79,
-"decompress_mbps": 914.7
+"compress_mbps": 70.31,
+"decompress_mbps": 1039.05
 },
 {
 "compressor": "miniz_oxide",
@@ -6584,8 +6584,8 @@
 "level": 8,
 "out_size": 3067318,
 "ratio": 0.0914,
-"compress_mbps": 50.08,
-"decompress_mbps": 913.84
+"compress_mbps": 50.03,
+"decompress_mbps": 1106.65
 },
 {
 "compressor": "miniz_oxide",
@@ -6594,8 +6594,8 @@
 "level": 9,
 "out_size": 3050695,
 "ratio": 0.0909,
-"compress_mbps": 42.09,
-"decompress_mbps": 1046.55
+"compress_mbps": 41.97,
+"decompress_mbps": 1029.15
 },
 {
 "compressor": "miniz_oxide",
@@ -6604,8 +6604,8 @@
 "level": 1,
 "out_size": 3543611,
 "ratio": 0.576,
-"compress_mbps": 156.89,
-"decompress_mbps": 275.49
+"compress_mbps": 168.83,
+"decompress_mbps": 270.29
 },
 {
 "compressor": "miniz_oxide",
@@ -6614,8 +6614,8 @@
 "level": 2,
 "out_size": 3226818,
 "ratio": 0.5245,
-"compress_mbps": 86.5,
-"decompress_mbps": 274.03
+"compress_mbps": 87.44,
+"decompress_mbps": 289.54
 },
 {
 "compressor": "miniz_oxide",
@@ -6624,8 +6624,8 @@
 "level": 3,
 "out_size": 3144140,
 "ratio": 0.5111,
-"compress_mbps": 52.75,
-"decompress_mbps": 294.18
+"compress_mbps": 53.18,
+"decompress_mbps": 299.76
 },
 {
 "compressor": "miniz_oxide",
@@ -6634,8 +6634,8 @@
 "level": 4,
 "out_size": 3129833,
 "ratio": 0.5087,
-"compress_mbps": 51.99,
-"decompress_mbps": 318.88
+"compress_mbps": 51.9,
+"decompress_mbps": 328.34
 },
 {
 "compressor": "miniz_oxide",
@@ -6644,8 +6644,8 @@
 "level": 5,
 "out_size": 3114809,
 "ratio": 0.5063,
-"compress_mbps": 40.58,
-"decompress_mbps": 329.39
+"compress_mbps": 40.62,
+"decompress_mbps": 340.96
 },
 {
 "compressor": "miniz_oxide",
@@ -6654,8 +6654,8 @@
 "level": 6,
 "out_size": 3095705,
 "ratio": 0.5032,
-"compress_mbps": 25.25,
-"decompress_mbps": 333.64
+"compress_mbps": 25.22,
+"decompress_mbps": 347.21
 },
 {
 "compressor": "miniz_oxide",
@@ -6665,7 +6665,7 @@
 "out_size": 3090055,
 "ratio": 0.5023,
 "compress_mbps": 20.53,
-"decompress_mbps": 336.92
+"decompress_mbps": 348.36
 },
 {
 "compressor": "miniz_oxide",
@@ -6674,8 +6674,8 @@
 "level": 8,
 "out_size": 3087665,
 "ratio": 0.5019,
-"compress_mbps": 17.44,
-"decompress_mbps": 335.6
+"compress_mbps": 17.45,
+"decompress_mbps": 350.0
 },
 {
 "compressor": "miniz_oxide",
@@ -6684,8 +6684,8 @@
 "level": 9,
 "out_size": 3087158,
 "ratio": 0.5018,
-"compress_mbps": 16.32,
-"decompress_mbps": 334.64
+"compress_mbps": 16.36,
+"decompress_mbps": 349.97
 },
 {
 "compressor": "miniz_oxide",
@@ -6694,8 +6694,8 @@
 "level": 1,
 "out_size": 5419510,
 "ratio": 0.5373,
-"compress_mbps": 239.05,
-"decompress_mbps": 492.24
+"compress_mbps": 240.15,
+"decompress_mbps": 510.17
 },
 {
 "compressor": "miniz_oxide",
@@ -6704,8 +6704,8 @@
 "level": 2,
 "out_size": 3982547,
 "ratio": 0.3949,
-"compress_mbps": 124.9,
-"decompress_mbps": 558.85
+"compress_mbps": 124.58,
+"decompress_mbps": 555.69
 },
 {
 "compressor": "miniz_oxide",
@@ -6714,8 +6714,8 @@
 "level": 3,
 "out_size": 3806102,
 "ratio": 0.3774,
-"compress_mbps": 82.62,
-"decompress_mbps": 538.28
+"compress_mbps": 82.59,
+"decompress_mbps": 570.77
 },
 {
 "compressor": "miniz_oxide",
@@ -6724,8 +6724,8 @@
 "level": 4,
 "out_size": 3761477,
 "ratio": 0.373,
-"compress_mbps": 79.06,
-"decompress_mbps": 611.45
+"compress_mbps": 79.44,
+"decompress_mbps": 609.34
 },
 {
 "compressor": "miniz_oxide",
@@ -6734,8 +6734,8 @@
 "level": 5,
 "out_size": 3740298,
 "ratio": 0.3709,
-"compress_mbps": 67.72,
-"decompress_mbps": 610.23
+"compress_mbps": 68.12,
+"decompress_mbps": 609.64
 },
 {
 "compressor": "miniz_oxide",
@@ -6744,8 +6744,8 @@
 "level": 6,
 "out_size": 3686116,
 "ratio": 0.3655,
-"compress_mbps": 49.54,
-"decompress_mbps": 637.71
+"compress_mbps": 49.72,
+"decompress_mbps": 644.56
 },
 {
 "compressor": "miniz_oxide",
@@ -6754,8 +6754,8 @@
 "level": 7,
 "out_size": 3668442,
 "ratio": 0.3637,
-"compress_mbps": 38.88,
-"decompress_mbps": 652.89
+"compress_mbps": 38.97,
+"decompress_mbps": 656.81
 },
 {
 "compressor": "miniz_oxide",
@@ -6764,8 +6764,8 @@
 "level": 8,
 "out_size": 3665072,
 "ratio": 0.3634,
-"compress_mbps": 33.22,
-"decompress_mbps": 654.95
+"compress_mbps": 33.28,
+"decompress_mbps": 653.63
 },
 {
 "compressor": "miniz_oxide",
@@ -6774,8 +6774,8 @@
 "level": 9,
 "out_size": 3665057,
 "ratio": 0.3634,
-"compress_mbps": 33.12,
-"decompress_mbps": 653.75
+"compress_mbps": 33.18,
+"decompress_mbps": 650.86
 },
 {
 "compressor": "miniz_oxide",
@@ -6784,8 +6784,8 @@
 "level": 1,
 "out_size": 2842321,
 "ratio": 0.4289,
-"compress_mbps": 187.44,
-"decompress_mbps": 462.15
+"compress_mbps": 192.16,
+"decompress_mbps": 474.73
 },
 {
 "compressor": "miniz_oxide",
@@ -6794,8 +6794,8 @@
 "level": 2,
 "out_size": 2232180,
 "ratio": 0.3368,
-"compress_mbps": 151.21,
-"decompress_mbps": 531.43
+"compress_mbps": 153.55,
+"decompress_mbps": 516.91
 },
 {
 "compressor": "miniz_oxide",
@@ -6804,8 +6804,8 @@
 "level": 3,
 "out_size": 2003056,
 "ratio": 0.3022,
-"compress_mbps": 81.84,
-"decompress_mbps": 568.16
+"compress_mbps": 82.19,
+"decompress_mbps": 554.98
 },
 {
 "compressor": "miniz_oxide",
@@ -6814,8 +6814,8 @@
 "level": 4,
 "out_size": 1985375,
 "ratio": 0.2996,
-"compress_mbps": 74.11,
-"decompress_mbps": 572.15
+"compress_mbps": 74.02,
+"decompress_mbps": 562.56
 },
 {
 "compressor": "miniz_oxide",
@@ -6824,8 +6824,8 @@
 "level": 5,
 "out_size": 1933775,
 "ratio": 0.2918,
-"compress_mbps": 51.8,
-"decompress_mbps": 538.01
+"compress_mbps": 52.01,
+"decompress_mbps": 541.61
 },
 {
 "compressor": "miniz_oxide",
@@ -6835,7 +6835,7 @@
 "out_size": 1858103,
 "ratio": 0.2804,
 "compress_mbps": 22.0,
-"decompress_mbps": 549.23
+"decompress_mbps": 545.38
 },
 {
 "compressor": "miniz_oxide",
@@ -6844,8 +6844,8 @@
 "level": 7,
 "out_size": 1840414,
 "ratio": 0.2777,
-"compress_mbps": 15.04,
-"decompress_mbps": 483.84
+"compress_mbps": 15.1,
+"decompress_mbps": 548.02
 },
 {
 "compressor": "miniz_oxide",
@@ -6854,8 +6854,8 @@
 "level": 8,
 "out_size": 1831679,
 "ratio": 0.2764,
-"compress_mbps": 11.74,
-"decompress_mbps": 538.21
+"compress_mbps": 11.71,
+"decompress_mbps": 539.13
 },
 {
 "compressor": "miniz_oxide",
@@ -6864,8 +6864,8 @@
 "level": 9,
 "out_size": 1827137,
 "ratio": 0.2757,
-"compress_mbps": 10.15,
-"decompress_mbps": 545.24
+"compress_mbps": 10.13,
+"decompress_mbps": 542.48
 },
 {
 "compressor": "miniz_oxide",
@@ -6874,8 +6874,8 @@
 "level": 1,
 "out_size": 7089759,
 "ratio": 0.3281,
-"compress_mbps": 286.06,
-"decompress_mbps": 549.69
+"compress_mbps": 288.38,
+"decompress_mbps": 559.54
 },
 {
 "compressor": "miniz_oxide",
@@ -6884,8 +6884,8 @@
 "level": 2,
 "out_size": 5966231,
 "ratio": 0.2761,
-"compress_mbps": 173.93,
-"decompress_mbps": 637.33
+"compress_mbps": 173.81,
+"decompress_mbps": 625.71
 },
 {
 "compressor": "miniz_oxide",
@@ -6894,8 +6894,8 @@
 "level": 3,
 "out_size": 5611838,
 "ratio": 0.2597,
-"compress_mbps": 111.45,
-"decompress_mbps": 664.33
+"compress_mbps": 111.48,
+"decompress_mbps": 638.16
 },
 {
 "compressor": "miniz_oxide",
@@ -6904,8 +6904,8 @@
 "level": 4,
 "out_size": 5535436,
 "ratio": 0.2562,
-"compress_mbps": 105.5,
-"decompress_mbps": 688.4
+"compress_mbps": 105.57,
+"decompress_mbps": 677.58
 },
 {
 "compressor": "miniz_oxide",
@@ -6914,8 +6914,8 @@
 "level": 5,
 "out_size": 5480971,
 "ratio": 0.2537,
-"compress_mbps": 81.01,
-"decompress_mbps": 685.03
+"compress_mbps": 81.79,
+"decompress_mbps": 688.57
 },
 {
 "compressor": "miniz_oxide",
@@ -6924,8 +6924,8 @@
 "level": 6,
 "out_size": 5437556,
 "ratio": 0.2517,
-"compress_mbps": 49.39,
-"decompress_mbps": 622.13
+"compress_mbps": 49.61,
+"decompress_mbps": 694.4
 },
 {
 "compressor": "miniz_oxide",
@@ -6934,8 +6934,8 @@
 "level": 7,
 "out_size": 5432108,
 "ratio": 0.2514,
-"compress_mbps": 40.5,
-"decompress_mbps": 710.16
+"compress_mbps": 40.14,
+"decompress_mbps": 698.93
 },
 {
 "compressor": "miniz_oxide",
@@ -6944,8 +6944,8 @@
 "level": 8,
 "out_size": 5428571,
 "ratio": 0.2512,
-"compress_mbps": 33.67,
-"decompress_mbps": 711.2
+"compress_mbps": 33.6,
+"decompress_mbps": 643.9
 },
 {
 "compressor": "miniz_oxide",
@@ -6954,8 +6954,8 @@
 "level": 9,
 "out_size": 5425526,
 "ratio": 0.2511,
-"compress_mbps": 30.48,
-"decompress_mbps": 708.69
+"compress_mbps": 30.47,
+"decompress_mbps": 654.29
 },
 {
 "compressor": "miniz_oxide",
@@ -6964,8 +6964,8 @@
 "level": 1,
 "out_size": 5900800,
 "ratio": 0.8137,
-"compress_mbps": 185.42,
-"decompress_mbps": 319.28
+"compress_mbps": 188.31,
+"decompress_mbps": 313.03
 },
 {
 "compressor": "miniz_oxide",
@@ -6974,8 +6974,8 @@
 "level": 2,
 "out_size": 5523611,
 "ratio": 0.7617,
-"compress_mbps": 69.73,
-"decompress_mbps": 347.51
+"compress_mbps": 70.12,
+"decompress_mbps": 340.36
 },
 {
 "compressor": "miniz_oxide",
@@ -6984,8 +6984,8 @@
 "level": 3,
 "out_size": 5393086,
 "ratio": 0.7437,
-"compress_mbps": 40.48,
-"decompress_mbps": 355.45
+"compress_mbps": 40.6,
+"decompress_mbps": 350.73
 },
 {
 "compressor": "miniz_oxide",
@@ -6994,8 +6994,8 @@
 "level": 4,
 "out_size": 5401582,
 "ratio": 0.7448,
-"compress_mbps": 40.75,
-"decompress_mbps": 371.45
+"compress_mbps": 40.79,
+"decompress_mbps": 367.44
 },
 {
 "compressor": "miniz_oxide",
@@ -7004,8 +7004,8 @@
 "level": 5,
 "out_size": 5371274,
 "ratio": 0.7407,
-"compress_mbps": 31.31,
-"decompress_mbps": 361.6
+"compress_mbps": 31.25,
+"decompress_mbps": 358.87
 },
 {
 "compressor": "miniz_oxide",
@@ -7014,8 +7014,8 @@
 "level": 6,
 "out_size": 5330096,
 "ratio": 0.735,
-"compress_mbps": 20.8,
-"decompress_mbps": 368.27
+"compress_mbps": 20.96,
+"decompress_mbps": 364.81
 },
 {
 "compressor": "miniz_oxide",
@@ -7024,8 +7024,8 @@
 "level": 7,
 "out_size": 5325437,
 "ratio": 0.7343,
-"compress_mbps": 19.04,
-"decompress_mbps": 368.37
+"compress_mbps": 19.1,
+"decompress_mbps": 365.32
 },
 {
 "compressor": "miniz_oxide",
@@ -7034,8 +7034,8 @@
 "level": 8,
 "out_size": 5323934,
 "ratio": 0.7341,
-"compress_mbps": 18.06,
-"decompress_mbps": 351.2
+"compress_mbps": 18.14,
+"decompress_mbps": 366.67
 },
 {
 "compressor": "miniz_oxide",
@@ -7044,8 +7044,8 @@
 "level": 9,
 "out_size": 5323621,
 "ratio": 0.7341,
-"compress_mbps": 17.7,
-"decompress_mbps": 362.29
+"compress_mbps": 17.82,
+"decompress_mbps": 366.31
 },
 {
 "compressor": "miniz_oxide",
@@ -7054,8 +7054,8 @@
 "level": 1,
 "out_size": 17587173,
 "ratio": 0.4242,
-"compress_mbps": 181.01,
-"decompress_mbps": 370.12
+"compress_mbps": 182.41,
+"decompress_mbps": 371.38
 },
 {
 "compressor": "miniz_oxide",
@@ -7064,8 +7064,8 @@
 "level": 2,
 "out_size": 14171707,
 "ratio": 0.3418,
-"compress_mbps": 148.49,
-"decompress_mbps": 420.51
+"compress_mbps": 150.18,
+"decompress_mbps": 422.05
 },
 {
 "compressor": "miniz_oxide",
@@ -7074,8 +7074,8 @@
 "level": 3,
 "out_size": 12774851,
 "ratio": 0.3081,
-"compress_mbps": 85.61,
-"decompress_mbps": 448.49
+"compress_mbps": 85.98,
+"decompress_mbps": 450.71
 },
 {
 "compressor": "miniz_oxide",
@@ -7084,8 +7084,8 @@
 "level": 4,
 "out_size": 12612554,
 "ratio": 0.3042,
-"compress_mbps": 76.05,
-"decompress_mbps": 447.75
+"compress_mbps": 76.8,
+"decompress_mbps": 452.79
 },
 {
 "compressor": "miniz_oxide",
@@ -7094,8 +7094,8 @@
 "level": 5,
 "out_size": 12392339,
 "ratio": 0.2989,
-"compress_mbps": 57.86,
-"decompress_mbps": 452.17
+"compress_mbps": 58.34,
+"decompress_mbps": 467.04
 },
 {
 "compressor": "miniz_oxide",
@@ -7104,8 +7104,8 @@
 "level": 6,
 "out_size": 12158314,
 "ratio": 0.2933,
-"compress_mbps": 34.35,
-"decompress_mbps": 466.04
+"compress_mbps": 34.46,
+"decompress_mbps": 473.44
 },
 {
 "compressor": "miniz_oxide",
@@ -7114,8 +7114,8 @@
 "level": 7,
 "out_size": 12107840,
 "ratio": 0.292,
-"compress_mbps": 27.58,
-"decompress_mbps": 445.65
+"compress_mbps": 27.59,
+"decompress_mbps": 480.16
 },
 {
 "compressor": "miniz_oxide",
@@ -7124,8 +7124,8 @@
 "level": 8,
 "out_size": 12081311,
 "ratio": 0.2914,
-"compress_mbps": 22.83,
-"decompress_mbps": 469.12
+"compress_mbps": 22.89,
+"decompress_mbps": 476.85
 },
 {
 "compressor": "miniz_oxide",
@@ -7134,8 +7134,8 @@
 "level": 9,
 "out_size": 12081011,
 "ratio": 0.2914,
-"compress_mbps": 22.78,
-"decompress_mbps": 465.96
+"compress_mbps": 22.8,
+"decompress_mbps": 475.03
 },
 {
 "compressor": "miniz_oxide",
@@ -7144,8 +7144,8 @@
 "level": 1,
 "out_size": 6527324,
 "ratio": 0.7703,
-"compress_mbps": 236.18,
-"decompress_mbps": 320.69
+"compress_mbps": 236.9,
+"decompress_mbps": 320.91
 },
 {
 "compressor": "miniz_oxide",
@@ -7154,8 +7154,8 @@
 "level": 2,
 "out_size": 6051483,
 "ratio": 0.7141,
-"compress_mbps": 77.06,
-"decompress_mbps": 332.99
+"compress_mbps": 76.73,
+"decompress_mbps": 329.26
 },
 {
 "compressor": "miniz_oxide",
@@ -7164,8 +7164,8 @@
 "level": 3,
 "out_size": 6010123,
 "ratio": 0.7092,
-"compress_mbps": 53.05,
-"decompress_mbps": 334.23
+"compress_mbps": 52.87,
+"decompress_mbps": 330.73
 },
 {
 "compressor": "miniz_oxide",
@@ -7174,8 +7174,8 @@
 "level": 4,
 "out_size": 6024815,
 "ratio": 0.711,
-"compress_mbps": 45.03,
-"decompress_mbps": 287.58
+"compress_mbps": 45.17,
+"decompress_mbps": 282.92
 },
 {
 "compressor": "miniz_oxide",
@@ -7184,8 +7184,8 @@
 "level": 5,
 "out_size": 6005181,
 "ratio": 0.7086,
-"compress_mbps": 40.81,
-"decompress_mbps": 295.29
+"compress_mbps": 40.91,
+"decompress_mbps": 289.63
 },
 {
 "compressor": "miniz_oxide",
@@ -7194,8 +7194,8 @@
 "level": 6,
 "out_size": 5997508,
 "ratio": 0.7077,
-"compress_mbps": 38.17,
-"decompress_mbps": 298.87
+"compress_mbps": 38.25,
+"decompress_mbps": 294.01
 },
 {
 "compressor": "miniz_oxide",
@@ -7204,8 +7204,8 @@
 "level": 7,
 "out_size": 5997403,
 "ratio": 0.7077,
-"compress_mbps": 38.1,
-"decompress_mbps": 299.01
+"compress_mbps": 38.31,
+"decompress_mbps": 292.95
 },
 {
 "compressor": "miniz_oxide",
@@ -7214,8 +7214,8 @@
 "level": 8,
 "out_size": 5997403,
 "ratio": 0.7077,
-"compress_mbps": 38.14,
-"decompress_mbps": 299.32
+"compress_mbps": 38.23,
+"decompress_mbps": 294.49
 },
 {
 "compressor": "miniz_oxide",
@@ -7224,8 +7224,8 @@
 "level": 9,
 "out_size": 5997403,
 "ratio": 0.7077,
-"compress_mbps": 38.16,
-"decompress_mbps": 298.26
+"compress_mbps": 38.3,
+"decompress_mbps": 294.64
 },
 {
 "compressor": "miniz_oxide",
@@ -7234,8 +7234,8 @@
 "level": 1,
 "out_size": 1147652,
 "ratio": 0.2147,
-"compress_mbps": 385.8,
-"decompress_mbps": 858.2
+"compress_mbps": 385.61,
+"decompress_mbps": 842.34
 },
 {
 "compressor": "miniz_oxide",
@@ -7244,8 +7244,8 @@
 "level": 2,
 "out_size": 919639,
 "ratio": 0.172,
-"compress_mbps": 261.16,
-"decompress_mbps": 978.81
+"compress_mbps": 263.55,
+"decompress_mbps": 956.94
 },
 {
 "compressor": "miniz_oxide",
@@ -7254,8 +7254,8 @@
 "level": 3,
 "out_size": 752341,
 "ratio": 0.1407,
-"compress_mbps": 167.32,
-"decompress_mbps": 1086.64
+"compress_mbps": 167.38,
+"decompress_mbps": 1054.37
 },
 {
 "compressor": "miniz_oxide",
@@ -7264,8 +7264,8 @@
 "level": 4,
 "out_size": 735537,
 "ratio": 0.1376,
-"compress_mbps": 161.05,
-"decompress_mbps": 1045.16
+"compress_mbps": 161.64,
+"decompress_mbps": 1041.68
 },
 {
 "compressor": "miniz_oxide",
@@ -7274,8 +7274,8 @@
 "level": 5,
 "out_size": 706789,
 "ratio": 0.1322,
-"compress_mbps": 123.69,
-"decompress_mbps": 1157.55
+"compress_mbps": 123.85,
+"decompress_mbps": 1133.46
 },
 {
 "compressor": "miniz_oxide",
@@ -7284,8 +7284,8 @@
 "level": 6,
 "out_size": 676279,
 "ratio": 0.1265,
-"compress_mbps": 69.39,
-"decompress_mbps": 1196.76
+"compress_mbps": 69.63,
+"decompress_mbps": 1225.82
 },
 {
 "compressor": "miniz_oxide",
@@ -7294,8 +7294,8 @@
 "level": 7,
 "out_size": 668772,
 "ratio": 0.1251,
-"compress_mbps": 56.11,
-"decompress_mbps": 1229.43
+"compress_mbps": 56.1,
+"decompress_mbps": 1225.27
 },
 {
 "compressor": "miniz_oxide",
@@ -7304,8 +7304,8 @@
 "level": 8,
 "out_size": 665340,
 "ratio": 0.1245,
-"compress_mbps": 47.64,
-"decompress_mbps": 1195.6
+"compress_mbps": 47.58,
+"decompress_mbps": 1193.27
 },
 {
 "compressor": "miniz_oxide",
@@ -7315,7 +7315,7 @@
 "out_size": 664273,
 "ratio": 0.1243,
 "compress_mbps": 45.86,
-"decompress_mbps": 1217.55
+"decompress_mbps": 1220.7
 },
 {
 "compressor": "libdeflate",
@@ -7324,8 +7324,8 @@
 "level": 1,
 "out_size": 4217525,
 "ratio": 0.4138,
-"compress_mbps": 243.9,
-"decompress_mbps": 803.03
+"compress_mbps": 242.6,
+"decompress_mbps": 818.09
 },
 {
 "compressor": "libdeflate",
@@ -7334,8 +7334,8 @@
 "level": 2,
 "out_size": 4053259,
 "ratio": 0.3977,
-"compress_mbps": 170.52,
-"decompress_mbps": 860.77
+"compress_mbps": 169.42,
+"decompress_mbps": 892.23
 },
 {
 "compressor": "libdeflate",
@@ -7344,8 +7344,8 @@
 "level": 3,
 "out_size": 3989875,
 "ratio": 0.3915,
-"compress_mbps": 139.64,
-"decompress_mbps": 933.46
+"compress_mbps": 138.93,
+"decompress_mbps": 957.58
 },
 {
 "compressor": "libdeflate",
@@ -7354,8 +7354,8 @@
 "level": 4,
 "out_size": 3972869,
 "ratio": 0.3898,
-"compress_mbps": 127.62,
-"decompress_mbps": 813.95
+"compress_mbps": 127.06,
+"decompress_mbps": 859.71
 },
 {
 "compressor": "libdeflate",
@@ -7364,8 +7364,8 @@
 "level": 5,
 "out_size": 3894026,
 "ratio": 0.3821,
-"compress_mbps": 97.4,
-"decompress_mbps": 740.42
+"compress_mbps": 99.05,
+"decompress_mbps": 812.25
 },
 {
 "compressor": "libdeflate",
@@ -7374,8 +7374,8 @@
 "level": 6,
 "out_size": 3859436,
 "ratio": 0.3787,
-"compress_mbps": 75.57,
-"decompress_mbps": 763.66
+"compress_mbps": 75.48,
+"decompress_mbps": 831.21
 },
 {
 "compressor": "libdeflate",
@@ -7384,8 +7384,8 @@
 "level": 7,
 "out_size": 3837515,
 "ratio": 0.3765,
-"compress_mbps": 55.37,
-"decompress_mbps": 783.6
+"compress_mbps": 55.65,
+"decompress_mbps": 834.16
 },
 {
 "compressor": "libdeflate",
@@ -7394,8 +7394,8 @@
 "level": 8,
 "out_size": 3811467,
 "ratio": 0.374,
-"compress_mbps": 35.93,
-"decompress_mbps": 803.75
+"compress_mbps": 35.89,
+"decompress_mbps": 829.5
 },
 {
 "compressor": "libdeflate",
@@ -7404,8 +7404,8 @@
 "level": 9,
 "out_size": 3810354,
 "ratio": 0.3738,
-"compress_mbps": 32.7,
-"decompress_mbps": 813.03
+"compress_mbps": 32.66,
+"decompress_mbps": 824.07
 },
 {
 "compressor": "libdeflate",
@@ -7414,8 +7414,8 @@
 "level": 1,
 "out_size": 20192961,
 "ratio": 0.3942,
-"compress_mbps": 240.72,
-"decompress_mbps": 650.69
+"compress_mbps": 240.28,
+"decompress_mbps": 699.48
 },
 {
 "compressor": "libdeflate",
@@ -7424,8 +7424,8 @@
 "level": 2,
 "out_size": 19374226,
 "ratio": 0.3783,
-"compress_mbps": 186.71,
-"decompress_mbps": 713.92
+"compress_mbps": 183.08,
+"decompress_mbps": 675.72
 },
 {
 "compressor": "libdeflate",
@@ -7434,8 +7434,8 @@
 "level": 3,
 "out_size": 19234937,
 "ratio": 0.3755,
-"compress_mbps": 174.25,
-"decompress_mbps": 736.84
+"compress_mbps": 174.16,
+"decompress_mbps": 748.95
 },
 {
 "compressor": "libdeflate",
@@ -7444,8 +7444,8 @@
 "level": 4,
 "out_size": 19145385,
 "ratio": 0.3738,
-"compress_mbps": 163.57,
-"decompress_mbps": 732.37
+"compress_mbps": 163.12,
+"decompress_mbps": 746.06
 },
 {
 "compressor": "libdeflate",
@@ -7454,8 +7454,8 @@
 "level": 5,
 "out_size": 18878875,
 "ratio": 0.3686,
-"compress_mbps": 143.99,
-"decompress_mbps": 756.51
+"compress_mbps": 143.29,
+"decompress_mbps": 765.87
 },
 {
 "compressor": "libdeflate",
@@ -7464,8 +7464,8 @@
 "level": 6,
 "out_size": 18805391,
 "ratio": 0.3671,
-"compress_mbps": 120.71,
-"decompress_mbps": 761.1
+"compress_mbps": 120.44,
+"decompress_mbps": 782.21
 },
 {
 "compressor": "libdeflate",
@@ -7474,8 +7474,8 @@
 "level": 7,
 "out_size": 18749947,
 "ratio": 0.3661,
-"compress_mbps": 87.23,
-"decompress_mbps": 759.09
+"compress_mbps": 87.66,
+"decompress_mbps": 785.12
 },
 {
 "compressor": "libdeflate",
@@ -7484,8 +7484,8 @@
 "level": 8,
 "out_size": 18718540,
 "ratio": 0.3655,
-"compress_mbps": 47.48,
-"decompress_mbps": 706.36
+"compress_mbps": 47.37,
+"decompress_mbps": 783.8
 },
 {
 "compressor": "libdeflate",
@@ -7494,8 +7494,8 @@
 "level": 9,
 "out_size": 18713659,
 "ratio": 0.3654,
-"compress_mbps": 33.65,
-"decompress_mbps": 767.33
+"compress_mbps": 33.57,
+"decompress_mbps": 784.05
 },
 {
 "compressor": "libdeflate",
@@ -7504,8 +7504,8 @@
 "level": 1,
 "out_size": 3740775,
 "ratio": 0.3752,
-"compress_mbps": 294.36,
-"decompress_mbps": 830.03
+"compress_mbps": 291.97,
+"decompress_mbps": 776.47
 },
 {
 "compressor": "libdeflate",
@@ -7514,8 +7514,8 @@
 "level": 2,
 "out_size": 3707407,
 "ratio": 0.3718,
-"compress_mbps": 216.05,
-"decompress_mbps": 876.29
+"compress_mbps": 217.32,
+"decompress_mbps": 886.08
 },
 {
 "compressor": "libdeflate",
@@ -7524,8 +7524,8 @@
 "level": 3,
 "out_size": 3672389,
 "ratio": 0.3683,
-"compress_mbps": 184.2,
-"decompress_mbps": 912.54
+"compress_mbps": 184.26,
+"decompress_mbps": 946.97
 },
 {
 "compressor": "libdeflate",
@@ -7534,8 +7534,8 @@
 "level": 4,
 "out_size": 3660011,
 "ratio": 0.3671,
-"compress_mbps": 170.74,
-"decompress_mbps": 843.92
+"compress_mbps": 170.13,
+"decompress_mbps": 850.17
 },
 {
 "compressor": "libdeflate",
@@ -7544,8 +7544,8 @@
 "level": 5,
 "out_size": 3664245,
 "ratio": 0.3675,
-"compress_mbps": 141.74,
-"decompress_mbps": 789.28
+"compress_mbps": 140.85,
+"decompress_mbps": 804.63
 },
 {
 "compressor": "libdeflate",
@@ -7554,8 +7554,8 @@
 "level": 6,
 "out_size": 3648644,
 "ratio": 0.3659,
-"compress_mbps": 104.99,
-"decompress_mbps": 827.34
+"compress_mbps": 106.31,
+"decompress_mbps": 852.28
 },
 {
 "compressor": "libdeflate",
@@ -7564,8 +7564,8 @@
 "level": 7,
 "out_size": 3635323,
 "ratio": 0.3646,
-"compress_mbps": 68.55,
-"decompress_mbps": 812.24
+"compress_mbps": 68.48,
+"decompress_mbps": 848.26
 },
 {
 "compressor": "libdeflate",
@@ -7574,8 +7574,8 @@
 "level": 8,
 "out_size": 3624778,
 "ratio": 0.3635,
-"compress_mbps": 43.18,
-"decompress_mbps": 848.35
+"compress_mbps": 43.01,
+"decompress_mbps": 876.22
 },
 {
 "compressor": "libdeflate",
@@ -7584,8 +7584,8 @@
 "level": 9,
 "out_size": 3625176,
 "ratio": 0.3636,
-"compress_mbps": 38.96,
-"decompress_mbps": 852.45
+"compress_mbps": 38.87,
+"decompress_mbps": 871.55
 },
 {
 "compressor": "libdeflate",
@@ -7594,8 +7594,8 @@
 "level": 1,
 "out_size": 3837577,
 "ratio": 0.1144,
-"compress_mbps": 608.28,
-"decompress_mbps": 1637.82
+"compress_mbps": 606.99,
+"decompress_mbps": 1661.25
 },
 {
 "compressor": "libdeflate",
@@ -7604,8 +7604,8 @@
 "level": 2,
 "out_size": 3714632,
 "ratio": 0.1107,
-"compress_mbps": 466.33,
-"decompress_mbps": 1770.68
+"compress_mbps": 462.59,
+"decompress_mbps": 1844.81
 },
 {
 "compressor": "libdeflate",
@@ -7614,8 +7614,8 @@
 "level": 3,
 "out_size": 3599455,
 "ratio": 0.1073,
-"compress_mbps": 428.51,
-"decompress_mbps": 1822.99
+"compress_mbps": 427.37,
+"decompress_mbps": 1897.12
 },
 {
 "compressor": "libdeflate",
@@ -7624,8 +7624,8 @@
 "level": 4,
 "out_size": 3431843,
 "ratio": 0.1023,
-"compress_mbps": 391.16,
-"decompress_mbps": 1824.3
+"compress_mbps": 385.66,
+"decompress_mbps": 1807.07
 },
 {
 "compressor": "libdeflate",
@@ -7634,8 +7634,8 @@
 "level": 5,
 "out_size": 3268188,
 "ratio": 0.0974,
-"compress_mbps": 348.59,
-"decompress_mbps": 1807.05
+"compress_mbps": 343.98,
+"decompress_mbps": 1794.53
 },
 {
 "compressor": "libdeflate",
@@ -7644,8 +7644,8 @@
 "level": 6,
 "out_size": 3091741,
 "ratio": 0.0921,
-"compress_mbps": 264.85,
-"decompress_mbps": 1796.43
+"compress_mbps": 263.6,
+"decompress_mbps": 1869.06
 },
 {
 "compressor": "libdeflate",
@@ -7654,8 +7654,8 @@
 "level": 7,
 "out_size": 3032499,
 "ratio": 0.0904,
-"compress_mbps": 186.38,
-"decompress_mbps": 1790.21
+"compress_mbps": 185.24,
+"decompress_mbps": 1853.29
 },
 {
 "compressor": "libdeflate",
@@ -7664,8 +7664,8 @@
 "level": 8,
 "out_size": 2949097,
 "ratio": 0.0879,
-"compress_mbps": 97.47,
-"decompress_mbps": 1774.73
+"compress_mbps": 97.07,
+"decompress_mbps": 1836.13
 },
 {
 "compressor": "libdeflate",
@@ -7674,8 +7674,8 @@
 "level": 9,
 "out_size": 2925243,
 "ratio": 0.0872,
-"compress_mbps": 69.23,
-"decompress_mbps": 1774.26
+"compress_mbps": 69.03,
+"decompress_mbps": 1867.12
 },
 {
 "compressor": "libdeflate",
@@ -7684,8 +7684,8 @@
 "level": 1,
 "out_size": 3275124,
 "ratio": 0.5324,
-"compress_mbps": 166.56,
-"decompress_mbps": 467.63
+"compress_mbps": 166.23,
+"decompress_mbps": 470.77
 },
 {
 "compressor": "libdeflate",
@@ -7694,8 +7694,8 @@
 "level": 2,
 "out_size": 3150806,
 "ratio": 0.5121,
-"compress_mbps": 128.46,
-"decompress_mbps": 482.45
+"compress_mbps": 126.97,
+"decompress_mbps": 504.39
 },
 {
 "compressor": "libdeflate",
@@ -7704,8 +7704,8 @@
 "level": 3,
 "out_size": 3137061,
 "ratio": 0.5099,
-"compress_mbps": 120.59,
-"decompress_mbps": 492.73
+"compress_mbps": 120.1,
+"decompress_mbps": 521.94
 },
 {
 "compressor": "libdeflate",
@@ -7714,8 +7714,8 @@
 "level": 4,
 "out_size": 3129676,
 "ratio": 0.5087,
-"compress_mbps": 116.94,
-"decompress_mbps": 510.55
+"compress_mbps": 116.2,
+"decompress_mbps": 542.2
 },
 {
 "compressor": "libdeflate",
@@ -7724,8 +7724,8 @@
 "level": 5,
 "out_size": 3079277,
 "ratio": 0.5005,
-"compress_mbps": 99.64,
-"decompress_mbps": 506.55
+"compress_mbps": 98.62,
+"decompress_mbps": 556.32
 },
 {
 "compressor": "libdeflate",
@@ -7734,8 +7734,8 @@
 "level": 6,
 "out_size": 3072378,
 "ratio": 0.4994,
-"compress_mbps": 88.8,
-"decompress_mbps": 526.08
+"compress_mbps": 87.95,
+"decompress_mbps": 562.57
 },
 {
 "compressor": "libdeflate",
@@ -7744,8 +7744,8 @@
 "level": 7,
 "out_size": 3068123,
 "ratio": 0.4987,
-"compress_mbps": 75.8,
-"decompress_mbps": 516.96
+"compress_mbps": 75.3,
+"decompress_mbps": 568.54
 },
 {
 "compressor": "libdeflate",
@@ -7754,8 +7754,8 @@
 "level": 8,
 "out_size": 3067299,
 "ratio": 0.4986,
-"compress_mbps": 55.21,
-"decompress_mbps": 518.77
+"compress_mbps": 55.06,
+"decompress_mbps": 564.55
 },
 {
 "compressor": "libdeflate",
@@ -7764,8 +7764,8 @@
 "level": 9,
 "out_size": 3066968,
 "ratio": 0.4985,
-"compress_mbps": 49.02,
-"decompress_mbps": 508.89
+"compress_mbps": 49.63,
+"decompress_mbps": 568.19
 },
 {
 "compressor": "libdeflate",
@@ -7774,8 +7774,8 @@
 "level": 1,
 "out_size": 3868663,
 "ratio": 0.3836,
-"compress_mbps": 285.51,
-"decompress_mbps": 873.44
+"compress_mbps": 286.3,
+"decompress_mbps": 902.6
 },
 {
 "compressor": "libdeflate",
@@ -7784,8 +7784,8 @@
 "level": 2,
 "out_size": 3839158,
 "ratio": 0.3807,
-"compress_mbps": 208.62,
-"decompress_mbps": 886.43
+"compress_mbps": 209.99,
+"decompress_mbps": 924.39
 },
 {
 "compressor": "libdeflate",
@@ -7794,8 +7794,8 @@
 "level": 3,
 "out_size": 3818964,
 "ratio": 0.3787,
-"compress_mbps": 195.39,
-"decompress_mbps": 908.09
+"compress_mbps": 195.21,
+"decompress_mbps": 952.29
 },
 {
 "compressor": "libdeflate",
@@ -7804,8 +7804,8 @@
 "level": 4,
 "out_size": 3789325,
 "ratio": 0.3757,
-"compress_mbps": 179.13,
-"decompress_mbps": 935.88
+"compress_mbps": 178.2,
+"decompress_mbps": 981.11
 },
 {
 "compressor": "libdeflate",
@@ -7814,8 +7814,8 @@
 "level": 5,
 "out_size": 3666476,
 "ratio": 0.3635,
-"compress_mbps": 158.68,
-"decompress_mbps": 924.77
+"compress_mbps": 154.7,
+"decompress_mbps": 967.38
 },
 {
 "compressor": "libdeflate",
@@ -7824,8 +7824,8 @@
 "level": 6,
 "out_size": 3660266,
 "ratio": 0.3629,
-"compress_mbps": 142.66,
-"decompress_mbps": 964.17
+"compress_mbps": 139.26,
+"decompress_mbps": 1013.09
 },
 {
 "compressor": "libdeflate",
@@ -7834,8 +7834,8 @@
 "level": 7,
 "out_size": 3659491,
 "ratio": 0.3628,
-"compress_mbps": 135.43,
-"decompress_mbps": 965.29
+"compress_mbps": 132.39,
+"decompress_mbps": 1027.6
 },
 {
 "compressor": "libdeflate",
@@ -7844,8 +7844,8 @@
 "level": 8,
 "out_size": 3654863,
 "ratio": 0.3624,
-"compress_mbps": 114.96,
-"decompress_mbps": 974.57
+"compress_mbps": 111.69,
+"decompress_mbps": 1012.61
 },
 {
 "compressor": "libdeflate",
@@ -7854,8 +7854,8 @@
 "level": 9,
 "out_size": 3654860,
 "ratio": 0.3624,
-"compress_mbps": 114.36,
-"decompress_mbps": 950.44
+"compress_mbps": 108.45,
+"decompress_mbps": 1027.94
 },
 {
 "compressor": "libdeflate",
@@ -7864,8 +7864,8 @@
 "level": 1,
 "out_size": 2197055,
 "ratio": 0.3315,
-"compress_mbps": 299.21,
-"decompress_mbps": 850.67
+"compress_mbps": 296.9,
+"decompress_mbps": 1030.56
 },
 {
 "compressor": "libdeflate",
@@ -7874,8 +7874,8 @@
 "level": 2,
 "out_size": 2082309,
 "ratio": 0.3142,
-"compress_mbps": 214.66,
-"decompress_mbps": 1063.73
+"compress_mbps": 214.98,
+"decompress_mbps": 1124.97
 },
 {
 "compressor": "libdeflate",
@@ -7884,8 +7884,8 @@
 "level": 3,
 "out_size": 2021047,
 "ratio": 0.305,
-"compress_mbps": 178.55,
-"decompress_mbps": 1140.32
+"compress_mbps": 177.64,
+"decompress_mbps": 1229.27
 },
 {
 "compressor": "libdeflate",
@@ -7894,8 +7894,8 @@
 "level": 4,
 "out_size": 1990952,
 "ratio": 0.3004,
-"compress_mbps": 158.64,
-"decompress_mbps": 1085.31
+"compress_mbps": 157.84,
+"decompress_mbps": 1118.07
 },
 {
 "compressor": "libdeflate",
@@ -7904,8 +7904,8 @@
 "level": 5,
 "out_size": 1921113,
 "ratio": 0.2899,
-"compress_mbps": 127.34,
-"decompress_mbps": 1004.86
+"compress_mbps": 126.58,
+"decompress_mbps": 1070.38
 },
 {
 "compressor": "libdeflate",
@@ -7914,8 +7914,8 @@
 "level": 6,
 "out_size": 1876257,
 "ratio": 0.2831,
-"compress_mbps": 86.86,
-"decompress_mbps": 1035.1
+"compress_mbps": 86.57,
+"decompress_mbps": 1061.22
 },
 {
 "compressor": "libdeflate",
@@ -7924,8 +7924,8 @@
 "level": 7,
 "out_size": 1832695,
 "ratio": 0.2765,
-"compress_mbps": 46.59,
-"decompress_mbps": 1022.51
+"compress_mbps": 46.39,
+"decompress_mbps": 1072.81
 },
 {
 "compressor": "libdeflate",
@@ -7934,8 +7934,8 @@
 "level": 8,
 "out_size": 1809967,
 "ratio": 0.2731,
-"compress_mbps": 24.34,
-"decompress_mbps": 989.14
+"compress_mbps": 24.26,
+"decompress_mbps": 1042.35
 },
 {
 "compressor": "libdeflate",
@@ -7944,8 +7944,8 @@
 "level": 9,
 "out_size": 1806374,
 "ratio": 0.2726,
-"compress_mbps": 19.91,
-"decompress_mbps": 967.26
+"compress_mbps": 19.85,
+"decompress_mbps": 1040.37
 },
 {
 "compressor": "libdeflate",
@@ -7954,8 +7954,8 @@
 "level": 1,
 "out_size": 5866517,
 "ratio": 0.2715,
-"compress_mbps": 340.58,
-"decompress_mbps": 914.33
+"compress_mbps": 340.15,
+"decompress_mbps": 921.76
 },
 {
 "compressor": "libdeflate",
@@ -7964,8 +7964,8 @@
 "level": 2,
 "out_size": 5695942,
 "ratio": 0.2636,
-"compress_mbps": 256.62,
-"decompress_mbps": 1051.33
+"compress_mbps": 254.58,
+"decompress_mbps": 1071.02
 },
 {
 "compressor": "libdeflate",
@@ -7974,8 +7974,8 @@
 "level": 3,
 "out_size": 5605878,
 "ratio": 0.2595,
-"compress_mbps": 234.17,
-"decompress_mbps": 1091.46
+"compress_mbps": 231.86,
+"decompress_mbps": 1101.06
 },
 {
 "compressor": "libdeflate",
@@ -7984,8 +7984,8 @@
 "level": 4,
 "out_size": 5553432,
 "ratio": 0.257,
-"compress_mbps": 218.62,
-"decompress_mbps": 1066.6
+"compress_mbps": 215.5,
+"decompress_mbps": 1089.28
 },
 {
 "compressor": "libdeflate",
@@ -7994,8 +7994,8 @@
 "level": 5,
 "out_size": 5416713,
 "ratio": 0.2507,
-"compress_mbps": 188.73,
-"decompress_mbps": 1082.9
+"compress_mbps": 186.25,
+"decompress_mbps": 1081.28
 },
 {
 "compressor": "libdeflate",
@@ -8004,8 +8004,8 @@
 "level": 6,
 "out_size": 5337149,
 "ratio": 0.247,
-"compress_mbps": 143.64,
-"decompress_mbps": 1107.33
+"compress_mbps": 143.26,
+"decompress_mbps": 1105.44
 },
 {
 "compressor": "libdeflate",
@@ -8014,8 +8014,8 @@
 "level": 7,
 "out_size": 5310181,
 "ratio": 0.2458,
-"compress_mbps": 99.83,
-"decompress_mbps": 1096.8
+"compress_mbps": 100.1,
+"decompress_mbps": 1084.81
 },
 {
 "compressor": "libdeflate",
@@ -8024,8 +8024,8 @@
 "level": 8,
 "out_size": 5272761,
 "ratio": 0.244,
-"compress_mbps": 61.94,
-"decompress_mbps": 976.35
+"compress_mbps": 62.13,
+"decompress_mbps": 976.16
 },
 {
 "compressor": "libdeflate",
@@ -8034,8 +8034,8 @@
 "level": 9,
 "out_size": 5270405,
 "ratio": 0.2439,
-"compress_mbps": 50.3,
-"decompress_mbps": 1052.19
+"compress_mbps": 50.05,
+"decompress_mbps": 1087.32
 },
 {
 "compressor": "libdeflate",
@@ -8044,8 +8044,8 @@
 "level": 1,
 "out_size": 5575128,
 "ratio": 0.7688,
-"compress_mbps": 164.26,
-"decompress_mbps": 473.82
+"compress_mbps": 163.15,
+"decompress_mbps": 471.48
 },
 {
 "compressor": "libdeflate",
@@ -8054,8 +8054,8 @@
 "level": 2,
 "out_size": 5417142,
 "ratio": 0.747,
-"compress_mbps": 116.91,
-"decompress_mbps": 509.22
+"compress_mbps": 116.27,
+"decompress_mbps": 507.65
 },
 {
 "compressor": "libdeflate",
@@ -8064,8 +8064,8 @@
 "level": 3,
 "out_size": 5397999,
 "ratio": 0.7444,
-"compress_mbps": 105.55,
-"decompress_mbps": 521.38
+"compress_mbps": 104.56,
+"decompress_mbps": 519.84
 },
 {
 "compressor": "libdeflate",
@@ -8074,8 +8074,8 @@
 "level": 4,
 "out_size": 5391125,
 "ratio": 0.7434,
-"compress_mbps": 99.62,
-"decompress_mbps": 531.42
+"compress_mbps": 99.09,
+"decompress_mbps": 533.62
 },
 {
 "compressor": "libdeflate",
@@ -8084,8 +8084,8 @@
 "level": 5,
 "out_size": 5352212,
 "ratio": 0.738,
-"compress_mbps": 87.04,
-"decompress_mbps": 510.09
+"compress_mbps": 86.61,
+"decompress_mbps": 504.71
 },
 {
 "compressor": "libdeflate",
@@ -8094,8 +8094,8 @@
 "level": 6,
 "out_size": 5335405,
 "ratio": 0.7357,
-"compress_mbps": 73.14,
-"decompress_mbps": 516.71
+"compress_mbps": 72.93,
+"decompress_mbps": 520.88
 },
 {
 "compressor": "libdeflate",
@@ -8104,8 +8104,8 @@
 "level": 7,
 "out_size": 5325697,
 "ratio": 0.7344,
-"compress_mbps": 63.2,
-"decompress_mbps": 521.66
+"compress_mbps": 62.79,
+"decompress_mbps": 516.62
 },
 {
 "compressor": "libdeflate",
@@ -8114,8 +8114,8 @@
 "level": 8,
 "out_size": 5324004,
 "ratio": 0.7341,
-"compress_mbps": 52.23,
-"decompress_mbps": 519.29
+"compress_mbps": 51.84,
+"decompress_mbps": 519.17
 },
 {
 "compressor": "libdeflate",
@@ -8124,8 +8124,8 @@
 "level": 9,
 "out_size": 5323197,
 "ratio": 0.734,
-"compress_mbps": 50.72,
-"decompress_mbps": 520.97
+"compress_mbps": 50.26,
+"decompress_mbps": 518.34
 },
 {
 "compressor": "libdeflate",
@@ -8134,8 +8134,8 @@
 "level": 1,
 "out_size": 13550569,
 "ratio": 0.3268,
-"compress_mbps": 267.57,
-"decompress_mbps": 849.42
+"compress_mbps": 265.53,
+"decompress_mbps": 834.05
 },
 {
 "compressor": "libdeflate",
@@ -8144,8 +8144,8 @@
 "level": 2,
 "out_size": 13130705,
 "ratio": 0.3167,
-"compress_mbps": 202.4,
-"decompress_mbps": 971.37
+"compress_mbps": 198.98,
+"decompress_mbps": 970.73
 },
 {
 "compressor": "libdeflate",
@@ -8154,8 +8154,8 @@
 "level": 3,
 "out_size": 12839361,
 "ratio": 0.3097,
-"compress_mbps": 179.7,
-"decompress_mbps": 1021.6
+"compress_mbps": 178.35,
+"decompress_mbps": 1056.9
 },
 {
 "compressor": "libdeflate",
@@ -8164,8 +8164,8 @@
 "level": 4,
 "out_size": 12601933,
 "ratio": 0.304,
-"compress_mbps": 164.18,
-"decompress_mbps": 924.71
+"compress_mbps": 162.87,
+"decompress_mbps": 949.71
 },
 {
 "compressor": "libdeflate",
@@ -8174,8 +8174,8 @@
 "level": 5,
 "out_size": 12310776,
 "ratio": 0.2969,
-"compress_mbps": 133.5,
-"decompress_mbps": 881.72
+"compress_mbps": 132.54,
+"decompress_mbps": 932.97
 },
 {
 "compressor": "libdeflate",
@@ -8184,8 +8184,8 @@
 "level": 6,
 "out_size": 12140474,
 "ratio": 0.2928,
-"compress_mbps": 106.11,
-"decompress_mbps": 908.28
+"compress_mbps": 105.72,
+"decompress_mbps": 936.75
 },
 {
 "compressor": "libdeflate",
@@ -8194,8 +8194,8 @@
 "level": 7,
 "out_size": 12025296,
 "ratio": 0.2901,
-"compress_mbps": 75.91,
-"decompress_mbps": 907.86
+"compress_mbps": 75.47,
+"decompress_mbps": 942.86
 },
 {
 "compressor": "libdeflate",
@@ -8204,8 +8204,8 @@
 "level": 8,
 "out_size": 11893824,
 "ratio": 0.2869,
-"compress_mbps": 46.26,
-"decompress_mbps": 884.35
+"compress_mbps": 46.02,
+"decompress_mbps": 931.18
 },
 {
 "compressor": "libdeflate",
@@ -8214,8 +8214,8 @@
 "level": 9,
 "out_size": 11882496,
 "ratio": 0.2866,
-"compress_mbps": 39.81,
-"decompress_mbps": 829.81
+"compress_mbps": 39.58,
+"decompress_mbps": 927.94
 },
 {
 "compressor": "libdeflate",
@@ -8224,8 +8224,8 @@
 "level": 1,
 "out_size": 6293390,
 "ratio": 0.7426,
-"compress_mbps": 144.78,
-"decompress_mbps": 466.79
+"compress_mbps": 145.19,
+"decompress_mbps": 520.0
 },
 {
 "compressor": "libdeflate",
@@ -8234,8 +8234,8 @@
 "level": 2,
 "out_size": 6058412,
 "ratio": 0.7149,
-"compress_mbps": 120.54,
-"decompress_mbps": 537.97
+"compress_mbps": 120.56,
+"decompress_mbps": 530.7
 },
 {
 "compressor": "libdeflate",
@@ -8244,8 +8244,8 @@
 "level": 3,
 "out_size": 6058381,
 "ratio": 0.7149,
-"compress_mbps": 120.17,
-"decompress_mbps": 546.47
+"compress_mbps": 120.42,
+"decompress_mbps": 549.0
 },
 {
 "compressor": "libdeflate",
@@ -8254,8 +8254,8 @@
 "level": 4,
 "out_size": 6058363,
 "ratio": 0.7149,
-"compress_mbps": 121.15,
-"decompress_mbps": 434.58
+"compress_mbps": 120.32,
+"decompress_mbps": 437.12
 },
 {
 "compressor": "libdeflate",
@@ -8264,8 +8264,8 @@
 "level": 5,
 "out_size": 5998400,
 "ratio": 0.7078,
-"compress_mbps": 108.25,
-"decompress_mbps": 455.65
+"compress_mbps": 108.06,
+"decompress_mbps": 464.03
 },
 {
 "compressor": "libdeflate",
@@ -8274,8 +8274,8 @@
 "level": 6,
 "out_size": 5998438,
 "ratio": 0.7078,
-"compress_mbps": 108.48,
-"decompress_mbps": 458.59
+"compress_mbps": 108.12,
+"decompress_mbps": 465.54
 },
 {
 "compressor": "libdeflate",
@@ -8284,8 +8284,8 @@
 "level": 7,
 "out_size": 5998439,
 "ratio": 0.7078,
-"compress_mbps": 108.14,
-"decompress_mbps": 461.97
+"compress_mbps": 108.07,
+"decompress_mbps": 467.11
 },
 {
 "compressor": "libdeflate",
@@ -8294,8 +8294,8 @@
 "level": 8,
 "out_size": 5986859,
 "ratio": 0.7065,
-"compress_mbps": 90.48,
-"decompress_mbps": 460.2
+"compress_mbps": 88.91,
+"decompress_mbps": 468.68
 },
 {
 "compressor": "libdeflate",
@@ -8304,8 +8304,8 @@
 "level": 9,
 "out_size": 5986859,
 "ratio": 0.7065,
-"compress_mbps": 90.89,
-"decompress_mbps": 461.67
+"compress_mbps": 89.07,
+"decompress_mbps": 462.26
 },
 {
 "compressor": "libdeflate",
@@ -8314,8 +8314,8 @@
 "level": 1,
 "out_size": 887708,
 "ratio": 0.1661,
-"compress_mbps": 492.82,
-"decompress_mbps": 1404.0
+"compress_mbps": 490.35,
+"decompress_mbps": 1623.47
 },
 {
 "compressor": "libdeflate",
@@ -8324,8 +8324,8 @@
 "level": 2,
 "out_size": 843475,
 "ratio": 0.1578,
-"compress_mbps": 362.28,
-"decompress_mbps": 1720.2
+"compress_mbps": 365.58,
+"decompress_mbps": 1813.05
 },
 {
 "compressor": "libdeflate",
@@ -8334,8 +8334,8 @@
 "level": 3,
 "out_size": 793388,
 "ratio": 0.1484,
-"compress_mbps": 338.1,
-"decompress_mbps": 1886.6
+"compress_mbps": 337.28,
+"decompress_mbps": 1889.12
 },
 {
 "compressor": "libdeflate",
@@ -8344,8 +8344,8 @@
 "level": 4,
 "out_size": 747602,
 "ratio": 0.1399,
-"compress_mbps": 304.46,
-"decompress_mbps": 1815.85
+"compress_mbps": 300.06,
+"decompress_mbps": 1807.37
 },
 {
 "compressor": "libdeflate",
@@ -8354,8 +8354,8 @@
 "level": 5,
 "out_size": 718615,
 "ratio": 0.1344,
-"compress_mbps": 262.89,
-"decompress_mbps": 1812.25
+"compress_mbps": 261.74,
+"decompress_mbps": 1848.0
 },
 {
 "compressor": "libdeflate",
@@ -8364,8 +8364,8 @@
 "level": 6,
 "out_size": 684405,
 "ratio": 0.128,
-"compress_mbps": 195.06,
-"decompress_mbps": 1831.11
+"compress_mbps": 205.37,
+"decompress_mbps": 1930.7
 },
 {
 "compressor": "libdeflate",
@@ -8374,8 +8374,8 @@
 "level": 7,
 "out_size": 664859,
 "ratio": 0.1244,
-"compress_mbps": 143.1,
-"decompress_mbps": 1848.44
+"compress_mbps": 141.74,
+"decompress_mbps": 1908.84
 },
 {
 "compressor": "libdeflate",
@@ -8384,8 +8384,8 @@
 "level": 8,
 "out_size": 650835,
 "ratio": 0.1218,
-"compress_mbps": 84.82,
-"decompress_mbps": 1869.81
+"compress_mbps": 84.63,
+"decompress_mbps": 1879.7
 },
 {
 "compressor": "libdeflate",
@@ -8394,8 +8394,8 @@
 "level": 9,
 "out_size": 649494,
 "ratio": 0.1215,
-"compress_mbps": 68.51,
-"decompress_mbps": 1662.48
+"compress_mbps": 68.28,
+"decompress_mbps": 1857.99
 },
 {
 "compressor": "go",
@@ -8404,8 +8404,8 @@
 "level": 1,
 "out_size": 65708,
 "ratio": 0.432,
-"compress_mbps": 93.97,
-"decompress_mbps": 168.58
+"compress_mbps": 91.12,
+"decompress_mbps": 168.87
 },
 {
 "compressor": "go",
@@ -8414,8 +8414,8 @@
 "level": 2,
 "out_size": 60259,
 "ratio": 0.3962,
-"compress_mbps": 69.13,
-"decompress_mbps": 189.8
+"compress_mbps": 68.69,
+"decompress_mbps": 186.71
 },
 {
 "compressor": "go",
@@ -8424,8 +8424,8 @@
 "level": 3,
 "out_size": 58544,
 "ratio": 0.3849,
-"compress_mbps": 58.71,
-"decompress_mbps": 196.44
+"compress_mbps": 59.01,
+"decompress_mbps": 196.54
 },
 {
 "compressor": "go",
@@ -8434,8 +8434,8 @@
 "level": 4,
 "out_size": 56238,
 "ratio": 0.3698,
-"compress_mbps": 58.8,
-"decompress_mbps": 201.92
+"compress_mbps": 58.4,
+"decompress_mbps": 196.67
 },
 {
 "compressor": "go",
@@ -8444,8 +8444,8 @@
 "level": 5,
 "out_size": 54764,
 "ratio": 0.3601,
-"compress_mbps": 36.27,
-"decompress_mbps": 198.52
+"compress_mbps": 36.47,
+"decompress_mbps": 203.11
 },
 {
 "compressor": "go",
@@ -8454,8 +8454,8 @@
 "level": 6,
 "out_size": 54311,
 "ratio": 0.3571,
-"compress_mbps": 28.95,
-"decompress_mbps": 203.17
+"compress_mbps": 28.72,
+"decompress_mbps": 201.81
 },
 {
 "compressor": "go",
@@ -8464,8 +8464,8 @@
 "level": 7,
 "out_size": 54262,
 "ratio": 0.3568,
-"compress_mbps": 25.69,
-"decompress_mbps": 201.42
+"compress_mbps": 25.77,
+"decompress_mbps": 205.05
 },
 {
 "compressor": "go",
@@ -8474,8 +8474,8 @@
 "level": 8,
 "out_size": 54247,
 "ratio": 0.3567,
-"compress_mbps": 24.62,
-"decompress_mbps": 201.68
+"compress_mbps": 24.71,
+"decompress_mbps": 202.6
 },
 {
 "compressor": "go",
@@ -8484,8 +8484,8 @@
 "level": 9,
 "out_size": 54247,
 "ratio": 0.3567,
-"compress_mbps": 24.83,
-"decompress_mbps": 204.29
+"compress_mbps": 24.25,
+"decompress_mbps": 200.32
 },
 {
 "compressor": "go",
@@ -8494,8 +8494,8 @@
 "level": 1,
 "out_size": 56882,
 "ratio": 0.4544,
-"compress_mbps": 86.09,
-"decompress_mbps": 164.96
+"compress_mbps": 87.87,
+"decompress_mbps": 159.35
 },
 {
 "compressor": "go",
@@ -8504,8 +8504,8 @@
 "level": 2,
 "out_size": 52826,
 "ratio": 0.422,
-"compress_mbps": 61.37,
-"decompress_mbps": 174.8
+"compress_mbps": 62.64,
+"decompress_mbps": 174.97
 },
 {
 "compressor": "go",
@@ -8514,8 +8514,8 @@
 "level": 3,
 "out_size": 51625,
 "ratio": 0.4124,
-"compress_mbps": 56.41,
-"decompress_mbps": 182.62
+"compress_mbps": 53.67,
+"decompress_mbps": 180.78
 },
 {
 "compressor": "go",
@@ -8524,8 +8524,8 @@
 "level": 4,
 "out_size": 50034,
 "ratio": 0.3997,
-"compress_mbps": 53.68,
-"decompress_mbps": 194.83
+"compress_mbps": 53.12,
+"decompress_mbps": 183.04
 },
 {
 "compressor": "go",
@@ -8534,8 +8534,8 @@
 "level": 5,
 "out_size": 48912,
 "ratio": 0.3907,
-"compress_mbps": 34.72,
-"decompress_mbps": 186.81
+"compress_mbps": 34.54,
+"decompress_mbps": 187.79
 },
 {
 "compressor": "go",
@@ -8544,8 +8544,8 @@
 "level": 6,
 "out_size": 48738,
 "ratio": 0.3893,
-"compress_mbps": 28.92,
-"decompress_mbps": 184.76
+"compress_mbps": 28.61,
+"decompress_mbps": 186.89
 },
 {
 "compressor": "go",
@@ -8554,8 +8554,8 @@
 "level": 7,
 "out_size": 48719,
 "ratio": 0.3892,
-"compress_mbps": 27.76,
-"decompress_mbps": 180.64
+"compress_mbps": 27.95,
+"decompress_mbps": 189.27
 },
 {
 "compressor": "go",
@@ -8564,8 +8564,8 @@
 "level": 8,
 "out_size": 48716,
 "ratio": 0.3892,
-"compress_mbps": 27.37,
-"decompress_mbps": 181.63
+"compress_mbps": 27.73,
+"decompress_mbps": 190.13
 },
 {
 "compressor": "go",
@@ -8574,8 +8574,8 @@
 "level": 9,
 "out_size": 48716,
 "ratio": 0.3892,
-"compress_mbps": 27.47,
-"decompress_mbps": 184.73
+"compress_mbps": 27.53,
+"decompress_mbps": 188.66
 },
 {
 "compressor": "go",
@@ -8584,8 +8584,8 @@
 "level": 1,
 "out_size": 8988,
 "ratio": 0.3653,
-"compress_mbps": 56.99,
-"decompress_mbps": 172.99
+"compress_mbps": 55.21,
+"decompress_mbps": 184.79
 },
 {
 "compressor": "go",
@@ -8594,8 +8594,8 @@
 "level": 2,
 "out_size": 8564,
 "ratio": 0.3481,
-"compress_mbps": 63.84,
-"decompress_mbps": 257.83
+"compress_mbps": 58.82,
+"decompress_mbps": 199.5
 },
 {
 "compressor": "go",
@@ -8604,8 +8604,8 @@
 "level": 3,
 "out_size": 8390,
 "ratio": 0.341,
-"compress_mbps": 58.81,
-"decompress_mbps": 262.18
+"compress_mbps": 61.66,
+"decompress_mbps": 279.41
 },
 {
 "compressor": "go",
@@ -8614,8 +8614,8 @@
 "level": 4,
 "out_size": 8167,
 "ratio": 0.332,
-"compress_mbps": 55.67,
-"decompress_mbps": 215.44
+"compress_mbps": 54.86,
+"decompress_mbps": 276.56
 },
 {
 "compressor": "go",
@@ -8624,8 +8624,8 @@
 "level": 5,
 "out_size": 7965,
 "ratio": 0.3237,
-"compress_mbps": 46.53,
-"decompress_mbps": 190.83
+"compress_mbps": 48.85,
+"decompress_mbps": 294.35
 },
 {
 "compressor": "go",
@@ -8634,8 +8634,8 @@
 "level": 6,
 "out_size": 7916,
 "ratio": 0.3217,
-"compress_mbps": 42.42,
-"decompress_mbps": 296.25
+"compress_mbps": 41.99,
+"decompress_mbps": 211.56
 },
 {
 "compressor": "go",
@@ -8644,8 +8644,8 @@
 "level": 7,
 "out_size": 7900,
 "ratio": 0.3211,
-"compress_mbps": 38.7,
-"decompress_mbps": 276.33
+"compress_mbps": 39.21,
+"decompress_mbps": 287.36
 },
 {
 "compressor": "go",
@@ -8654,8 +8654,8 @@
 "level": 8,
 "out_size": 7900,
 "ratio": 0.3211,
-"compress_mbps": 42.57,
-"decompress_mbps": 204.24
+"compress_mbps": 38.37,
+"decompress_mbps": 292.73
 },
 {
 "compressor": "go",
@@ -8664,8 +8664,8 @@
 "level": 9,
 "out_size": 7900,
 "ratio": 0.3211,
-"compress_mbps": 35.62,
-"decompress_mbps": 276
+"compress_mbps": 38.68,
+"decompress_mbps": 277.06
 },
 {
 "compressor": "go",
@@ -8674,8 +8674,8 @@
 "level": 1,
 "out_size": 3731,
 "ratio": 0.3346,
-"compress_mbps": 38.33,
-"decompress_mbps": 192.01
+"compress_mbps": 36.53,
+"decompress_mbps": 214.37
 },
 {
 "compressor": "go",
@@ -8684,8 +8684,8 @@
 "level": 2,
 "out_size": 3491,
 "ratio": 0.3131,
-"compress_mbps": 47.67,
-"decompress_mbps": 219.54
+"compress_mbps": 45.63,
+"decompress_mbps": 232.49
 },
 {
 "compressor": "go",
@@ -8694,8 +8694,8 @@
 "level": 3,
 "out_size": 3384,
 "ratio": 0.3035,
-"compress_mbps": 48.06,
-"decompress_mbps": 221.19
+"compress_mbps": 44.74,
+"decompress_mbps": 230.1
 },
 {
 "compressor": "go",
@@ -8704,8 +8704,8 @@
 "level": 4,
 "out_size": 3220,
 "ratio": 0.2888,
-"compress_mbps": 44.97,
-"decompress_mbps": 225.06
+"compress_mbps": 42.34,
+"decompress_mbps": 222.63
 },
 {
 "compressor": "go",
@@ -8714,8 +8714,8 @@
 "level": 5,
 "out_size": 3138,
 "ratio": 0.2814,
-"compress_mbps": 37.04,
-"decompress_mbps": 232.57
+"compress_mbps": 36.87,
+"decompress_mbps": 227.93
 },
 {
 "compressor": "go",
@@ -8724,8 +8724,8 @@
 "level": 6,
 "out_size": 3118,
 "ratio": 0.2796,
-"compress_mbps": 33.9,
-"decompress_mbps": 231.85
+"compress_mbps": 35.48,
+"decompress_mbps": 227.34
 },
 {
 "compressor": "go",
@@ -8734,8 +8734,8 @@
 "level": 7,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 32.44,
-"decompress_mbps": 224.78
+"compress_mbps": 35.29,
+"decompress_mbps": 220.03
 },
 {
 "compressor": "go",
@@ -8744,8 +8744,8 @@
 "level": 8,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 32.18,
-"decompress_mbps": 225.17
+"compress_mbps": 32.81,
+"decompress_mbps": 226.36
 },
 {
 "compressor": "go",
@@ -8754,8 +8754,8 @@
 "level": 9,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 32.73,
-"decompress_mbps": 228.53
+"compress_mbps": 32.86,
+"decompress_mbps": 226.31
 },
 {
 "compressor": "go",
@@ -8764,8 +8764,8 @@
 "level": 1,
 "out_size": 1352,
 "ratio": 0.3633,
-"compress_mbps": 14.66,
-"decompress_mbps": 157.46
+"compress_mbps": 15.28,
+"decompress_mbps": 158.19
 },
 {
 "compressor": "go",
@@ -8774,8 +8774,8 @@
 "level": 2,
 "out_size": 1287,
 "ratio": 0.3459,
-"compress_mbps": 21.15,
-"decompress_mbps": 161.8
+"compress_mbps": 20.26,
+"decompress_mbps": 156.58
 },
 {
 "compressor": "go",
@@ -8784,8 +8784,8 @@
 "level": 3,
 "out_size": 1284,
 "ratio": 0.3451,
-"compress_mbps": 21.34,
-"decompress_mbps": 167.05
+"compress_mbps": 19.32,
+"decompress_mbps": 147.04
 },
 {
 "compressor": "go",
@@ -8794,8 +8794,8 @@
 "level": 4,
 "out_size": 1226,
 "ratio": 0.3295,
-"compress_mbps": 18.11,
-"decompress_mbps": 148.99
+"compress_mbps": 20.83,
+"decompress_mbps": 151.22
 },
 {
 "compressor": "go",
@@ -8804,8 +8804,8 @@
 "level": 5,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 19.08,
-"decompress_mbps": 147.93
+"compress_mbps": 18.43,
+"decompress_mbps": 163.99
 },
 {
 "compressor": "go",
@@ -8814,8 +8814,8 @@
 "level": 6,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 18.77,
-"decompress_mbps": 150.99
+"compress_mbps": 18.11,
+"decompress_mbps": 159.18
 },
 {
 "compressor": "go",
@@ -8824,8 +8824,8 @@
 "level": 7,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 18.17,
-"decompress_mbps": 144.52
+"compress_mbps": 17.52,
+"decompress_mbps": 150.52
 },
 {
 "compressor": "go",
@@ -8834,8 +8834,8 @@
 "level": 8,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 18.88,
-"decompress_mbps": 161.89
+"compress_mbps": 19.77,
+"decompress_mbps": 148.8
 },
 {
 "compressor": "go",
@@ -8844,8 +8844,8 @@
 "level": 9,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 18.36,
-"decompress_mbps": 162.23
+"compress_mbps": 18.73,
+"decompress_mbps": 147.9
 },
 {
 "compressor": "go",
@@ -8854,8 +8854,8 @@
 "level": 1,
 "out_size": 245423,
 "ratio": 0.2383,
-"compress_mbps": 235.4,
-"decompress_mbps": 372.54
+"compress_mbps": 235.01,
+"decompress_mbps": 368.42
 },
 {
 "compressor": "go",
@@ -8864,8 +8864,8 @@
 "level": 2,
 "out_size": 229642,
 "ratio": 0.223,
-"compress_mbps": 209.32,
-"decompress_mbps": 425.39
+"compress_mbps": 200.74,
+"decompress_mbps": 427.98
 },
 {
 "compressor": "go",
@@ -8874,8 +8874,8 @@
 "level": 3,
 "out_size": 225678,
 "ratio": 0.2192,
-"compress_mbps": 173.13,
-"decompress_mbps": 434.55
+"compress_mbps": 175.33,
+"decompress_mbps": 423.12
 },
 {
 "compressor": "go",
@@ -8884,8 +8884,8 @@
 "level": 4,
 "out_size": 218218,
 "ratio": 0.2119,
-"compress_mbps": 161.96,
-"decompress_mbps": 462.23
+"compress_mbps": 161.64,
+"decompress_mbps": 460.83
 },
 {
 "compressor": "go",
@@ -8894,7 +8894,7 @@
 "level": 5,
 "out_size": 210550,
 "ratio": 0.2045,
-"compress_mbps": 95.4,
+"compress_mbps": 95.15,
 "decompress_mbps": 420.28
 },
 {
@@ -8904,8 +8904,8 @@
 "level": 6,
 "out_size": 207949,
 "ratio": 0.2019,
-"compress_mbps": 41.76,
-"decompress_mbps": 430.42
+"compress_mbps": 41.26,
+"decompress_mbps": 399.73
 },
 {
 "compressor": "go",
@@ -8915,7 +8915,7 @@
 "out_size": 207413,
 "ratio": 0.2014,
 "compress_mbps": 24.25,
-"decompress_mbps": 389.81
+"decompress_mbps": 392.86
 },
 {
 "compressor": "go",
@@ -8924,8 +8924,8 @@
 "level": 8,
 "out_size": 207478,
 "ratio": 0.2015,
-"compress_mbps": 7.41,
-"decompress_mbps": 427.67
+"compress_mbps": 7.28,
+"decompress_mbps": 429.08
 },
 {
 "compressor": "go",
@@ -8934,8 +8934,8 @@
 "level": 9,
 "out_size": 207482,
 "ratio": 0.2015,
-"compress_mbps": 3.72,
-"decompress_mbps": 426.18
+"compress_mbps": 3.5,
+"decompress_mbps": 417.45
 },
 {
 "compressor": "go",
@@ -8944,8 +8944,8 @@
 "level": 1,
 "out_size": 175980,
 "ratio": 0.4124,
-"compress_mbps": 104.44,
-"decompress_mbps": 182.23
+"compress_mbps": 105.8,
+"decompress_mbps": 178.78
 },
 {
 "compressor": "go",
@@ -8954,8 +8954,8 @@
 "level": 2,
 "out_size": 160455,
 "ratio": 0.376,
-"compress_mbps": 78.66,
-"decompress_mbps": 202.11
+"compress_mbps": 78.59,
+"decompress_mbps": 207.33
 },
 {
 "compressor": "go",
@@ -8964,8 +8964,8 @@
 "level": 3,
 "out_size": 156690,
 "ratio": 0.3672,
-"compress_mbps": 68.11,
-"decompress_mbps": 209.35
+"compress_mbps": 67.52,
+"decompress_mbps": 211.87
 },
 {
 "compressor": "go",
@@ -8974,8 +8974,8 @@
 "level": 4,
 "out_size": 149064,
 "ratio": 0.3493,
-"compress_mbps": 65.7,
-"decompress_mbps": 217.57
+"compress_mbps": 64.12,
+"decompress_mbps": 214.73
 },
 {
 "compressor": "go",
@@ -8984,8 +8984,8 @@
 "level": 5,
 "out_size": 145616,
 "ratio": 0.3412,
-"compress_mbps": 39.99,
-"decompress_mbps": 215.14
+"compress_mbps": 40.2,
+"decompress_mbps": 214.54
 },
 {
 "compressor": "go",
@@ -8994,8 +8994,8 @@
 "level": 6,
 "out_size": 144773,
 "ratio": 0.3392,
-"compress_mbps": 32.96,
-"decompress_mbps": 219.96
+"compress_mbps": 32.41,
+"decompress_mbps": 212.71
 },
 {
 "compressor": "go",
@@ -9004,8 +9004,8 @@
 "level": 7,
 "out_size": 144603,
 "ratio": 0.3388,
-"compress_mbps": 29.78,
-"decompress_mbps": 219.01
+"compress_mbps": 29.21,
+"decompress_mbps": 215.31
 },
 {
 "compressor": "go",
@@ -9014,8 +9014,8 @@
 "level": 8,
 "out_size": 144573,
 "ratio": 0.3388,
-"compress_mbps": 28.72,
-"decompress_mbps": 217.1
+"compress_mbps": 28.34,
+"decompress_mbps": 208.31
 },
 {
 "compressor": "go",
@@ -9024,8 +9024,8 @@
 "level": 9,
 "out_size": 144570,
 "ratio": 0.3388,
-"compress_mbps": 28.43,
-"decompress_mbps": 215.15
+"compress_mbps": 28.93,
+"decompress_mbps": 218.05
 },
 {
 "compressor": "go",
@@ -9034,8 +9034,8 @@
 "level": 1,
 "out_size": 228837,
 "ratio": 0.4749,
-"compress_mbps": 94.82,
-"decompress_mbps": 160.47
+"compress_mbps": 94.32,
+"decompress_mbps": 157.6
 },
 {
 "compressor": "go",
@@ -9044,8 +9044,8 @@
 "level": 2,
 "out_size": 211248,
 "ratio": 0.4384,
-"compress_mbps": 64.98,
-"decompress_mbps": 176.58
+"compress_mbps": 65.19,
+"decompress_mbps": 173.09
 },
 {
 "compressor": "go",
@@ -9054,8 +9054,8 @@
 "level": 3,
 "out_size": 205619,
 "ratio": 0.4267,
-"compress_mbps": 53.94,
-"decompress_mbps": 182.92
+"compress_mbps": 53.75,
+"decompress_mbps": 185.52
 },
 {
 "compressor": "go",
@@ -9064,8 +9064,8 @@
 "level": 4,
 "out_size": 200595,
 "ratio": 0.4163,
-"compress_mbps": 55.38,
-"decompress_mbps": 190.22
+"compress_mbps": 54.25,
+"decompress_mbps": 188.4
 },
 {
 "compressor": "go",
@@ -9074,8 +9074,8 @@
 "level": 5,
 "out_size": 195418,
 "ratio": 0.4055,
-"compress_mbps": 31.86,
-"decompress_mbps": 183.17
+"compress_mbps": 32.63,
+"decompress_mbps": 187.92
 },
 {
 "compressor": "go",
@@ -9084,8 +9084,8 @@
 "level": 6,
 "out_size": 194148,
 "ratio": 0.4029,
-"compress_mbps": 25.26,
-"decompress_mbps": 183.91
+"compress_mbps": 24.74,
+"decompress_mbps": 185.8
 },
 {
 "compressor": "go",
@@ -9094,8 +9094,8 @@
 "level": 7,
 "out_size": 193994,
 "ratio": 0.4026,
-"compress_mbps": 23.36,
-"decompress_mbps": 184.67
+"compress_mbps": 22.93,
+"decompress_mbps": 187.63
 },
 {
 "compressor": "go",
@@ -9104,8 +9104,8 @@
 "level": 8,
 "out_size": 193991,
 "ratio": 0.4026,
-"compress_mbps": 23.33,
-"decompress_mbps": 183.29
+"compress_mbps": 23.2,
+"decompress_mbps": 184.03
 },
 {
 "compressor": "go",
@@ -9114,8 +9114,8 @@
 "level": 9,
 "out_size": 193991,
 "ratio": 0.4026,
-"compress_mbps": 23.18,
-"decompress_mbps": 182.03
+"compress_mbps": 23.01,
+"decompress_mbps": 184.96
 },
 {
 "compressor": "go",
@@ -9124,8 +9124,8 @@
 "level": 1,
 "out_size": 60990,
 "ratio": 0.1188,
-"compress_mbps": 279.08,
-"decompress_mbps": 486.6
+"compress_mbps": 276.53,
+"decompress_mbps": 485.64
 },
 {
 "compressor": "go",
@@ -9134,8 +9134,8 @@
 "level": 2,
 "out_size": 61650,
 "ratio": 0.1201,
-"compress_mbps": 255.34,
-"decompress_mbps": 527.01
+"compress_mbps": 260.46,
+"decompress_mbps": 530.04
 },
 {
 "compressor": "go",
@@ -9144,8 +9144,8 @@
 "level": 3,
 "out_size": 60035,
 "ratio": 0.117,
-"compress_mbps": 227.47,
-"decompress_mbps": 507.73
+"compress_mbps": 237.8,
+"decompress_mbps": 552.41
 },
 {
 "compressor": "go",
@@ -9154,8 +9154,8 @@
 "level": 4,
 "out_size": 57005,
 "ratio": 0.1111,
-"compress_mbps": 192.08,
-"decompress_mbps": 523.08
+"compress_mbps": 192.91,
+"decompress_mbps": 526.51
 },
 {
 "compressor": "go",
@@ -9164,8 +9164,8 @@
 "level": 5,
 "out_size": 55779,
 "ratio": 0.1087,
-"compress_mbps": 163.01,
-"decompress_mbps": 564.34
+"compress_mbps": 157.4,
+"decompress_mbps": 568.7
 },
 {
 "compressor": "go",
@@ -9174,8 +9174,8 @@
 "level": 6,
 "out_size": 54970,
 "ratio": 0.1071,
-"compress_mbps": 109.02,
-"decompress_mbps": 566.98
+"compress_mbps": 107.4,
+"decompress_mbps": 547.83
 },
 {
 "compressor": "go",
@@ -9184,8 +9184,8 @@
 "level": 7,
 "out_size": 53922,
 "ratio": 0.1051,
-"compress_mbps": 81.32,
-"decompress_mbps": 534.98
+"compress_mbps": 80.07,
+"decompress_mbps": 577.25
 },
 {
 "compressor": "go",
@@ -9194,8 +9194,8 @@
 "level": 8,
 "out_size": 51977,
 "ratio": 0.1013,
-"compress_mbps": 28.9,
-"decompress_mbps": 559.44
+"compress_mbps": 28.81,
+"decompress_mbps": 576.83
 },
 {
 "compressor": "go",
@@ -9204,8 +9204,8 @@
 "level": 9,
 "out_size": 51474,
 "ratio": 0.1003,
-"compress_mbps": 7.48,
-"decompress_mbps": 572.73
+"compress_mbps": 7.4,
+"decompress_mbps": 571.72
 },
 {
 "compressor": "go",
@@ -9214,8 +9214,8 @@
 "level": 1,
 "out_size": 14783,
 "ratio": 0.3866,
-"compress_mbps": 68.02,
-"decompress_mbps": 184.29
+"compress_mbps": 65.48,
+"decompress_mbps": 186.82
 },
 {
 "compressor": "go",
@@ -9224,8 +9224,8 @@
 "level": 2,
 "out_size": 14101,
 "ratio": 0.3688,
-"compress_mbps": 75.23,
-"decompress_mbps": 197.03
+"compress_mbps": 67.16,
+"decompress_mbps": 203.32
 },
 {
 "compressor": "go",
@@ -9234,8 +9234,8 @@
 "level": 3,
 "out_size": 13975,
 "ratio": 0.3655,
-"compress_mbps": 68.45,
-"decompress_mbps": 207.15
+"compress_mbps": 62.18,
+"decompress_mbps": 212
 },
 {
 "compressor": "go",
@@ -9244,8 +9244,8 @@
 "level": 4,
 "out_size": 13632,
 "ratio": 0.3565,
-"compress_mbps": 60.58,
-"decompress_mbps": 200.98
+"compress_mbps": 63,
+"decompress_mbps": 196.27
 },
 {
 "compressor": "go",
@@ -9254,8 +9254,8 @@
 "level": 5,
 "out_size": 13302,
 "ratio": 0.3479,
-"compress_mbps": 51.74,
-"decompress_mbps": 212.11
+"compress_mbps": 49.99,
+"decompress_mbps": 214.25
 },
 {
 "compressor": "go",
@@ -9264,8 +9264,8 @@
 "level": 6,
 "out_size": 13279,
 "ratio": 0.3473,
-"compress_mbps": 42.06,
-"decompress_mbps": 210.88
+"compress_mbps": 41.62,
+"decompress_mbps": 214.73
 },
 {
 "compressor": "go",
@@ -9274,8 +9274,8 @@
 "level": 7,
 "out_size": 13274,
 "ratio": 0.3471,
-"compress_mbps": 34.25,
-"decompress_mbps": 223.25
+"compress_mbps": 34.17,
+"decompress_mbps": 213.82
 },
 {
 "compressor": "go",
@@ -9284,8 +9284,8 @@
 "level": 8,
 "out_size": 13260,
 "ratio": 0.3468,
-"compress_mbps": 19.79,
-"decompress_mbps": 223.22
+"compress_mbps": 19.97,
+"decompress_mbps": 245.75
 },
 {
 "compressor": "go",
@@ -9294,8 +9294,8 @@
 "level": 9,
 "out_size": 13260,
 "ratio": 0.3468,
-"compress_mbps": 13.24,
-"decompress_mbps": 207.56
+"compress_mbps": 13.04,
+"decompress_mbps": 223.24
 },
 {
 "compressor": "go",
@@ -9304,8 +9304,8 @@
 "level": 1,
 "out_size": 1862,
 "ratio": 0.4405,
-"compress_mbps": 16.18,
-"decompress_mbps": 133.98
+"compress_mbps": 16.08,
+"decompress_mbps": 122.75
 },
 {
 "compressor": "go",
@@ -9314,8 +9314,8 @@
 "level": 2,
 "out_size": 1803,
 "ratio": 0.4265,
-"compress_mbps": 22.61,
-"decompress_mbps": 130.35
+"compress_mbps": 21.05,
+"decompress_mbps": 150.87
 },
 {
 "compressor": "go",
@@ -9324,8 +9324,8 @@
 "level": 3,
 "out_size": 1791,
 "ratio": 0.4237,
-"compress_mbps": 20.89,
-"decompress_mbps": 139.54
+"compress_mbps": 20.68,
+"decompress_mbps": 119.84
 },
 {
 "compressor": "go",
@@ -9334,8 +9334,8 @@
 "level": 4,
 "out_size": 1746,
 "ratio": 0.4131,
-"compress_mbps": 21.34,
-"decompress_mbps": 145.46
+"compress_mbps": 20.37,
+"decompress_mbps": 165.4
 },
 {
 "compressor": "go",
@@ -9344,8 +9344,8 @@
 "level": 5,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 20.3,
-"decompress_mbps": 154.69
+"compress_mbps": 20.57,
+"decompress_mbps": 133.37
 },
 {
 "compressor": "go",
@@ -9354,8 +9354,8 @@
 "level": 6,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 21.13,
-"decompress_mbps": 151.85
+"compress_mbps": 18.78,
+"decompress_mbps": 153.49
 },
 {
 "compressor": "go",
@@ -9364,8 +9364,8 @@
 "level": 7,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 19.71,
-"decompress_mbps": 149.19
+"compress_mbps": 22.55,
+"decompress_mbps": 157.42
 },
 {
 "compressor": "go",
@@ -9374,8 +9374,8 @@
 "level": 8,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 22.59,
-"decompress_mbps": 162.23
+"compress_mbps": 19.69,
+"decompress_mbps": 146.79
 },
 {
 "compressor": "go",
@@ -9384,8 +9384,8 @@
 "level": 9,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 20.81,
-"decompress_mbps": 151.2
+"compress_mbps": 20.66,
+"decompress_mbps": 152.12
 },
 {
 "compressor": "go",
@@ -9394,8 +9394,8 @@
 "level": 1,
 "out_size": 4623589,
 "ratio": 0.4536,
-"compress_mbps": 107.09,
-"decompress_mbps": 174.19
+"compress_mbps": 106.46,
+"decompress_mbps": 174.84
 },
 {
 "compressor": "go",
@@ -9404,8 +9404,8 @@
 "level": 2,
 "out_size": 4241525,
 "ratio": 0.4161,
-"compress_mbps": 71.73,
-"decompress_mbps": 197.33
+"compress_mbps": 71.24,
+"decompress_mbps": 194.62
 },
 {
 "compressor": "go",
@@ -9414,8 +9414,8 @@
 "level": 3,
 "out_size": 4123202,
 "ratio": 0.4045,
-"compress_mbps": 59.24,
-"decompress_mbps": 204.76
+"compress_mbps": 59.05,
+"decompress_mbps": 204.17
 },
 {
 "compressor": "go",
@@ -9424,8 +9424,8 @@
 "level": 4,
 "out_size": 3985937,
 "ratio": 0.3911,
-"compress_mbps": 61.34,
-"decompress_mbps": 209.14
+"compress_mbps": 61.33,
+"decompress_mbps": 209.58
 },
 {
 "compressor": "go",
@@ -9434,8 +9434,8 @@
 "level": 5,
 "out_size": 3883839,
 "ratio": 0.3811,
-"compress_mbps": 35.62,
-"decompress_mbps": 201.59
+"compress_mbps": 35.66,
+"decompress_mbps": 202.59
 },
 {
 "compressor": "go",
@@ -9444,8 +9444,8 @@
 "level": 6,
 "out_size": 3860437,
 "ratio": 0.3788,
-"compress_mbps": 27.77,
-"decompress_mbps": 209.52
+"compress_mbps": 28.04,
+"decompress_mbps": 202.01
 },
 {
 "compressor": "go",
@@ -9454,8 +9454,8 @@
 "level": 7,
 "out_size": 3857076,
 "ratio": 0.3784,
-"compress_mbps": 25.44,
-"decompress_mbps": 206.32
+"compress_mbps": 24.78,
+"decompress_mbps": 203.77
 },
 {
 "compressor": "go",
@@ -9464,8 +9464,8 @@
 "level": 8,
 "out_size": 3856651,
 "ratio": 0.3784,
-"compress_mbps": 24.83,
-"decompress_mbps": 210.43
+"compress_mbps": 24.63,
+"decompress_mbps": 203.27
 },
 {
 "compressor": "go",
@@ -9474,8 +9474,8 @@
 "level": 9,
 "out_size": 3856651,
 "ratio": 0.3784,
-"compress_mbps": 24.8,
-"decompress_mbps": 209.2
+"compress_mbps": 24.76,
+"decompress_mbps": 211.72
 },
 {
 "compressor": "go",
@@ -9484,8 +9484,8 @@
 "level": 1,
 "out_size": 21508211,
 "ratio": 0.4199,
-"compress_mbps": 142.2,
-"decompress_mbps": 243.36
+"compress_mbps": 142.98,
+"decompress_mbps": 246.74
 },
 {
 "compressor": "go",
@@ -9494,8 +9494,8 @@
 "level": 2,
 "out_size": 20538783,
 "ratio": 0.401,
-"compress_mbps": 104.33,
-"decompress_mbps": 240.17
+"compress_mbps": 108.3,
+"decompress_mbps": 228.71
 },
 {
 "compressor": "go",
@@ -9504,8 +9504,8 @@
 "level": 3,
 "out_size": 20334352,
 "ratio": 0.397,
-"compress_mbps": 90.9,
-"decompress_mbps": 239.8
+"compress_mbps": 93.47,
+"decompress_mbps": 246.34
 },
 {
 "compressor": "go",
@@ -9514,8 +9514,8 @@
 "level": 4,
 "out_size": 19886937,
 "ratio": 0.3883,
-"compress_mbps": 90.36,
-"decompress_mbps": 247.44
+"compress_mbps": 87.89,
+"decompress_mbps": 238.01
 },
 {
 "compressor": "go",
@@ -9524,8 +9524,8 @@
 "level": 5,
 "out_size": 19582363,
 "ratio": 0.3823,
-"compress_mbps": 64.34,
-"decompress_mbps": 253.04
+"compress_mbps": 64.2,
+"decompress_mbps": 242.86
 },
 {
 "compressor": "go",
@@ -9534,8 +9534,8 @@
 "level": 6,
 "out_size": 19512479,
 "ratio": 0.381,
-"compress_mbps": 44.35,
-"decompress_mbps": 249.7
+"compress_mbps": 44.15,
+"decompress_mbps": 255.88
 },
 {
 "compressor": "go",
@@ -9544,8 +9544,8 @@
 "level": 7,
 "out_size": 19489160,
 "ratio": 0.3805,
-"compress_mbps": 32.39,
-"decompress_mbps": 254.06
+"compress_mbps": 32.36,
+"decompress_mbps": 252.49
 },
 {
 "compressor": "go",
@@ -9554,8 +9554,8 @@
 "level": 8,
 "out_size": 19475109,
 "ratio": 0.3802,
-"compress_mbps": 18.49,
-"decompress_mbps": 248.3
+"compress_mbps": 18.59,
+"decompress_mbps": 247.27
 },
 {
 "compressor": "go",
@@ -9564,8 +9564,8 @@
 "level": 9,
 "out_size": 19476276,
 "ratio": 0.3802,
-"compress_mbps": 10.49,
-"decompress_mbps": 257.21
+"compress_mbps": 10.51,
+"decompress_mbps": 243.51
 },
 {
 "compressor": "go",
@@ -9574,8 +9574,8 @@
 "level": 1,
 "out_size": 3967718,
 "ratio": 0.3979,
-"compress_mbps": 147.83,
-"decompress_mbps": 231.92
+"compress_mbps": 146.46,
+"decompress_mbps": 222.75
 },
 {
 "compressor": "go",
@@ -9584,8 +9584,8 @@
 "level": 2,
 "out_size": 3773274,
 "ratio": 0.3784,
-"compress_mbps": 103.65,
-"decompress_mbps": 228.92
+"compress_mbps": 102.39,
+"decompress_mbps": 230.13
 },
 {
 "compressor": "go",
@@ -9594,8 +9594,8 @@
 "level": 3,
 "out_size": 3670460,
 "ratio": 0.3681,
-"compress_mbps": 77.92,
-"decompress_mbps": 245.25
+"compress_mbps": 75.33,
+"decompress_mbps": 242.04
 },
 {
 "compressor": "go",
@@ -9604,8 +9604,8 @@
 "level": 4,
 "out_size": 3655100,
 "ratio": 0.3666,
-"compress_mbps": 86.98,
-"decompress_mbps": 241.98
+"compress_mbps": 87.59,
+"decompress_mbps": 238.12
 },
 {
 "compressor": "go",
@@ -9614,8 +9614,8 @@
 "level": 5,
 "out_size": 3620881,
 "ratio": 0.3632,
-"compress_mbps": 49.84,
-"decompress_mbps": 255.79
+"compress_mbps": 50.88,
+"decompress_mbps": 250.51
 },
 {
 "compressor": "go",
@@ -9624,8 +9624,8 @@
 "level": 6,
 "out_size": 3606626,
 "ratio": 0.3617,
-"compress_mbps": 33.66,
-"decompress_mbps": 250.71
+"compress_mbps": 33.89,
+"decompress_mbps": 247.41
 },
 {
 "compressor": "go",
@@ -9634,8 +9634,8 @@
 "level": 7,
 "out_size": 3605405,
 "ratio": 0.3616,
-"compress_mbps": 30.75,
-"decompress_mbps": 260.48
+"compress_mbps": 30.81,
+"decompress_mbps": 246.74
 },
 {
 "compressor": "go",
@@ -9644,8 +9644,8 @@
 "level": 8,
 "out_size": 3601635,
 "ratio": 0.3612,
-"compress_mbps": 26.17,
-"decompress_mbps": 249.75
+"compress_mbps": 25.68,
+"decompress_mbps": 227.24
 },
 {
 "compressor": "go",
@@ -9654,8 +9654,8 @@
 "level": 9,
 "out_size": 3601151,
 "ratio": 0.3612,
-"compress_mbps": 19.09,
-"decompress_mbps": 249.72
+"compress_mbps": 19.2,
+"decompress_mbps": 245.97
 },
 {
 "compressor": "go",
@@ -9664,8 +9664,8 @@
 "level": 1,
 "out_size": 4501482,
 "ratio": 0.1342,
-"compress_mbps": 334.24,
-"decompress_mbps": 508.33
+"compress_mbps": 333.02,
+"decompress_mbps": 483.43
 },
 {
 "compressor": "go",
@@ -9674,8 +9674,8 @@
 "level": 2,
 "out_size": 3875891,
 "ratio": 0.1155,
-"compress_mbps": 317.8,
-"decompress_mbps": 614.15
+"compress_mbps": 306.97,
+"decompress_mbps": 612.28
 },
 {
 "compressor": "go",
@@ -9684,8 +9684,8 @@
 "level": 3,
 "out_size": 3731525,
 "ratio": 0.1112,
-"compress_mbps": 286.08,
-"decompress_mbps": 651.73
+"compress_mbps": 279.53,
+"decompress_mbps": 632.7
 },
 {
 "compressor": "go",
@@ -9694,8 +9694,8 @@
 "level": 4,
 "out_size": 3542242,
 "ratio": 0.1056,
-"compress_mbps": 237.37,
-"decompress_mbps": 643.17
+"compress_mbps": 236.63,
+"decompress_mbps": 649.49
 },
 {
 "compressor": "go",
@@ -9704,8 +9704,8 @@
 "level": 5,
 "out_size": 3239184,
 "ratio": 0.0965,
-"compress_mbps": 175.04,
-"decompress_mbps": 677.11
+"compress_mbps": 173.99,
+"decompress_mbps": 719.1
 },
 {
 "compressor": "go",
@@ -9714,8 +9714,8 @@
 "level": 6,
 "out_size": 3113927,
 "ratio": 0.0928,
-"compress_mbps": 123.16,
-"decompress_mbps": 698.68
+"compress_mbps": 118.81,
+"decompress_mbps": 719.15
 },
 {
 "compressor": "go",
@@ -9724,8 +9724,8 @@
 "level": 7,
 "out_size": 3063520,
 "ratio": 0.0913,
-"compress_mbps": 84.21,
-"decompress_mbps": 656.38
+"compress_mbps": 82.15,
+"decompress_mbps": 681.16
 },
 {
 "compressor": "go",
@@ -9734,8 +9734,8 @@
 "level": 8,
 "out_size": 2961320,
 "ratio": 0.0883,
-"compress_mbps": 29.45,
-"decompress_mbps": 676.27
+"compress_mbps": 28.78,
+"decompress_mbps": 725.62
 },
 {
 "compressor": "go",
@@ -9744,8 +9744,8 @@
 "level": 9,
 "out_size": 2940087,
 "ratio": 0.0876,
-"compress_mbps": 20.46,
-"decompress_mbps": 725.24
+"compress_mbps": 20.5,
+"decompress_mbps": 702.47
 },
 {
 "compressor": "go",
@@ -9754,8 +9754,8 @@
 "level": 1,
 "out_size": 3462708,
 "ratio": 0.5628,
-"compress_mbps": 99.8,
-"decompress_mbps": 164.39
+"compress_mbps": 96.7,
+"decompress_mbps": 163.94
 },
 {
 "compressor": "go",
@@ -9764,8 +9764,8 @@
 "level": 2,
 "out_size": 3327399,
 "ratio": 0.5408,
-"compress_mbps": 73.4,
-"decompress_mbps": 172.44
+"compress_mbps": 69.38,
+"decompress_mbps": 172
 },
 {
 "compressor": "go",
@@ -9774,8 +9774,8 @@
 "level": 3,
 "out_size": 3297422,
 "ratio": 0.536,
-"compress_mbps": 64.55,
-"decompress_mbps": 169.04
+"compress_mbps": 66.48,
+"decompress_mbps": 168.63
 },
 {
 "compressor": "go",
@@ -9784,8 +9784,8 @@
 "level": 4,
 "out_size": 3249485,
 "ratio": 0.5282,
-"compress_mbps": 62.2,
-"decompress_mbps": 173.32
+"compress_mbps": 64.43,
+"decompress_mbps": 170.8
 },
 {
 "compressor": "go",
@@ -9794,8 +9794,8 @@
 "level": 5,
 "out_size": 3220046,
 "ratio": 0.5234,
-"compress_mbps": 48.42,
-"decompress_mbps": 178.35
+"compress_mbps": 47.97,
+"decompress_mbps": 180.46
 },
 {
 "compressor": "go",
@@ -9804,8 +9804,8 @@
 "level": 6,
 "out_size": 3213239,
 "ratio": 0.5223,
-"compress_mbps": 42.53,
-"decompress_mbps": 178.68
+"compress_mbps": 41.91,
+"decompress_mbps": 177.23
 },
 {
 "compressor": "go",
@@ -9814,8 +9814,8 @@
 "level": 7,
 "out_size": 3212009,
 "ratio": 0.5221,
-"compress_mbps": 39.56,
-"decompress_mbps": 177.69
+"compress_mbps": 38.45,
+"decompress_mbps": 176.52
 },
 {
 "compressor": "go",
@@ -9824,8 +9824,8 @@
 "level": 8,
 "out_size": 3211575,
 "ratio": 0.522,
-"compress_mbps": 32.83,
-"decompress_mbps": 177.42
+"compress_mbps": 33.68,
+"decompress_mbps": 178.54
 },
 {
 "compressor": "go",
@@ -9834,8 +9834,8 @@
 "level": 9,
 "out_size": 3211561,
 "ratio": 0.522,
-"compress_mbps": 30.36,
-"decompress_mbps": 174.62
+"compress_mbps": 30.24,
+"decompress_mbps": 175.6
 },
 {
 "compressor": "go",
@@ -9844,8 +9844,8 @@
 "level": 1,
 "out_size": 4334497,
 "ratio": 0.4298,
-"compress_mbps": 139.69,
-"decompress_mbps": 229.1
+"compress_mbps": 137.98,
+"decompress_mbps": 232.72
 },
 {
 "compressor": "go",
@@ -9854,8 +9854,8 @@
 "level": 2,
 "out_size": 3900156,
 "ratio": 0.3867,
-"compress_mbps": 131.1,
-"decompress_mbps": 257.92
+"compress_mbps": 132.35,
+"decompress_mbps": 249.83
 },
 {
 "compressor": "go",
@@ -9864,8 +9864,8 @@
 "level": 3,
 "out_size": 3876099,
 "ratio": 0.3843,
-"compress_mbps": 121.58,
-"decompress_mbps": 255.66
+"compress_mbps": 118.4,
+"decompress_mbps": 253.84
 },
 {
 "compressor": "go",
@@ -9874,8 +9874,8 @@
 "level": 4,
 "out_size": 3782364,
 "ratio": 0.375,
-"compress_mbps": 107.02,
-"decompress_mbps": 263.28
+"compress_mbps": 108.19,
+"decompress_mbps": 260.26
 },
 {
 "compressor": "go",
@@ -9884,8 +9884,8 @@
 "level": 5,
 "out_size": 3679310,
 "ratio": 0.3648,
-"compress_mbps": 88.88,
-"decompress_mbps": 272.83
+"compress_mbps": 86.38,
+"decompress_mbps": 271
 },
 {
 "compressor": "go",
@@ -9894,8 +9894,8 @@
 "level": 6,
 "out_size": 3679424,
 "ratio": 0.3648,
-"compress_mbps": 87.42,
-"decompress_mbps": 271.32
+"compress_mbps": 85,
+"decompress_mbps": 272.89
 },
 {
 "compressor": "go",
@@ -9904,8 +9904,8 @@
 "level": 7,
 "out_size": 3679163,
 "ratio": 0.3648,
-"compress_mbps": 80.87,
-"decompress_mbps": 270.59
+"compress_mbps": 82.65,
+"decompress_mbps": 270.6
 },
 {
 "compressor": "go",
@@ -9914,8 +9914,8 @@
 "level": 8,
 "out_size": 3679169,
 "ratio": 0.3648,
-"compress_mbps": 79.39,
-"decompress_mbps": 270.96
+"compress_mbps": 79.52,
+"decompress_mbps": 273.9
 },
 {
 "compressor": "go",
@@ -9924,8 +9924,8 @@
 "level": 9,
 "out_size": 3679169,
 "ratio": 0.3648,
-"compress_mbps": 79.39,
-"decompress_mbps": 271.62
+"compress_mbps": 81.42,
+"decompress_mbps": 271.83
 },
 {
 "compressor": "go",
@@ -9934,8 +9934,8 @@
 "level": 1,
 "out_size": 2496363,
 "ratio": 0.3767,
-"compress_mbps": 126.83,
-"decompress_mbps": 206.84
+"compress_mbps": 129.12,
+"decompress_mbps": 204.48
 },
 {
 "compressor": "go",
@@ -9944,8 +9944,8 @@
 "level": 2,
 "out_size": 2202601,
 "ratio": 0.3324,
-"compress_mbps": 94.3,
-"decompress_mbps": 235.58
+"compress_mbps": 92.91,
+"decompress_mbps": 241.42
 },
 {
 "compressor": "go",
@@ -9954,8 +9954,8 @@
 "level": 3,
 "out_size": 2103089,
 "ratio": 0.3173,
-"compress_mbps": 66.96,
-"decompress_mbps": 251.05
+"compress_mbps": 67.1,
+"decompress_mbps": 251.29
 },
 {
 "compressor": "go",
@@ -9964,8 +9964,8 @@
 "level": 4,
 "out_size": 1999697,
 "ratio": 0.3017,
-"compress_mbps": 72.98,
-"decompress_mbps": 257.6
+"compress_mbps": 73.42,
+"decompress_mbps": 259.63
 },
 {
 "compressor": "go",
@@ -9974,8 +9974,8 @@
 "level": 5,
 "out_size": 1892143,
 "ratio": 0.2855,
-"compress_mbps": 35.71,
-"decompress_mbps": 256.83
+"compress_mbps": 36.54,
+"decompress_mbps": 258.67
 },
 {
 "compressor": "go",
@@ -9984,8 +9984,8 @@
 "level": 6,
 "out_size": 1838372,
 "ratio": 0.2774,
-"compress_mbps": 20.4,
-"decompress_mbps": 261.4
+"compress_mbps": 20.22,
+"decompress_mbps": 254.09
 },
 {
 "compressor": "go",
@@ -9994,8 +9994,8 @@
 "level": 7,
 "out_size": 1828850,
 "ratio": 0.276,
-"compress_mbps": 15.61,
-"decompress_mbps": 254.38
+"compress_mbps": 15.81,
+"decompress_mbps": 261.92
 },
 {
 "compressor": "go",
@@ -10004,8 +10004,8 @@
 "level": 8,
 "out_size": 1823159,
 "ratio": 0.2751,
-"compress_mbps": 12.34,
-"decompress_mbps": 253.75
+"compress_mbps": 12.48,
+"decompress_mbps": 258.66
 },
 {
 "compressor": "go",
@@ -10014,8 +10014,8 @@
 "level": 9,
 "out_size": 1823159,
 "ratio": 0.2751,
-"compress_mbps": 12.38,
-"decompress_mbps": 263.27
+"compress_mbps": 12.35,
+"decompress_mbps": 259.37
 },
 {
 "compressor": "go",
@@ -10024,8 +10024,8 @@
 "level": 1,
 "out_size": 6447290,
 "ratio": 0.2984,
-"compress_mbps": 190.64,
-"decompress_mbps": 295.26
+"compress_mbps": 188.76,
+"decompress_mbps": 308.38
 },
 {
 "compressor": "go",
@@ -10034,8 +10034,8 @@
 "level": 2,
 "out_size": 6030257,
 "ratio": 0.2791,
-"compress_mbps": 148.16,
-"decompress_mbps": 328.02
+"compress_mbps": 146.76,
+"decompress_mbps": 321.61
 },
 {
 "compressor": "go",
@@ -10044,8 +10044,8 @@
 "level": 3,
 "out_size": 5928121,
 "ratio": 0.2744,
-"compress_mbps": 127.49,
-"decompress_mbps": 332.2
+"compress_mbps": 127.38,
+"decompress_mbps": 314.13
 },
 {
 "compressor": "go",
@@ -10054,8 +10054,8 @@
 "level": 4,
 "out_size": 5615804,
 "ratio": 0.2599,
-"compress_mbps": 122.18,
-"decompress_mbps": 347.57
+"compress_mbps": 116.92,
+"decompress_mbps": 352.74
 },
 {
 "compressor": "go",
@@ -10064,8 +10064,8 @@
 "level": 5,
 "out_size": 5496738,
 "ratio": 0.2544,
-"compress_mbps": 81.35,
-"decompress_mbps": 339.22
+"compress_mbps": 82.63,
+"decompress_mbps": 353.09
 },
 {
 "compressor": "go",
@@ -10074,8 +10074,8 @@
 "level": 6,
 "out_size": 5464184,
 "ratio": 0.2529,
-"compress_mbps": 62.88,
-"decompress_mbps": 357.13
+"compress_mbps": 62.47,
+"decompress_mbps": 338.22
 },
 {
 "compressor": "go",
@@ -10084,8 +10084,8 @@
 "level": 7,
 "out_size": 5429645,
 "ratio": 0.2513,
-"compress_mbps": 47.62,
-"decompress_mbps": 338.72
+"compress_mbps": 48.92,
+"decompress_mbps": 346.05
 },
 {
 "compressor": "go",
@@ -10094,8 +10094,8 @@
 "level": 8,
 "out_size": 5418135,
 "ratio": 0.2508,
-"compress_mbps": 37.79,
-"decompress_mbps": 347.72
+"compress_mbps": 37.6,
+"decompress_mbps": 331.17
 },
 {
 "compressor": "go",
@@ -10104,8 +10104,8 @@
 "level": 9,
 "out_size": 5416628,
 "ratio": 0.2507,
-"compress_mbps": 33.8,
-"decompress_mbps": 336.42
+"compress_mbps": 33.11,
+"decompress_mbps": 340.52
 },
 {
 "compressor": "go",
@@ -10114,8 +10114,8 @@
 "level": 1,
 "out_size": 5759187,
 "ratio": 0.7942,
-"compress_mbps": 100.77,
-"decompress_mbps": 178.32
+"compress_mbps": 98.44,
+"decompress_mbps": 174.26
 },
 {
 "compressor": "go",
@@ -10124,8 +10124,8 @@
 "level": 2,
 "out_size": 5619390,
 "ratio": 0.7749,
-"compress_mbps": 65.88,
-"decompress_mbps": 172.31
+"compress_mbps": 64.68,
+"decompress_mbps": 173.71
 },
 {
 "compressor": "go",
@@ -10134,8 +10134,8 @@
 "level": 3,
 "out_size": 5560914,
 "ratio": 0.7668,
-"compress_mbps": 55.19,
-"decompress_mbps": 182.18
+"compress_mbps": 55.42,
+"decompress_mbps": 176.35
 },
 {
 "compressor": "go",
@@ -10144,8 +10144,8 @@
 "level": 4,
 "out_size": 5544069,
 "ratio": 0.7645,
-"compress_mbps": 57.65,
-"decompress_mbps": 181.24
+"compress_mbps": 56.96,
+"decompress_mbps": 180.58
 },
 {
 "compressor": "go",
@@ -10154,8 +10154,8 @@
 "level": 5,
 "out_size": 5518257,
 "ratio": 0.7609,
-"compress_mbps": 44.34,
-"decompress_mbps": 183.52
+"compress_mbps": 43.87,
+"decompress_mbps": 181.18
 },
 {
 "compressor": "go",
@@ -10164,8 +10164,8 @@
 "level": 6,
 "out_size": 5508662,
 "ratio": 0.7596,
-"compress_mbps": 39.75,
-"decompress_mbps": 178.79
+"compress_mbps": 40.09,
+"decompress_mbps": 184.24
 },
 {
 "compressor": "go",
@@ -10174,8 +10174,8 @@
 "level": 7,
 "out_size": 5507534,
 "ratio": 0.7595,
-"compress_mbps": 39.09,
-"decompress_mbps": 182.14
+"compress_mbps": 38.84,
+"decompress_mbps": 185.4
 },
 {
 "compressor": "go",
@@ -10184,8 +10184,8 @@
 "level": 8,
 "out_size": 5507183,
 "ratio": 0.7594,
-"compress_mbps": 38.84,
-"decompress_mbps": 180.55
+"compress_mbps": 38.12,
+"decompress_mbps": 181.95
 },
 {
 "compressor": "go",
@@ -10194,8 +10194,8 @@
 "level": 9,
 "out_size": 5507183,
 "ratio": 0.7594,
-"compress_mbps": 38.49,
-"decompress_mbps": 184.13
+"compress_mbps": 38.4,
+"decompress_mbps": 180.12
 },
 {
 "compressor": "go",
@@ -10204,8 +10204,8 @@
 "level": 1,
 "out_size": 15230651,
 "ratio": 0.3674,
-"compress_mbps": 122.81,
-"decompress_mbps": 203.89
+"compress_mbps": 123.34,
+"decompress_mbps": 204.2
 },
 {
 "compressor": "go",
@@ -10214,8 +10214,8 @@
 "level": 2,
 "out_size": 13822040,
 "ratio": 0.3334,
-"compress_mbps": 92.26,
-"decompress_mbps": 217.55
+"compress_mbps": 92.99,
+"decompress_mbps": 227.62
 },
 {
 "compressor": "go",
@@ -10224,8 +10224,8 @@
 "level": 3,
 "out_size": 13397592,
 "ratio": 0.3232,
-"compress_mbps": 82.63,
-"decompress_mbps": 226.38
+"compress_mbps": 83.93,
+"decompress_mbps": 237.25
 },
 {
 "compressor": "go",
@@ -10234,8 +10234,8 @@
 "level": 4,
 "out_size": 12759940,
 "ratio": 0.3078,
-"compress_mbps": 81.96,
-"decompress_mbps": 249.23
+"compress_mbps": 82.09,
+"decompress_mbps": 245.12
 },
 {
 "compressor": "go",
@@ -10244,8 +10244,8 @@
 "level": 5,
 "out_size": 12274278,
 "ratio": 0.2961,
-"compress_mbps": 52.63,
-"decompress_mbps": 246.37
+"compress_mbps": 52.94,
+"decompress_mbps": 238.04
 },
 {
 "compressor": "go",
@@ -10254,8 +10254,8 @@
 "level": 6,
 "out_size": 12131738,
 "ratio": 0.2926,
-"compress_mbps": 40.6,
-"decompress_mbps": 255.74
+"compress_mbps": 40.1,
+"decompress_mbps": 245.6
 },
 {
 "compressor": "go",
@@ -10264,8 +10264,8 @@
 "level": 7,
 "out_size": 12060450,
 "ratio": 0.2909,
-"compress_mbps": 33.47,
-"decompress_mbps": 244.44
+"compress_mbps": 32.69,
+"decompress_mbps": 256.06
 },
 {
 "compressor": "go",
@@ -10274,8 +10274,8 @@
 "level": 8,
 "out_size": 12036900,
 "ratio": 0.2903,
-"compress_mbps": 30.23,
-"decompress_mbps": 260.16
+"compress_mbps": 29.36,
+"decompress_mbps": 256.57
 },
 {
 "compressor": "go",
@@ -10284,8 +10284,8 @@
 "level": 9,
 "out_size": 12036900,
 "ratio": 0.2903,
-"compress_mbps": 29.57,
-"decompress_mbps": 241.67
+"compress_mbps": 29.24,
+"decompress_mbps": 255.77
 },
 {
 "compressor": "go",
@@ -10294,8 +10294,8 @@
 "level": 1,
 "out_size": 6653052,
 "ratio": 0.7851,
-"compress_mbps": 175.48,
-"decompress_mbps": 182.91
+"compress_mbps": 174.98,
+"decompress_mbps": 178.76
 },
 {
 "compressor": "go",
@@ -10304,8 +10304,8 @@
 "level": 2,
 "out_size": 6305035,
 "ratio": 0.744,
-"compress_mbps": 67.51,
-"decompress_mbps": 163.49
+"compress_mbps": 67.83,
+"decompress_mbps": 162.76
 },
 {
 "compressor": "go",
@@ -10314,8 +10314,8 @@
 "level": 3,
 "out_size": 6302730,
 "ratio": 0.7438,
-"compress_mbps": 68.63,
-"decompress_mbps": 165.35
+"compress_mbps": 67.37,
+"decompress_mbps": 163.05
 },
 {
 "compressor": "go",
@@ -10324,8 +10324,8 @@
 "level": 4,
 "out_size": 6299134,
 "ratio": 0.7433,
-"compress_mbps": 67.45,
-"decompress_mbps": 163.65
+"compress_mbps": 67.02,
+"decompress_mbps": 163.39
 },
 {
 "compressor": "go",
@@ -10334,8 +10334,8 @@
 "level": 5,
 "out_size": 6289022,
 "ratio": 0.7421,
-"compress_mbps": 65.09,
-"decompress_mbps": 165.1
+"compress_mbps": 63.92,
+"decompress_mbps": 165.24
 },
 {
 "compressor": "go",
@@ -10344,8 +10344,8 @@
 "level": 6,
 "out_size": 6289013,
 "ratio": 0.7421,
-"compress_mbps": 65.03,
-"decompress_mbps": 165.15
+"compress_mbps": 64.58,
+"decompress_mbps": 165.92
 },
 {
 "compressor": "go",
@@ -10354,8 +10354,8 @@
 "level": 7,
 "out_size": 6289013,
 "ratio": 0.7421,
-"compress_mbps": 64.27,
-"decompress_mbps": 165.14
+"compress_mbps": 64.28,
+"decompress_mbps": 163.17
 },
 {
 "compressor": "go",
@@ -10364,8 +10364,8 @@
 "level": 8,
 "out_size": 6289012,
 "ratio": 0.7421,
-"compress_mbps": 64.2,
-"decompress_mbps": 164.9
+"compress_mbps": 63.72,
+"decompress_mbps": 163.75
 },
 {
 "compressor": "go",
@@ -10374,8 +10374,8 @@
 "level": 9,
 "out_size": 6289012,
 "ratio": 0.7421,
-"compress_mbps": 64.85,
-"decompress_mbps": 166.62
+"compress_mbps": 63.85,
+"decompress_mbps": 166.63
 },
 {
 "compressor": "go",
@@ -10384,8 +10384,8 @@
 "level": 1,
 "out_size": 989456,
 "ratio": 0.1851,
-"compress_mbps": 249.4,
-"decompress_mbps": 374.12
+"compress_mbps": 251.05,
+"decompress_mbps": 381.62
 },
 {
 "compressor": "go",
@@ -10394,8 +10394,8 @@
 "level": 2,
 "out_size": 839766,
 "ratio": 0.1571,
-"compress_mbps": 222.45,
-"decompress_mbps": 453.31
+"compress_mbps": 229.03,
+"decompress_mbps": 483.44
 },
 {
 "compressor": "go",
@@ -10404,8 +10404,8 @@
 "level": 3,
 "out_size": 800619,
 "ratio": 0.1498,
-"compress_mbps": 199.17,
-"decompress_mbps": 497.06
+"compress_mbps": 191.04,
+"decompress_mbps": 522.72
 },
 {
 "compressor": "go",
@@ -10414,8 +10414,8 @@
 "level": 4,
 "out_size": 776397,
 "ratio": 0.1452,
-"compress_mbps": 173.34,
-"decompress_mbps": 451.21
+"compress_mbps": 169.69,
+"decompress_mbps": 486.85
 },
 {
 "compressor": "go",
@@ -10424,8 +10424,8 @@
 "level": 5,
 "out_size": 712679,
 "ratio": 0.1333,
-"compress_mbps": 119.36,
-"decompress_mbps": 510.5
+"compress_mbps": 122.98,
+"decompress_mbps": 536.51
 },
 {
 "compressor": "go",
@@ -10434,8 +10434,8 @@
 "level": 6,
 "out_size": 683707,
 "ratio": 0.1279,
-"compress_mbps": 93.44,
-"decompress_mbps": 542.98
+"compress_mbps": 93.21,
+"decompress_mbps": 563.06
 },
 {
 "compressor": "go",
@@ -10444,8 +10444,8 @@
 "level": 7,
 "out_size": 668601,
 "ratio": 0.1251,
-"compress_mbps": 70.12,
-"decompress_mbps": 569.67
+"compress_mbps": 70.72,
+"decompress_mbps": 550.36
 },
 {
 "compressor": "go",
@@ -10454,8 +10454,8 @@
 "level": 8,
 "out_size": 659106,
 "ratio": 0.1233,
-"compress_mbps": 47.35,
-"decompress_mbps": 571.09
+"compress_mbps": 48.38,
+"decompress_mbps": 601.92
 },
 {
 "compressor": "go",
@@ -10464,8 +10464,8 @@
 "level": 9,
 "out_size": 658920,
 "ratio": 0.1233,
-"compress_mbps": 47.26,
-"decompress_mbps": 573.62
+"compress_mbps": 46.58,
+"decompress_mbps": 561.41
 },
 {
 "compressor": "js",
@@ -10474,8 +10474,8 @@
 "level": 1,
 "out_size": 62797,
 "ratio": 0.4129,
-"compress_mbps": 76.55,
-"decompress_mbps": 168.04
+"compress_mbps": 74.25,
+"decompress_mbps": 167.23
 },
 {
 "compressor": "js",
@@ -10484,8 +10484,8 @@
 "level": 2,
 "out_size": 59605,
 "ratio": 0.3919,
-"compress_mbps": 52.48,
-"decompress_mbps": 200.71
+"compress_mbps": 51.93,
+"decompress_mbps": 207.48
 },
 {
 "compressor": "js",
@@ -10494,8 +10494,8 @@
 "level": 3,
 "out_size": 57675,
 "ratio": 0.3792,
-"compress_mbps": 45.22,
-"decompress_mbps": 187.82
+"compress_mbps": 44.8,
+"decompress_mbps": 192.69
 },
 {
 "compressor": "js",
@@ -10504,8 +10504,8 @@
 "level": 4,
 "out_size": 56500,
 "ratio": 0.3715,
-"compress_mbps": 38.27,
-"decompress_mbps": 193.48
+"compress_mbps": 39.14,
+"decompress_mbps": 204.7
 },
 {
 "compressor": "js",
@@ -10514,8 +10514,8 @@
 "level": 5,
 "out_size": 56440,
 "ratio": 0.3711,
-"compress_mbps": 38.71,
-"decompress_mbps": 192.73
+"compress_mbps": 38.88,
+"decompress_mbps": 206.94
 },
 {
 "compressor": "js",
@@ -10524,8 +10524,8 @@
 "level": 6,
 "out_size": 55443,
 "ratio": 0.3645,
-"compress_mbps": 32.29,
-"decompress_mbps": 222.43
+"compress_mbps": 31.58,
+"decompress_mbps": 226.48
 },
 {
 "compressor": "js",
@@ -10534,8 +10534,8 @@
 "level": 7,
 "out_size": 55373,
 "ratio": 0.3641,
-"compress_mbps": 32.28,
-"decompress_mbps": 202.12
+"compress_mbps": 31.78,
+"decompress_mbps": 207.48
 },
 {
 "compressor": "js",
@@ -10544,8 +10544,8 @@
 "level": 8,
 "out_size": 55352,
 "ratio": 0.3639,
-"compress_mbps": 31.43,
-"decompress_mbps": 197.54
+"compress_mbps": 31.54,
+"decompress_mbps": 202.08
 },
 {
 "compressor": "js",
@@ -10554,8 +10554,8 @@
 "level": 9,
 "out_size": 55352,
 "ratio": 0.3639,
-"compress_mbps": 30.84,
-"decompress_mbps": 199.72
+"compress_mbps": 31.51,
+"decompress_mbps": 211.38
 },
 {
 "compressor": "js",
@@ -10564,8 +10564,8 @@
 "level": 1,
 "out_size": 55063,
 "ratio": 0.4399,
-"compress_mbps": 74.71,
-"decompress_mbps": 166.16
+"compress_mbps": 76.04,
+"decompress_mbps": 187.2
 },
 {
 "compressor": "js",
@@ -10574,8 +10574,8 @@
 "level": 2,
 "out_size": 52932,
 "ratio": 0.4229,
-"compress_mbps": 61.16,
-"decompress_mbps": 170.72
+"compress_mbps": 61.88,
+"decompress_mbps": 175.39
 },
 {
 "compressor": "js",
@@ -10584,8 +10584,8 @@
 "level": 3,
 "out_size": 51597,
 "ratio": 0.4122,
-"compress_mbps": 43.19,
-"decompress_mbps": 163.28
+"compress_mbps": 44.51,
+"decompress_mbps": 171.18
 },
 {
 "compressor": "js",
@@ -10594,8 +10594,8 @@
 "level": 4,
 "out_size": 50780,
 "ratio": 0.4057,
-"compress_mbps": 38.73,
-"decompress_mbps": 189.43
+"compress_mbps": 38.47,
+"decompress_mbps": 173.54
 },
 {
 "compressor": "js",
@@ -10604,8 +10604,8 @@
 "level": 5,
 "out_size": 50767,
 "ratio": 0.4056,
-"compress_mbps": 38.25,
-"decompress_mbps": 185.68
+"compress_mbps": 38.3,
+"decompress_mbps": 177.12
 },
 {
 "compressor": "js",
@@ -10614,8 +10614,8 @@
 "level": 6,
 "out_size": 50160,
 "ratio": 0.4007,
-"compress_mbps": 33.21,
-"decompress_mbps": 184.63
+"compress_mbps": 32.93,
+"decompress_mbps": 192.43
 },
 {
 "compressor": "js",
@@ -10624,8 +10624,8 @@
 "level": 7,
 "out_size": 50138,
 "ratio": 0.4005,
-"compress_mbps": 32.52,
-"decompress_mbps": 185.34
+"compress_mbps": 31.87,
+"decompress_mbps": 182.06
 },
 {
 "compressor": "js",
@@ -10634,8 +10634,8 @@
 "level": 8,
 "out_size": 50138,
 "ratio": 0.4005,
-"compress_mbps": 32.54,
-"decompress_mbps": 185.9
+"compress_mbps": 32.19,
+"decompress_mbps": 181.45
 },
 {
 "compressor": "js",
@@ -10644,8 +10644,8 @@
 "level": 9,
 "out_size": 50138,
 "ratio": 0.4005,
-"compress_mbps": 32.25,
-"decompress_mbps": 202.45
+"compress_mbps": 32.34,
+"decompress_mbps": 179.48
 },
 {
 "compressor": "js",
@@ -10654,8 +10654,8 @@
 "level": 1,
 "out_size": 8730,
 "ratio": 0.3548,
-"compress_mbps": 61.29,
-"decompress_mbps": 131.38
+"compress_mbps": 73.88,
+"decompress_mbps": 132.63
 },
 {
 "compressor": "js",
@@ -10664,8 +10664,8 @@
 "level": 2,
 "out_size": 8457,
 "ratio": 0.3437,
-"compress_mbps": 59,
-"decompress_mbps": 133.06
+"compress_mbps": 58.43,
+"decompress_mbps": 134.93
 },
 {
 "compressor": "js",
@@ -10674,8 +10674,8 @@
 "level": 3,
 "out_size": 8353,
 "ratio": 0.3395,
-"compress_mbps": 65.53,
-"decompress_mbps": 113.73
+"compress_mbps": 63.02,
+"decompress_mbps": 116.37
 },
 {
 "compressor": "js",
@@ -10684,8 +10684,8 @@
 "level": 4,
 "out_size": 8301,
 "ratio": 0.3374,
-"compress_mbps": 62.58,
-"decompress_mbps": 137.46
+"compress_mbps": 60.52,
+"decompress_mbps": 140.58
 },
 {
 "compressor": "js",
@@ -10694,8 +10694,8 @@
 "level": 5,
 "out_size": 8212,
 "ratio": 0.3338,
-"compress_mbps": 58.58,
-"decompress_mbps": 115.08
+"compress_mbps": 62.76,
+"decompress_mbps": 114.25
 },
 {
 "compressor": "js",
@@ -10704,8 +10704,8 @@
 "level": 6,
 "out_size": 8172,
 "ratio": 0.3322,
-"compress_mbps": 52.85,
-"decompress_mbps": 115.09
+"compress_mbps": 55.65,
+"decompress_mbps": 115.06
 },
 {
 "compressor": "js",
@@ -10714,8 +10714,8 @@
 "level": 7,
 "out_size": 8171,
 "ratio": 0.3321,
-"compress_mbps": 55.59,
-"decompress_mbps": 113.76
+"compress_mbps": 55.83,
+"decompress_mbps": 115.26
 },
 {
 "compressor": "js",
@@ -10724,8 +10724,8 @@
 "level": 8,
 "out_size": 8171,
 "ratio": 0.3321,
-"compress_mbps": 58.27,
-"decompress_mbps": 114.23
+"compress_mbps": 52.89,
+"decompress_mbps": 116.01
 },
 {
 "compressor": "js",
@@ -10734,8 +10734,8 @@
 "level": 9,
 "out_size": 8171,
 "ratio": 0.3321,
-"compress_mbps": 55.26,
-"decompress_mbps": 116.91
+"compress_mbps": 56.37,
+"decompress_mbps": 113.83
 },
 {
 "compressor": "js",
@@ -10744,8 +10744,8 @@
 "level": 1,
 "out_size": 3475,
 "ratio": 0.3117,
-"compress_mbps": 110.57,
-"decompress_mbps": 104.55
+"compress_mbps": 112.85,
+"decompress_mbps": 115.46
 },
 {
 "compressor": "js",
@@ -10754,8 +10754,8 @@
 "level": 2,
 "out_size": 3305,
 "ratio": 0.2964,
-"compress_mbps": 106.41,
-"decompress_mbps": 106.58
+"compress_mbps": 101.69,
+"decompress_mbps": 105.52
 },
 {
 "compressor": "js",
@@ -10764,8 +10764,8 @@
 "level": 3,
 "out_size": 3225,
 "ratio": 0.2892,
-"compress_mbps": 103.63,
-"decompress_mbps": 113.79
+"compress_mbps": 102.05,
+"decompress_mbps": 109.18
 },
 {
 "compressor": "js",
@@ -10774,8 +10774,8 @@
 "level": 4,
 "out_size": 3192,
 "ratio": 0.2863,
-"compress_mbps": 101.41,
-"decompress_mbps": 125.77
+"compress_mbps": 101.53,
+"decompress_mbps": 127.86
 },
 {
 "compressor": "js",
@@ -10784,8 +10784,8 @@
 "level": 5,
 "out_size": 3180,
 "ratio": 0.2852,
-"compress_mbps": 99.8,
-"decompress_mbps": 127.37
+"compress_mbps": 100.58,
+"decompress_mbps": 129.11
 },
 {
 "compressor": "js",
@@ -10794,8 +10794,8 @@
 "level": 6,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 97.01,
-"decompress_mbps": 123.1
+"compress_mbps": 97.53,
+"decompress_mbps": 143.25
 },
 {
 "compressor": "js",
@@ -10804,8 +10804,8 @@
 "level": 7,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 95.04,
-"decompress_mbps": 100.6
+"compress_mbps": 95.44,
+"decompress_mbps": 119.68
 },
 {
 "compressor": "js",
@@ -10814,8 +10814,8 @@
 "level": 8,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 93.47,
-"decompress_mbps": 128.21
+"compress_mbps": 94.85,
+"decompress_mbps": 122.41
 },
 {
 "compressor": "js",
@@ -10824,8 +10824,8 @@
 "level": 9,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 95.31,
-"decompress_mbps": 128.52
+"compress_mbps": 96.48,
+"decompress_mbps": 134.8
 },
 {
 "compressor": "js",
@@ -10834,8 +10834,8 @@
 "level": 1,
 "out_size": 1275,
 "ratio": 0.3426,
-"compress_mbps": 57.58,
-"decompress_mbps": 52.84
+"compress_mbps": 61.69,
+"decompress_mbps": 49.2
 },
 {
 "compressor": "js",
@@ -10844,8 +10844,8 @@
 "level": 2,
 "out_size": 1247,
 "ratio": 0.3351,
-"compress_mbps": 61.07,
-"decompress_mbps": 51.06
+"compress_mbps": 60.51,
+"decompress_mbps": 50.56
 },
 {
 "compressor": "js",
@@ -10854,8 +10854,8 @@
 "level": 3,
 "out_size": 1239,
 "ratio": 0.333,
-"compress_mbps": 59.84,
-"decompress_mbps": 54.29
+"compress_mbps": 58.82,
+"decompress_mbps": 52.09
 },
 {
 "compressor": "js",
@@ -10864,8 +10864,8 @@
 "level": 4,
 "out_size": 1238,
 "ratio": 0.3327,
-"compress_mbps": 58.96,
-"decompress_mbps": 55.41
+"compress_mbps": 58.29,
+"decompress_mbps": 50.06
 },
 {
 "compressor": "js",
@@ -10874,8 +10874,8 @@
 "level": 5,
 "out_size": 1239,
 "ratio": 0.333,
-"compress_mbps": 60.04,
-"decompress_mbps": 51.67
+"compress_mbps": 59.27,
+"decompress_mbps": 53.66
 },
 {
 "compressor": "js",
@@ -10884,8 +10884,8 @@
 "level": 6,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 58.51,
-"decompress_mbps": 54.4
+"compress_mbps": 63.19,
+"decompress_mbps": 51.87
 },
 {
 "compressor": "js",
@@ -10894,8 +10894,8 @@
 "level": 7,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 56.32,
-"decompress_mbps": 49.1
+"compress_mbps": 59.33,
+"decompress_mbps": 53.75
 },
 {
 "compressor": "js",
@@ -10904,8 +10904,8 @@
 "level": 8,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 57.18,
-"decompress_mbps": 55.95
+"compress_mbps": 61.83,
+"decompress_mbps": 52.24
 },
 {
 "compressor": "js",
@@ -10914,8 +10914,8 @@
 "level": 9,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 58.75,
-"decompress_mbps": 50.75
+"compress_mbps": 58.73,
+"decompress_mbps": 53.98
 },
 {
 "compressor": "js",
@@ -10924,8 +10924,8 @@
 "level": 1,
 "out_size": 226284,
 "ratio": 0.2197,
-"compress_mbps": 113.52,
-"decompress_mbps": 302.96
+"compress_mbps": 110.56,
+"decompress_mbps": 297.22
 },
 {
 "compressor": "js",
@@ -10934,8 +10934,8 @@
 "level": 2,
 "out_size": 221369,
 "ratio": 0.215,
-"compress_mbps": 90.46,
-"decompress_mbps": 304.27
+"compress_mbps": 88.86,
+"decompress_mbps": 311.44
 },
 {
 "compressor": "js",
@@ -10944,8 +10944,8 @@
 "level": 3,
 "out_size": 218607,
 "ratio": 0.2123,
-"compress_mbps": 79.67,
-"decompress_mbps": 318.92
+"compress_mbps": 79.85,
+"decompress_mbps": 314.72
 },
 {
 "compressor": "js",
@@ -10954,8 +10954,8 @@
 "level": 4,
 "out_size": 217919,
 "ratio": 0.2116,
-"compress_mbps": 69.19,
-"decompress_mbps": 317.49
+"compress_mbps": 70.99,
+"decompress_mbps": 327.79
 },
 {
 "compressor": "js",
@@ -10964,8 +10964,8 @@
 "level": 5,
 "out_size": 217919,
 "ratio": 0.2116,
-"compress_mbps": 67.85,
-"decompress_mbps": 323.77
+"compress_mbps": 61.76,
+"decompress_mbps": 315.73
 },
 {
 "compressor": "js",
@@ -10974,8 +10974,8 @@
 "level": 6,
 "out_size": 217312,
 "ratio": 0.211,
-"compress_mbps": 44.49,
-"decompress_mbps": 310.09
+"compress_mbps": 44.12,
+"decompress_mbps": 310.73
 },
 {
 "compressor": "js",
@@ -10984,8 +10984,8 @@
 "level": 7,
 "out_size": 215966,
 "ratio": 0.2097,
-"compress_mbps": 31.36,
-"decompress_mbps": 309.38
+"compress_mbps": 31.28,
+"decompress_mbps": 305.83
 },
 {
 "compressor": "js",
@@ -10994,8 +10994,8 @@
 "level": 8,
 "out_size": 215930,
 "ratio": 0.2097,
-"compress_mbps": 14.36,
-"decompress_mbps": 321.59
+"compress_mbps": 14.26,
+"decompress_mbps": 303.4
 },
 {
 "compressor": "js",
@@ -11004,8 +11004,8 @@
 "level": 9,
 "out_size": 215912,
 "ratio": 0.2097,
-"compress_mbps": 11.32,
-"decompress_mbps": 342.58
+"compress_mbps": 11.29,
+"decompress_mbps": 350.23
 },
 {
 "compressor": "js",
@@ -11014,8 +11014,8 @@
 "level": 1,
 "out_size": 167622,
 "ratio": 0.3928,
-"compress_mbps": 64.41,
-"decompress_mbps": 152.52
+"compress_mbps": 61.66,
+"decompress_mbps": 168.94
 },
 {
 "compressor": "js",
@@ -11024,8 +11024,8 @@
 "level": 2,
 "out_size": 158003,
 "ratio": 0.3702,
-"compress_mbps": 54.1,
-"decompress_mbps": 183
+"compress_mbps": 54.4,
+"decompress_mbps": 186.71
 },
 {
 "compressor": "js",
@@ -11034,8 +11034,8 @@
 "level": 3,
 "out_size": 152928,
 "ratio": 0.3584,
-"compress_mbps": 44.89,
-"decompress_mbps": 186.05
+"compress_mbps": 46.97,
+"decompress_mbps": 189.26
 },
 {
 "compressor": "js",
@@ -11044,8 +11044,8 @@
 "level": 4,
 "out_size": 149886,
 "ratio": 0.3512,
-"compress_mbps": 40.31,
-"decompress_mbps": 171.72
+"compress_mbps": 40.23,
+"decompress_mbps": 158.73
 },
 {
 "compressor": "js",
@@ -11054,8 +11054,8 @@
 "level": 5,
 "out_size": 149767,
 "ratio": 0.3509,
-"compress_mbps": 38.35,
-"decompress_mbps": 173.32
+"compress_mbps": 40.02,
+"decompress_mbps": 191.87
 },
 {
 "compressor": "js",
@@ -11064,8 +11064,8 @@
 "level": 6,
 "out_size": 147818,
 "ratio": 0.3464,
-"compress_mbps": 33.17,
-"decompress_mbps": 187.21
+"compress_mbps": 33.31,
+"decompress_mbps": 180.4
 },
 {
 "compressor": "js",
@@ -11074,8 +11074,8 @@
 "level": 7,
 "out_size": 147733,
 "ratio": 0.3462,
-"compress_mbps": 31.52,
-"decompress_mbps": 178.75
+"compress_mbps": 32.8,
+"decompress_mbps": 191.02
 },
 {
 "compressor": "js",
@@ -11084,8 +11084,8 @@
 "level": 8,
 "out_size": 147709,
 "ratio": 0.3461,
-"compress_mbps": 32.49,
-"decompress_mbps": 177.09
+"compress_mbps": 31.96,
+"decompress_mbps": 164.61
 },
 {
 "compressor": "js",
@@ -11094,8 +11094,8 @@
 "level": 9,
 "out_size": 147705,
 "ratio": 0.3461,
-"compress_mbps": 32.62,
-"decompress_mbps": 154.41
+"compress_mbps": 32.64,
+"decompress_mbps": 153.65
 },
 {
 "compressor": "js",
@@ -11104,8 +11104,8 @@
 "level": 1,
 "out_size": 222866,
 "ratio": 0.4625,
-"compress_mbps": 59.99,
-"decompress_mbps": 166.04
+"compress_mbps": 58.94,
+"decompress_mbps": 158.31
 },
 {
 "compressor": "js",
@@ -11114,8 +11114,8 @@
 "level": 2,
 "out_size": 212925,
 "ratio": 0.4419,
-"compress_mbps": 49.6,
-"decompress_mbps": 190.63
+"compress_mbps": 48.98,
+"decompress_mbps": 189.98
 },
 {
 "compressor": "js",
@@ -11124,8 +11124,8 @@
 "level": 3,
 "out_size": 206913,
 "ratio": 0.4294,
-"compress_mbps": 40.87,
-"decompress_mbps": 181.32
+"compress_mbps": 40.43,
+"decompress_mbps": 174.84
 },
 {
 "compressor": "js",
@@ -11134,8 +11134,8 @@
 "level": 4,
 "out_size": 202875,
 "ratio": 0.421,
-"compress_mbps": 34.13,
-"decompress_mbps": 181.14
+"compress_mbps": 34.16,
+"decompress_mbps": 178.06
 },
 {
 "compressor": "js",
@@ -11144,8 +11144,8 @@
 "level": 5,
 "out_size": 202867,
 "ratio": 0.421,
-"compress_mbps": 34.26,
-"decompress_mbps": 206.67
+"compress_mbps": 33.29,
+"decompress_mbps": 195.75
 },
 {
 "compressor": "js",
@@ -11154,8 +11154,8 @@
 "level": 6,
 "out_size": 199818,
 "ratio": 0.4147,
-"compress_mbps": 28.69,
-"decompress_mbps": 209.29
+"compress_mbps": 27.78,
+"decompress_mbps": 195.46
 },
 {
 "compressor": "js",
@@ -11164,8 +11164,8 @@
 "level": 7,
 "out_size": 199664,
 "ratio": 0.4144,
-"compress_mbps": 27.71,
-"decompress_mbps": 189.99
+"compress_mbps": 27.21,
+"decompress_mbps": 174.87
 },
 {
 "compressor": "js",
@@ -11174,8 +11174,8 @@
 "level": 8,
 "out_size": 199634,
 "ratio": 0.4143,
-"compress_mbps": 28.38,
-"decompress_mbps": 185.16
+"compress_mbps": 28.08,
+"decompress_mbps": 179.17
 },
 {
 "compressor": "js",
@@ -11184,8 +11184,8 @@
 "level": 9,
 "out_size": 199634,
 "ratio": 0.4143,
-"compress_mbps": 28.56,
-"decompress_mbps": 183.42
+"compress_mbps": 27.59,
+"decompress_mbps": 176.39
 },
 {
 "compressor": "js",
@@ -11194,8 +11194,8 @@
 "level": 1,
 "out_size": 60580,
 "ratio": 0.118,
-"compress_mbps": 118.9,
-"decompress_mbps": 270.44
+"compress_mbps": 113.36,
+"decompress_mbps": 280.91
 },
 {
 "compressor": "js",
@@ -11204,8 +11204,8 @@
 "level": 2,
 "out_size": 59663,
 "ratio": 0.1163,
-"compress_mbps": 109.34,
-"decompress_mbps": 315.26
+"compress_mbps": 107.03,
+"decompress_mbps": 307.86
 },
 {
 "compressor": "js",
@@ -11214,8 +11214,8 @@
 "level": 3,
 "out_size": 59465,
 "ratio": 0.1159,
-"compress_mbps": 102.77,
-"decompress_mbps": 320.06
+"compress_mbps": 101.79,
+"decompress_mbps": 300.57
 },
 {
 "compressor": "js",
@@ -11224,8 +11224,8 @@
 "level": 4,
 "out_size": 59353,
 "ratio": 0.1156,
-"compress_mbps": 95.56,
-"decompress_mbps": 288.79
+"compress_mbps": 95.8,
+"decompress_mbps": 293.13
 },
 {
 "compressor": "js",
@@ -11234,8 +11234,8 @@
 "level": 5,
 "out_size": 58830,
 "ratio": 0.1146,
-"compress_mbps": 92.07,
-"decompress_mbps": 271.38
+"compress_mbps": 86.05,
+"decompress_mbps": 301.25
 },
 {
 "compressor": "js",
@@ -11244,8 +11244,8 @@
 "level": 6,
 "out_size": 57884,
 "ratio": 0.1128,
-"compress_mbps": 58.11,
-"decompress_mbps": 303.24
+"compress_mbps": 57.39,
+"decompress_mbps": 290.58
 },
 {
 "compressor": "js",
@@ -11254,8 +11254,8 @@
 "level": 7,
 "out_size": 57206,
 "ratio": 0.1115,
-"compress_mbps": 45.73,
-"decompress_mbps": 303.36
+"compress_mbps": 45.57,
+"decompress_mbps": 300.04
 },
 {
 "compressor": "js",
@@ -11264,8 +11264,8 @@
 "level": 8,
 "out_size": 56545,
 "ratio": 0.1102,
-"compress_mbps": 23.15,
-"decompress_mbps": 306.65
+"compress_mbps": 23.23,
+"decompress_mbps": 284.03
 },
 {
 "compressor": "js",
@@ -11274,8 +11274,8 @@
 "level": 9,
 "out_size": 56454,
 "ratio": 0.11,
-"compress_mbps": 9.19,
-"decompress_mbps": 312.05
+"compress_mbps": 9.14,
+"decompress_mbps": 302.34
 },
 {
 "compressor": "js",
@@ -11284,8 +11284,8 @@
 "level": 1,
 "out_size": 14194,
 "ratio": 0.3712,
-"compress_mbps": 82.37,
-"decompress_mbps": 135.25
+"compress_mbps": 81.24,
+"decompress_mbps": 136.64
 },
 {
 "compressor": "js",
@@ -11294,8 +11294,8 @@
 "level": 2,
 "out_size": 13770,
 "ratio": 0.3601,
-"compress_mbps": 71.75,
-"decompress_mbps": 128.59
+"compress_mbps": 70.56,
+"decompress_mbps": 119.31
 },
 {
 "compressor": "js",
@@ -11304,8 +11304,8 @@
 "level": 3,
 "out_size": 13611,
 "ratio": 0.3559,
-"compress_mbps": 67.83,
-"decompress_mbps": 119.79
+"compress_mbps": 66.71,
+"decompress_mbps": 122.65
 },
 {
 "compressor": "js",
@@ -11314,8 +11314,8 @@
 "level": 4,
 "out_size": 13534,
 "ratio": 0.3539,
-"compress_mbps": 61.28,
-"decompress_mbps": 130.77
+"compress_mbps": 63.46,
+"decompress_mbps": 130.44
 },
 {
 "compressor": "js",
@@ -11324,8 +11324,8 @@
 "level": 5,
 "out_size": 13527,
 "ratio": 0.3537,
-"compress_mbps": 62.71,
-"decompress_mbps": 147.89
+"compress_mbps": 63.13,
+"decompress_mbps": 149.08
 },
 {
 "compressor": "js",
@@ -11334,8 +11334,8 @@
 "level": 6,
 "out_size": 13438,
 "ratio": 0.3514,
-"compress_mbps": 50.14,
-"decompress_mbps": 146.69
+"compress_mbps": 50.22,
+"decompress_mbps": 145.86
 },
 {
 "compressor": "js",
@@ -11344,8 +11344,8 @@
 "level": 7,
 "out_size": 13419,
 "ratio": 0.3509,
-"compress_mbps": 47.51,
-"decompress_mbps": 121.53
+"compress_mbps": 45.9,
+"decompress_mbps": 123.05
 },
 {
 "compressor": "js",
@@ -11354,8 +11354,8 @@
 "level": 8,
 "out_size": 13404,
 "ratio": 0.3505,
-"compress_mbps": 42.01,
-"decompress_mbps": 128.34
+"compress_mbps": 42.26,
+"decompress_mbps": 131.89
 },
 {
 "compressor": "js",
@@ -11364,8 +11364,8 @@
 "level": 9,
 "out_size": 13390,
 "ratio": 0.3502,
-"compress_mbps": 36.78,
-"decompress_mbps": 123.68
+"compress_mbps": 36.7,
+"decompress_mbps": 124.93
 },
 {
 "compressor": "js",
@@ -11374,8 +11374,8 @@
 "level": 1,
 "out_size": 1832,
 "ratio": 0.4334,
-"compress_mbps": 59.99,
-"decompress_mbps": 60.99
+"compress_mbps": 61.56,
+"decompress_mbps": 56.84
 },
 {
 "compressor": "js",
@@ -11384,8 +11384,8 @@
 "level": 2,
 "out_size": 1776,
 "ratio": 0.4202,
-"compress_mbps": 60.68,
-"decompress_mbps": 58.25
+"compress_mbps": 60.97,
+"decompress_mbps": 68.52
 },
 {
 "compressor": "js",
@@ -11394,8 +11394,8 @@
 "level": 3,
 "out_size": 1764,
 "ratio": 0.4173,
-"compress_mbps": 59.85,
-"decompress_mbps": 50.07
+"compress_mbps": 59.96,
+"decompress_mbps": 63.64
 },
 {
 "compressor": "js",
@@ -11404,8 +11404,8 @@
 "level": 4,
 "out_size": 1763,
 "ratio": 0.4171,
-"compress_mbps": 62.98,
-"decompress_mbps": 57.82
+"compress_mbps": 60.29,
+"decompress_mbps": 57.95
 },
 {
 "compressor": "js",
@@ -11414,8 +11414,8 @@
 "level": 5,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 59.5,
-"decompress_mbps": 60.72
+"compress_mbps": 57.26,
+"decompress_mbps": 57.5
 },
 {
 "compressor": "js",
@@ -11424,8 +11424,8 @@
 "level": 6,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 58.56,
-"decompress_mbps": 55.96
+"compress_mbps": 59.69,
+"decompress_mbps": 64.6
 },
 {
 "compressor": "js",
@@ -11434,8 +11434,8 @@
 "level": 7,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 59.79,
-"decompress_mbps": 62.77
+"compress_mbps": 59.23,
+"decompress_mbps": 68.61
 },
 {
 "compressor": "js",
@@ -11444,8 +11444,8 @@
 "level": 8,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 59.06,
-"decompress_mbps": 57.09
+"compress_mbps": 59.56,
+"decompress_mbps": 68.42
 },
 {
 "compressor": "js",
@@ -11454,8 +11454,8 @@
 "level": 9,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 59.56,
-"decompress_mbps": 59.7
+"compress_mbps": 59.83,
+"decompress_mbps": 58.69
 },
 {
 "compressor": "js",
@@ -11464,8 +11464,8 @@
 "level": 1,
 "out_size": 4462632,
 "ratio": 0.4378,
-"compress_mbps": 62.91,
-"decompress_mbps": 168.3
+"compress_mbps": 62.18,
+"decompress_mbps": 173.87
 },
 {
 "compressor": "js",
@@ -11474,8 +11474,8 @@
 "level": 2,
 "out_size": 4244833,
 "ratio": 0.4165,
-"compress_mbps": 50.87,
-"decompress_mbps": 206.2
+"compress_mbps": 50.89,
+"decompress_mbps": 201.85
 },
 {
 "compressor": "js",
@@ -11484,8 +11484,8 @@
 "level": 3,
 "out_size": 4112285,
 "ratio": 0.4035,
-"compress_mbps": 42,
-"decompress_mbps": 188.74
+"compress_mbps": 42.09,
+"decompress_mbps": 183.1
 },
 {
 "compressor": "js",
@@ -11494,8 +11494,8 @@
 "level": 4,
 "out_size": 4020435,
 "ratio": 0.3945,
-"compress_mbps": 36.09,
-"decompress_mbps": 198.6
+"compress_mbps": 35.57,
+"decompress_mbps": 195.02
 },
 {
 "compressor": "js",
@@ -11504,8 +11504,8 @@
 "level": 5,
 "out_size": 4019177,
 "ratio": 0.3943,
-"compress_mbps": 35.16,
-"decompress_mbps": 188.08
+"compress_mbps": 35.98,
+"decompress_mbps": 195.68
 },
 {
 "compressor": "js",
@@ -11514,8 +11514,8 @@
 "level": 6,
 "out_size": 3956464,
 "ratio": 0.3882,
-"compress_mbps": 29.71,
-"decompress_mbps": 219.83
+"compress_mbps": 28.83,
+"decompress_mbps": 187.08
 },
 {
 "compressor": "js",
@@ -11524,8 +11524,8 @@
 "level": 7,
 "out_size": 3953310,
 "ratio": 0.3879,
-"compress_mbps": 28.49,
-"decompress_mbps": 199.06
+"compress_mbps": 28.68,
+"decompress_mbps": 201.81
 },
 {
 "compressor": "js",
@@ -11534,8 +11534,8 @@
 "level": 8,
 "out_size": 3952872,
 "ratio": 0.3878,
-"compress_mbps": 29.32,
-"decompress_mbps": 190.33
+"compress_mbps": 29.26,
+"decompress_mbps": 223.56
 },
 {
 "compressor": "js",
@@ -11544,8 +11544,8 @@
 "level": 9,
 "out_size": 3952872,
 "ratio": 0.3878,
-"compress_mbps": 29.38,
-"decompress_mbps": 220.38
+"compress_mbps": 29.19,
+"decompress_mbps": 229.9
 },
 {
 "compressor": "js",
@@ -11554,8 +11554,8 @@
 "level": 1,
 "out_size": 20177423,
 "ratio": 0.3939,
-"compress_mbps": 72.31,
-"decompress_mbps": 217.31
+"compress_mbps": 72.38,
+"decompress_mbps": 217.73
 },
 {
 "compressor": "js",
@@ -11564,8 +11564,8 @@
 "level": 2,
 "out_size": 19759467,
 "ratio": 0.3858,
-"compress_mbps": 63.6,
-"decompress_mbps": 200.6
+"compress_mbps": 63.54,
+"decompress_mbps": 200.68
 },
 {
 "compressor": "js",
@@ -11574,8 +11574,8 @@
 "level": 3,
 "out_size": 19583171,
 "ratio": 0.3823,
-"compress_mbps": 57.05,
-"decompress_mbps": 220.36
+"compress_mbps": 56.88,
+"decompress_mbps": 213.41
 },
 {
 "compressor": "js",
@@ -11584,8 +11584,8 @@
 "level": 4,
 "out_size": 19479125,
 "ratio": 0.3803,
-"compress_mbps": 51.2,
-"decompress_mbps": 223.17
+"compress_mbps": 51.05,
+"decompress_mbps": 226.18
 },
 {
 "compressor": "js",
@@ -11594,8 +11594,8 @@
 "level": 5,
 "out_size": 19423693,
 "ratio": 0.3792,
-"compress_mbps": 48.39,
-"decompress_mbps": 206.02
+"compress_mbps": 48.99,
+"decompress_mbps": 195.52
 },
 {
 "compressor": "js",
@@ -11604,8 +11604,8 @@
 "level": 6,
 "out_size": 19337683,
 "ratio": 0.3775,
-"compress_mbps": 36.32,
-"decompress_mbps": 202.55
+"compress_mbps": 36.22,
+"decompress_mbps": 206.71
 },
 {
 "compressor": "js",
@@ -11614,8 +11614,8 @@
 "level": 7,
 "out_size": 19323922,
 "ratio": 0.3773,
-"compress_mbps": 29.89,
-"decompress_mbps": 200.64
+"compress_mbps": 30.44,
+"decompress_mbps": 203.82
 },
 {
 "compressor": "js",
@@ -11624,8 +11624,8 @@
 "level": 8,
 "out_size": 19314797,
 "ratio": 0.3771,
-"compress_mbps": 19.54,
-"decompress_mbps": 220.25
+"compress_mbps": 19.34,
+"decompress_mbps": 216.09
 },
 {
 "compressor": "js",
@@ -11634,8 +11634,8 @@
 "level": 9,
 "out_size": 19312663,
 "ratio": 0.377,
-"compress_mbps": 10.98,
-"decompress_mbps": 214.4
+"compress_mbps": 11.02,
+"decompress_mbps": 224.35
 },
 {
 "compressor": "js",
@@ -11644,8 +11644,8 @@
 "level": 1,
 "out_size": 3762978,
 "ratio": 0.3774,
-"compress_mbps": 77.69,
-"decompress_mbps": 187
+"compress_mbps": 78.06,
+"decompress_mbps": 158.08
 },
 {
 "compressor": "js",
@@ -11654,8 +11654,8 @@
 "level": 2,
 "out_size": 3711615,
 "ratio": 0.3723,
-"compress_mbps": 68.42,
-"decompress_mbps": 186.26
+"compress_mbps": 67.98,
+"decompress_mbps": 211.43
 },
 {
 "compressor": "js",
@@ -11664,8 +11664,8 @@
 "level": 3,
 "out_size": 3663131,
 "ratio": 0.3674,
-"compress_mbps": 58.75,
-"decompress_mbps": 224
+"compress_mbps": 57.96,
+"decompress_mbps": 221.94
 },
 {
 "compressor": "js",
@@ -11674,8 +11674,8 @@
 "level": 4,
 "out_size": 3631512,
 "ratio": 0.3642,
-"compress_mbps": 49.89,
-"decompress_mbps": 191.39
+"compress_mbps": 48.43,
+"decompress_mbps": 204.02
 },
 {
 "compressor": "js",
@@ -11684,8 +11684,8 @@
 "level": 5,
 "out_size": 3630867,
 "ratio": 0.3642,
-"compress_mbps": 49.09,
-"decompress_mbps": 200.81
+"compress_mbps": 48.23,
+"decompress_mbps": 201
 },
 {
 "compressor": "js",
@@ -11694,8 +11694,8 @@
 "level": 6,
 "out_size": 3615953,
 "ratio": 0.3627,
-"compress_mbps": 37.7,
-"decompress_mbps": 251.17
+"compress_mbps": 38.3,
+"decompress_mbps": 229.47
 },
 {
 "compressor": "js",
@@ -11704,8 +11704,8 @@
 "level": 7,
 "out_size": 3615518,
 "ratio": 0.3626,
-"compress_mbps": 35.93,
-"decompress_mbps": 204.39
+"compress_mbps": 35.97,
+"decompress_mbps": 204.3
 },
 {
 "compressor": "js",
@@ -11714,8 +11714,8 @@
 "level": 8,
 "out_size": 3613845,
 "ratio": 0.3625,
-"compress_mbps": 30.46,
-"decompress_mbps": 233.7
+"compress_mbps": 30.3,
+"decompress_mbps": 255.4
 },
 {
 "compressor": "js",
@@ -11725,7 +11725,7 @@
 "out_size": 3614283,
 "ratio": 0.3625,
 "compress_mbps": 26.31,
-"decompress_mbps": 225.29
+"decompress_mbps": 228.58
 },
 {
 "compressor": "js",
@@ -11734,8 +11734,8 @@
 "level": 1,
 "out_size": 4418800,
 "ratio": 0.1317,
-"compress_mbps": 132.54,
-"decompress_mbps": 377.26
+"compress_mbps": 130.71,
+"decompress_mbps": 369.72
 },
 {
 "compressor": "js",
@@ -11744,8 +11744,8 @@
 "level": 2,
 "out_size": 4026774,
 "ratio": 0.12,
-"compress_mbps": 121.68,
-"decompress_mbps": 389.73
+"compress_mbps": 122.45,
+"decompress_mbps": 389.14
 },
 {
 "compressor": "js",
@@ -11754,8 +11754,8 @@
 "level": 3,
 "out_size": 3837798,
 "ratio": 0.1144,
-"compress_mbps": 117.56,
-"decompress_mbps": 427.95
+"compress_mbps": 116.09,
+"decompress_mbps": 443.42
 },
 {
 "compressor": "js",
@@ -11764,8 +11764,8 @@
 "level": 4,
 "out_size": 3751023,
 "ratio": 0.1118,
-"compress_mbps": 111.11,
-"decompress_mbps": 411.61
+"compress_mbps": 111.56,
+"decompress_mbps": 413.61
 },
 {
 "compressor": "js",
@@ -11774,8 +11774,8 @@
 "level": 5,
 "out_size": 3643468,
 "ratio": 0.1086,
-"compress_mbps": 101.59,
-"decompress_mbps": 414.25
+"compress_mbps": 102.54,
+"decompress_mbps": 412.02
 },
 {
 "compressor": "js",
@@ -11784,8 +11784,8 @@
 "level": 6,
 "out_size": 3379481,
 "ratio": 0.1007,
-"compress_mbps": 69.14,
-"decompress_mbps": 422.94
+"compress_mbps": 69.02,
+"decompress_mbps": 429.31
 },
 {
 "compressor": "js",
@@ -11794,8 +11794,8 @@
 "level": 7,
 "out_size": 3354082,
 "ratio": 0.1,
-"compress_mbps": 61.41,
-"decompress_mbps": 414.8
+"compress_mbps": 61.13,
+"decompress_mbps": 431.77
 },
 {
 "compressor": "js",
@@ -11804,8 +11804,8 @@
 "level": 8,
 "out_size": 3330028,
 "ratio": 0.0992,
-"compress_mbps": 48.07,
-"decompress_mbps": 444.44
+"compress_mbps": 47.82,
+"decompress_mbps": 442.73
 },
 {
 "compressor": "js",
@@ -11814,8 +11814,8 @@
 "level": 9,
 "out_size": 3327482,
 "ratio": 0.0992,
-"compress_mbps": 38.1,
-"decompress_mbps": 406.56
+"compress_mbps": 37.59,
+"decompress_mbps": 421.2
 },
 {
 "compressor": "js",
@@ -11824,8 +11824,8 @@
 "level": 1,
 "out_size": 3233790,
 "ratio": 0.5256,
-"compress_mbps": 53.86,
-"decompress_mbps": 127.41
+"compress_mbps": 54.05,
+"decompress_mbps": 127.18
 },
 {
 "compressor": "js",
@@ -11834,8 +11834,8 @@
 "level": 2,
 "out_size": 3184644,
 "ratio": 0.5176,
-"compress_mbps": 48.34,
-"decompress_mbps": 131.35
+"compress_mbps": 47.33,
+"decompress_mbps": 128.98
 },
 {
 "compressor": "js",
@@ -11844,8 +11844,8 @@
 "level": 3,
 "out_size": 3160521,
 "ratio": 0.5137,
-"compress_mbps": 43.85,
-"decompress_mbps": 138.8
+"compress_mbps": 44.22,
+"decompress_mbps": 143.07
 },
 {
 "compressor": "js",
@@ -11854,8 +11854,8 @@
 "level": 4,
 "out_size": 3141929,
 "ratio": 0.5107,
-"compress_mbps": 39.77,
-"decompress_mbps": 141.37
+"compress_mbps": 39.8,
+"decompress_mbps": 162.49
 },
 {
 "compressor": "js",
@@ -11864,8 +11864,8 @@
 "level": 5,
 "out_size": 3138514,
 "ratio": 0.5101,
-"compress_mbps": 39.15,
-"decompress_mbps": 142.53
+"compress_mbps": 38.68,
+"decompress_mbps": 145.42
 },
 {
 "compressor": "js",
@@ -11874,8 +11874,8 @@
 "level": 6,
 "out_size": 3126843,
 "ratio": 0.5082,
-"compress_mbps": 32.95,
-"decompress_mbps": 140.76
+"compress_mbps": 32.2,
+"decompress_mbps": 146.98
 },
 {
 "compressor": "js",
@@ -11884,8 +11884,8 @@
 "level": 7,
 "out_size": 3126796,
 "ratio": 0.5082,
-"compress_mbps": 30.37,
-"decompress_mbps": 149.39
+"compress_mbps": 30.36,
+"decompress_mbps": 148.14
 },
 {
 "compressor": "js",
@@ -11894,8 +11894,8 @@
 "level": 8,
 "out_size": 3126322,
 "ratio": 0.5082,
-"compress_mbps": 27.12,
-"decompress_mbps": 147.78
+"compress_mbps": 26.94,
+"decompress_mbps": 146.91
 },
 {
 "compressor": "js",
@@ -11904,8 +11904,8 @@
 "level": 9,
 "out_size": 3126286,
 "ratio": 0.5082,
-"compress_mbps": 23.21,
-"decompress_mbps": 151.23
+"compress_mbps": 22.89,
+"decompress_mbps": 147.39
 },
 {
 "compressor": "js",
@@ -11914,8 +11914,8 @@
 "level": 1,
 "out_size": 4076349,
 "ratio": 0.4042,
-"compress_mbps": 78.82,
-"decompress_mbps": 201.37
+"compress_mbps": 78.93,
+"decompress_mbps": 211.38
 },
 {
 "compressor": "js",
@@ -11924,8 +11924,8 @@
 "level": 2,
 "out_size": 3914739,
 "ratio": 0.3881,
-"compress_mbps": 71.77,
-"decompress_mbps": 229.72
+"compress_mbps": 71.76,
+"decompress_mbps": 231.12
 },
 {
 "compressor": "js",
@@ -11934,8 +11934,8 @@
 "level": 3,
 "out_size": 3845160,
 "ratio": 0.3812,
-"compress_mbps": 66.88,
-"decompress_mbps": 274.71
+"compress_mbps": 68.63,
+"decompress_mbps": 282.67
 },
 {
 "compressor": "js",
@@ -11944,8 +11944,8 @@
 "level": 4,
 "out_size": 3822047,
 "ratio": 0.379,
-"compress_mbps": 64.42,
-"decompress_mbps": 249.63
+"compress_mbps": 64.6,
+"decompress_mbps": 254.1
 },
 {
 "compressor": "js",
@@ -11954,8 +11954,8 @@
 "level": 5,
 "out_size": 3799472,
 "ratio": 0.3767,
-"compress_mbps": 59.75,
-"decompress_mbps": 276.4
+"compress_mbps": 60.68,
+"decompress_mbps": 278.97
 },
 {
 "compressor": "js",
@@ -11964,8 +11964,8 @@
 "level": 6,
 "out_size": 3783861,
 "ratio": 0.3752,
-"compress_mbps": 57.88,
-"decompress_mbps": 237.31
+"compress_mbps": 58.24,
+"decompress_mbps": 284.08
 },
 {
 "compressor": "js",
@@ -11974,8 +11974,8 @@
 "level": 7,
 "out_size": 3783432,
 "ratio": 0.3751,
-"compress_mbps": 57.47,
-"decompress_mbps": 289
+"compress_mbps": 57.98,
+"decompress_mbps": 282.33
 },
 {
 "compressor": "js",
@@ -11984,8 +11984,8 @@
 "level": 8,
 "out_size": 3783342,
 "ratio": 0.3751,
-"compress_mbps": 57.51,
-"decompress_mbps": 286.2
+"compress_mbps": 57.83,
+"decompress_mbps": 287.15
 },
 {
 "compressor": "js",
@@ -11994,8 +11994,8 @@
 "level": 9,
 "out_size": 3783342,
 "ratio": 0.3751,
-"compress_mbps": 57.72,
-"decompress_mbps": 285.9
+"compress_mbps": 57.91,
+"decompress_mbps": 291.22
 },
 {
 "compressor": "js",
@@ -12004,8 +12004,8 @@
 "level": 1,
 "out_size": 2261112,
 "ratio": 0.3412,
-"compress_mbps": 71.65,
-"decompress_mbps": 224.42
+"compress_mbps": 72.06,
+"decompress_mbps": 226.8
 },
 {
 "compressor": "js",
@@ -12014,8 +12014,8 @@
 "level": 2,
 "out_size": 2128691,
 "ratio": 0.3212,
-"compress_mbps": 58.87,
-"decompress_mbps": 208.5
+"compress_mbps": 58.58,
+"decompress_mbps": 213.25
 },
 {
 "compressor": "js",
@@ -12024,8 +12024,8 @@
 "level": 3,
 "out_size": 2049023,
 "ratio": 0.3092,
-"compress_mbps": 49.13,
-"decompress_mbps": 232.59
+"compress_mbps": 49.56,
+"decompress_mbps": 233.33
 },
 {
 "compressor": "js",
@@ -12034,8 +12034,8 @@
 "level": 4,
 "out_size": 1990249,
 "ratio": 0.3003,
-"compress_mbps": 40.79,
-"decompress_mbps": 216.53
+"compress_mbps": 40.91,
+"decompress_mbps": 212.86
 },
 {
 "compressor": "js",
@@ -12044,8 +12044,8 @@
 "level": 5,
 "out_size": 1975224,
 "ratio": 0.298,
-"compress_mbps": 39.82,
-"decompress_mbps": 227.52
+"compress_mbps": 38.75,
+"decompress_mbps": 207.84
 },
 {
 "compressor": "js",
@@ -12054,8 +12054,8 @@
 "level": 6,
 "out_size": 1910262,
 "ratio": 0.2882,
-"compress_mbps": 27.6,
-"decompress_mbps": 210.6
+"compress_mbps": 27.88,
+"decompress_mbps": 195.73
 },
 {
 "compressor": "js",
@@ -12064,8 +12064,8 @@
 "level": 7,
 "out_size": 1902923,
 "ratio": 0.2871,
-"compress_mbps": 25.31,
-"decompress_mbps": 196.98
+"compress_mbps": 25.32,
+"decompress_mbps": 197.79
 },
 {
 "compressor": "js",
@@ -12074,8 +12074,8 @@
 "level": 8,
 "out_size": 1900964,
 "ratio": 0.2868,
-"compress_mbps": 23.16,
-"decompress_mbps": 231.53
+"compress_mbps": 23.18,
+"decompress_mbps": 229.68
 },
 {
 "compressor": "js",
@@ -12084,8 +12084,8 @@
 "level": 9,
 "out_size": 1900958,
 "ratio": 0.2868,
-"compress_mbps": 24.7,
-"decompress_mbps": 233.07
+"compress_mbps": 24.34,
+"decompress_mbps": 233.76
 },
 {
 "compressor": "js",
@@ -12094,8 +12094,8 @@
 "level": 1,
 "out_size": 6016919,
 "ratio": 0.2785,
-"compress_mbps": 92.6,
-"decompress_mbps": 231.42
+"compress_mbps": 92.98,
+"decompress_mbps": 252.21
 },
 {
 "compressor": "js",
@@ -12104,8 +12104,8 @@
 "level": 2,
 "out_size": 5767272,
 "ratio": 0.2669,
-"compress_mbps": 82.48,
-"decompress_mbps": 288.49
+"compress_mbps": 81.98,
+"decompress_mbps": 259.05
 },
 {
 "compressor": "js",
@@ -12114,8 +12114,8 @@
 "level": 3,
 "out_size": 5669548,
 "ratio": 0.2624,
-"compress_mbps": 74.74,
-"decompress_mbps": 267.85
+"compress_mbps": 76.36,
+"decompress_mbps": 272.14
 },
 {
 "compressor": "js",
@@ -12124,8 +12124,8 @@
 "level": 4,
 "out_size": 5619947,
 "ratio": 0.2601,
-"compress_mbps": 69.63,
-"decompress_mbps": 276.36
+"compress_mbps": 68.61,
+"decompress_mbps": 275.8
 },
 {
 "compressor": "js",
@@ -12134,8 +12134,8 @@
 "level": 5,
 "out_size": 5586034,
 "ratio": 0.2585,
-"compress_mbps": 64.88,
-"decompress_mbps": 280.44
+"compress_mbps": 65.35,
+"decompress_mbps": 283.34
 },
 {
 "compressor": "js",
@@ -12144,8 +12144,8 @@
 "level": 6,
 "out_size": 5540130,
 "ratio": 0.2564,
-"compress_mbps": 53,
-"decompress_mbps": 280.74
+"compress_mbps": 50.98,
+"decompress_mbps": 281.1
 },
 {
 "compressor": "js",
@@ -12154,8 +12154,8 @@
 "level": 7,
 "out_size": 5537271,
 "ratio": 0.2563,
-"compress_mbps": 47.13,
-"decompress_mbps": 273.85
+"compress_mbps": 48.19,
+"decompress_mbps": 261.4
 },
 {
 "compressor": "js",
@@ -12164,8 +12164,8 @@
 "level": 8,
 "out_size": 5530686,
 "ratio": 0.256,
-"compress_mbps": 37.42,
-"decompress_mbps": 307.11
+"compress_mbps": 37.62,
+"decompress_mbps": 305.35
 },
 {
 "compressor": "js",
@@ -12174,8 +12174,8 @@
 "level": 9,
 "out_size": 5529823,
 "ratio": 0.2559,
-"compress_mbps": 31.76,
-"decompress_mbps": 279.02
+"compress_mbps": 31.13,
+"decompress_mbps": 285.06
 },
 {
 "compressor": "js",
@@ -12184,8 +12184,8 @@
 "level": 1,
 "out_size": 5602819,
 "ratio": 0.7726,
-"compress_mbps": 49.12,
-"decompress_mbps": 168.27
+"compress_mbps": 49.13,
+"decompress_mbps": 166.9
 },
 {
 "compressor": "js",
@@ -12194,8 +12194,8 @@
 "level": 2,
 "out_size": 5504019,
 "ratio": 0.759,
-"compress_mbps": 42.05,
-"decompress_mbps": 153.75
+"compress_mbps": 43.06,
+"decompress_mbps": 155.83
 },
 {
 "compressor": "js",
@@ -12204,8 +12204,8 @@
 "level": 3,
 "out_size": 5452816,
 "ratio": 0.7519,
-"compress_mbps": 39.4,
-"decompress_mbps": 157.28
+"compress_mbps": 39.24,
+"decompress_mbps": 157.12
 },
 {
 "compressor": "js",
@@ -12214,8 +12214,8 @@
 "level": 4,
 "out_size": 5425752,
 "ratio": 0.7482,
-"compress_mbps": 35.87,
-"decompress_mbps": 183.48
+"compress_mbps": 34.72,
+"decompress_mbps": 189.99
 },
 {
 "compressor": "js",
@@ -12224,8 +12224,8 @@
 "level": 5,
 "out_size": 5425752,
 "ratio": 0.7482,
-"compress_mbps": 35.53,
-"decompress_mbps": 183.13
+"compress_mbps": 34.92,
+"decompress_mbps": 159.32
 },
 {
 "compressor": "js",
@@ -12234,8 +12234,8 @@
 "level": 6,
 "out_size": 5407602,
 "ratio": 0.7457,
-"compress_mbps": 30.8,
-"decompress_mbps": 158.34
+"compress_mbps": 30.72,
+"decompress_mbps": 160.05
 },
 {
 "compressor": "js",
@@ -12244,8 +12244,8 @@
 "level": 7,
 "out_size": 5406417,
 "ratio": 0.7455,
-"compress_mbps": 30.13,
-"decompress_mbps": 157.87
+"compress_mbps": 30.63,
+"decompress_mbps": 158.56
 },
 {
 "compressor": "js",
@@ -12254,8 +12254,8 @@
 "level": 8,
 "out_size": 5406380,
 "ratio": 0.7455,
-"compress_mbps": 30.8,
-"decompress_mbps": 159.91
+"compress_mbps": 30.03,
+"decompress_mbps": 139.82
 },
 {
 "compressor": "js",
@@ -12264,8 +12264,8 @@
 "level": 9,
 "out_size": 5406380,
 "ratio": 0.7455,
-"compress_mbps": 31.24,
-"decompress_mbps": 160.34
+"compress_mbps": 30.67,
+"decompress_mbps": 156.97
 },
 {
 "compressor": "js",
@@ -12274,8 +12274,8 @@
 "level": 1,
 "out_size": 14342407,
 "ratio": 0.3459,
-"compress_mbps": 74.3,
-"decompress_mbps": 191.94
+"compress_mbps": 74.36,
+"decompress_mbps": 194.26
 },
 {
 "compressor": "js",
@@ -12284,8 +12284,8 @@
 "level": 2,
 "out_size": 13424966,
 "ratio": 0.3238,
-"compress_mbps": 62.82,
-"decompress_mbps": 210.8
+"compress_mbps": 62.93,
+"decompress_mbps": 216.25
 },
 {
 "compressor": "js",
@@ -12294,8 +12294,8 @@
 "level": 3,
 "out_size": 13061399,
 "ratio": 0.315,
-"compress_mbps": 55.42,
-"decompress_mbps": 231.1
+"compress_mbps": 54.76,
+"decompress_mbps": 210.45
 },
 {
 "compressor": "js",
@@ -12304,8 +12304,8 @@
 "level": 4,
 "out_size": 12877207,
 "ratio": 0.3106,
-"compress_mbps": 49.74,
-"decompress_mbps": 202.59
+"compress_mbps": 50,
+"decompress_mbps": 214.23
 },
 {
 "compressor": "js",
@@ -12314,8 +12314,8 @@
 "level": 5,
 "out_size": 12671090,
 "ratio": 0.3056,
-"compress_mbps": 47.56,
-"decompress_mbps": 211.79
+"compress_mbps": 47.01,
+"decompress_mbps": 215.37
 },
 {
 "compressor": "js",
@@ -12324,8 +12324,8 @@
 "level": 6,
 "out_size": 12511088,
 "ratio": 0.3018,
-"compress_mbps": 39.74,
-"decompress_mbps": 224.47
+"compress_mbps": 40.19,
+"decompress_mbps": 236.92
 },
 {
 "compressor": "js",
@@ -12334,8 +12334,8 @@
 "level": 7,
 "out_size": 12503313,
 "ratio": 0.3016,
-"compress_mbps": 38.39,
-"decompress_mbps": 236.24
+"compress_mbps": 38.48,
+"decompress_mbps": 236.41
 },
 {
 "compressor": "js",
@@ -12344,8 +12344,8 @@
 "level": 8,
 "out_size": 12502263,
 "ratio": 0.3016,
-"compress_mbps": 39.72,
-"decompress_mbps": 232.92
+"compress_mbps": 39.01,
+"decompress_mbps": 227.08
 },
 {
 "compressor": "js",
@@ -12354,8 +12354,8 @@
 "level": 9,
 "out_size": 12502263,
 "ratio": 0.3016,
-"compress_mbps": 39.39,
-"decompress_mbps": 231.27
+"compress_mbps": 39.8,
+"decompress_mbps": 236.88
 },
 {
 "compressor": "js",
@@ -12364,8 +12364,8 @@
 "level": 1,
 "out_size": 6022390,
 "ratio": 0.7107,
-"compress_mbps": 54.57,
-"decompress_mbps": 147.43
+"compress_mbps": 54.54,
+"decompress_mbps": 147.7
 },
 {
 "compressor": "js",
@@ -12374,8 +12374,8 @@
 "level": 2,
 "out_size": 5997124,
 "ratio": 0.7077,
-"compress_mbps": 47.73,
-"decompress_mbps": 140.57
+"compress_mbps": 49,
+"decompress_mbps": 150.97
 },
 {
 "compressor": "js",
@@ -12384,8 +12384,8 @@
 "level": 3,
 "out_size": 5979254,
 "ratio": 0.7056,
-"compress_mbps": 43.37,
-"decompress_mbps": 154.38
+"compress_mbps": 43.95,
+"decompress_mbps": 150.86
 },
 {
 "compressor": "js",
@@ -12394,8 +12394,8 @@
 "level": 4,
 "out_size": 5967955,
 "ratio": 0.7042,
-"compress_mbps": 42.05,
-"decompress_mbps": 185.18
+"compress_mbps": 42.03,
+"decompress_mbps": 185.25
 },
 {
 "compressor": "js",
@@ -12404,8 +12404,8 @@
 "level": 5,
 "out_size": 5967953,
 "ratio": 0.7042,
-"compress_mbps": 42.29,
-"decompress_mbps": 153.47
+"compress_mbps": 41.93,
+"decompress_mbps": 152.87
 },
 {
 "compressor": "js",
@@ -12414,8 +12414,8 @@
 "level": 6,
 "out_size": 5965386,
 "ratio": 0.7039,
-"compress_mbps": 41.92,
-"decompress_mbps": 142.4
+"compress_mbps": 41.38,
+"decompress_mbps": 157.82
 },
 {
 "compressor": "js",
@@ -12424,8 +12424,8 @@
 "level": 7,
 "out_size": 5965383,
 "ratio": 0.7039,
-"compress_mbps": 41.56,
-"decompress_mbps": 130.96
+"compress_mbps": 42.2,
+"decompress_mbps": 155.95
 },
 {
 "compressor": "js",
@@ -12434,8 +12434,8 @@
 "level": 8,
 "out_size": 5965383,
 "ratio": 0.7039,
-"compress_mbps": 41.96,
-"decompress_mbps": 149.36
+"compress_mbps": 41.73,
+"decompress_mbps": 154.98
 },
 {
 "compressor": "js",
@@ -12444,8 +12444,8 @@
 "level": 9,
 "out_size": 5965383,
 "ratio": 0.7039,
-"compress_mbps": 42.02,
-"decompress_mbps": 156.34
+"compress_mbps": 41.71,
+"decompress_mbps": 140.86
 },
 {
 "compressor": "js",
@@ -12454,8 +12454,8 @@
 "level": 1,
 "out_size": 985606,
 "ratio": 0.1844,
-"compress_mbps": 109.85,
-"decompress_mbps": 310.58
+"compress_mbps": 112.33,
+"decompress_mbps": 311.7
 },
 {
 "compressor": "js",
@@ -12464,8 +12464,8 @@
 "level": 2,
 "out_size": 852636,
 "ratio": 0.1595,
-"compress_mbps": 101.45,
-"decompress_mbps": 349.85
+"compress_mbps": 101.36,
+"decompress_mbps": 349.1
 },
 {
 "compressor": "js",
@@ -12474,8 +12474,8 @@
 "level": 3,
 "out_size": 814293,
 "ratio": 0.1523,
-"compress_mbps": 95.35,
-"decompress_mbps": 331.29
+"compress_mbps": 96.4,
+"decompress_mbps": 340.21
 },
 {
 "compressor": "js",
@@ -12484,8 +12484,8 @@
 "level": 4,
 "out_size": 788388,
 "ratio": 0.1475,
-"compress_mbps": 89.82,
-"decompress_mbps": 352.77
+"compress_mbps": 90.28,
+"decompress_mbps": 353.5
 },
 {
 "compressor": "js",
@@ -12494,8 +12494,8 @@
 "level": 5,
 "out_size": 749390,
 "ratio": 0.1402,
-"compress_mbps": 83.35,
-"decompress_mbps": 380.11
+"compress_mbps": 81.91,
+"decompress_mbps": 381.16
 },
 {
 "compressor": "js",
@@ -12504,8 +12504,8 @@
 "level": 6,
 "out_size": 706892,
 "ratio": 0.1322,
-"compress_mbps": 67.15,
-"decompress_mbps": 376.91
+"compress_mbps": 67.06,
+"decompress_mbps": 383.86
 },
 {
 "compressor": "js",
@@ -12514,8 +12514,8 @@
 "level": 7,
 "out_size": 705695,
 "ratio": 0.132,
-"compress_mbps": 64.52,
-"decompress_mbps": 406.06
+"compress_mbps": 64.89,
+"decompress_mbps": 409.17
 },
 {
 "compressor": "js",
@@ -12524,8 +12524,8 @@
 "level": 8,
 "out_size": 703904,
 "ratio": 0.1317,
-"compress_mbps": 60.78,
-"decompress_mbps": 376.24
+"compress_mbps": 60.32,
+"decompress_mbps": 376.72
 },
 {
 "compressor": "js",
@@ -12534,8 +12534,8 @@
 "level": 9,
 "out_size": 703900,
 "ratio": 0.1317,
-"compress_mbps": 61.14,
-"decompress_mbps": 397.03
+"compress_mbps": 60.38,
+"decompress_mbps": 403.97
 },
 {
 "compressor": "zig",
@@ -12544,8 +12544,8 @@
 "level": 1,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 88.91,
-"decompress_mbps": 315.05
+"compress_mbps": 84.63,
+"decompress_mbps": 312.12
 },
 {
 "compressor": "zig",
@@ -12554,8 +12554,8 @@
 "level": 2,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 88.82,
-"decompress_mbps": 314.07
+"compress_mbps": 86.16,
+"decompress_mbps": 314.27
 },
 {
 "compressor": "zig",
@@ -12564,8 +12564,8 @@
 "level": 3,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 88.9,
-"decompress_mbps": 310.21
+"compress_mbps": 89.15,
+"decompress_mbps": 312.88
 },
 {
 "compressor": "zig",
@@ -12574,8 +12574,8 @@
 "level": 4,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 85.95,
-"decompress_mbps": 313.18
+"compress_mbps": 88.94,
+"decompress_mbps": 315.76
 },
 {
 "compressor": "zig",
@@ -12584,8 +12584,8 @@
 "level": 5,
 "out_size": 54531,
 "ratio": 0.3585,
-"compress_mbps": 53.67,
-"decompress_mbps": 306.9
+"compress_mbps": 55.32,
+"decompress_mbps": 305.77
 },
 {
 "compressor": "zig",
@@ -12594,8 +12594,8 @@
 "level": 6,
 "out_size": 54068,
 "ratio": 0.3555,
-"compress_mbps": 42.01,
-"decompress_mbps": 309.23
+"compress_mbps": 41.3,
+"decompress_mbps": 307.21
 },
 {
 "compressor": "zig",
@@ -12604,8 +12604,8 @@
 "level": 7,
 "out_size": 54003,
 "ratio": 0.3551,
-"compress_mbps": 37.64,
-"decompress_mbps": 306.7
+"compress_mbps": 37.63,
+"decompress_mbps": 308.6
 },
 {
 "compressor": "zig",
@@ -12614,8 +12614,8 @@
 "level": 8,
 "out_size": 53974,
 "ratio": 0.3549,
-"compress_mbps": 31.88,
-"decompress_mbps": 306.27
+"compress_mbps": 33.19,
+"decompress_mbps": 310.69
 },
 {
 "compressor": "zig",
@@ -12624,8 +12624,8 @@
 "level": 9,
 "out_size": 53974,
 "ratio": 0.3549,
-"compress_mbps": 33.02,
-"decompress_mbps": 307.08
+"compress_mbps": 33.38,
+"decompress_mbps": 305.28
 },
 {
 "compressor": "zig",
@@ -12634,8 +12634,8 @@
 "level": 1,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 79.59,
-"decompress_mbps": 275.38
+"compress_mbps": 84.35,
+"decompress_mbps": 277.41
 },
 {
 "compressor": "zig",
@@ -12644,8 +12644,8 @@
 "level": 2,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 82.0,
-"decompress_mbps": 278.95
+"compress_mbps": 84.49,
+"decompress_mbps": 281.17
 },
 {
 "compressor": "zig",
@@ -12654,8 +12654,8 @@
 "level": 3,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 81.45,
-"decompress_mbps": 276.39
+"compress_mbps": 84.68,
+"decompress_mbps": 276.72
 },
 {
 "compressor": "zig",
@@ -12664,8 +12664,8 @@
 "level": 4,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 84.1,
-"decompress_mbps": 275.58
+"compress_mbps": 84.68,
+"decompress_mbps": 272.42
 },
 {
 "compressor": "zig",
@@ -12674,8 +12674,8 @@
 "level": 5,
 "out_size": 48753,
 "ratio": 0.3895,
-"compress_mbps": 49.28,
-"decompress_mbps": 276.64
+"compress_mbps": 49.42,
+"decompress_mbps": 273.36
 },
 {
 "compressor": "zig",
@@ -12684,8 +12684,8 @@
 "level": 6,
 "out_size": 48557,
 "ratio": 0.3879,
-"compress_mbps": 41.08,
-"decompress_mbps": 272.23
+"compress_mbps": 41.15,
+"decompress_mbps": 278.92
 },
 {
 "compressor": "zig",
@@ -12694,8 +12694,8 @@
 "level": 7,
 "out_size": 48523,
 "ratio": 0.3876,
-"compress_mbps": 38.92,
-"decompress_mbps": 277.27
+"compress_mbps": 39.03,
+"decompress_mbps": 277.67
 },
 {
 "compressor": "zig",
@@ -12704,8 +12704,8 @@
 "level": 8,
 "out_size": 48522,
 "ratio": 0.3876,
-"compress_mbps": 37.97,
-"decompress_mbps": 276.72
+"compress_mbps": 38.15,
+"decompress_mbps": 271.91
 },
 {
 "compressor": "zig",
@@ -12714,8 +12714,8 @@
 "level": 9,
 "out_size": 48522,
 "ratio": 0.3876,
-"compress_mbps": 38.15,
-"decompress_mbps": 275.9
+"compress_mbps": 38.25,
+"decompress_mbps": 272.16
 },
 {
 "compressor": "zig",
@@ -12724,8 +12724,8 @@
 "level": 1,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 170.0,
-"decompress_mbps": 283.43
+"compress_mbps": 176.49,
+"decompress_mbps": 283.21
 },
 {
 "compressor": "zig",
@@ -12734,8 +12734,8 @@
 "level": 2,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 171.42,
-"decompress_mbps": 282.89
+"compress_mbps": 157.0,
+"decompress_mbps": 283.62
 },
 {
 "compressor": "zig",
@@ -12744,8 +12744,8 @@
 "level": 3,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 159.73,
-"decompress_mbps": 281.91
+"compress_mbps": 168.95,
+"decompress_mbps": 283.35
 },
 {
 "compressor": "zig",
@@ -12754,8 +12754,8 @@
 "level": 4,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 167.97,
-"decompress_mbps": 284.0
+"compress_mbps": 164.57,
+"decompress_mbps": 283.89
 },
 {
 "compressor": "zig",
@@ -12764,8 +12764,8 @@
 "level": 5,
 "out_size": 7965,
 "ratio": 0.3237,
-"compress_mbps": 109.99,
-"decompress_mbps": 288.93
+"compress_mbps": 107.86,
+"decompress_mbps": 289.08
 },
 {
 "compressor": "zig",
@@ -12774,8 +12774,8 @@
 "level": 6,
 "out_size": 7914,
 "ratio": 0.3217,
-"compress_mbps": 89.17,
-"decompress_mbps": 291.02
+"compress_mbps": 88.23,
+"decompress_mbps": 289.56
 },
 {
 "compressor": "zig",
@@ -12784,8 +12784,8 @@
 "level": 7,
 "out_size": 7895,
 "ratio": 0.3209,
-"compress_mbps": 78.05,
-"decompress_mbps": 290.89
+"compress_mbps": 76.27,
+"decompress_mbps": 292.21
 },
 {
 "compressor": "zig",
@@ -12794,8 +12794,8 @@
 "level": 8,
 "out_size": 7896,
 "ratio": 0.3209,
-"compress_mbps": 72.83,
-"decompress_mbps": 288.41
+"compress_mbps": 74.65,
+"decompress_mbps": 291.45
 },
 {
 "compressor": "zig",
@@ -12804,8 +12804,8 @@
 "level": 9,
 "out_size": 7896,
 "ratio": 0.3209,
-"compress_mbps": 74.07,
-"decompress_mbps": 291.72
+"compress_mbps": 71.51,
+"decompress_mbps": 291.41
 },
 {
 "compressor": "zig",
@@ -12814,8 +12814,8 @@
 "level": 1,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 169.05,
-"decompress_mbps": 258.64
+"compress_mbps": 170.11,
+"decompress_mbps": 258.5
 },
 {
 "compressor": "zig",
@@ -12824,8 +12824,8 @@
 "level": 2,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 165.99,
-"decompress_mbps": 254.49
+"compress_mbps": 171.12,
+"decompress_mbps": 256.78
 },
 {
 "compressor": "zig",
@@ -12834,8 +12834,8 @@
 "level": 3,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 166.66,
-"decompress_mbps": 258.08
+"compress_mbps": 177.2,
+"decompress_mbps": 261.19
 },
 {
 "compressor": "zig",
@@ -12844,8 +12844,8 @@
 "level": 4,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 166.05,
-"decompress_mbps": 256.08
+"compress_mbps": 176.99,
+"decompress_mbps": 260.26
 },
 {
 "compressor": "zig",
@@ -12854,8 +12854,8 @@
 "level": 5,
 "out_size": 3136,
 "ratio": 0.2813,
-"compress_mbps": 141.69,
-"decompress_mbps": 261.62
+"compress_mbps": 151.39,
+"decompress_mbps": 266.63
 },
 {
 "compressor": "zig",
@@ -12864,8 +12864,8 @@
 "level": 6,
 "out_size": 3115,
 "ratio": 0.2794,
-"compress_mbps": 124.39,
-"decompress_mbps": 265.19
+"compress_mbps": 127.43,
+"decompress_mbps": 267.56
 },
 {
 "compressor": "zig",
@@ -12874,8 +12874,8 @@
 "level": 7,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 113.46,
-"decompress_mbps": 263.59
+"compress_mbps": 118.23,
+"decompress_mbps": 269.45
 },
 {
 "compressor": "zig",
@@ -12884,8 +12884,8 @@
 "level": 8,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 105.51,
-"decompress_mbps": 263.92
+"compress_mbps": 107.09,
+"decompress_mbps": 268.59
 },
 {
 "compressor": "zig",
@@ -12894,8 +12894,8 @@
 "level": 9,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 105.45,
-"decompress_mbps": 264.16
+"compress_mbps": 107.78,
+"decompress_mbps": 269.38
 },
 {
 "compressor": "zig",
@@ -12904,8 +12904,8 @@
 "level": 1,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 119.2,
-"decompress_mbps": 117.71
+"compress_mbps": 111.06,
+"decompress_mbps": 120.59
 },
 {
 "compressor": "zig",
@@ -12914,8 +12914,8 @@
 "level": 2,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 119.0,
-"decompress_mbps": 119.68
+"compress_mbps": 114.25,
+"decompress_mbps": 117.15
 },
 {
 "compressor": "zig",
@@ -12924,8 +12924,8 @@
 "level": 3,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 120.92,
-"decompress_mbps": 119.78
+"compress_mbps": 114.48,
+"decompress_mbps": 117.08
 },
 {
 "compressor": "zig",
@@ -12934,8 +12934,8 @@
 "level": 4,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 115.62,
-"decompress_mbps": 120.26
+"compress_mbps": 122.1,
+"decompress_mbps": 119.19
 },
 {
 "compressor": "zig",
@@ -12944,8 +12944,8 @@
 "level": 5,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 108.83,
-"decompress_mbps": 121.08
+"compress_mbps": 112.57,
+"decompress_mbps": 119.9
 },
 {
 "compressor": "zig",
@@ -12954,8 +12954,8 @@
 "level": 6,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 104.91,
-"decompress_mbps": 120.1
+"compress_mbps": 102.93,
+"decompress_mbps": 119.04
 },
 {
 "compressor": "zig",
@@ -12964,8 +12964,8 @@
 "level": 7,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 101.15,
-"decompress_mbps": 121.62
+"compress_mbps": 101.26,
+"decompress_mbps": 118.89
 },
 {
 "compressor": "zig",
@@ -12974,8 +12974,8 @@
 "level": 8,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 104.15,
-"decompress_mbps": 119.41
+"compress_mbps": 102.37,
+"decompress_mbps": 120.33
 },
 {
 "compressor": "zig",
@@ -12984,8 +12984,8 @@
 "level": 9,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 101.89,
-"decompress_mbps": 120.34
+"compress_mbps": 102.25,
+"decompress_mbps": 120.01
 },
 {
 "compressor": "zig",
@@ -12994,8 +12994,8 @@
 "level": 1,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 226.61,
-"decompress_mbps": 461.39
+"compress_mbps": 231.42,
+"decompress_mbps": 460.38
 },
 {
 "compressor": "zig",
@@ -13004,8 +13004,8 @@
 "level": 2,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 225.16,
-"decompress_mbps": 461.69
+"compress_mbps": 228.39,
+"decompress_mbps": 462.25
 },
 {
 "compressor": "zig",
@@ -13014,8 +13014,8 @@
 "level": 3,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 225.72,
-"decompress_mbps": 461.06
+"compress_mbps": 232.41,
+"decompress_mbps": 462.41
 },
 {
 "compressor": "zig",
@@ -13024,8 +13024,8 @@
 "level": 4,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 231.2,
-"decompress_mbps": 458.35
+"compress_mbps": 227.78,
+"decompress_mbps": 463.25
 },
 {
 "compressor": "zig",
@@ -13034,8 +13034,8 @@
 "level": 5,
 "out_size": 218313,
 "ratio": 0.212,
-"compress_mbps": 162.17,
-"decompress_mbps": 444.84
+"compress_mbps": 164.41,
+"decompress_mbps": 446.66
 },
 {
 "compressor": "zig",
@@ -13044,8 +13044,8 @@
 "level": 6,
 "out_size": 215095,
 "ratio": 0.2089,
-"compress_mbps": 106.73,
-"decompress_mbps": 447.63
+"compress_mbps": 105.73,
+"decompress_mbps": 445.2
 },
 {
 "compressor": "zig",
@@ -13054,8 +13054,8 @@
 "level": 7,
 "out_size": 213213,
 "ratio": 0.2071,
-"compress_mbps": 72.85,
-"decompress_mbps": 448.46
+"compress_mbps": 73.14,
+"decompress_mbps": 453.02
 },
 {
 "compressor": "zig",
@@ -13064,8 +13064,8 @@
 "level": 8,
 "out_size": 210955,
 "ratio": 0.2049,
-"compress_mbps": 9.38,
-"decompress_mbps": 451.33
+"compress_mbps": 9.43,
+"decompress_mbps": 453.8
 },
 {
 "compressor": "zig",
@@ -13074,8 +13074,8 @@
 "level": 9,
 "out_size": 210981,
 "ratio": 0.2049,
-"compress_mbps": 4.63,
-"decompress_mbps": 451.02
+"compress_mbps": 4.64,
+"decompress_mbps": 451.7
 },
 {
 "compressor": "zig",
@@ -13084,8 +13084,8 @@
 "level": 1,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 92.88,
-"decompress_mbps": 305.78
+"compress_mbps": 92.4,
+"decompress_mbps": 306.71
 },
 {
 "compressor": "zig",
@@ -13094,8 +13094,8 @@
 "level": 2,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 91.73,
-"decompress_mbps": 306.69
+"compress_mbps": 92.81,
+"decompress_mbps": 306.22
 },
 {
 "compressor": "zig",
@@ -13104,8 +13104,8 @@
 "level": 3,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 88.28,
-"decompress_mbps": 302.93
+"compress_mbps": 89.76,
+"decompress_mbps": 303.23
 },
 {
 "compressor": "zig",
@@ -13114,8 +13114,8 @@
 "level": 4,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 91.63,
-"decompress_mbps": 304.27
+"compress_mbps": 90.15,
+"decompress_mbps": 305.08
 },
 {
 "compressor": "zig",
@@ -13124,8 +13124,8 @@
 "level": 5,
 "out_size": 145024,
 "ratio": 0.3398,
-"compress_mbps": 58.33,
-"decompress_mbps": 303.54
+"compress_mbps": 58.08,
+"decompress_mbps": 304.88
 },
 {
 "compressor": "zig",
@@ -13134,8 +13134,8 @@
 "level": 6,
 "out_size": 144159,
 "ratio": 0.3378,
-"compress_mbps": 44.7,
-"decompress_mbps": 306.43
+"compress_mbps": 44.57,
+"decompress_mbps": 306.06
 },
 {
 "compressor": "zig",
@@ -13144,8 +13144,8 @@
 "level": 7,
 "out_size": 143991,
 "ratio": 0.3374,
-"compress_mbps": 40.05,
-"decompress_mbps": 303.48
+"compress_mbps": 39.42,
+"decompress_mbps": 299.5
 },
 {
 "compressor": "zig",
@@ -13154,8 +13154,8 @@
 "level": 8,
 "out_size": 143941,
 "ratio": 0.3373,
-"compress_mbps": 37.1,
-"decompress_mbps": 307.41
+"compress_mbps": 37.28,
+"decompress_mbps": 307.95
 },
 {
 "compressor": "zig",
@@ -13164,8 +13164,8 @@
 "level": 9,
 "out_size": 143939,
 "ratio": 0.3373,
-"compress_mbps": 36.2,
-"decompress_mbps": 299.45
+"compress_mbps": 36.26,
+"decompress_mbps": 304.87
 },
 {
 "compressor": "zig",
@@ -13174,8 +13174,8 @@
 "level": 1,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 82.1,
-"decompress_mbps": 259.69
+"compress_mbps": 81.79,
+"decompress_mbps": 257.44
 },
 {
 "compressor": "zig",
@@ -13184,8 +13184,8 @@
 "level": 2,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 81.95,
-"decompress_mbps": 255.9
+"compress_mbps": 81.97,
+"decompress_mbps": 257.92
 },
 {
 "compressor": "zig",
@@ -13194,8 +13194,8 @@
 "level": 3,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 81.79,
-"decompress_mbps": 257.49
+"compress_mbps": 82.18,
+"decompress_mbps": 256.18
 },
 {
 "compressor": "zig",
@@ -13204,8 +13204,8 @@
 "level": 4,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 81.34,
-"decompress_mbps": 258.31
+"compress_mbps": 81.68,
+"decompress_mbps": 255.75
 },
 {
 "compressor": "zig",
@@ -13214,8 +13214,8 @@
 "level": 5,
 "out_size": 194496,
 "ratio": 0.4036,
-"compress_mbps": 46.33,
-"decompress_mbps": 250.66
+"compress_mbps": 46.2,
+"decompress_mbps": 250.51
 },
 {
 "compressor": "zig",
@@ -13224,8 +13224,8 @@
 "level": 6,
 "out_size": 193176,
 "ratio": 0.4009,
-"compress_mbps": 34.68,
-"decompress_mbps": 252.15
+"compress_mbps": 34.69,
+"decompress_mbps": 249.92
 },
 {
 "compressor": "zig",
@@ -13234,8 +13234,8 @@
 "level": 7,
 "out_size": 192991,
 "ratio": 0.4005,
-"compress_mbps": 31.28,
-"decompress_mbps": 254.16
+"compress_mbps": 30.65,
+"decompress_mbps": 250.16
 },
 {
 "compressor": "zig",
@@ -13244,8 +13244,8 @@
 "level": 8,
 "out_size": 192980,
 "ratio": 0.4005,
-"compress_mbps": 29.85,
-"decompress_mbps": 251.54
+"compress_mbps": 29.84,
+"decompress_mbps": 254.16
 },
 {
 "compressor": "zig",
@@ -13254,8 +13254,8 @@
 "level": 9,
 "out_size": 192980,
 "ratio": 0.4005,
-"compress_mbps": 29.78,
-"decompress_mbps": 252.63
+"compress_mbps": 29.85,
+"decompress_mbps": 252.99
 },
 {
 "compressor": "zig",
@@ -13264,8 +13264,8 @@
 "level": 1,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 297.61,
-"decompress_mbps": 735.64
+"compress_mbps": 294.51,
+"decompress_mbps": 736.64
 },
 {
 "compressor": "zig",
@@ -13274,8 +13274,8 @@
 "level": 2,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 296.91,
-"decompress_mbps": 734.27
+"compress_mbps": 297.67,
+"decompress_mbps": 734.2
 },
 {
 "compressor": "zig",
@@ -13284,8 +13284,8 @@
 "level": 3,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 297.9,
-"decompress_mbps": 737.74
+"compress_mbps": 294.46,
+"decompress_mbps": 736.7
 },
 {
 "compressor": "zig",
@@ -13294,8 +13294,8 @@
 "level": 4,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 297.0,
-"decompress_mbps": 732.69
+"compress_mbps": 295.54,
+"decompress_mbps": 739.72
 },
 {
 "compressor": "zig",
@@ -13304,8 +13304,8 @@
 "level": 5,
 "out_size": 56050,
 "ratio": 0.1092,
-"compress_mbps": 233.63,
-"decompress_mbps": 760.32
+"compress_mbps": 232.0,
+"decompress_mbps": 760.55
 },
 {
 "compressor": "zig",
@@ -13314,8 +13314,8 @@
 "level": 6,
 "out_size": 55292,
 "ratio": 0.1077,
-"compress_mbps": 148.58,
-"decompress_mbps": 770.33
+"compress_mbps": 149.88,
+"decompress_mbps": 772.53
 },
 {
 "compressor": "zig",
@@ -13324,8 +13324,8 @@
 "level": 7,
 "out_size": 54651,
 "ratio": 0.1065,
-"compress_mbps": 124.98,
-"decompress_mbps": 799.34
+"compress_mbps": 123.87,
+"decompress_mbps": 797.45
 },
 {
 "compressor": "zig",
@@ -13334,8 +13334,8 @@
 "level": 8,
 "out_size": 52583,
 "ratio": 0.1025,
-"compress_mbps": 47.43,
-"decompress_mbps": 821.51
+"compress_mbps": 46.68,
+"decompress_mbps": 821.02
 },
 {
 "compressor": "zig",
@@ -13344,8 +13344,8 @@
 "level": 9,
 "out_size": 51816,
 "ratio": 0.101,
-"compress_mbps": 15.77,
-"decompress_mbps": 839.64
+"compress_mbps": 15.7,
+"decompress_mbps": 839.84
 },
 {
 "compressor": "zig",
@@ -13354,8 +13354,8 @@
 "level": 1,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 113.78,
-"decompress_mbps": 305.77
+"compress_mbps": 118.05,
+"decompress_mbps": 306.01
 },
 {
 "compressor": "zig",
@@ -13364,8 +13364,8 @@
 "level": 2,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 119.13,
-"decompress_mbps": 305.24
+"compress_mbps": 117.56,
+"decompress_mbps": 309.08
 },
 {
 "compressor": "zig",
@@ -13374,8 +13374,8 @@
 "level": 3,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 119.79,
-"decompress_mbps": 307.5
+"compress_mbps": 119.56,
+"decompress_mbps": 305.2
 },
 {
 "compressor": "zig",
@@ -13384,8 +13384,8 @@
 "level": 4,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 117.74,
-"decompress_mbps": 306.41
+"compress_mbps": 113.19,
+"decompress_mbps": 304.41
 },
 {
 "compressor": "zig",
@@ -13394,8 +13394,8 @@
 "level": 5,
 "out_size": 13290,
 "ratio": 0.3475,
-"compress_mbps": 89.93,
-"decompress_mbps": 318.38
+"compress_mbps": 84.8,
+"decompress_mbps": 316.74
 },
 {
 "compressor": "zig",
@@ -13404,8 +13404,8 @@
 "level": 6,
 "out_size": 13258,
 "ratio": 0.3467,
-"compress_mbps": 69.72,
-"decompress_mbps": 318.62
+"compress_mbps": 65.11,
+"decompress_mbps": 315.1
 },
 {
 "compressor": "zig",
@@ -13414,8 +13414,8 @@
 "level": 7,
 "out_size": 13246,
 "ratio": 0.3464,
-"compress_mbps": 55.24,
-"decompress_mbps": 321.48
+"compress_mbps": 56.55,
+"decompress_mbps": 320.71
 },
 {
 "compressor": "zig",
@@ -13424,8 +13424,8 @@
 "level": 8,
 "out_size": 13236,
 "ratio": 0.3461,
-"compress_mbps": 25.48,
-"decompress_mbps": 323.37
+"compress_mbps": 24.91,
+"decompress_mbps": 322.05
 },
 {
 "compressor": "zig",
@@ -13435,7 +13435,7 @@
 "out_size": 13233,
 "ratio": 0.3461,
 "compress_mbps": 16.19,
-"decompress_mbps": 322.16
+"decompress_mbps": 321.85
 },
 {
 "compressor": "zig",
@@ -13444,8 +13444,8 @@
 "level": 1,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 97.27,
-"decompress_mbps": 133.05
+"compress_mbps": 96.4,
+"decompress_mbps": 133.7
 },
 {
 "compressor": "zig",
@@ -13454,8 +13454,8 @@
 "level": 2,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 97.48,
-"decompress_mbps": 132.23
+"compress_mbps": 95.34,
+"decompress_mbps": 133.58
 },
 {
 "compressor": "zig",
@@ -13464,8 +13464,8 @@
 "level": 3,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 100.1,
-"decompress_mbps": 131.83
+"compress_mbps": 96.07,
+"decompress_mbps": 135.51
 },
 {
 "compressor": "zig",
@@ -13474,8 +13474,8 @@
 "level": 4,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 96.34,
-"decompress_mbps": 133.53
+"compress_mbps": 95.82,
+"decompress_mbps": 135.16
 },
 {
 "compressor": "zig",
@@ -13484,8 +13484,8 @@
 "level": 5,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 97.65,
-"decompress_mbps": 134.47
+"compress_mbps": 91.54,
+"decompress_mbps": 135.99
 },
 {
 "compressor": "zig",
@@ -13494,8 +13494,8 @@
 "level": 6,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 91.4,
-"decompress_mbps": 133.83
+"compress_mbps": 91.04,
+"decompress_mbps": 135.74
 },
 {
 "compressor": "zig",
@@ -13504,8 +13504,8 @@
 "level": 7,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 96.3,
-"decompress_mbps": 134.23
+"compress_mbps": 90.12,
+"decompress_mbps": 136.28
 },
 {
 "compressor": "zig",
@@ -13514,8 +13514,8 @@
 "level": 8,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 92.53,
-"decompress_mbps": 132.87
+"compress_mbps": 91.0,
+"decompress_mbps": 136.31
 },
 {
 "compressor": "zig",
@@ -13524,8 +13524,8 @@
 "level": 9,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 90.13,
-"decompress_mbps": 134.26
+"compress_mbps": 91.66,
+"decompress_mbps": 136.03
 },
 {
 "compressor": "zig",
@@ -13534,8 +13534,8 @@
 "level": 1,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 80.44,
-"decompress_mbps": 272.57
+"compress_mbps": 83.98,
+"decompress_mbps": 273.26
 },
 {
 "compressor": "zig",
@@ -13544,8 +13544,8 @@
 "level": 2,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 84.4,
-"decompress_mbps": 272.73
+"compress_mbps": 80.13,
+"decompress_mbps": 270.86
 },
 {
 "compressor": "zig",
@@ -13554,8 +13554,8 @@
 "level": 3,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 84.05,
-"decompress_mbps": 272.79
+"compress_mbps": 83.53,
+"decompress_mbps": 270.42
 },
 {
 "compressor": "zig",
@@ -13564,8 +13564,8 @@
 "level": 4,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 84.1,
-"decompress_mbps": 271.71
+"compress_mbps": 81.44,
+"decompress_mbps": 268.13
 },
 {
 "compressor": "zig",
@@ -13574,8 +13574,8 @@
 "level": 5,
 "out_size": 3863846,
 "ratio": 0.3791,
-"compress_mbps": 47.9,
-"decompress_mbps": 263.79
+"compress_mbps": 49.14,
+"decompress_mbps": 268.57
 },
 {
 "compressor": "zig",
@@ -13584,8 +13584,8 @@
 "level": 6,
 "out_size": 3838854,
 "ratio": 0.3766,
-"compress_mbps": 37.56,
-"decompress_mbps": 271.0
+"compress_mbps": 36.09,
+"decompress_mbps": 265.48
 },
 {
 "compressor": "zig",
@@ -13594,8 +13594,8 @@
 "level": 7,
 "out_size": 3835182,
 "ratio": 0.3763,
-"compress_mbps": 33.78,
-"decompress_mbps": 269.73
+"compress_mbps": 32.84,
+"decompress_mbps": 266.63
 },
 {
 "compressor": "zig",
@@ -13604,8 +13604,8 @@
 "level": 8,
 "out_size": 3834518,
 "ratio": 0.3762,
-"compress_mbps": 31.35,
-"decompress_mbps": 271.39
+"compress_mbps": 30.85,
+"decompress_mbps": 265.36
 },
 {
 "compressor": "zig",
@@ -13614,8 +13614,8 @@
 "level": 9,
 "out_size": 3834518,
 "ratio": 0.3762,
-"compress_mbps": 31.38,
-"decompress_mbps": 269.66
+"compress_mbps": 31.51,
+"decompress_mbps": 271.03
 },
 {
 "compressor": "zig",
@@ -13624,8 +13624,8 @@
 "level": 1,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 103.87,
-"decompress_mbps": 251.19
+"compress_mbps": 98.52,
+"decompress_mbps": 246.32
 },
 {
 "compressor": "zig",
@@ -13634,8 +13634,8 @@
 "level": 2,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 103.78,
-"decompress_mbps": 252.0
+"compress_mbps": 104.17,
+"decompress_mbps": 253.04
 },
 {
 "compressor": "zig",
@@ -13644,8 +13644,8 @@
 "level": 3,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 103.78,
-"decompress_mbps": 251.47
+"compress_mbps": 104.59,
+"decompress_mbps": 253.23
 },
 {
 "compressor": "zig",
@@ -13654,8 +13654,8 @@
 "level": 4,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 98.22,
-"decompress_mbps": 245.68
+"compress_mbps": 104.72,
+"decompress_mbps": 253.32
 },
 {
 "compressor": "zig",
@@ -13664,8 +13664,8 @@
 "level": 5,
 "out_size": 19578840,
 "ratio": 0.3822,
-"compress_mbps": 78.47,
-"decompress_mbps": 260.4
+"compress_mbps": 78.85,
+"decompress_mbps": 260.58
 },
 {
 "compressor": "zig",
@@ -13674,8 +13674,8 @@
 "level": 6,
 "out_size": 19492445,
 "ratio": 0.3806,
-"compress_mbps": 56.06,
-"decompress_mbps": 256.86
+"compress_mbps": 55.6,
+"decompress_mbps": 260.04
 },
 {
 "compressor": "zig",
@@ -13684,8 +13684,8 @@
 "level": 7,
 "out_size": 19463481,
 "ratio": 0.38,
-"compress_mbps": 46.51,
-"decompress_mbps": 263.98
+"compress_mbps": 46.38,
+"decompress_mbps": 262.76
 },
 {
 "compressor": "zig",
@@ -13694,8 +13694,8 @@
 "level": 8,
 "out_size": 19444704,
 "ratio": 0.3796,
-"compress_mbps": 22.85,
-"decompress_mbps": 264.17
+"compress_mbps": 22.63,
+"decompress_mbps": 260.74
 },
 {
 "compressor": "zig",
@@ -13704,8 +13704,8 @@
 "level": 9,
 "out_size": 19440748,
 "ratio": 0.3796,
-"compress_mbps": 13.08,
-"decompress_mbps": 264.03
+"compress_mbps": 13.11,
+"decompress_mbps": 265.47
 },
 {
 "compressor": "zig",
@@ -13714,8 +13714,8 @@
 "level": 1,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 112.66,
-"decompress_mbps": 260.14
+"compress_mbps": 113.01,
+"decompress_mbps": 260.13
 },
 {
 "compressor": "zig",
@@ -13724,8 +13724,8 @@
 "level": 2,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 112.18,
-"decompress_mbps": 261.17
+"compress_mbps": 113.77,
+"decompress_mbps": 262.27
 },
 {
 "compressor": "zig",
@@ -13734,8 +13734,8 @@
 "level": 3,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 112.22,
-"decompress_mbps": 260.82
+"compress_mbps": 112.99,
+"decompress_mbps": 260.29
 },
 {
 "compressor": "zig",
@@ -13744,8 +13744,8 @@
 "level": 4,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 108.26,
-"decompress_mbps": 255.87
+"compress_mbps": 113.64,
+"decompress_mbps": 262.21
 },
 {
 "compressor": "zig",
@@ -13754,8 +13754,8 @@
 "level": 5,
 "out_size": 3637736,
 "ratio": 0.3648,
-"compress_mbps": 66.19,
-"decompress_mbps": 268.56
+"compress_mbps": 64.5,
+"decompress_mbps": 266.08
 },
 {
 "compressor": "zig",
@@ -13764,8 +13764,8 @@
 "level": 6,
 "out_size": 3621530,
 "ratio": 0.3632,
-"compress_mbps": 46.79,
-"decompress_mbps": 269.56
+"compress_mbps": 46.74,
+"decompress_mbps": 269.66
 },
 {
 "compressor": "zig",
@@ -13774,8 +13774,8 @@
 "level": 7,
 "out_size": 3623924,
 "ratio": 0.3635,
-"compress_mbps": 41.33,
-"decompress_mbps": 266.67
+"compress_mbps": 42.18,
+"decompress_mbps": 267.79
 },
 {
 "compressor": "zig",
@@ -13784,8 +13784,8 @@
 "level": 8,
 "out_size": 3623112,
 "ratio": 0.3634,
-"compress_mbps": 32.95,
-"decompress_mbps": 270.13
+"compress_mbps": 33.06,
+"decompress_mbps": 270.3
 },
 {
 "compressor": "zig",
@@ -13794,8 +13794,8 @@
 "level": 9,
 "out_size": 3623382,
 "ratio": 0.3634,
-"compress_mbps": 24.97,
-"decompress_mbps": 270.5
+"compress_mbps": 24.26,
+"decompress_mbps": 264.04
 },
 {
 "compressor": "zig",
@@ -13804,8 +13804,8 @@
 "level": 1,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 307.87,
-"decompress_mbps": 875.53
+"compress_mbps": 310.52,
+"decompress_mbps": 887.67
 },
 {
 "compressor": "zig",
@@ -13814,8 +13814,8 @@
 "level": 2,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 307.41,
-"decompress_mbps": 873.28
+"compress_mbps": 309.19,
+"decompress_mbps": 878.9
 },
 {
 "compressor": "zig",
@@ -13824,8 +13824,8 @@
 "level": 3,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 307.21,
-"decompress_mbps": 871.22
+"compress_mbps": 310.94,
+"decompress_mbps": 889.01
 },
 {
 "compressor": "zig",
@@ -13834,8 +13834,8 @@
 "level": 4,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 309.49,
-"decompress_mbps": 882.0
+"compress_mbps": 310.69,
+"decompress_mbps": 881.41
 },
 {
 "compressor": "zig",
@@ -13844,8 +13844,8 @@
 "level": 5,
 "out_size": 3268887,
 "ratio": 0.0974,
-"compress_mbps": 230.18,
-"decompress_mbps": 923.75
+"compress_mbps": 219.28,
+"decompress_mbps": 920.89
 },
 {
 "compressor": "zig",
@@ -13854,8 +13854,8 @@
 "level": 6,
 "out_size": 3131445,
 "ratio": 0.0933,
-"compress_mbps": 163.6,
-"decompress_mbps": 948.69
+"compress_mbps": 159.25,
+"decompress_mbps": 961.72
 },
 {
 "compressor": "zig",
@@ -13864,8 +13864,8 @@
 "level": 7,
 "out_size": 3080217,
 "ratio": 0.0918,
-"compress_mbps": 123.79,
-"decompress_mbps": 940.95
+"compress_mbps": 130.17,
+"decompress_mbps": 972.76
 },
 {
 "compressor": "zig",
@@ -13874,8 +13874,8 @@
 "level": 8,
 "out_size": 2978354,
 "ratio": 0.0888,
-"compress_mbps": 57.23,
-"decompress_mbps": 969.18
+"compress_mbps": 57.2,
+"decompress_mbps": 973.27
 },
 {
 "compressor": "zig",
@@ -13884,8 +13884,8 @@
 "level": 9,
 "out_size": 2947971,
 "ratio": 0.0879,
-"compress_mbps": 34.89,
-"decompress_mbps": 981.3
+"compress_mbps": 33.86,
+"decompress_mbps": 969.27
 },
 {
 "compressor": "zig",
@@ -13894,8 +13894,8 @@
 "level": 1,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 72.27,
-"decompress_mbps": 183.13
+"compress_mbps": 72.55,
+"decompress_mbps": 182.62
 },
 {
 "compressor": "zig",
@@ -13904,8 +13904,8 @@
 "level": 2,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 72.58,
-"decompress_mbps": 183.37
+"compress_mbps": 69.82,
+"decompress_mbps": 180.39
 },
 {
 "compressor": "zig",
@@ -13914,8 +13914,8 @@
 "level": 3,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 72.59,
-"decompress_mbps": 182.72
+"compress_mbps": 72.37,
+"decompress_mbps": 183.48
 },
 {
 "compressor": "zig",
@@ -13924,8 +13924,8 @@
 "level": 4,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 72.7,
-"decompress_mbps": 183.0
+"compress_mbps": 72.75,
+"decompress_mbps": 183.3
 },
 {
 "compressor": "zig",
@@ -13934,8 +13934,8 @@
 "level": 5,
 "out_size": 3178914,
 "ratio": 0.5167,
-"compress_mbps": 55.79,
-"decompress_mbps": 190.66
+"compress_mbps": 56.18,
+"decompress_mbps": 190.61
 },
 {
 "compressor": "zig",
@@ -13944,8 +13944,8 @@
 "level": 6,
 "out_size": 3174170,
 "ratio": 0.5159,
-"compress_mbps": 48.82,
-"decompress_mbps": 191.8
+"compress_mbps": 47.0,
+"decompress_mbps": 187.25
 },
 {
 "compressor": "zig",
@@ -13954,8 +13954,8 @@
 "level": 7,
 "out_size": 3172734,
 "ratio": 0.5157,
-"compress_mbps": 46.21,
-"decompress_mbps": 191.98
+"compress_mbps": 44.06,
+"decompress_mbps": 186.9
 },
 {
 "compressor": "zig",
@@ -13964,8 +13964,8 @@
 "level": 8,
 "out_size": 3171353,
 "ratio": 0.5155,
-"compress_mbps": 38.76,
-"decompress_mbps": 192.02
+"compress_mbps": 38.68,
+"decompress_mbps": 192.17
 },
 {
 "compressor": "zig",
@@ -13974,8 +13974,8 @@
 "level": 9,
 "out_size": 3171299,
 "ratio": 0.5155,
-"compress_mbps": 34.88,
-"decompress_mbps": 191.58
+"compress_mbps": 34.82,
+"decompress_mbps": 191.22
 },
 {
 "compressor": "zig",
@@ -13984,8 +13984,8 @@
 "level": 1,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 122.75,
-"decompress_mbps": 273.24
+"compress_mbps": 122.98,
+"decompress_mbps": 273.83
 },
 {
 "compressor": "zig",
@@ -13994,8 +13994,8 @@
 "level": 2,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 118.55,
-"decompress_mbps": 270.62
+"compress_mbps": 116.9,
+"decompress_mbps": 265.81
 },
 {
 "compressor": "zig",
@@ -14004,8 +14004,8 @@
 "level": 3,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 123.24,
-"decompress_mbps": 274.18
+"compress_mbps": 122.87,
+"decompress_mbps": 273.85
 },
 {
 "compressor": "zig",
@@ -14014,8 +14014,8 @@
 "level": 4,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 122.69,
-"decompress_mbps": 272.5
+"compress_mbps": 123.15,
+"decompress_mbps": 272.43
 },
 {
 "compressor": "zig",
@@ -14024,8 +14024,8 @@
 "level": 5,
 "out_size": 3654027,
 "ratio": 0.3623,
-"compress_mbps": 95.46,
-"decompress_mbps": 275.77
+"compress_mbps": 96.12,
+"decompress_mbps": 275.81
 },
 {
 "compressor": "zig",
@@ -14034,8 +14034,8 @@
 "level": 6,
 "out_size": 3652732,
 "ratio": 0.3622,
-"compress_mbps": 90.44,
-"decompress_mbps": 273.41
+"compress_mbps": 93.23,
+"decompress_mbps": 276.92
 },
 {
 "compressor": "zig",
@@ -14044,8 +14044,8 @@
 "level": 7,
 "out_size": 3652496,
 "ratio": 0.3621,
-"compress_mbps": 86.87,
-"decompress_mbps": 275.23
+"compress_mbps": 87.58,
+"decompress_mbps": 276.22
 },
 {
 "compressor": "zig",
@@ -14054,8 +14054,8 @@
 "level": 8,
 "out_size": 3652505,
 "ratio": 0.3621,
-"compress_mbps": 86.72,
-"decompress_mbps": 276.09
+"compress_mbps": 87.26,
+"decompress_mbps": 275.69
 },
 {
 "compressor": "zig",
@@ -14064,8 +14064,8 @@
 "level": 9,
 "out_size": 3652505,
 "ratio": 0.3621,
-"compress_mbps": 87.18,
-"decompress_mbps": 275.97
+"compress_mbps": 83.87,
+"decompress_mbps": 271.98
 },
 {
 "compressor": "zig",
@@ -14074,8 +14074,8 @@
 "level": 1,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 99.27,
-"decompress_mbps": 353.86
+"compress_mbps": 95.25,
+"decompress_mbps": 349.29
 },
 {
 "compressor": "zig",
@@ -14084,8 +14084,8 @@
 "level": 2,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 99.39,
-"decompress_mbps": 353.58
+"compress_mbps": 96.26,
+"decompress_mbps": 352.89
 },
 {
 "compressor": "zig",
@@ -14094,8 +14094,8 @@
 "level": 3,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 99.78,
-"decompress_mbps": 353.12
+"compress_mbps": 100.25,
+"decompress_mbps": 354.4
 },
 {
 "compressor": "zig",
@@ -14104,8 +14104,8 @@
 "level": 4,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 96.05,
-"decompress_mbps": 350.42
+"compress_mbps": 99.91,
+"decompress_mbps": 354.49
 },
 {
 "compressor": "zig",
@@ -14114,8 +14114,8 @@
 "level": 5,
 "out_size": 1892183,
 "ratio": 0.2855,
-"compress_mbps": 53.81,
-"decompress_mbps": 353.36
+"compress_mbps": 53.67,
+"decompress_mbps": 353.03
 },
 {
 "compressor": "zig",
@@ -14124,8 +14124,8 @@
 "level": 6,
 "out_size": 1837957,
 "ratio": 0.2773,
-"compress_mbps": 30.64,
-"decompress_mbps": 362.81
+"compress_mbps": 29.78,
+"decompress_mbps": 357.23
 },
 {
 "compressor": "zig",
@@ -14134,8 +14134,8 @@
 "level": 7,
 "out_size": 1826603,
 "ratio": 0.2756,
-"compress_mbps": 24.39,
-"decompress_mbps": 360.16
+"compress_mbps": 24.43,
+"decompress_mbps": 362.47
 },
 {
 "compressor": "zig",
@@ -14144,8 +14144,8 @@
 "level": 8,
 "out_size": 1818702,
 "ratio": 0.2744,
-"compress_mbps": 16.11,
-"decompress_mbps": 358.98
+"compress_mbps": 16.14,
+"decompress_mbps": 362.63
 },
 {
 "compressor": "zig",
@@ -14154,8 +14154,8 @@
 "level": 9,
 "out_size": 1818702,
 "ratio": 0.2744,
-"compress_mbps": 16.03,
-"decompress_mbps": 359.67
+"compress_mbps": 15.98,
+"decompress_mbps": 366.35
 },
 {
 "compressor": "zig",
@@ -14164,8 +14164,8 @@
 "level": 1,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 145.57,
-"decompress_mbps": 396.97
+"compress_mbps": 145.97,
+"decompress_mbps": 400.39
 },
 {
 "compressor": "zig",
@@ -14174,8 +14174,8 @@
 "level": 2,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 146.19,
-"decompress_mbps": 397.36
+"compress_mbps": 145.73,
+"decompress_mbps": 402.35
 },
 {
 "compressor": "zig",
@@ -14184,8 +14184,8 @@
 "level": 3,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 145.72,
-"decompress_mbps": 400.38
+"compress_mbps": 145.9,
+"decompress_mbps": 401.81
 },
 {
 "compressor": "zig",
@@ -14194,8 +14194,8 @@
 "level": 4,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 145.25,
-"decompress_mbps": 398.35
+"compress_mbps": 146.24,
+"decompress_mbps": 400.01
 },
 {
 "compressor": "zig",
@@ -14204,8 +14204,8 @@
 "level": 5,
 "out_size": 5501344,
 "ratio": 0.2546,
-"compress_mbps": 103.67,
-"decompress_mbps": 403.67
+"compress_mbps": 100.6,
+"decompress_mbps": 398.03
 },
 {
 "compressor": "zig",
@@ -14214,8 +14214,8 @@
 "level": 6,
 "out_size": 5464646,
 "ratio": 0.2529,
-"compress_mbps": 79.62,
-"decompress_mbps": 407.97
+"compress_mbps": 79.6,
+"decompress_mbps": 408.78
 },
 {
 "compressor": "zig",
@@ -14224,8 +14224,8 @@
 "level": 7,
 "out_size": 5429975,
 "ratio": 0.2513,
-"compress_mbps": 67.01,
-"decompress_mbps": 407.82
+"compress_mbps": 67.13,
+"decompress_mbps": 407.38
 },
 {
 "compressor": "zig",
@@ -14234,8 +14234,8 @@
 "level": 8,
 "out_size": 5419566,
 "ratio": 0.2508,
-"compress_mbps": 49.42,
-"decompress_mbps": 407.14
+"compress_mbps": 49.67,
+"decompress_mbps": 412.93
 },
 {
 "compressor": "zig",
@@ -14244,8 +14244,8 @@
 "level": 9,
 "out_size": 5417952,
 "ratio": 0.2508,
-"compress_mbps": 45.4,
-"decompress_mbps": 409.08
+"compress_mbps": 44.29,
+"decompress_mbps": 403.48
 },
 {
 "compressor": "zig",
@@ -14254,8 +14254,8 @@
 "level": 1,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 60.6,
-"decompress_mbps": 161.13
+"compress_mbps": 60.43,
+"decompress_mbps": 161.36
 },
 {
 "compressor": "zig",
@@ -14264,8 +14264,8 @@
 "level": 2,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 60.15,
-"decompress_mbps": 160.0
+"compress_mbps": 60.35,
+"decompress_mbps": 160.93
 },
 {
 "compressor": "zig",
@@ -14274,8 +14274,8 @@
 "level": 3,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 60.33,
-"decompress_mbps": 161.26
+"compress_mbps": 60.57,
+"decompress_mbps": 161.7
 },
 {
 "compressor": "zig",
@@ -14284,8 +14284,8 @@
 "level": 4,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 60.17,
-"decompress_mbps": 160.91
+"compress_mbps": 60.63,
+"decompress_mbps": 160.7
 },
 {
 "compressor": "zig",
@@ -14294,8 +14294,8 @@
 "level": 5,
 "out_size": 5450496,
 "ratio": 0.7516,
-"compress_mbps": 46.85,
-"decompress_mbps": 163.07
+"compress_mbps": 45.59,
+"decompress_mbps": 166.62
 },
 {
 "compressor": "zig",
@@ -14304,8 +14304,8 @@
 "level": 6,
 "out_size": 5440281,
 "ratio": 0.7502,
-"compress_mbps": 41.87,
-"decompress_mbps": 164.65
+"compress_mbps": 42.27,
+"decompress_mbps": 166.03
 },
 {
 "compressor": "zig",
@@ -14314,8 +14314,8 @@
 "level": 7,
 "out_size": 5439077,
 "ratio": 0.75,
-"compress_mbps": 40.74,
-"decompress_mbps": 163.58
+"compress_mbps": 40.8,
+"decompress_mbps": 165.53
 },
 {
 "compressor": "zig",
@@ -14324,8 +14324,8 @@
 "level": 8,
 "out_size": 5438787,
 "ratio": 0.75,
-"compress_mbps": 39.83,
-"decompress_mbps": 163.61
+"compress_mbps": 38.69,
+"decompress_mbps": 166.59
 },
 {
 "compressor": "zig",
@@ -14334,8 +14334,8 @@
 "level": 9,
 "out_size": 5438787,
 "ratio": 0.75,
-"compress_mbps": 39.93,
-"decompress_mbps": 164.19
+"compress_mbps": 40.07,
+"decompress_mbps": 165.14
 },
 {
 "compressor": "zig",
@@ -14344,8 +14344,8 @@
 "level": 1,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 108.21,
-"decompress_mbps": 315.95
+"compress_mbps": 108.32,
+"decompress_mbps": 316.81
 },
 {
 "compressor": "zig",
@@ -14354,8 +14354,8 @@
 "level": 2,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 108.39,
-"decompress_mbps": 317.23
+"compress_mbps": 103.66,
+"decompress_mbps": 312.29
 },
 {
 "compressor": "zig",
@@ -14364,8 +14364,8 @@
 "level": 3,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 108.99,
-"decompress_mbps": 315.0
+"compress_mbps": 108.87,
+"decompress_mbps": 315.6
 },
 {
 "compressor": "zig",
@@ -14374,8 +14374,8 @@
 "level": 4,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 109.03,
-"decompress_mbps": 315.63
+"compress_mbps": 108.96,
+"decompress_mbps": 314.93
 },
 {
 "compressor": "zig",
@@ -14384,8 +14384,8 @@
 "level": 5,
 "out_size": 12238874,
 "ratio": 0.2952,
-"compress_mbps": 72.84,
-"decompress_mbps": 317.51
+"compress_mbps": 68.98,
+"decompress_mbps": 315.04
 },
 {
 "compressor": "zig",
@@ -14394,8 +14394,8 @@
 "level": 6,
 "out_size": 12086531,
 "ratio": 0.2915,
-"compress_mbps": 53.88,
-"decompress_mbps": 323.9
+"compress_mbps": 54.11,
+"decompress_mbps": 321.25
 },
 {
 "compressor": "zig",
@@ -14404,8 +14404,8 @@
 "level": 7,
 "out_size": 12020742,
 "ratio": 0.2899,
-"compress_mbps": 46.51,
-"decompress_mbps": 321.01
+"compress_mbps": 46.63,
+"decompress_mbps": 321.66
 },
 {
 "compressor": "zig",
@@ -14414,8 +14414,8 @@
 "level": 8,
 "out_size": 11987253,
 "ratio": 0.2891,
-"compress_mbps": 38.29,
-"decompress_mbps": 322.03
+"compress_mbps": 38.19,
+"decompress_mbps": 320.79
 },
 {
 "compressor": "zig",
@@ -14424,8 +14424,8 @@
 "level": 9,
 "out_size": 11987245,
 "ratio": 0.2891,
-"compress_mbps": 38.07,
-"decompress_mbps": 321.02
+"compress_mbps": 37.19,
+"decompress_mbps": 317.49
 },
 {
 "compressor": "zig",
@@ -14434,8 +14434,8 @@
 "level": 1,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 60.86,
-"decompress_mbps": 147.16
+"compress_mbps": 60.39,
+"decompress_mbps": 146.84
 },
 {
 "compressor": "zig",
@@ -14444,8 +14444,8 @@
 "level": 2,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 60.81,
-"decompress_mbps": 147.18
+"compress_mbps": 60.89,
+"decompress_mbps": 147.32
 },
 {
 "compressor": "zig",
@@ -14454,8 +14454,8 @@
 "level": 3,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 58.35,
-"decompress_mbps": 145.65
+"compress_mbps": 57.25,
+"decompress_mbps": 144.18
 },
 {
 "compressor": "zig",
@@ -14464,8 +14464,8 @@
 "level": 4,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 60.49,
-"decompress_mbps": 147.76
+"compress_mbps": 60.77,
+"decompress_mbps": 147.19
 },
 {
 "compressor": "zig",
@@ -14474,8 +14474,8 @@
 "level": 5,
 "out_size": 6244483,
 "ratio": 0.7369,
-"compress_mbps": 55.6,
-"decompress_mbps": 149.26
+"compress_mbps": 52.46,
+"decompress_mbps": 146.52
 },
 {
 "compressor": "zig",
@@ -14484,8 +14484,8 @@
 "level": 6,
 "out_size": 6244482,
 "ratio": 0.7369,
-"compress_mbps": 56.1,
-"decompress_mbps": 149.43
+"compress_mbps": 55.35,
+"decompress_mbps": 149.04
 },
 {
 "compressor": "zig",
@@ -14494,8 +14494,8 @@
 "level": 7,
 "out_size": 6244482,
 "ratio": 0.7369,
-"compress_mbps": 55.99,
-"decompress_mbps": 149.32
+"compress_mbps": 55.26,
+"decompress_mbps": 148.96
 },
 {
 "compressor": "zig",
@@ -14504,8 +14504,8 @@
 "level": 8,
 "out_size": 6244480,
 "ratio": 0.7369,
-"compress_mbps": 52.87,
-"decompress_mbps": 147.01
+"compress_mbps": 55.76,
+"decompress_mbps": 149.15
 },
 {
 "compressor": "zig",
@@ -14514,8 +14514,8 @@
 "level": 9,
 "out_size": 6244480,
 "ratio": 0.7369,
-"compress_mbps": 55.89,
-"decompress_mbps": 149.48
+"compress_mbps": 55.76,
+"decompress_mbps": 149.06
 },
 {
 "compressor": "zig",
@@ -14524,8 +14524,8 @@
 "level": 1,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 230.97,
-"decompress_mbps": 672.16
+"compress_mbps": 230.26,
+"decompress_mbps": 672.2
 },
 {
 "compressor": "zig",
@@ -14534,8 +14534,8 @@
 "level": 2,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 230.3,
-"decompress_mbps": 670.4
+"compress_mbps": 231.2,
+"decompress_mbps": 669.36
 },
 {
 "compressor": "zig",
@@ -14544,8 +14544,8 @@
 "level": 3,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 231.18,
-"decompress_mbps": 671.19
+"compress_mbps": 230.77,
+"decompress_mbps": 670.71
 },
 {
 "compressor": "zig",
@@ -14554,8 +14554,8 @@
 "level": 4,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 230.93,
-"decompress_mbps": 670.1
+"compress_mbps": 230.62,
+"decompress_mbps": 675.03
 },
 {
 "compressor": "zig",
@@ -14564,8 +14564,8 @@
 "level": 5,
 "out_size": 716461,
 "ratio": 0.134,
-"compress_mbps": 166.23,
-"decompress_mbps": 701.81
+"compress_mbps": 166.95,
+"decompress_mbps": 717.65
 },
 {
 "compressor": "zig",
@@ -14574,8 +14574,8 @@
 "level": 6,
 "out_size": 687053,
 "ratio": 0.1285,
-"compress_mbps": 124.83,
-"decompress_mbps": 737.97
+"compress_mbps": 119.59,
+"decompress_mbps": 723.82
 },
 {
 "compressor": "zig",
@@ -14584,8 +14584,8 @@
 "level": 7,
 "out_size": 673597,
 "ratio": 0.126,
-"compress_mbps": 101.1,
-"decompress_mbps": 747.62
+"compress_mbps": 101.21,
+"decompress_mbps": 741.82
 },
 {
 "compressor": "zig",
@@ -14594,8 +14594,8 @@
 "level": 8,
 "out_size": 662156,
 "ratio": 0.1239,
-"compress_mbps": 65.54,
-"decompress_mbps": 756.01
+"compress_mbps": 65.52,
+"decompress_mbps": 755.83
 },
 {
 "compressor": "zig",
@@ -14604,8 +14604,8 @@
 "level": 9,
 "out_size": 661610,
 "ratio": 0.1238,
-"compress_mbps": 60.95,
-"decompress_mbps": 752.04
+"compress_mbps": 61.34,
+"decompress_mbps": 749.89
 },
 {
 "compressor": "ocaml",
@@ -14614,8 +14614,8 @@
 "level": 1,
 "out_size": 73589,
 "ratio": 0.4839,
-"compress_mbps": 33.95,
-"decompress_mbps": 57.54
+"compress_mbps": 34.0,
+"decompress_mbps": 57.86
 },
 {
 "compressor": "ocaml",
@@ -14624,8 +14624,8 @@
 "level": 2,
 "out_size": 69878,
 "ratio": 0.4595,
-"compress_mbps": 32.18,
-"decompress_mbps": 58.01
+"compress_mbps": 31.61,
+"decompress_mbps": 57.3
 },
 {
 "compressor": "ocaml",
@@ -14634,8 +14634,8 @@
 "level": 3,
 "out_size": 66917,
 "ratio": 0.44,
-"compress_mbps": 26.86,
-"decompress_mbps": 66.53
+"compress_mbps": 26.18,
+"decompress_mbps": 64.01
 },
 {
 "compressor": "ocaml",
@@ -14644,8 +14644,8 @@
 "level": 4,
 "out_size": 59388,
 "ratio": 0.3905,
-"compress_mbps": 31.56,
-"decompress_mbps": 79.33
+"compress_mbps": 31.49,
+"decompress_mbps": 79.65
 },
 {
 "compressor": "ocaml",
@@ -14654,8 +14654,8 @@
 "level": 5,
 "out_size": 57062,
 "ratio": 0.3752,
-"compress_mbps": 22.81,
-"decompress_mbps": 80.43
+"compress_mbps": 22.75,
+"decompress_mbps": 79.85
 },
 {
 "compressor": "ocaml",
@@ -14664,8 +14664,8 @@
 "level": 6,
 "out_size": 55472,
 "ratio": 0.3647,
-"compress_mbps": 16.3,
-"decompress_mbps": 80.07
+"compress_mbps": 16.03,
+"decompress_mbps": 78.4
 },
 {
 "compressor": "ocaml",
@@ -14675,7 +14675,7 @@
 "out_size": 55265,
 "ratio": 0.3634,
 "compress_mbps": 14.39,
-"decompress_mbps": 79.65
+"decompress_mbps": 79.58
 },
 {
 "compressor": "ocaml",
@@ -14684,8 +14684,8 @@
 "level": 8,
 "out_size": 55168,
 "ratio": 0.3627,
-"compress_mbps": 11.93,
-"decompress_mbps": 78.43
+"compress_mbps": 11.79,
+"decompress_mbps": 78.8
 },
 {
 "compressor": "ocaml",
@@ -14694,8 +14694,8 @@
 "level": 9,
 "out_size": 55168,
 "ratio": 0.3627,
-"compress_mbps": 12.01,
-"decompress_mbps": 79.65
+"compress_mbps": 11.98,
+"decompress_mbps": 79.72
 },
 {
 "compressor": "ocaml",
@@ -14704,8 +14704,8 @@
 "level": 1,
 "out_size": 64551,
 "ratio": 0.5157,
-"compress_mbps": 32.07,
-"decompress_mbps": 54.14
+"compress_mbps": 32.2,
+"decompress_mbps": 53.55
 },
 {
 "compressor": "ocaml",
@@ -14714,8 +14714,8 @@
 "level": 2,
 "out_size": 62089,
 "ratio": 0.496,
-"compress_mbps": 30.35,
-"decompress_mbps": 58.39
+"compress_mbps": 30.3,
+"decompress_mbps": 58.28
 },
 {
 "compressor": "ocaml",
@@ -14724,8 +14724,8 @@
 "level": 3,
 "out_size": 58690,
 "ratio": 0.4688,
-"compress_mbps": 24.75,
-"decompress_mbps": 60.45
+"compress_mbps": 24.56,
+"decompress_mbps": 60.54
 },
 {
 "compressor": "ocaml",
@@ -14734,8 +14734,8 @@
 "level": 4,
 "out_size": 53521,
 "ratio": 0.4276,
-"compress_mbps": 30.27,
-"decompress_mbps": 79.97
+"compress_mbps": 29.54,
+"decompress_mbps": 77.82
 },
 {
 "compressor": "ocaml",
@@ -14744,8 +14744,8 @@
 "level": 5,
 "out_size": 51677,
 "ratio": 0.4128,
-"compress_mbps": 20.88,
-"decompress_mbps": 78.06
+"compress_mbps": 20.38,
+"decompress_mbps": 76.66
 },
 {
 "compressor": "ocaml",
@@ -14754,8 +14754,8 @@
 "level": 6,
 "out_size": 50638,
 "ratio": 0.4045,
-"compress_mbps": 14.95,
-"decompress_mbps": 82.4
+"compress_mbps": 15.06,
+"decompress_mbps": 82.8
 },
 {
 "compressor": "ocaml",
@@ -14764,8 +14764,8 @@
 "level": 7,
 "out_size": 50501,
 "ratio": 0.4034,
-"compress_mbps": 13.59,
-"decompress_mbps": 78.56
+"compress_mbps": 13.27,
+"decompress_mbps": 77.7
 },
 {
 "compressor": "ocaml",
@@ -14774,8 +14774,8 @@
 "level": 8,
 "out_size": 50452,
 "ratio": 0.403,
-"compress_mbps": 12.68,
-"decompress_mbps": 83.34
+"compress_mbps": 12.35,
+"decompress_mbps": 80.51
 },
 {
 "compressor": "ocaml",
@@ -14784,8 +14784,8 @@
 "level": 9,
 "out_size": 50452,
 "ratio": 0.403,
-"compress_mbps": 12.58,
-"decompress_mbps": 83.27
+"compress_mbps": 12.52,
+"decompress_mbps": 82.94
 },
 {
 "compressor": "ocaml",
@@ -14794,8 +14794,8 @@
 "level": 1,
 "out_size": 9859,
 "ratio": 0.4007,
-"compress_mbps": 43.83,
-"decompress_mbps": 112.64
+"compress_mbps": 42.58,
+"decompress_mbps": 110.57
 },
 {
 "compressor": "ocaml",
@@ -14804,8 +14804,8 @@
 "level": 2,
 "out_size": 10473,
 "ratio": 0.4257,
-"compress_mbps": 46.7,
-"decompress_mbps": 147.4
+"compress_mbps": 46.43,
+"decompress_mbps": 148.02
 },
 {
 "compressor": "ocaml",
@@ -14814,8 +14814,8 @@
 "level": 3,
 "out_size": 10172,
 "ratio": 0.4134,
-"compress_mbps": 43.33,
-"decompress_mbps": 153.27
+"compress_mbps": 42.8,
+"decompress_mbps": 152.86
 },
 {
 "compressor": "ocaml",
@@ -14824,8 +14824,8 @@
 "level": 4,
 "out_size": 8692,
 "ratio": 0.3533,
-"compress_mbps": 41.01,
-"decompress_mbps": 152.45
+"compress_mbps": 39.93,
+"decompress_mbps": 153.37
 },
 {
 "compressor": "ocaml",
@@ -14834,8 +14834,8 @@
 "level": 5,
 "out_size": 8440,
 "ratio": 0.343,
-"compress_mbps": 35.19,
-"decompress_mbps": 157.05
+"compress_mbps": 34.87,
+"decompress_mbps": 156.11
 },
 {
 "compressor": "ocaml",
@@ -14844,8 +14844,8 @@
 "level": 6,
 "out_size": 8385,
 "ratio": 0.3408,
-"compress_mbps": 31.9,
-"decompress_mbps": 159.26
+"compress_mbps": 30.54,
+"decompress_mbps": 157.37
 },
 {
 "compressor": "ocaml",
@@ -14854,8 +14854,8 @@
 "level": 7,
 "out_size": 8366,
 "ratio": 0.34,
-"compress_mbps": 29.18,
-"decompress_mbps": 156.73
+"compress_mbps": 29.81,
+"decompress_mbps": 158.65
 },
 {
 "compressor": "ocaml",
@@ -14864,8 +14864,8 @@
 "level": 8,
 "out_size": 8367,
 "ratio": 0.3401,
-"compress_mbps": 28.32,
-"decompress_mbps": 157.67
+"compress_mbps": 28.3,
+"decompress_mbps": 156.11
 },
 {
 "compressor": "ocaml",
@@ -14874,8 +14874,8 @@
 "level": 9,
 "out_size": 8367,
 "ratio": 0.3401,
-"compress_mbps": 28.31,
-"decompress_mbps": 158.54
+"compress_mbps": 28.21,
+"decompress_mbps": 158.02
 },
 {
 "compressor": "ocaml",
@@ -14884,8 +14884,8 @@
 "level": 1,
 "out_size": 4822,
 "ratio": 0.4325,
-"compress_mbps": 54.64,
-"decompress_mbps": 186.94
+"compress_mbps": 54.86,
+"decompress_mbps": 187.41
 },
 {
 "compressor": "ocaml",
@@ -14894,8 +14894,8 @@
 "level": 2,
 "out_size": 4593,
 "ratio": 0.4119,
-"compress_mbps": 53.78,
-"decompress_mbps": 193.27
+"compress_mbps": 54.7,
+"decompress_mbps": 193.9
 },
 {
 "compressor": "ocaml",
@@ -14904,8 +14904,8 @@
 "level": 3,
 "out_size": 4381,
 "ratio": 0.3929,
-"compress_mbps": 51.46,
-"decompress_mbps": 200.08
+"compress_mbps": 50.46,
+"decompress_mbps": 200.04
 },
 {
 "compressor": "ocaml",
@@ -14914,8 +14914,8 @@
 "level": 4,
 "out_size": 3725,
 "ratio": 0.3341,
-"compress_mbps": 52.12,
-"decompress_mbps": 203.31
+"compress_mbps": 51.11,
+"decompress_mbps": 207.85
 },
 {
 "compressor": "ocaml",
@@ -14924,8 +14924,8 @@
 "level": 5,
 "out_size": 3614,
 "ratio": 0.3241,
-"compress_mbps": 44.22,
-"decompress_mbps": 207.35
+"compress_mbps": 42.95,
+"decompress_mbps": 207.77
 },
 {
 "compressor": "ocaml",
@@ -14934,8 +14934,8 @@
 "level": 6,
 "out_size": 3578,
 "ratio": 0.3209,
-"compress_mbps": 39.39,
-"decompress_mbps": 212.34
+"compress_mbps": 37.66,
+"decompress_mbps": 209.09
 },
 {
 "compressor": "ocaml",
@@ -14944,8 +14944,8 @@
 "level": 7,
 "out_size": 3572,
 "ratio": 0.3204,
-"compress_mbps": 36.75,
-"decompress_mbps": 206.86
+"compress_mbps": 36.73,
+"decompress_mbps": 206.73
 },
 {
 "compressor": "ocaml",
@@ -14954,8 +14954,8 @@
 "level": 8,
 "out_size": 3568,
 "ratio": 0.32,
-"compress_mbps": 33.76,
-"decompress_mbps": 207.77
+"compress_mbps": 34.26,
+"decompress_mbps": 207.27
 },
 {
 "compressor": "ocaml",
@@ -14964,8 +14964,8 @@
 "level": 9,
 "out_size": 3568,
 "ratio": 0.32,
-"compress_mbps": 34.86,
-"decompress_mbps": 208.58
+"compress_mbps": 33.81,
+"decompress_mbps": 206.08
 },
 {
 "compressor": "ocaml",
@@ -14974,8 +14974,8 @@
 "level": 1,
 "out_size": 1738,
 "ratio": 0.4671,
-"compress_mbps": 32.8,
-"decompress_mbps": 174.49
+"compress_mbps": 32.91,
+"decompress_mbps": 175.87
 },
 {
 "compressor": "ocaml",
@@ -14984,8 +14984,8 @@
 "level": 2,
 "out_size": 1709,
 "ratio": 0.4593,
-"compress_mbps": 32.17,
-"decompress_mbps": 179.93
+"compress_mbps": 32.02,
+"decompress_mbps": 179.28
 },
 {
 "compressor": "ocaml",
@@ -14994,8 +14994,8 @@
 "level": 3,
 "out_size": 1694,
 "ratio": 0.4553,
-"compress_mbps": 31.1,
-"decompress_mbps": 178.36
+"compress_mbps": 30.64,
+"decompress_mbps": 172.97
 },
 {
 "compressor": "ocaml",
@@ -15004,8 +15004,8 @@
 "level": 4,
 "out_size": 1458,
 "ratio": 0.3918,
-"compress_mbps": 30.75,
-"decompress_mbps": 188.34
+"compress_mbps": 30.66,
+"decompress_mbps": 187.78
 },
 {
 "compressor": "ocaml",
@@ -15014,8 +15014,8 @@
 "level": 5,
 "out_size": 1441,
 "ratio": 0.3873,
-"compress_mbps": 28.57,
-"decompress_mbps": 188.96
+"compress_mbps": 27.46,
+"decompress_mbps": 188.54
 },
 {
 "compressor": "ocaml",
@@ -15024,8 +15024,8 @@
 "level": 6,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 28.24,
-"decompress_mbps": 190.62
+"compress_mbps": 27.47,
+"decompress_mbps": 190.41
 },
 {
 "compressor": "ocaml",
@@ -15034,8 +15034,8 @@
 "level": 7,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 28.01,
-"decompress_mbps": 190.57
+"compress_mbps": 27.01,
+"decompress_mbps": 190.2
 },
 {
 "compressor": "ocaml",
@@ -15044,8 +15044,8 @@
 "level": 8,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 27.51,
-"decompress_mbps": 191.2
+"compress_mbps": 27.2,
+"decompress_mbps": 189.99
 },
 {
 "compressor": "ocaml",
@@ -15054,8 +15054,8 @@
 "level": 9,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 27.86,
-"decompress_mbps": 190.62
+"compress_mbps": 27.88,
+"decompress_mbps": 189.94
 },
 {
 "compressor": "ocaml",
@@ -15064,8 +15064,8 @@
 "level": 1,
 "out_size": 260073,
 "ratio": 0.2526,
-"compress_mbps": 52.48,
-"decompress_mbps": 57.64
+"compress_mbps": 52.79,
+"decompress_mbps": 57.19
 },
 {
 "compressor": "ocaml",
@@ -15074,8 +15074,8 @@
 "level": 2,
 "out_size": 296764,
 "ratio": 0.2882,
-"compress_mbps": 48.91,
-"decompress_mbps": 76.95
+"compress_mbps": 48.12,
+"decompress_mbps": 75.97
 },
 {
 "compressor": "ocaml",
@@ -15084,8 +15084,8 @@
 "level": 3,
 "out_size": 288989,
 "ratio": 0.2806,
-"compress_mbps": 37.34,
-"decompress_mbps": 77.44
+"compress_mbps": 37.74,
+"decompress_mbps": 78.57
 },
 {
 "compressor": "ocaml",
@@ -15094,8 +15094,8 @@
 "level": 4,
 "out_size": 246442,
 "ratio": 0.2393,
-"compress_mbps": 55.17,
-"decompress_mbps": 83.19
+"compress_mbps": 54.55,
+"decompress_mbps": 83.01
 },
 {
 "compressor": "ocaml",
@@ -15104,8 +15104,8 @@
 "level": 5,
 "out_size": 218888,
 "ratio": 0.2126,
-"compress_mbps": 40.83,
-"decompress_mbps": 77.12
+"compress_mbps": 40.77,
+"decompress_mbps": 77.4
 },
 {
 "compressor": "ocaml",
@@ -15114,8 +15114,8 @@
 "level": 6,
 "out_size": 217830,
 "ratio": 0.2115,
-"compress_mbps": 24.19,
-"decompress_mbps": 87.86
+"compress_mbps": 24.23,
+"decompress_mbps": 87.72
 },
 {
 "compressor": "ocaml",
@@ -15124,8 +15124,8 @@
 "level": 7,
 "out_size": 221437,
 "ratio": 0.215,
-"compress_mbps": 19.44,
-"decompress_mbps": 86.43
+"compress_mbps": 19.48,
+"decompress_mbps": 86.9
 },
 {
 "compressor": "ocaml",
@@ -15134,8 +15134,8 @@
 "level": 8,
 "out_size": 219666,
 "ratio": 0.2133,
-"compress_mbps": 5.52,
-"decompress_mbps": 86.38
+"compress_mbps": 5.5,
+"decompress_mbps": 85.51
 },
 {
 "compressor": "ocaml",
@@ -15144,8 +15144,8 @@
 "level": 9,
 "out_size": 219921,
 "ratio": 0.2136,
-"compress_mbps": 2.76,
-"decompress_mbps": 86.98
+"compress_mbps": 2.8,
+"decompress_mbps": 87.33
 },
 {
 "compressor": "ocaml",
@@ -15154,8 +15154,8 @@
 "level": 1,
 "out_size": 194588,
 "ratio": 0.456,
-"compress_mbps": 34.17,
-"decompress_mbps": 51.7
+"compress_mbps": 34.49,
+"decompress_mbps": 51.6
 },
 {
 "compressor": "ocaml",
@@ -15164,8 +15164,8 @@
 "level": 2,
 "out_size": 185757,
 "ratio": 0.4353,
-"compress_mbps": 33.03,
-"decompress_mbps": 49.98
+"compress_mbps": 32.22,
+"decompress_mbps": 48.32
 },
 {
 "compressor": "ocaml",
@@ -15174,8 +15174,8 @@
 "level": 3,
 "out_size": 175850,
 "ratio": 0.4121,
-"compress_mbps": 27.43,
-"decompress_mbps": 59.2
+"compress_mbps": 27.33,
+"decompress_mbps": 60.3
 },
 {
 "compressor": "ocaml",
@@ -15184,8 +15184,8 @@
 "level": 4,
 "out_size": 155951,
 "ratio": 0.3654,
-"compress_mbps": 31.58,
-"decompress_mbps": 71.79
+"compress_mbps": 32.18,
+"decompress_mbps": 72.7
 },
 {
 "compressor": "ocaml",
@@ -15194,8 +15194,8 @@
 "level": 5,
 "out_size": 150274,
 "ratio": 0.3521,
-"compress_mbps": 23.26,
-"decompress_mbps": 71.1
+"compress_mbps": 23.21,
+"decompress_mbps": 71.72
 },
 {
 "compressor": "ocaml",
@@ -15204,8 +15204,8 @@
 "level": 6,
 "out_size": 147958,
 "ratio": 0.3467,
-"compress_mbps": 16.55,
-"decompress_mbps": 72.89
+"compress_mbps": 16.54,
+"decompress_mbps": 71.31
 },
 {
 "compressor": "ocaml",
@@ -15214,8 +15214,8 @@
 "level": 7,
 "out_size": 147522,
 "ratio": 0.3457,
-"compress_mbps": 15.22,
-"decompress_mbps": 71.8
+"compress_mbps": 15.18,
+"decompress_mbps": 71.53
 },
 {
 "compressor": "ocaml",
@@ -15224,8 +15224,8 @@
 "level": 8,
 "out_size": 147331,
 "ratio": 0.3452,
-"compress_mbps": 13.56,
-"decompress_mbps": 72.12
+"compress_mbps": 13.48,
+"decompress_mbps": 71.56
 },
 {
 "compressor": "ocaml",
@@ -15234,8 +15234,8 @@
 "level": 9,
 "out_size": 147328,
 "ratio": 0.3452,
-"compress_mbps": 13.62,
-"decompress_mbps": 72.49
+"compress_mbps": 13.54,
+"decompress_mbps": 72.26
 },
 {
 "compressor": "ocaml",
@@ -15244,8 +15244,8 @@
 "level": 1,
 "out_size": 256904,
 "ratio": 0.5331,
-"compress_mbps": 29.13,
-"decompress_mbps": 46.09
+"compress_mbps": 29.48,
+"decompress_mbps": 46.38
 },
 {
 "compressor": "ocaml",
@@ -15254,8 +15254,8 @@
 "level": 2,
 "out_size": 245675,
 "ratio": 0.5098,
-"compress_mbps": 28.5,
-"decompress_mbps": 49.67
+"compress_mbps": 28.42,
+"decompress_mbps": 49.26
 },
 {
 "compressor": "ocaml",
@@ -15264,8 +15264,8 @@
 "level": 3,
 "out_size": 231519,
 "ratio": 0.4805,
-"compress_mbps": 22.32,
-"decompress_mbps": 55.88
+"compress_mbps": 22.72,
+"decompress_mbps": 56.6
 },
 {
 "compressor": "ocaml",
@@ -15274,8 +15274,8 @@
 "level": 4,
 "out_size": 210028,
 "ratio": 0.4359,
-"compress_mbps": 27.98,
-"decompress_mbps": 65.31
+"compress_mbps": 26.96,
+"decompress_mbps": 63.53
 },
 {
 "compressor": "ocaml",
@@ -15285,7 +15285,7 @@
 "out_size": 203312,
 "ratio": 0.4219,
 "compress_mbps": 18.71,
-"decompress_mbps": 61.15
+"decompress_mbps": 61.26
 },
 {
 "compressor": "ocaml",
@@ -15294,8 +15294,8 @@
 "level": 6,
 "out_size": 199287,
 "ratio": 0.4136,
-"compress_mbps": 12.92,
-"decompress_mbps": 66.2
+"compress_mbps": 12.82,
+"decompress_mbps": 66.09
 },
 {
 "compressor": "ocaml",
@@ -15304,8 +15304,8 @@
 "level": 7,
 "out_size": 198474,
 "ratio": 0.4119,
-"compress_mbps": 10.99,
-"decompress_mbps": 64.94
+"compress_mbps": 11.26,
+"decompress_mbps": 66.09
 },
 {
 "compressor": "ocaml",
@@ -15314,8 +15314,8 @@
 "level": 8,
 "out_size": 198080,
 "ratio": 0.4111,
-"compress_mbps": 8.91,
-"decompress_mbps": 64.32
+"compress_mbps": 8.84,
+"decompress_mbps": 64.95
 },
 {
 "compressor": "ocaml",
@@ -15324,8 +15324,8 @@
 "level": 9,
 "out_size": 198080,
 "ratio": 0.4111,
-"compress_mbps": 8.76,
-"decompress_mbps": 64.76
+"compress_mbps": 8.83,
+"decompress_mbps": 65.35
 },
 {
 "compressor": "ocaml",
@@ -15334,8 +15334,8 @@
 "level": 1,
 "out_size": 71229,
 "ratio": 0.1388,
-"compress_mbps": 82.1,
-"decompress_mbps": 135.63
+"compress_mbps": 83.11,
+"decompress_mbps": 135.9
 },
 {
 "compressor": "ocaml",
@@ -15344,8 +15344,8 @@
 "level": 2,
 "out_size": 69946,
 "ratio": 0.1363,
-"compress_mbps": 79.15,
-"decompress_mbps": 137.78
+"compress_mbps": 79.64,
+"decompress_mbps": 137.51
 },
 {
 "compressor": "ocaml",
@@ -15354,8 +15354,8 @@
 "level": 3,
 "out_size": 68538,
 "ratio": 0.1335,
-"compress_mbps": 70.5,
-"decompress_mbps": 151.36
+"compress_mbps": 68.34,
+"decompress_mbps": 151.14
 },
 {
 "compressor": "ocaml",
@@ -15364,8 +15364,8 @@
 "level": 4,
 "out_size": 61320,
 "ratio": 0.1195,
-"compress_mbps": 65.74,
-"decompress_mbps": 163.45
+"compress_mbps": 65.95,
+"decompress_mbps": 164.46
 },
 {
 "compressor": "ocaml",
@@ -15374,8 +15374,8 @@
 "level": 5,
 "out_size": 59993,
 "ratio": 0.1169,
-"compress_mbps": 57.64,
-"decompress_mbps": 168.25
+"compress_mbps": 55.91,
+"decompress_mbps": 163.24
 },
 {
 "compressor": "ocaml",
@@ -15384,8 +15384,8 @@
 "level": 6,
 "out_size": 58637,
 "ratio": 0.1143,
-"compress_mbps": 40.66,
-"decompress_mbps": 166.59
+"compress_mbps": 41.4,
+"decompress_mbps": 168.02
 },
 {
 "compressor": "ocaml",
@@ -15394,8 +15394,8 @@
 "level": 7,
 "out_size": 58209,
 "ratio": 0.1134,
-"compress_mbps": 35.61,
-"decompress_mbps": 171.82
+"compress_mbps": 35.53,
+"decompress_mbps": 172.34
 },
 {
 "compressor": "ocaml",
@@ -15404,8 +15404,8 @@
 "level": 8,
 "out_size": 55749,
 "ratio": 0.1086,
-"compress_mbps": 19.38,
-"decompress_mbps": 177.18
+"compress_mbps": 19.07,
+"decompress_mbps": 176.44
 },
 {
 "compressor": "ocaml",
@@ -15414,8 +15414,8 @@
 "level": 9,
 "out_size": 54927,
 "ratio": 0.107,
-"compress_mbps": 7.54,
-"decompress_mbps": 178.15
+"compress_mbps": 7.46,
+"decompress_mbps": 174.22
 },
 {
 "compressor": "ocaml",
@@ -15424,8 +15424,8 @@
 "level": 1,
 "out_size": 16399,
 "ratio": 0.4288,
-"compress_mbps": 36.03,
-"decompress_mbps": 88.4
+"compress_mbps": 35.77,
+"decompress_mbps": 89.38
 },
 {
 "compressor": "ocaml",
@@ -15434,8 +15434,8 @@
 "level": 2,
 "out_size": 15933,
 "ratio": 0.4167,
-"compress_mbps": 34.0,
-"decompress_mbps": 89.39
+"compress_mbps": 33.98,
+"decompress_mbps": 89.54
 },
 {
 "compressor": "ocaml",
@@ -15444,8 +15444,8 @@
 "level": 3,
 "out_size": 15739,
 "ratio": 0.4116,
-"compress_mbps": 28.08,
-"decompress_mbps": 89.15
+"compress_mbps": 27.4,
+"decompress_mbps": 86.39
 },
 {
 "compressor": "ocaml",
@@ -15454,8 +15454,8 @@
 "level": 4,
 "out_size": 13834,
 "ratio": 0.3618,
-"compress_mbps": 31.72,
-"decompress_mbps": 106.64
+"compress_mbps": 31.54,
+"decompress_mbps": 108.73
 },
 {
 "compressor": "ocaml",
@@ -15464,8 +15464,8 @@
 "level": 5,
 "out_size": 13463,
 "ratio": 0.3521,
-"compress_mbps": 26.05,
-"decompress_mbps": 109.22
+"compress_mbps": 25.5,
+"decompress_mbps": 110.75
 },
 {
 "compressor": "ocaml",
@@ -15474,8 +15474,8 @@
 "level": 6,
 "out_size": 13353,
 "ratio": 0.3492,
-"compress_mbps": 19.01,
-"decompress_mbps": 110.28
+"compress_mbps": 18.6,
+"decompress_mbps": 110.51
 },
 {
 "compressor": "ocaml",
@@ -15484,8 +15484,8 @@
 "level": 7,
 "out_size": 13317,
 "ratio": 0.3482,
-"compress_mbps": 15.82,
-"decompress_mbps": 110.58
+"compress_mbps": 16.01,
+"decompress_mbps": 110.41
 },
 {
 "compressor": "ocaml",
@@ -15494,8 +15494,8 @@
 "level": 8,
 "out_size": 13255,
 "ratio": 0.3466,
-"compress_mbps": 8.39,
-"decompress_mbps": 113.33
+"compress_mbps": 8.37,
+"decompress_mbps": 110.21
 },
 {
 "compressor": "ocaml",
@@ -15504,8 +15504,8 @@
 "level": 9,
 "out_size": 13171,
 "ratio": 0.3444,
-"compress_mbps": 4.15,
-"decompress_mbps": 111.97
+"compress_mbps": 4.12,
+"decompress_mbps": 111.73
 },
 {
 "compressor": "ocaml",
@@ -15514,8 +15514,8 @@
 "level": 1,
 "out_size": 2512,
 "ratio": 0.5943,
-"compress_mbps": 30.36,
-"decompress_mbps": 156.72
+"compress_mbps": 30.51,
+"decompress_mbps": 156.62
 },
 {
 "compressor": "ocaml",
@@ -15524,8 +15524,8 @@
 "level": 2,
 "out_size": 2477,
 "ratio": 0.586,
-"compress_mbps": 30.13,
-"decompress_mbps": 157.85
+"compress_mbps": 28.61,
+"decompress_mbps": 159.7
 },
 {
 "compressor": "ocaml",
@@ -15534,8 +15534,8 @@
 "level": 3,
 "out_size": 2452,
 "ratio": 0.5801,
-"compress_mbps": 31.2,
-"decompress_mbps": 158.48
+"compress_mbps": 30.04,
+"decompress_mbps": 157.59
 },
 {
 "compressor": "ocaml",
@@ -15544,8 +15544,8 @@
 "level": 4,
 "out_size": 2110,
 "ratio": 0.4992,
-"compress_mbps": 29.52,
-"decompress_mbps": 165.23
+"compress_mbps": 29.9,
+"decompress_mbps": 163.35
 },
 {
 "compressor": "ocaml",
@@ -15554,8 +15554,8 @@
 "level": 5,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 27.63,
-"decompress_mbps": 168.41
+"compress_mbps": 28.79,
+"decompress_mbps": 167.52
 },
 {
 "compressor": "ocaml",
@@ -15564,8 +15564,8 @@
 "level": 6,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 29.43,
-"decompress_mbps": 166.32
+"compress_mbps": 28.45,
+"decompress_mbps": 167.55
 },
 {
 "compressor": "ocaml",
@@ -15574,8 +15574,8 @@
 "level": 7,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 28.61,
-"decompress_mbps": 169.94
+"compress_mbps": 28.07,
+"decompress_mbps": 167.91
 },
 {
 "compressor": "ocaml",
@@ -15584,8 +15584,8 @@
 "level": 8,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 28.74,
-"decompress_mbps": 166.6
+"compress_mbps": 27.07,
+"decompress_mbps": 166.74
 },
 {
 "compressor": "ocaml",
@@ -15594,8 +15594,8 @@
 "level": 9,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 28.91,
-"decompress_mbps": 168.52
+"compress_mbps": 28.84,
+"decompress_mbps": 169.65
 },
 {
 "compressor": "ocaml",
@@ -15604,8 +15604,8 @@
 "level": 1,
 "out_size": 5183792,
 "ratio": 0.5086,
-"compress_mbps": 31.24,
-"decompress_mbps": 40.54
+"compress_mbps": 30.88,
+"decompress_mbps": 40.4
 },
 {
 "compressor": "ocaml",
@@ -15614,8 +15614,8 @@
 "level": 2,
 "out_size": 4956750,
 "ratio": 0.4863,
-"compress_mbps": 29.95,
-"decompress_mbps": 43.53
+"compress_mbps": 30.07,
+"decompress_mbps": 43.55
 },
 {
 "compressor": "ocaml",
@@ -15624,8 +15624,8 @@
 "level": 3,
 "out_size": 4644095,
 "ratio": 0.4556,
-"compress_mbps": 23.94,
-"decompress_mbps": 47.86
+"compress_mbps": 23.2,
+"decompress_mbps": 47.39
 },
 {
 "compressor": "ocaml",
@@ -15634,8 +15634,8 @@
 "level": 4,
 "out_size": 4178564,
 "ratio": 0.41,
-"compress_mbps": 29.47,
-"decompress_mbps": 62.49
+"compress_mbps": 28.62,
+"decompress_mbps": 61.44
 },
 {
 "compressor": "ocaml",
@@ -15644,8 +15644,8 @@
 "level": 5,
 "out_size": 4034632,
 "ratio": 0.3958,
-"compress_mbps": 20.07,
-"decompress_mbps": 60.97
+"compress_mbps": 19.71,
+"decompress_mbps": 59.65
 },
 {
 "compressor": "ocaml",
@@ -15654,8 +15654,8 @@
 "level": 6,
 "out_size": 3952244,
 "ratio": 0.3878,
-"compress_mbps": 14.07,
-"decompress_mbps": 61.49
+"compress_mbps": 13.81,
+"decompress_mbps": 60.65
 },
 {
 "compressor": "ocaml",
@@ -15665,7 +15665,7 @@
 "out_size": 3938822,
 "ratio": 0.3864,
 "compress_mbps": 12.19,
-"decompress_mbps": 62.32
+"decompress_mbps": 61.86
 },
 {
 "compressor": "ocaml",
@@ -15674,8 +15674,8 @@
 "level": 8,
 "out_size": 3935171,
 "ratio": 0.3861,
-"compress_mbps": 10.72,
-"decompress_mbps": 61.55
+"compress_mbps": 10.83,
+"decompress_mbps": 60.81
 },
 {
 "compressor": "ocaml",
@@ -15684,8 +15684,8 @@
 "level": 9,
 "out_size": 3935171,
 "ratio": 0.3861,
-"compress_mbps": 10.88,
-"decompress_mbps": 61.52
+"compress_mbps": 10.77,
+"decompress_mbps": 60.93
 },
 {
 "compressor": "ocaml",
@@ -15694,8 +15694,8 @@
 "level": 1,
 "out_size": 25320013,
 "ratio": 0.4943,
-"compress_mbps": 32.03,
-"decompress_mbps": 35.27
+"compress_mbps": 31.38,
+"decompress_mbps": 35.11
 },
 {
 "compressor": "ocaml",
@@ -15704,8 +15704,8 @@
 "level": 2,
 "out_size": 24804084,
 "ratio": 0.4843,
-"compress_mbps": 30.39,
-"decompress_mbps": 36.48
+"compress_mbps": 30.32,
+"decompress_mbps": 36.38
 },
 {
 "compressor": "ocaml",
@@ -15714,8 +15714,8 @@
 "level": 3,
 "out_size": 24241121,
 "ratio": 0.4733,
-"compress_mbps": 25.75,
-"decompress_mbps": 38.22
+"compress_mbps": 25.68,
+"decompress_mbps": 38.29
 },
 {
 "compressor": "ocaml",
@@ -15724,8 +15724,8 @@
 "level": 4,
 "out_size": 20950547,
 "ratio": 0.409,
-"compress_mbps": 29.31,
-"decompress_mbps": 44.59
+"compress_mbps": 29.3,
+"decompress_mbps": 44.31
 },
 {
 "compressor": "ocaml",
@@ -15734,8 +15734,8 @@
 "level": 5,
 "out_size": 20592289,
 "ratio": 0.402,
-"compress_mbps": 24.53,
-"decompress_mbps": 46.38
+"compress_mbps": 24.8,
+"decompress_mbps": 46.43
 },
 {
 "compressor": "ocaml",
@@ -15744,8 +15744,8 @@
 "level": 6,
 "out_size": 20445232,
 "ratio": 0.3992,
-"compress_mbps": 18.78,
-"decompress_mbps": 46.29
+"compress_mbps": 18.69,
+"decompress_mbps": 46.27
 },
 {
 "compressor": "ocaml",
@@ -15754,8 +15754,8 @@
 "level": 7,
 "out_size": 20407676,
 "ratio": 0.3984,
-"compress_mbps": 16.06,
-"decompress_mbps": 46.55
+"compress_mbps": 15.98,
+"decompress_mbps": 46.7
 },
 {
 "compressor": "ocaml",
@@ -15764,8 +15764,8 @@
 "level": 8,
 "out_size": 20389473,
 "ratio": 0.3981,
-"compress_mbps": 10.12,
-"decompress_mbps": 46.3
+"compress_mbps": 10.15,
+"decompress_mbps": 45.81
 },
 {
 "compressor": "ocaml",
@@ -15774,8 +15774,8 @@
 "level": 9,
 "out_size": 20386824,
 "ratio": 0.398,
-"compress_mbps": 6.76,
-"decompress_mbps": 45.93
+"compress_mbps": 6.84,
+"decompress_mbps": 46.29
 },
 {
 "compressor": "ocaml",
@@ -15784,8 +15784,8 @@
 "level": 1,
 "out_size": 3964698,
 "ratio": 0.3976,
-"compress_mbps": 38.18,
-"decompress_mbps": 47.93
+"compress_mbps": 37.98,
+"decompress_mbps": 49.6
 },
 {
 "compressor": "ocaml",
@@ -15794,8 +15794,8 @@
 "level": 2,
 "out_size": 3936391,
 "ratio": 0.3948,
-"compress_mbps": 34.93,
-"decompress_mbps": 47.89
+"compress_mbps": 35.04,
+"decompress_mbps": 48.16
 },
 {
 "compressor": "ocaml",
@@ -15804,8 +15804,8 @@
 "level": 3,
 "out_size": 3823540,
 "ratio": 0.3835,
-"compress_mbps": 27.69,
-"decompress_mbps": 51.33
+"compress_mbps": 28.04,
+"decompress_mbps": 51.71
 },
 {
 "compressor": "ocaml",
@@ -15814,8 +15814,8 @@
 "level": 4,
 "out_size": 3799601,
 "ratio": 0.3811,
-"compress_mbps": 33.2,
-"decompress_mbps": 63.61
+"compress_mbps": 33.33,
+"decompress_mbps": 63.69
 },
 {
 "compressor": "ocaml",
@@ -15824,8 +15824,8 @@
 "level": 5,
 "out_size": 3830938,
 "ratio": 0.3842,
-"compress_mbps": 22.56,
-"decompress_mbps": 57.85
+"compress_mbps": 22.17,
+"decompress_mbps": 58.23
 },
 {
 "compressor": "ocaml",
@@ -15834,8 +15834,8 @@
 "level": 6,
 "out_size": 3808303,
 "ratio": 0.382,
-"compress_mbps": 14.84,
-"decompress_mbps": 57.5
+"compress_mbps": 14.78,
+"decompress_mbps": 57.63
 },
 {
 "compressor": "ocaml",
@@ -15844,8 +15844,8 @@
 "level": 7,
 "out_size": 3802814,
 "ratio": 0.3814,
-"compress_mbps": 12.13,
-"decompress_mbps": 57.26
+"compress_mbps": 11.97,
+"decompress_mbps": 57.81
 },
 {
 "compressor": "ocaml",
@@ -15855,7 +15855,7 @@
 "out_size": 3800355,
 "ratio": 0.3812,
 "compress_mbps": 6.73,
-"decompress_mbps": 59.09
+"decompress_mbps": 57.92
 },
 {
 "compressor": "ocaml",
@@ -15865,7 +15865,7 @@
 "out_size": 3799676,
 "ratio": 0.3811,
 "compress_mbps": 6.05,
-"decompress_mbps": 58.35
+"decompress_mbps": 58.97
 },
 {
 "compressor": "ocaml",
@@ -15874,8 +15874,8 @@
 "level": 1,
 "out_size": 4899547,
 "ratio": 0.146,
-"compress_mbps": 95.03,
-"decompress_mbps": 131.4
+"compress_mbps": 95.96,
+"decompress_mbps": 131.72
 },
 {
 "compressor": "ocaml",
@@ -15884,8 +15884,8 @@
 "level": 2,
 "out_size": 4587004,
 "ratio": 0.1367,
-"compress_mbps": 95.46,
-"decompress_mbps": 142.79
+"compress_mbps": 95.4,
+"decompress_mbps": 144.38
 },
 {
 "compressor": "ocaml",
@@ -15894,8 +15894,8 @@
 "level": 3,
 "out_size": 4229035,
 "ratio": 0.126,
-"compress_mbps": 90.24,
-"decompress_mbps": 152.36
+"compress_mbps": 90.75,
+"decompress_mbps": 154.08
 },
 {
 "compressor": "ocaml",
@@ -15904,8 +15904,8 @@
 "level": 4,
 "out_size": 3791322,
 "ratio": 0.113,
-"compress_mbps": 82.4,
-"decompress_mbps": 161.7
+"compress_mbps": 81.31,
+"decompress_mbps": 160.64
 },
 {
 "compressor": "ocaml",
@@ -15914,8 +15914,8 @@
 "level": 5,
 "out_size": 3449193,
 "ratio": 0.1028,
-"compress_mbps": 73.46,
-"decompress_mbps": 168.48
+"compress_mbps": 73.45,
+"decompress_mbps": 169.63
 },
 {
 "compressor": "ocaml",
@@ -15924,8 +15924,8 @@
 "level": 6,
 "out_size": 3269452,
 "ratio": 0.0974,
-"compress_mbps": 58.78,
-"decompress_mbps": 174.05
+"compress_mbps": 58.52,
+"decompress_mbps": 173.97
 },
 {
 "compressor": "ocaml",
@@ -15934,8 +15934,8 @@
 "level": 7,
 "out_size": 3211286,
 "ratio": 0.0957,
-"compress_mbps": 50.44,
-"decompress_mbps": 173.94
+"compress_mbps": 50.5,
+"decompress_mbps": 174.44
 },
 {
 "compressor": "ocaml",
@@ -15944,8 +15944,8 @@
 "level": 8,
 "out_size": 3101534,
 "ratio": 0.0924,
-"compress_mbps": 27.63,
-"decompress_mbps": 176.69
+"compress_mbps": 27.56,
+"decompress_mbps": 176.12
 },
 {
 "compressor": "ocaml",
@@ -15954,8 +15954,8 @@
 "level": 9,
 "out_size": 3058177,
 "ratio": 0.0911,
-"compress_mbps": 16.5,
-"decompress_mbps": 176.2
+"compress_mbps": 16.59,
+"decompress_mbps": 176.36
 },
 {
 "compressor": "ocaml",
@@ -15964,8 +15964,8 @@
 "level": 1,
 "out_size": 4024327,
 "ratio": 0.6541,
-"compress_mbps": 22.97,
-"decompress_mbps": 30.0
+"compress_mbps": 22.34,
+"decompress_mbps": 29.69
 },
 {
 "compressor": "ocaml",
@@ -15974,8 +15974,8 @@
 "level": 2,
 "out_size": 3953722,
 "ratio": 0.6427,
-"compress_mbps": 21.8,
-"decompress_mbps": 30.49
+"compress_mbps": 21.83,
+"decompress_mbps": 30.54
 },
 {
 "compressor": "ocaml",
@@ -15984,8 +15984,8 @@
 "level": 3,
 "out_size": 3887921,
 "ratio": 0.632,
-"compress_mbps": 18.49,
-"decompress_mbps": 31.17
+"compress_mbps": 18.53,
+"decompress_mbps": 31.51
 },
 {
 "compressor": "ocaml",
@@ -15994,8 +15994,8 @@
 "level": 4,
 "out_size": 3320440,
 "ratio": 0.5397,
-"compress_mbps": 21.32,
-"decompress_mbps": 37.23
+"compress_mbps": 21.35,
+"decompress_mbps": 37.56
 },
 {
 "compressor": "ocaml",
@@ -16004,8 +16004,8 @@
 "level": 5,
 "out_size": 3279338,
 "ratio": 0.533,
-"compress_mbps": 17.94,
-"decompress_mbps": 38.42
+"compress_mbps": 17.93,
+"decompress_mbps": 38.03
 },
 {
 "compressor": "ocaml",
@@ -16014,8 +16014,8 @@
 "level": 6,
 "out_size": 3254309,
 "ratio": 0.529,
-"compress_mbps": 14.01,
-"decompress_mbps": 37.8
+"compress_mbps": 13.71,
+"decompress_mbps": 37.84
 },
 {
 "compressor": "ocaml",
@@ -16024,8 +16024,8 @@
 "level": 7,
 "out_size": 3250139,
 "ratio": 0.5283,
-"compress_mbps": 12.33,
-"decompress_mbps": 37.98
+"compress_mbps": 12.24,
+"decompress_mbps": 37.76
 },
 {
 "compressor": "ocaml",
@@ -16034,8 +16034,8 @@
 "level": 8,
 "out_size": 3247018,
 "ratio": 0.5278,
-"compress_mbps": 10.17,
-"decompress_mbps": 38.04
+"compress_mbps": 10.18,
+"decompress_mbps": 37.87
 },
 {
 "compressor": "ocaml",
@@ -16044,8 +16044,8 @@
 "level": 9,
 "out_size": 3246865,
 "ratio": 0.5278,
-"compress_mbps": 9.47,
-"decompress_mbps": 38.07
+"compress_mbps": 9.45,
+"decompress_mbps": 37.98
 },
 {
 "compressor": "ocaml",
@@ -16054,8 +16054,8 @@
 "level": 1,
 "out_size": 4471091,
 "ratio": 0.4433,
-"compress_mbps": 35.0,
-"decompress_mbps": 69.69
+"compress_mbps": 35.03,
+"decompress_mbps": 69.78
 },
 {
 "compressor": "ocaml",
@@ -16064,8 +16064,8 @@
 "level": 2,
 "out_size": 4372105,
 "ratio": 0.4335,
-"compress_mbps": 34.08,
-"decompress_mbps": 72.67
+"compress_mbps": 33.16,
+"decompress_mbps": 71.97
 },
 {
 "compressor": "ocaml",
@@ -16074,8 +16074,8 @@
 "level": 3,
 "out_size": 4305270,
 "ratio": 0.4269,
-"compress_mbps": 30.33,
-"decompress_mbps": 73.57
+"compress_mbps": 30.15,
+"decompress_mbps": 73.19
 },
 {
 "compressor": "ocaml",
@@ -16084,8 +16084,8 @@
 "level": 4,
 "out_size": 3920495,
 "ratio": 0.3887,
-"compress_mbps": 30.34,
-"decompress_mbps": 64.42
+"compress_mbps": 30.43,
+"decompress_mbps": 64.99
 },
 {
 "compressor": "ocaml",
@@ -16094,8 +16094,8 @@
 "level": 5,
 "out_size": 3853177,
 "ratio": 0.382,
-"compress_mbps": 26.78,
-"decompress_mbps": 63.84
+"compress_mbps": 26.27,
+"decompress_mbps": 63.33
 },
 {
 "compressor": "ocaml",
@@ -16104,8 +16104,8 @@
 "level": 6,
 "out_size": 3780878,
 "ratio": 0.3749,
-"compress_mbps": 23.24,
-"decompress_mbps": 64.07
+"compress_mbps": 22.95,
+"decompress_mbps": 63.59
 },
 {
 "compressor": "ocaml",
@@ -16114,8 +16114,8 @@
 "level": 7,
 "out_size": 3763880,
 "ratio": 0.3732,
-"compress_mbps": 20.22,
-"decompress_mbps": 73.9
+"compress_mbps": 19.76,
+"decompress_mbps": 72.71
 },
 {
 "compressor": "ocaml",
@@ -16124,8 +16124,8 @@
 "level": 8,
 "out_size": 3757719,
 "ratio": 0.3726,
-"compress_mbps": 18.23,
-"decompress_mbps": 73.35
+"compress_mbps": 18.09,
+"decompress_mbps": 72.73
 },
 {
 "compressor": "ocaml",
@@ -16134,8 +16134,8 @@
 "level": 9,
 "out_size": 3757719,
 "ratio": 0.3726,
-"compress_mbps": 18.44,
-"decompress_mbps": 72.92
+"compress_mbps": 18.27,
+"decompress_mbps": 73.27
 },
 {
 "compressor": "ocaml",
@@ -16144,8 +16144,8 @@
 "level": 1,
 "out_size": 2722387,
 "ratio": 0.4108,
-"compress_mbps": 38.31,
-"decompress_mbps": 65.35
+"compress_mbps": 38.11,
+"decompress_mbps": 64.91
 },
 {
 "compressor": "ocaml",
@@ -16154,8 +16154,8 @@
 "level": 2,
 "out_size": 2572544,
 "ratio": 0.3882,
-"compress_mbps": 37.37,
-"decompress_mbps": 71.26
+"compress_mbps": 36.89,
+"decompress_mbps": 70.61
 },
 {
 "compressor": "ocaml",
@@ -16164,8 +16164,8 @@
 "level": 3,
 "out_size": 2384328,
 "ratio": 0.3598,
-"compress_mbps": 28.57,
-"decompress_mbps": 77.96
+"compress_mbps": 28.61,
+"decompress_mbps": 77.97
 },
 {
 "compressor": "ocaml",
@@ -16174,8 +16174,8 @@
 "level": 4,
 "out_size": 2112060,
 "ratio": 0.3187,
-"compress_mbps": 36.49,
-"decompress_mbps": 84.65
+"compress_mbps": 36.54,
+"decompress_mbps": 85.76
 },
 {
 "compressor": "ocaml",
@@ -16184,8 +16184,8 @@
 "level": 5,
 "out_size": 1991581,
 "ratio": 0.3005,
-"compress_mbps": 25.62,
-"decompress_mbps": 89.47
+"compress_mbps": 25.58,
+"decompress_mbps": 91.86
 },
 {
 "compressor": "ocaml",
@@ -16194,8 +16194,8 @@
 "level": 6,
 "out_size": 1917866,
 "ratio": 0.2894,
-"compress_mbps": 15.15,
-"decompress_mbps": 90.66
+"compress_mbps": 15.19,
+"decompress_mbps": 91.06
 },
 {
 "compressor": "ocaml",
@@ -16204,8 +16204,8 @@
 "level": 7,
 "out_size": 1895353,
 "ratio": 0.286,
-"compress_mbps": 10.92,
-"decompress_mbps": 89.46
+"compress_mbps": 11.07,
+"decompress_mbps": 90.89
 },
 {
 "compressor": "ocaml",
@@ -16215,7 +16215,7 @@
 "out_size": 1880740,
 "ratio": 0.2838,
 "compress_mbps": 5.58,
-"decompress_mbps": 91.07
+"decompress_mbps": 91.62
 },
 {
 "compressor": "ocaml",
@@ -16225,7 +16225,7 @@
 "out_size": 1880711,
 "ratio": 0.2838,
 "compress_mbps": 5.57,
-"decompress_mbps": 91.13
+"decompress_mbps": 92.01
 },
 {
 "compressor": "ocaml",
@@ -16234,8 +16234,8 @@
 "level": 1,
 "out_size": 7441483,
 "ratio": 0.3444,
-"compress_mbps": 44.06,
-"decompress_mbps": 66.48
+"compress_mbps": 44.52,
+"decompress_mbps": 67.14
 },
 {
 "compressor": "ocaml",
@@ -16244,8 +16244,8 @@
 "level": 2,
 "out_size": 7229248,
 "ratio": 0.3346,
-"compress_mbps": 43.12,
-"decompress_mbps": 68.76
+"compress_mbps": 42.44,
+"decompress_mbps": 68.92
 },
 {
 "compressor": "ocaml",
@@ -16254,8 +16254,8 @@
 "level": 3,
 "out_size": 7083451,
 "ratio": 0.3278,
-"compress_mbps": 38.99,
-"decompress_mbps": 71.31
+"compress_mbps": 39.23,
+"decompress_mbps": 71.48
 },
 {
 "compressor": "ocaml",
@@ -16264,8 +16264,8 @@
 "level": 4,
 "out_size": 6189639,
 "ratio": 0.2865,
-"compress_mbps": 42.47,
-"decompress_mbps": 92.5
+"compress_mbps": 42.14,
+"decompress_mbps": 92.48
 },
 {
 "compressor": "ocaml",
@@ -16274,8 +16274,8 @@
 "level": 5,
 "out_size": 6053058,
 "ratio": 0.2802,
-"compress_mbps": 34.44,
-"decompress_mbps": 95.5
+"compress_mbps": 35.22,
+"decompress_mbps": 96.15
 },
 {
 "compressor": "ocaml",
@@ -16284,8 +16284,8 @@
 "level": 6,
 "out_size": 5988137,
 "ratio": 0.2771,
-"compress_mbps": 28.64,
-"decompress_mbps": 102.56
+"compress_mbps": 28.91,
+"decompress_mbps": 102.51
 },
 {
 "compressor": "ocaml",
@@ -16294,8 +16294,8 @@
 "level": 7,
 "out_size": 5949908,
 "ratio": 0.2754,
-"compress_mbps": 25.18,
-"decompress_mbps": 104.39
+"compress_mbps": 25.24,
+"decompress_mbps": 103.3
 },
 {
 "compressor": "ocaml",
@@ -16304,8 +16304,8 @@
 "level": 8,
 "out_size": 5936656,
 "ratio": 0.2748,
-"compress_mbps": 19.29,
-"decompress_mbps": 106.41
+"compress_mbps": 19.41,
+"decompress_mbps": 106.03
 },
 {
 "compressor": "ocaml",
@@ -16314,8 +16314,8 @@
 "level": 9,
 "out_size": 5934701,
 "ratio": 0.2747,
-"compress_mbps": 17.96,
-"decompress_mbps": 105.65
+"compress_mbps": 18.05,
+"decompress_mbps": 105.62
 },
 {
 "compressor": "ocaml",
@@ -16324,8 +16324,8 @@
 "level": 1,
 "out_size": 6335542,
 "ratio": 0.8736,
-"compress_mbps": 18.55,
-"decompress_mbps": 31.43
+"compress_mbps": 18.5,
+"decompress_mbps": 31.54
 },
 {
 "compressor": "ocaml",
@@ -16335,7 +16335,7 @@
 "out_size": 6247260,
 "ratio": 0.8615,
 "compress_mbps": 17.56,
-"decompress_mbps": 48.44
+"decompress_mbps": 48.25
 },
 {
 "compressor": "ocaml",
@@ -16344,8 +16344,8 @@
 "level": 3,
 "out_size": 6064713,
 "ratio": 0.8363,
-"compress_mbps": 15.2,
-"decompress_mbps": 56.63
+"compress_mbps": 14.81,
+"decompress_mbps": 56.29
 },
 {
 "compressor": "ocaml",
@@ -16354,8 +16354,8 @@
 "level": 4,
 "out_size": 5568111,
 "ratio": 0.7678,
-"compress_mbps": 17.6,
-"decompress_mbps": 59.45
+"compress_mbps": 17.57,
+"decompress_mbps": 58.14
 },
 {
 "compressor": "ocaml",
@@ -16364,8 +16364,8 @@
 "level": 5,
 "out_size": 5544524,
 "ratio": 0.7646,
-"compress_mbps": 14.51,
-"decompress_mbps": 66.18
+"compress_mbps": 14.15,
+"decompress_mbps": 65.58
 },
 {
 "compressor": "ocaml",
@@ -16374,8 +16374,8 @@
 "level": 6,
 "out_size": 5513056,
 "ratio": 0.7602,
-"compress_mbps": 11.98,
-"decompress_mbps": 62.95
+"compress_mbps": 11.94,
+"decompress_mbps": 62.93
 },
 {
 "compressor": "ocaml",
@@ -16384,8 +16384,8 @@
 "level": 7,
 "out_size": 5508915,
 "ratio": 0.7596,
-"compress_mbps": 11.34,
-"decompress_mbps": 64.97
+"compress_mbps": 11.17,
+"decompress_mbps": 63.48
 },
 {
 "compressor": "ocaml",
@@ -16394,8 +16394,8 @@
 "level": 8,
 "out_size": 5508365,
 "ratio": 0.7596,
-"compress_mbps": 10.61,
-"decompress_mbps": 63.85
+"compress_mbps": 10.39,
+"decompress_mbps": 64.75
 },
 {
 "compressor": "ocaml",
@@ -16404,8 +16404,8 @@
 "level": 9,
 "out_size": 5508365,
 "ratio": 0.7596,
-"compress_mbps": 10.59,
-"decompress_mbps": 64.19
+"compress_mbps": 10.35,
+"decompress_mbps": 63.58
 },
 {
 "compressor": "ocaml",
@@ -16414,8 +16414,8 @@
 "level": 1,
 "out_size": 16776095,
 "ratio": 0.4046,
-"compress_mbps": 37.78,
-"decompress_mbps": 51.38
+"compress_mbps": 37.06,
+"decompress_mbps": 50.77
 },
 {
 "compressor": "ocaml",
@@ -16424,8 +16424,8 @@
 "level": 2,
 "out_size": 16032651,
 "ratio": 0.3867,
-"compress_mbps": 36.19,
-"decompress_mbps": 54.78
+"compress_mbps": 35.71,
+"decompress_mbps": 54.63
 },
 {
 "compressor": "ocaml",
@@ -16434,8 +16434,8 @@
 "level": 3,
 "out_size": 15180334,
 "ratio": 0.3662,
-"compress_mbps": 31.2,
-"decompress_mbps": 52.36
+"compress_mbps": 31.09,
+"decompress_mbps": 52.01
 },
 {
 "compressor": "ocaml",
@@ -16444,8 +16444,8 @@
 "level": 4,
 "out_size": 13261924,
 "ratio": 0.3199,
-"compress_mbps": 36.1,
-"decompress_mbps": 68.69
+"compress_mbps": 35.02,
+"decompress_mbps": 68.02
 },
 {
 "compressor": "ocaml",
@@ -16454,8 +16454,8 @@
 "level": 5,
 "out_size": 12706028,
 "ratio": 0.3065,
-"compress_mbps": 27.82,
-"decompress_mbps": 71.53
+"compress_mbps": 27.56,
+"decompress_mbps": 71.11
 },
 {
 "compressor": "ocaml",
@@ -16464,8 +16464,8 @@
 "level": 6,
 "out_size": 12464158,
 "ratio": 0.3006,
-"compress_mbps": 21.35,
-"decompress_mbps": 70.7
+"compress_mbps": 20.73,
+"decompress_mbps": 70.78
 },
 {
 "compressor": "ocaml",
@@ -16474,8 +16474,8 @@
 "level": 7,
 "out_size": 12375954,
 "ratio": 0.2985,
-"compress_mbps": 18.29,
-"decompress_mbps": 72.74
+"compress_mbps": 17.9,
+"decompress_mbps": 71.29
 },
 {
 "compressor": "ocaml",
@@ -16484,8 +16484,8 @@
 "level": 8,
 "out_size": 12321552,
 "ratio": 0.2972,
-"compress_mbps": 14.48,
-"decompress_mbps": 70.48
+"compress_mbps": 14.46,
+"decompress_mbps": 70.23
 },
 {
 "compressor": "ocaml",
@@ -16494,8 +16494,8 @@
 "level": 9,
 "out_size": 12320276,
 "ratio": 0.2972,
-"compress_mbps": 14.47,
-"decompress_mbps": 70.51
+"compress_mbps": 14.29,
+"decompress_mbps": 70.56
 },
 {
 "compressor": "ocaml",
@@ -16504,8 +16504,8 @@
 "level": 1,
 "out_size": 6799201,
 "ratio": 0.8023,
-"compress_mbps": 18.48,
-"decompress_mbps": 18.32
+"compress_mbps": 18.07,
+"decompress_mbps": 18.28
 },
 {
 "compressor": "ocaml",
@@ -16514,8 +16514,8 @@
 "level": 2,
 "out_size": 6800500,
 "ratio": 0.8025,
-"compress_mbps": 16.97,
-"decompress_mbps": 18.57
+"compress_mbps": 16.96,
+"decompress_mbps": 18.38
 },
 {
 "compressor": "ocaml",
@@ -16524,8 +16524,8 @@
 "level": 3,
 "out_size": 6803212,
 "ratio": 0.8028,
-"compress_mbps": 14.91,
-"decompress_mbps": 18.41
+"compress_mbps": 14.66,
+"decompress_mbps": 18.44
 },
 {
 "compressor": "ocaml",
@@ -16534,8 +16534,8 @@
 "level": 4,
 "out_size": 6264611,
 "ratio": 0.7393,
-"compress_mbps": 17.16,
-"decompress_mbps": 24.72
+"compress_mbps": 16.89,
+"decompress_mbps": 24.79
 },
 {
 "compressor": "ocaml",
@@ -16544,8 +16544,8 @@
 "level": 5,
 "out_size": 6217901,
 "ratio": 0.7337,
-"compress_mbps": 15.85,
-"decompress_mbps": 25.44
+"compress_mbps": 15.52,
+"decompress_mbps": 25.08
 },
 {
 "compressor": "ocaml",
@@ -16554,8 +16554,8 @@
 "level": 6,
 "out_size": 6201999,
 "ratio": 0.7319,
-"compress_mbps": 15.41,
-"decompress_mbps": 25.4
+"compress_mbps": 15.26,
+"decompress_mbps": 25.27
 },
 {
 "compressor": "ocaml",
@@ -16564,8 +16564,8 @@
 "level": 7,
 "out_size": 6201883,
 "ratio": 0.7319,
-"compress_mbps": 15.38,
-"decompress_mbps": 25.02
+"compress_mbps": 15.29,
+"decompress_mbps": 24.94
 },
 {
 "compressor": "ocaml",
@@ -16574,8 +16574,8 @@
 "level": 8,
 "out_size": 6201887,
 "ratio": 0.7319,
-"compress_mbps": 15.41,
-"decompress_mbps": 24.94
+"compress_mbps": 14.91,
+"decompress_mbps": 24.78
 },
 {
 "compressor": "ocaml",
@@ -16584,8 +16584,8 @@
 "level": 9,
 "out_size": 6201887,
 "ratio": 0.7319,
-"compress_mbps": 15.37,
-"decompress_mbps": 24.92
+"compress_mbps": 15.21,
+"decompress_mbps": 24.8
 },
 {
 "compressor": "ocaml",
@@ -16594,8 +16594,8 @@
 "level": 1,
 "out_size": 1081679,
 "ratio": 0.2024,
-"compress_mbps": 73.03,
-"decompress_mbps": 108.07
+"compress_mbps": 74.77,
+"decompress_mbps": 107.65
 },
 {
 "compressor": "ocaml",
@@ -16604,8 +16604,8 @@
 "level": 2,
 "out_size": 1001890,
 "ratio": 0.1874,
-"compress_mbps": 73.86,
-"decompress_mbps": 117.58
+"compress_mbps": 72.28,
+"decompress_mbps": 116.39
 },
 {
 "compressor": "ocaml",
@@ -16614,7 +16614,7 @@
 "level": 3,
 "out_size": 921722,
 "ratio": 0.1724,
-"compress_mbps": 67.29,
+"compress_mbps": 66.78,
 "decompress_mbps": 128.43
 },
 {
@@ -16624,8 +16624,8 @@
 "level": 4,
 "out_size": 849263,
 "ratio": 0.1589,
-"compress_mbps": 65.72,
-"decompress_mbps": 142.74
+"compress_mbps": 64.02,
+"decompress_mbps": 140.82
 },
 {
 "compressor": "ocaml",
@@ -16634,8 +16634,8 @@
 "level": 5,
 "out_size": 771964,
 "ratio": 0.1444,
-"compress_mbps": 55.23,
-"decompress_mbps": 143.96
+"compress_mbps": 54.38,
+"decompress_mbps": 142.2
 },
 {
 "compressor": "ocaml",
@@ -16644,8 +16644,8 @@
 "level": 6,
 "out_size": 728098,
 "ratio": 0.1362,
-"compress_mbps": 42.9,
-"decompress_mbps": 151.53
+"compress_mbps": 42.78,
+"decompress_mbps": 149.85
 },
 {
 "compressor": "ocaml",
@@ -16654,8 +16654,8 @@
 "level": 7,
 "out_size": 713635,
 "ratio": 0.1335,
-"compress_mbps": 37.37,
-"decompress_mbps": 155.41
+"compress_mbps": 37.25,
+"decompress_mbps": 153.54
 },
 {
 "compressor": "ocaml",
@@ -16664,8 +16664,8 @@
 "level": 8,
 "out_size": 699093,
 "ratio": 0.1308,
-"compress_mbps": 27.38,
-"decompress_mbps": 146.92
+"compress_mbps": 26.78,
+"decompress_mbps": 143.66
 },
 {
 "compressor": "ocaml",
@@ -16674,8 +16674,8 @@
 "level": 9,
 "out_size": 698459,
 "ratio": 0.1307,
-"compress_mbps": 25.12,
-"decompress_mbps": 148.81
+"compress_mbps": 25.0,
+"decompress_mbps": 147.53
 }
 ]
 }


### PR DESCRIPTION
This PR adds a one-byte-lookahead (zlib `deflate_slow`-style) lazy variant of the greedy hash-chain LZ77 matcher and dispatches compression levels ≥4 to it, closing part (1) of https://github.com/kim-em/lean-zip/issues/2526 — stronger LZ77 parsing to close the ratio gap. The new `lz77ChainLazy`/`lz77ChainLazyIter` reuse `lz77Chain`'s `chainWalk`/`updateHashes` unchanged; match-finding stays opaque to correctness, so the four contracts (`valid`, `resolves`, `encodable`, `empty`) carry through `chainWalk_spec` exactly as for the greedy matcher, and the end-to-end capstone `inflate_deflateRaw` is proven for the new path with zero new `sorry`.

The deferral is distance-guarded: it emits a literal and defers to the `pos+1` match only when that match is **both longer and no farther** than the `pos` match. A naive length-only deferral (plain zlib lazy) regressed large text up to +22% on Canterbury — it trades a cheap close match for an expensive far one — because the extra distance bits outweigh the saved length. Guarding on distance keeps only the beneficial deferrals: **−5.2% vs the greedy chain across Canterbury levels 4–9, 64/66 cells improved**. The guard is opaque to the proofs (`chainWalk_spec` validates any chosen match under any deferral predicate), so it required no proof changes.

It is not a global optimum — `lcet10` at the shallow levels 4–5 still loses ~19% to a Huffman-distribution effect that no purely *local* deferral rule separates from the marginal deferrals other text needs; closing that needs the cost-model parse of #2526 part (2). The level dispatch routes through a single `lzMatch` selector (greedy at 1–3, lazy at ≥4), and the roundtrip and block-split proofs consume a shared `lzMatch_*` contract trio that cases on the level, so the greedy/lazy split lives in exactly one place. All three matcher consumers — the single-block `deflateRawBase`, the self-contained split, and the cross-block shared-window split (#2527) — go through `lzMatch`, so the lazy parse also applies inside the level-≥7 block-split candidates where it matters most for large text.

🤖 Prepared with Claude Code