### PR TITLE
perf: corpus-validated block-split chunk defaults (sc 16384, shared 8192)

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -456,12 +456,17 @@ def deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (level : UInt8) 
   else
     (emitChunkBlocks data chunkSize level 0 BitWriter.empty).flush
 
-/-- Chunk size for block splitting in `deflateRaw`: each ~32 KiB run gets its own
+/-- Chunk size for block splitting in `deflateRaw`: each ~16 KiB run gets its own
     dynamic Huffman tree and a fresh match window. Large enough to keep per-block
     header overhead negligible, small enough to let the trees track local
     statistics. `pickSmaller` makes the exact value a pure ratio knob (never a
-    correctness or regression concern). -/
-def splitChunkSize : Nat := 32768
+    correctness or regression concern). 16384 is the joint optimum with
+    `sharedTokChunk` of a Canterbury + Silesia sweep at levels 7–9 (#2529, `lake
+    exe ratio-sweep`). The joint framing matters: in isolation ever-larger chunks
+    sized smaller (less window loss), but `deflateRaw` deploys this variant only
+    on the files where it beats the cross-block split, and there 16384 won at
+    every level. -/
+def splitChunkSize : Nat := 16384
 
 /-! ## Cross-block (shared-window) block-split dynamic compression
 
@@ -501,10 +506,14 @@ termination_by toks.size - pos
 decreasing_by simp_all only [Nat.not_le]; omega
 
 /-- Token-group size for cross-block splitting in `deflateRaw`: number of LZ77
-    tokens per block. A pure ratio knob (`pickSmaller` guards regression); 4096
-    is the measured optimum on text (smaller groups are dominated by per-block
-    header overhead, larger ones by coarser local-statistics tracking). -/
-def sharedTokChunk : Nat := 4096
+    tokens per block. A pure ratio knob (`pickSmaller` guards regression); 8192
+    is the joint optimum with `splitChunkSize` of a Canterbury + Silesia sweep at
+    levels 7–9 (#2529, `lake exe ratio-sweep`) — the same value at every level,
+    so a single global default suffices. Smaller groups are dominated by
+    per-block header overhead, larger ones by coarser local-statistics tracking;
+    the curve is shallow around the optimum (8192 beat 16384 by ~0.015% of
+    corpus total) but moving off the prior single-sample 4096 was worth ~0.19%. -/
+def sharedTokChunk : Nat := 8192
 
 /-- Cross-block (shared-window) block-split dynamic compression. Matches the
     whole input once, then partitions the token stream into `tokChunk`-token

--- a/ZipRatioSweep.lean
+++ b/ZipRatioSweep.lean
@@ -1,0 +1,100 @@
+import Zip
+/-! # ratio-sweep — block-split knob sweep probe
+
+Sweeps the two `deflateRaw` block-split size knobs — `splitChunkSize`
+(self-contained split) and `sharedTokChunk` (cross-block split) — over corpus
+files at the max-compression tiers (levels 7–9, the only levels where the
+splits activate), printing one CSV row per measurement:
+
+    <file>,<level>,<variant>,<knob>,<size>
+
+with no header (invocations are concatenated by a parallel driver). Variants:
+
+  * `base`   — single-block `deflateRawBase` (the `pickSmaller` floor); empty knob
+  * `sc`     — `deflateDynamicBlocksSC` at each chunk-size candidate (each is a
+               full fresh-window match pass — chunks must be matched in isolation,
+               so the passes cannot be shared across candidates)
+  * `shared` — cross-block split at each token-chunk candidate; the whole-file
+               `lzMatch` token pass is computed **once** per (file, level) and
+               re-partitioned per candidate via `emitSharedBlocks`
+  * `zlib`   — FFI zlib raw deflate at the same level (reference); empty knob
+
+Sanity assertions cross-check the reused-token-pass emission against the real
+`deflateDynamicBlocksShared`, and `min` over the candidates at the current
+defaults against what `deflateRaw` actually emits — so the sweep measures the
+deployed candidates, not near-copies. `--fast` skips these (re-running the
+default candidates roughly doubles the per-file cost on large inputs).
+
+Usage: lake exe ratio-sweep [--fast] <file> [<file> ...]
+-/
+
+open Zip.Native (BitWriter)
+open Zip.Native.Deflate
+
+/-- Self-contained split chunk-size candidates (powers of two bracketing the
+    current `splitChunkSize = 32768`). -/
+def scGrid : List Nat := [8192, 16384, 32768, 65536, 131072]
+
+/-- Cross-block split token-chunk candidates (powers of two bracketing the
+    current `sharedTokChunk = 4096`). -/
+def sharedGrid : List Nat := [1024, 2048, 4096, 8192, 16384, 32768]
+
+/-- The block-split activation range of `deflateRaw`. -/
+def sweepLevels : List UInt8 := [7, 8, 9]
+
+/-- Shared-variant compressed size at `tokChunk`, reusing the precomputed
+    whole-file token stream (`deflateDynamicBlocksShared` recomputes it per
+    call; the partitioning itself is cheap). Mirrors its empty-input guard. -/
+def sharedSizeAt (data : ByteArray) (toks : Array LZ77Token) (level : UInt8)
+    (tokChunk : Nat) : Nat :=
+  if data.size == 0 then (deflateDynamicBlocksShared data tokChunk level).size
+  else ((emitSharedBlocks data toks tokChunk 0 BitWriter.empty).flush).size
+
+def row (file : String) (level : UInt8) (variant knob : String) (size : Nat) :
+    String :=
+  s!"{file},{level},{variant},{knob},{size}"
+
+/-- Sweep one file at all `sweepLevels`, printing CSV rows to stdout. -/
+def runFile (verify : Bool) (path : String) : IO Unit := do
+  let data ← IO.FS.readBinFile path
+  -- Label rows as "<parent>/<file>" (e.g. "silesia/dickens") when available.
+  let p := System.FilePath.mk path
+  let label := match p.parent >>= (·.fileName), p.fileName with
+    | some d, some f => s!"{d}/{f}"
+    | _, some f => f
+    | _, _ => path
+  for level in sweepLevels do
+    IO.println (row label level "base" "" (deflateRawBase data level).size)
+    -- One match pass per (file, level), re-partitioned per candidate.
+    let toks := lzMatch data level
+    let mut sharedDefault := 0
+    for t in sharedGrid do
+      let sz := sharedSizeAt data toks level t
+      if t == sharedTokChunk then sharedDefault := sz
+      IO.println (row label level "shared" (toString t) sz)
+    let mut scDefault := 0
+    for c in scGrid do
+      let sz := (deflateDynamicBlocksSC data c level).size
+      if c == splitChunkSize then scDefault := sz
+      IO.println (row label level "sc" (toString c) sz)
+    IO.println (row label level "zlib" "" (← RawDeflate.compress data level).size)
+    if verify then
+      -- The reused-token-pass emission must equal the deployed shared variant …
+      let sharedReal := (deflateDynamicBlocksShared data sharedTokChunk level).size
+      unless sharedDefault == sharedReal do
+        throw (IO.userError
+          s!"{label} L{level}: shared probe {sharedDefault} ≠ deflateDynamicBlocksShared {sharedReal}")
+      -- … and the best candidate at the current defaults must be what
+      -- `deflateRaw` emits (`pickSmaller` over the same three streams).
+      let emitted := (deflateRaw data level).size
+      let best := min (deflateRawBase data level).size (min scDefault sharedDefault)
+      unless best == emitted do
+        throw (IO.userError
+          s!"{label} L{level}: min(candidates) {best} ≠ deflateRaw {emitted}")
+    IO.eprintln s!"  {label} L{level} done"
+
+def main (args : List String) : IO Unit := do
+  let (fast, files) := (args.contains "--fast", args.filter (· ≠ "--fast"))
+  if files.isEmpty then
+    throw (IO.userError "usage: ratio-sweep [--fast] <file> [<file> ...]")
+  files.forM (runFile (verify := !fast))

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -267,6 +267,9 @@ lean_exe bench where
 lean_exe «bench-report» where
   root := `ZipBenchReport
 
+lean_exe «ratio-sweep» where
+  root := `ZipRatioSweep
+
 lean_exe fuzz_inflate where
   root := `ZipFuzzInflate
 

--- a/progress/2529-knob-sweep.md
+++ b/progress/2529-knob-sweep.md
@@ -1,0 +1,60 @@
+# Progress: Corpus-validated block-split knob defaults (#2529)
+
+- **Date**: 2026-06-10 UTC
+- **Session**: interactive (Kim + Claude), isolated worktree
+- **Issue**: #2529
+
+## Accomplished
+
+Swept both `deflateRaw` block-split size knobs over Canterbury (11 files)
++ Silesia (12 files, ~202 MB) at levels 7–9 with a new compiled probe
+(`lake exe ratio-sweep`, committed), and retuned the defaults:
+
+- `sharedTokChunk`: 4096 → **8192**
+- `splitChunkSize`: 32768 → **16384**
+
+Headline: −0.188% corpus-total compressed size across levels 7–9
+(−389 KB; ~−128–134 KB per level), with the same optimum at every level
+— so single global defaults, **no level-dependence** (headroom of the
+per-level optima over the best global pair was exactly 0 bytes).
+
+## Method
+
+Probe prints CSV sizes per (file, level) for: single-block base, the
+self-contained split at chunk sizes {8192…131072}, the cross-block split
+at token chunks {1024…32768} (one `lzMatch` pass per (file, level),
+re-partitioned per candidate), and FFI zlib reference. 897 rows total.
+
+Selection was **joint**, not independent per knob: `deflateRaw` emits
+`min(base, sc(c), shared(t))`, and the full 30-cell Cartesian grid per
+level showed the interaction matters — in isolation the self-contained
+curve improves monotonically toward 131072, but jointly (with `shared`
+already winning the large-text files) `sc = 16384` beats it. An
+independent argmin would have picked the wrong value.
+
+Optimum (16384, 8192) is interior to both grids (no endpoint extension
+needed). Per-file regression policy (reject if any file regresses
+> 0.5% **and** > 1 KiB vs the old defaults): 13 small regressions, all
+≤ 180 bytes / ≤ 0.36% (Canterbury small files), summed ~660 bytes vs
+~390 KB total win — passes.
+
+Probe self-checks (always on unless `--fast`): the reused-token-pass
+emission equals `deflateDynamicBlocksShared`, and min over the default
+candidates equals `(deflateRaw …).size`. A post-change confirmation run
+over Canterbury matched the sweep's predicted sizes in all 33 cells.
+
+## Notes for #2528 (cost-model boundary heuristic)
+
+- The fixed-cadence baseline the heuristic must beat is now
+  (sc=16384, shared=8192) at 68,874,489 bytes corpus-total at level 9.
+- The shared-knob curve is shallow around the optimum (8192 beat 16384
+  by ~0.015% of corpus total), so the heuristic's win, if any, will come
+  from *adaptive* boundaries, not from better fixed cadence.
+- Sweep data: probe is committed; sizes are deterministic and
+  reproducible via `bash bench/fetch_corpora.sh silesia` +
+  `ls bench/corpora/{canterbury,silesia}/* | xargs -P 4 -n 1
+  .lake/build/bin/ratio-sweep`.
+
+## Not completed
+
+Nothing outstanding; #2529 can close when the PR lands.


### PR DESCRIPTION
This PR retune the two `deflateRaw` block-split size knobs from a joint Canterbury + Silesia sweep at the max-compression tiers and add the compiled probe that produced the numbers (`lake exe ratio-sweep`). `sharedTokChunk` moves 4096 → 8192 and `splitChunkSize` 32768 → 16384, for −0.188% corpus-total compressed size across levels 7–9 (−389 KB; ~−130 KB per level). The optimum pair is identical at all three levels, so the defaults stay global — the issue's level-dependence question closes as "no" (per-level headroom over the best global pair was exactly 0 bytes). This is a pure ratio change: the roundtrip theorems quantify over arbitrary chunk sizes and `pickSmaller` floors every file at the single-block base.

Selection used the full Cartesian objective Σ min(base, sc(c), shared(t)) per level (30 cells from one 897-row sweep), not independent per-knob argmins — the interaction matters. In isolation the self-contained curve improves monotonically toward 131072, but `deflateRaw` only deploys that variant on files where it beats the cross-block split, and there 16384 wins at every level; an independent argmin would have mistuned. The chosen pair is interior to both candidate grids, and per-file checks against the old defaults show 13 regressions all ≤ 180 bytes / ≤ 0.36% (Canterbury small files, ~660 bytes summed) against the ~390 KB total win. Level-9 corpus totals land at 1.0074× FFI zlib.

The probe runs one `lzMatch` token pass per (file, level) and re-partitions it per `tokChunk` candidate, so the cross-block sweep costs one match pass regardless of grid size; the self-contained candidates each need their own fresh-window pass. Built-in assertions cross-check the probe's emission paths against `deflateDynamicBlocksShared` and `deflateRaw` at the current defaults (skippable with `--fast`), and a post-change confirmation run over Canterbury reproduced the sweep's predicted `deflateRaw` sizes in all 33 (file, level) cells. Fixes the fixed-cadence baseline that the #2528 boundary heuristic must beat.

Closes https://github.com/kim-em/lean-zip/issues/2529

🤖 Prepared with Claude Code