### PR TITLE
feat: entropy-divergence block splitting for the shared-window splitter

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -551,6 +551,173 @@ def deflateDynamicBlocksSharedAt (data : ByteArray)
     let toks := lzMatch data level
     (emitSharedBlocksAt data toks (choose toks) 0 BitWriter.empty).flush
 
+/-! ## Entropy-divergence boundary heuristic (libdeflate-style)
+
+Instead of cutting the shared-window token stream at a fixed cadence, walk it
+once and close a block where the symbol statistics *shift*: maintain a coarse
+observation histogram for the block so far and one for a recent window, and cut
+when the scaled distribution delta exceeds a threshold (libdeflate
+`deflate_compress.c`, `observe_literal`/`observe_match`/`do_end_block_check`).
+Every constant below is a pure ratio knob: the emitter clamps arbitrary cuts,
+so none of this carries proof obligations, and `chooseSplitsArbitrated` sizes
+the result against the fixed cadence in exact bits so the heuristic can never
+regress the shared-window candidate. -/
+
+/-- Number of literal observation classes (libdeflate
+    `NUM_LITERAL_OBSERVATION_TYPES`): literals are bucketed by bits 7,6,0 —
+    a cheap proxy separating case/digit/punctuation regimes. -/
+def splitNumLiteralClasses : Nat := 8
+
+/-- Total observation classes (libdeflate `NUM_OBSERVATION_TYPES`): 8 literal
+    classes plus 2 match classes (short/long). -/
+def splitNumClasses : Nat := 10
+
+/-- New observations between divergence checks (libdeflate
+    `NUM_OBSERVATIONS_PER_BLOCK_CHECK`): the recent-window size in tokens. -/
+def splitCheckTokens : Nat := 512
+
+/-- Floor on block *output* bytes, and on bytes remaining after a cut
+    (libdeflate `MIN_BLOCK_LENGTH`): per-block tree headers stop paying for
+    themselves below this, per the #2527 `sharedTokChunk` sweep. -/
+def splitMinBlockBytes : Nat := 10000
+
+/-- Unconditional cut ceiling on block output bytes (libdeflate
+    `SOFT_MAX_BLOCK_LENGTH`): even statistically-uniform runs get a fresh tree
+    at this scale, bounding how stale the code lengths can grow. -/
+def splitSoftMaxBlockBytes : Nat := 300000
+
+/-- Divergence threshold numerator/denominator (libdeflate's `200/512`): cut
+    when the sum of absolute probability deltas reaches ~39%. -/
+def splitCutoffNum : Nat := 200
+/-- See `splitCutoffNum`. -/
+def splitCutoffDen : Nat := 512
+
+/-- Length bias divisor (libdeflate's `block_length / 4096` term): longer
+    blocks cut progressively easier, since a fresh tree amortizes better. -/
+def splitBiasBytes : Nat := 4096
+
+/-- Observation class of a token (libdeflate `observe_literal`/`observe_match`):
+    literals map to 0–7 by bits 7,6,0; matches map to 8 (length < 9) or 9. -/
+@[inline] def splitTokenClass : LZ77Token → Nat
+  | .literal b => (((b >>> 5) &&& 6) ||| (b &&& 1)).toNat
+  | .reference len _ => splitNumLiteralClasses + (if len ≥ 9 then 1 else 0)
+
+/-- Output bytes a token contributes: 1 for a literal, the match length for a
+    reference. -/
+@[inline] def splitTokenBytes : LZ77Token → Nat
+  | .literal _ => 1
+  | .reference len _ => len
+
+/-- The divergence test (libdeflate `do_end_block_check`): cut when
+    `Σᵢ |new[i]·oldTot − old[i]·newTot| + (blockBytes/splitBiasBytes)·oldTot`
+    reaches `newTot·splitCutoffNum/splitCutoffDen·oldTot` — i.e. the recent
+    window's class distribution differs from the block-so-far distribution by
+    at least ~39% probability mass (less for long blocks). Integer-only; the
+    caller guarantees `oldTot > 0`. libdeflate additionally inflates the cutoff
+    for blocks under `MIN_BLOCK_LENGTH`, but our caller (like libdeflate's
+    `ready_to_check_block`) never checks such blocks, so that branch is omitted
+    as dead code. -/
+def splitEndBlockCheck (old : Array Nat) (oldTot : Nat) (new : Array Nat) (newTot : Nat)
+    (blockBytes : Nat) : Bool := Id.run do
+  let mut delta := 0
+  for i in [0:splitNumClasses] do
+    let a := new.getD i 0 * oldTot
+    let b := old.getD i 0 * newTot
+    delta := delta + (if a ≥ b then a - b else b - a)
+  let cutoff := newTot * splitCutoffNum / splitCutoffDen * oldTot
+  return delta + (blockBytes / splitBiasBytes) * oldTot ≥ cutoff
+
+/-- Entropy-divergence cut points for the shared-window token stream: one pass
+    over `toks`, accumulating per-class observation counts. Block-so-far
+    (`old`) and recent-window (`new`) histograms are compared every
+    `splitCheckTokens` tokens once the block and the remaining input are both
+    at least `splitMinBlockBytes` output bytes; on divergence the block is cut
+    at the next token boundary, otherwise the window merges into `old`. Blocks
+    are force-cut at `splitSoftMaxBlockBytes`. Byte floor/ceiling are enforced
+    per-token (a single 512-token window can span ~132 KB of output via long
+    matches, so checking them only at window boundaries could overshoot). -/
+def chooseSplitsHeuristic (toks : Array LZ77Token) : List Nat := Id.run do
+  let mut totalBytes := 0
+  for t in toks do
+    totalBytes := totalBytes + splitTokenBytes t
+  let mut old : Array Nat := Array.replicate splitNumClasses 0
+  let mut oldTot := 0
+  let mut new : Array Nat := Array.replicate splitNumClasses 0
+  let mut newTot := 0
+  let mut blockBytes := 0
+  let mut doneBytes := 0
+  let mut cuts : Array Nat := #[]
+  for h : i in [0:toks.size] do
+    let t := toks[i]
+    let c := splitTokenClass t
+    new := new.set! c (new.getD c 0 + 1)
+    newTot := newTot + 1
+    blockBytes := blockBytes + splitTokenBytes t
+    doneBytes := doneBytes + splitTokenBytes t
+    if blockBytes ≥ splitMinBlockBytes && totalBytes - doneBytes ≥ splitMinBlockBytes then
+      let cut :=
+        blockBytes ≥ splitSoftMaxBlockBytes ||
+        (newTot ≥ splitCheckTokens && oldTot > 0 &&
+          splitEndBlockCheck old oldTot new newTot blockBytes)
+      if cut then
+        cuts := cuts.push (i + 1)
+        old := Array.replicate splitNumClasses 0
+        oldTot := 0
+        new := Array.replicate splitNumClasses 0
+        newTot := 0
+        blockBytes := 0
+      else if newTot ≥ splitCheckTokens then
+        for j in [0:splitNumClasses] do
+          old := old.set! j (old.getD j 0 + new.getD j 0)
+        oldTot := oldTot + newTot
+        new := Array.replicate splitNumClasses 0
+        newTot := 0
+  return cuts.toList
+
+/-- The cut list equivalent to `emitSharedBlocks`'s fixed cadence: multiples of
+    `max tokChunk 1` strictly below `n`. `emitSharedBlocksAt … (fixedCadenceCuts
+    tokChunk toks.size)` emits byte-for-byte what `emitSharedBlocks … tokChunk`
+    emits (pinned by a conformance test). -/
+def fixedCadenceCuts (tokChunk n : Nat) : List Nat :=
+  let step := max tokChunk 1
+  (List.range ((n + step - 1) / step)).filterMap fun k =>
+    if k == 0 then none else some (k * step)
+
+/-- Exact bit size of the shared-window block stream `emitSharedBlocksAt` would
+    emit for this partition, without emitting: per group, `3` header bits plus
+    the dynamic-tree header (sized by running `writeDynamicHeader` into an
+    empty writer, as `dynBlockBytes` does) plus the freq·codeLen dot product
+    (`symbolBitCount`, which includes the end-of-block symbol). Mirrors the
+    emitter's grouping exactly — same clamped cut `j`, same final-block test —
+    so `(emitSharedBlocksAt …).bitLength` equals this sum (pinned by a
+    `SizeHelpers` conformance test; the flushed byte size is `⌈bits/8⌉`). -/
+def sharedPartitionBits (toks : Array LZ77Token) (cuts : List Nat) (pos : Nat) : Nat :=
+  let j := min (max (cuts.headD toks.size) (pos + 1)) toks.size
+  let f := tokenFreqs (toks.extract pos j)
+  let lens := dynamicCodeLengths f.1 f.2
+  let blockBits := 3 + (writeDynamicHeader BitWriter.empty lens.1 lens.2).bitLength
+    + symbolBitCount f.1 f.2 lens.1.toArray lens.2.toArray
+  if j ≥ toks.size then blockBits
+  else blockBits + sharedPartitionBits toks cuts.tail j
+termination_by toks.size - pos
+decreasing_by
+  rename_i h
+  simp only [Nat.not_le] at h
+  omega
+
+/-- Cost-model arbitration between the entropy-divergence cuts and the fixed
+    `sharedTokChunk` cadence: size both partitions in exact unflushed bits and
+    keep the smaller, **ties → fixed**. Since the emitted stream is one final
+    flush of exactly those bits (byte size `⌈bits/8⌉`), heuristic bits ≤ fixed
+    bits implies the emitted candidate never exceeds the old fixed-cadence one
+    — any observed regression is a `sharedPartitionBits` conformance bug, not
+    rounding. The sizing costs two extra `O(tokens)` passes; the matcher still
+    dominates at the levels that use this. -/
+def chooseSplitsArbitrated (toks : Array LZ77Token) : List Nat :=
+  let h := chooseSplitsHeuristic toks
+  let f := fixedCadenceCuts sharedTokChunk toks.size
+  if sharedPartitionBits toks h 0 < sharedPartitionBits toks f 0 then h else f
+
 /-- The compressed-block dispatch (no stored fallback). Every level ≥ 1 uses the
     hash-chain matcher with the level's search depth (`chainDepth`) and interior
     insertion cap (`insertCap`): low levels defer insertion + search shallowly
@@ -596,7 +763,11 @@ def deflateRawBase (data : ByteArray) (level : UInt8) : ByteArray :=
         (wins on locally-varying statistics, e.g. structured binary);
       * cross-block (shared-window) split — one whole-file match pass, token stream
         partitioned per block, references cross block boundaries (wins on large
-        text, where the self-contained split loses cross-chunk matches).
+        text, where the self-contained split loses cross-chunk matches). The
+        partition comes from the entropy-divergence heuristic arbitrated in
+        exact bits against the fixed `sharedTokChunk` cadence
+        (`chooseSplitsArbitrated`), so it cuts where the symbol statistics
+        shift and never sizes worse than the fixed cadence.
     The splits are first-class candidates compared against the whole base via
     `pickSmaller`, *not* nested inside the dynamic branch: on large heterogeneous
     inputs a single dynamic tree loses to fixed Huffman, so a base-internal gate
@@ -609,7 +780,7 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   else if 7 ≤ level then
     pickSmaller (deflateRawBase data level)
       (pickSmaller (deflateDynamicBlocksSC data splitChunkSize level)
-        (deflateDynamicBlocksShared data sharedTokChunk level))
+        (deflateDynamicBlocksSharedAt data chooseSplitsArbitrated level))
   else deflateRawBase data level
 
 end Zip.Native.Deflate

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -518,6 +518,39 @@ def deflateDynamicBlocksShared (data : ByteArray) (tokChunk : Nat) (level : UInt
     (emitSharedBlocks data (lzMatch data level)
       tokChunk 0 BitWriter.empty).flush
 
+/-- Emit shared-window blocks at explicit cut points: each element of `cuts` is
+    an absolute token index ending the current block. Every cut is clamped to
+    `(pos, toks.size]`, so **any** cuts list — empty, non-monotone, or out of
+    range — yields a valid total partition; an empty list emits one final block
+    of the rest. The clamping is what keeps the boundary *heuristic* free of
+    proof obligations: the roundtrip holds for an arbitrary partition. -/
+def emitSharedBlocksAt (data : ByteArray) (toks : Array LZ77Token) (cuts : List Nat)
+    (pos : Nat) (bw : BitWriter) : BitWriter :=
+  let j := min (max (cuts.headD toks.size) (pos + 1)) toks.size
+  let bw := emitSharedBlock bw data (toks.extract pos j) (decide (j ≥ toks.size))
+  if j ≥ toks.size then bw
+  else emitSharedBlocksAt data toks cuts.tail j bw
+termination_by toks.size - pos
+decreasing_by
+  rename_i h
+  simp only [Nat.not_le] at h
+  omega
+
+/-- Cross-block (shared-window) block-split dynamic compression with the
+    partition chosen by `choose`: like `deflateDynamicBlocksShared`, but the
+    per-block token groups come from the cut list `choose toks` instead of a
+    fixed cadence. The roundtrip holds for any `choose` (the emitter clamps
+    every cut), so the selector is a pure ratio heuristic. -/
+def deflateDynamicBlocksSharedAt (data : ByteArray)
+    (choose : Array LZ77Token → List Nat) (level : UInt8) : ByteArray :=
+  if data.size == 0 then
+    let f := tokenFreqs #[]
+    (emitDynBlock BitWriter.empty data #[] (dynamicCodeLengths f.1 f.2).1 (dynamicCodeLengths f.1 f.2).2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
+  else
+    let toks := lzMatch data level
+    (emitSharedBlocksAt data toks (choose toks) 0 BitWriter.empty).flush
+
 /-- The compressed-block dispatch (no stored fallback). Every level ≥ 1 uses the
     hash-chain matcher with the level's search depth (`chainDepth`) and interior
     insertion cap (`insertCap`): low levels defer insertion + search shallowly

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -840,4 +840,389 @@ theorem deflateDynamicBlocksShared_pad (data : ByteArray) (tokChunk : Nat) (leve
         data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
     exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
 
+/-! ## Cut-list (heuristic-partition) shared-window roundtrip
+
+`emitSharedBlocksAt` consumes an explicit cut list instead of a fixed cadence;
+every cut is clamped to `(pos, toks.size]`, so the theorems below hold for an
+**arbitrary** `cuts : List Nat` — the boundary heuristic carries no proof
+obligations. The proofs are the `emitSharedBlocks` proofs with the cut point
+`min (pos + max tokChunk 1) toks.size` replaced by
+`min (max (cuts.headD toks.size) (pos + 1)) toks.size` (the only facts used
+about it are `pos < j ≤ toks.size` and the final-block test). -/
+
+/-- Decode fold over the cut-list shared-window blocks: `emitSharedBlocksAt`
+    analogue of `emitSharedBlocks_decode`, for an arbitrary cut list. -/
+theorem emitSharedBlocksAt_decode (data : ByteArray) (toks : Array LZ77Token)
+    (hdata : data.size ≠ 0)
+    (henc : ∀ t ∈ toks.toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768) :
+    ∀ (fuel pos : Nat) (cuts : List Nat) (accOut wholeOut : List UInt8) (bw : BitWriter),
+      toks.size - pos ≤ fuel → pos < toks.size → bw.wf →
+      Deflate.Spec.resolveLZ77 ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos) accOut =
+        some wholeOut →
+      ∃ B, (emitSharedBlocksAt data toks cuts pos bw).toBits = bw.toBits ++ B ∧
+        (emitSharedBlocksAt data toks cuts pos bw).wf ∧
+        ∀ (tail : List Bool),
+          Deflate.Spec.decode.go (B ++ tail) accOut = some wholeOut := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos cuts accOut wholeOut bw hf hpos _ _; omega
+  | succ fuel ih =>
+    intro pos cuts accOut wholeOut bw hf hpos hbw hres
+    have hjle : min (max (cuts.headD toks.size) (pos + 1)) toks.size ≤ toks.size :=
+      Nat.min_le_right _ _
+    have hstep1 : pos + 1 ≤ max (cuts.headD toks.size) (pos + 1) := Nat.le_max_right _ _
+    have hjgt : pos < min (max (cuts.headD toks.size) (pos + 1)) toks.size := by
+      simp only [Nat.lt_min]; omega
+    have hMfree : ∀ s ∈ toks.toList.map LZ77Token.toLZ77Symbol,
+        s ≠ Deflate.Spec.LZ77Symbol.endOfBlock := mem_map_toLZ77Symbol_ne_endOfBlock toks.toList
+    have hgmfree : ∀ s ∈ ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+        (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos),
+        s ≠ Deflate.Spec.LZ77Symbol.endOfBlock :=
+      fun s hs => hMfree s (List.mem_of_mem_drop (List.mem_of_mem_take hs))
+    -- Split the residual at the partition point.
+    have hsplit : (toks.toList.map LZ77Token.toLZ77Symbol).drop pos =
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)
+        ++ (toks.toList.map LZ77Token.toLZ77Symbol).drop
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size) := by
+      conv => lhs; rw [← List.take_append_drop
+        (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos)]
+      rw [List.drop_drop, show pos +
+        (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)
+        = min (max (cuts.headD toks.size) (pos + 1)) toks.size from by omega]
+    rw [hsplit, Deflate.Spec.resolveLZ77_append_eobFree _ _ accOut hgmfree] at hres
+    -- Peel off the block's resolve and the recursive residual.
+    obtain ⟨out', hout'1, hout'2⟩ :
+        ∃ out', Deflate.Spec.resolveLZ77 (((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+            (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)) accOut = some out' ∧
+          Deflate.Spec.resolveLZ77 ((toks.toList.map LZ77Token.toLZ77Symbol).drop
+            (min (max (cuts.headD toks.size) (pos + 1)) toks.size)) out' = some wholeOut := by
+      cases hgm : Deflate.Spec.resolveLZ77 (((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)) accOut with
+      | none => rw [hgm] at hres; simp only [Option.bind_none, reduceCtorEq] at hres
+      | some o => rw [hgm] at hres; exact ⟨o, rfl, hres⟩
+    -- The block's symbol list resolves against `accOut` to `out'`.
+    have htts : tokensToSymbols
+        (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size)) =
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)
+        ++ [Deflate.Spec.LZ77Symbol.endOfBlock] := by
+      unfold tokensToSymbols
+      congr 1
+      simp only [Array.toList_extract, List.extract_eq_take_drop, List.map_take, List.map_drop]
+    have hblockres : Deflate.Spec.resolveLZ77
+        (tokensToSymbols
+          (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size))) accOut =
+        some out' := by
+      rw [htts, Deflate.Spec.resolveLZ77_eobFree_eob _ accOut hgmfree]; exact hout'1
+    obtain ⟨blockBits, htoBits, hwfblk, hdecblk, _⟩ :=
+      emitSharedBlock_decode data
+        (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size)) bw hbw
+        (decide (min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size)) hdata
+        (fun t ht => henc t (mem_extract_toList toks pos _ t ht)) accOut out' hblockres
+    by_cases hend : min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size
+    · -- Final block: j = toks.size, so the residual forces `out' = wholeOut`.
+      have hjeq : min (max (cuts.headD toks.size) (pos + 1)) toks.size = toks.size := by omega
+      have hdropnil : (toks.toList.map LZ77Token.toLZ77Symbol).drop
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size) = [] := by
+        rw [hjeq, show toks.size = (toks.toList.map LZ77Token.toLZ77Symbol).length from by
+          rw [List.length_map, Array.length_toList], List.drop_length]
+      have hwo : out' = wholeOut := by
+        rw [hdropnil, Deflate.Spec.resolveLZ77_nil, Option.some.injEq] at hout'2; exact hout'2
+      have hstep : emitSharedBlocksAt data toks cuts pos bw =
+          emitSharedBlock bw data
+            (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size))
+            (decide (min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size)) := by
+        conv => lhs; unfold emitSharedBlocksAt
+        simp only [if_pos hend]
+      refine ⟨blockBits, ?_, ?_, ?_⟩
+      · rw [hstep]; exact htoBits
+      · rw [hstep]; exact hwfblk
+      · intro tail
+        have hd := hdecblk tail
+        rw [if_pos (decide_eq_true hend)] at hd
+        rw [hd, hwo]
+    · -- Non-final block: recurse on the next token group.
+      have hbw' : (emitSharedBlock bw data
+          (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size))
+          (decide (min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size))).wf := hwfblk
+      have hstep : emitSharedBlocksAt data toks cuts pos bw =
+          emitSharedBlocksAt data toks cuts.tail
+            (min (max (cuts.headD toks.size) (pos + 1)) toks.size)
+            (emitSharedBlock bw data
+              (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size))
+              (decide (min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size))) := by
+        conv => lhs; unfold emitSharedBlocksAt
+        simp only [if_neg hend]
+      obtain ⟨B', htoBits', hwf', hdec'⟩ :=
+        ih (min (max (cuts.headD toks.size) (pos + 1)) toks.size) cuts.tail out' wholeOut _
+          (by omega) (by omega) hbw' hout'2
+      refine ⟨blockBits ++ B', ?_, ?_, ?_⟩
+      · rw [hstep, htoBits', htoBits, List.append_assoc]
+      · rw [hstep]; exact hwf'
+      · intro tail
+        rw [List.append_assoc]
+        have hd := hdecblk (B' ++ tail)
+        rw [if_neg (by simp only [decide_eq_true_eq]; exact hend)] at hd
+        rw [hd]; exact hdec' tail
+
+/-- `decode.goR` variant of `emitSharedBlocksAt_decode`: the remaining bits after
+    decoding all cut-list shared blocks are exactly the trailing `tail`. -/
+theorem emitSharedBlocksAt_decodeR (data : ByteArray) (toks : Array LZ77Token)
+    (hdata : data.size ≠ 0)
+    (henc : ∀ t ∈ toks.toList,
+      match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768) :
+    ∀ (fuel pos : Nat) (cuts : List Nat) (accOut wholeOut : List UInt8) (bw : BitWriter),
+      toks.size - pos ≤ fuel → pos < toks.size → bw.wf →
+      Deflate.Spec.resolveLZ77 ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos) accOut =
+        some wholeOut →
+      ∃ B, (emitSharedBlocksAt data toks cuts pos bw).toBits = bw.toBits ++ B ∧
+        (emitSharedBlocksAt data toks cuts pos bw).wf ∧
+        ∀ (tail : List Bool),
+          Deflate.Spec.decode.goR (B ++ tail) accOut = some (wholeOut, tail) := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos cuts accOut wholeOut bw hf hpos _ _; omega
+  | succ fuel ih =>
+    intro pos cuts accOut wholeOut bw hf hpos hbw hres
+    have hjle : min (max (cuts.headD toks.size) (pos + 1)) toks.size ≤ toks.size :=
+      Nat.min_le_right _ _
+    have hstep1 : pos + 1 ≤ max (cuts.headD toks.size) (pos + 1) := Nat.le_max_right _ _
+    have hjgt : pos < min (max (cuts.headD toks.size) (pos + 1)) toks.size := by
+      simp only [Nat.lt_min]; omega
+    have hMfree : ∀ s ∈ toks.toList.map LZ77Token.toLZ77Symbol,
+        s ≠ Deflate.Spec.LZ77Symbol.endOfBlock := mem_map_toLZ77Symbol_ne_endOfBlock toks.toList
+    have hgmfree : ∀ s ∈ ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+        (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos),
+        s ≠ Deflate.Spec.LZ77Symbol.endOfBlock :=
+      fun s hs => hMfree s (List.mem_of_mem_drop (List.mem_of_mem_take hs))
+    have hsplit : (toks.toList.map LZ77Token.toLZ77Symbol).drop pos =
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)
+        ++ (toks.toList.map LZ77Token.toLZ77Symbol).drop
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size) := by
+      conv => lhs; rw [← List.take_append_drop
+        (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos)]
+      rw [List.drop_drop, show pos +
+        (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)
+        = min (max (cuts.headD toks.size) (pos + 1)) toks.size from by omega]
+    rw [hsplit, Deflate.Spec.resolveLZ77_append_eobFree _ _ accOut hgmfree] at hres
+    obtain ⟨out', hout'1, hout'2⟩ :
+        ∃ out', Deflate.Spec.resolveLZ77 (((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+            (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)) accOut = some out' ∧
+          Deflate.Spec.resolveLZ77 ((toks.toList.map LZ77Token.toLZ77Symbol).drop
+            (min (max (cuts.headD toks.size) (pos + 1)) toks.size)) out' = some wholeOut := by
+      cases hgm : Deflate.Spec.resolveLZ77 (((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)) accOut with
+      | none => rw [hgm] at hres; simp only [Option.bind_none, reduceCtorEq] at hres
+      | some o => rw [hgm] at hres; exact ⟨o, rfl, hres⟩
+    have htts : tokensToSymbols
+        (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size)) =
+        ((toks.toList.map LZ77Token.toLZ77Symbol).drop pos).take
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size - pos)
+        ++ [Deflate.Spec.LZ77Symbol.endOfBlock] := by
+      unfold tokensToSymbols
+      congr 1
+      simp only [Array.toList_extract, List.extract_eq_take_drop, List.map_take, List.map_drop]
+    have hblockres : Deflate.Spec.resolveLZ77
+        (tokensToSymbols
+          (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size))) accOut =
+        some out' := by
+      rw [htts, Deflate.Spec.resolveLZ77_eobFree_eob _ accOut hgmfree]; exact hout'1
+    obtain ⟨blockBits, htoBits, hwfblk, _, hdecblk⟩ :=
+      emitSharedBlock_decode data
+        (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size)) bw hbw
+        (decide (min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size)) hdata
+        (fun t ht => henc t (mem_extract_toList toks pos _ t ht)) accOut out' hblockres
+    by_cases hend : min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size
+    · have hjeq : min (max (cuts.headD toks.size) (pos + 1)) toks.size = toks.size := by omega
+      have hdropnil : (toks.toList.map LZ77Token.toLZ77Symbol).drop
+          (min (max (cuts.headD toks.size) (pos + 1)) toks.size) = [] := by
+        rw [hjeq, show toks.size = (toks.toList.map LZ77Token.toLZ77Symbol).length from by
+          rw [List.length_map, Array.length_toList], List.drop_length]
+      have hwo : out' = wholeOut := by
+        rw [hdropnil, Deflate.Spec.resolveLZ77_nil, Option.some.injEq] at hout'2; exact hout'2
+      have hstep : emitSharedBlocksAt data toks cuts pos bw =
+          emitSharedBlock bw data
+            (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size))
+            (decide (min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size)) := by
+        conv => lhs; unfold emitSharedBlocksAt
+        simp only [if_pos hend]
+      refine ⟨blockBits, ?_, ?_, ?_⟩
+      · rw [hstep]; exact htoBits
+      · rw [hstep]; exact hwfblk
+      · intro tail
+        have hd := hdecblk tail
+        rw [if_pos (decide_eq_true hend)] at hd
+        rw [hd, hwo]
+    · have hbw' : (emitSharedBlock bw data
+          (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size))
+          (decide (min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size))).wf := hwfblk
+      have hstep : emitSharedBlocksAt data toks cuts pos bw =
+          emitSharedBlocksAt data toks cuts.tail
+            (min (max (cuts.headD toks.size) (pos + 1)) toks.size)
+            (emitSharedBlock bw data
+              (toks.extract pos (min (max (cuts.headD toks.size) (pos + 1)) toks.size))
+              (decide (min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size))) := by
+        conv => lhs; unfold emitSharedBlocksAt
+        simp only [if_neg hend]
+      obtain ⟨B', htoBits', hwf', hdec'⟩ :=
+        ih (min (max (cuts.headD toks.size) (pos + 1)) toks.size) cuts.tail out' wholeOut _
+          (by omega) (by omega) hbw' hout'2
+      refine ⟨blockBits ++ B', ?_, ?_, ?_⟩
+      · rw [hstep, htoBits', htoBits, List.append_assoc]
+      · rw [hstep]; exact hwf'
+      · intro tail
+        rw [List.append_assoc]
+        have hd := hdecblk (B' ++ tail)
+        rw [if_neg (by simp only [decide_eq_true_eq]; exact hend)] at hd
+        rw [hd]; exact hdec' tail
+
+/-- Cut-list shared-window roundtrip: decoding the heuristic-partition block
+    stream reproduces the input, for **any** boundary selector `choose`. -/
+theorem decode_deflateDynamicBlocksSharedAt (data : ByteArray)
+    (choose : Array LZ77Token → List Nat) (level : UInt8) :
+    Deflate.Spec.decode
+      (Deflate.Spec.bytesToBits (deflateDynamicBlocksSharedAt data choose level)) =
+      some data.data.toList := by
+  unfold deflateDynamicBlocksSharedAt
+  split
+  · -- data.size = 0: one final block over the empty token list (as in SC).
+    rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+      (symBits ++ List.replicate
+        ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+      hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+    rw [← List.append_assoc] at hheader
+    have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+      have he : data.data.toList = [] :=
+        List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+      rw [he]; rfl
+    exact Deflate.Spec.encodeDynamic_decode_append (tokensToSymbols #[]) data.data.toList
+      litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+      (tokensToSymbols_validSymbolList _)
+  · -- data.size > 0: the cut-list shared-window fold.
+    rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksShared_facts data level hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocksAt_decode data (lzMatch data level)
+        (by omega) henc
+        (lzMatch data level).size 0
+        (choose (lzMatch data level)) []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    exact hdec (List.replicate ((8 - B.length % 8) % 8) false)
+
+/-- Cut-list shared-window roundtrip: inflating `deflateDynamicBlocksSharedAt`
+    recovers the input, for any selector `choose` and any `maxOutputSize` large
+    enough to hold it. -/
+theorem inflate_deflateDynamicBlocksSharedAt (data : ByteArray)
+    (choose : Array LZ77Token → List Nat) (level : UInt8)
+    (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
+    Zip.Native.Inflate.inflate (deflateDynamicBlocksSharedAt data choose level) maxOutputSize =
+      .ok data := by
+  have hlen : data.data.toList.length ≤ maxOutputSize := by
+    simp only [Array.length_toList, ByteArray.size_data]; omega
+  rw [← show ByteArray.mk ⟨data.data.toList⟩ = data from by simp only [Array.toArray_toList]]
+  exact inflate_complete (deflateDynamicBlocksSharedAt data choose level) data.data.toList
+    maxOutputSize hlen (decode_deflateDynamicBlocksSharedAt data choose level)
+
+/-- The `decode.goR` of `deflateDynamicBlocksSharedAt` returns the input and
+    short (< 8-bit) trailing padding — needed to show the native decoder
+    consumes all of the deflated bytes. -/
+theorem deflateDynamicBlocksSharedAt_goR_pad (data : ByteArray)
+    (choose : Array LZ77Token → List Nat) (level : UInt8) :
+    ∃ remaining,
+      Deflate.Spec.decode.goR
+          (Deflate.Spec.bytesToBits (deflateDynamicBlocksSharedAt data choose level)) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+  unfold deflateDynamicBlocksSharedAt
+  split
+  · -- data.size = 0
+    rename_i hz
+    rw [beq_iff_eq] at hz
+    obtain ⟨litLens, distLens, headerBits, symBits, _, _, hlv, hdv,
+        hge1, hle1, hge2, hle2, hb1, hb2, htrees, hsyms, htoBits, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate
+      ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false, ?_, ?_⟩
+    · have hheader := Deflate.Spec.encodeDynamicTrees_decodeDynamicTables litLens distLens headerBits
+        (symBits ++ List.replicate
+          ((8 - ([true, false, true] ++ headerBits ++ symBits).length % 8) % 8) false)
+        hb1 hb2 ⟨hge1, hle1⟩ ⟨hge2, hle2⟩ hlv hdv htrees
+      rw [← List.append_assoc] at hheader
+      have hres : Deflate.Spec.resolveLZ77 (tokensToSymbols #[]) [] = some data.data.toList := by
+        have he : data.data.toList = [] :=
+          List.eq_nil_of_length_eq_zero (by simp only [Array.length_toList, ByteArray.size_data, hz])
+        rw [he]; rfl
+      exact Deflate.Spec.encodeDynamic_goR_rest (tokensToSymbols #[]) data.data.toList
+        litLens distLens headerBits symBits _ hlv hdv hheader hsyms hres
+        (tokensToSymbols_validSymbolList _)
+    · simp only [List.length_replicate]; omega
+  · -- data.size > 0
+    rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksShared_facts data level hpos
+    obtain ⟨B, htoBits, hwf, hdec⟩ :=
+      emitSharedBlocksAt_decodeR data
+        (lzMatch data level)
+        (by omega) henc
+        (lzMatch data level).size 0
+        (choose (lzMatch data level)) []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    rw [BitWriter.empty_toBits, List.nil_append] at htoBits
+    rw [flush_toBits_aligned _ hwf, htoBits]
+    refine ⟨List.replicate ((8 - B.length % 8) % 8) false, hdec _, ?_⟩
+    simp only [List.length_replicate]; omega
+
+/-- The output of `deflateDynamicBlocksSharedAt` decomposes into content bits
+    plus short (< 8-bit) padding. -/
+theorem deflateDynamicBlocksSharedAt_pad (data : ByteArray)
+    (choose : Array LZ77Token → List Nat) (level : UInt8) :
+    ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits (deflateDynamicBlocksSharedAt data choose level) =
+        contentBits ++ padding ∧ padding.length < 8 := by
+  unfold deflateDynamicBlocksSharedAt
+  split
+  · obtain ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hwf⟩ :=
+      emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+  · rename_i hz
+    have hpos : 0 < data.size := by
+      rcases Nat.eq_zero_or_pos data.size with h | h
+      · rw [h] at hz; simp at hz
+      · exact h
+    obtain ⟨henc, htokpos, hres0⟩ := deflateDynamicBlocksShared_facts data level hpos
+    obtain ⟨B, _, hwf, _⟩ :=
+      emitSharedBlocksAt_decode data
+        (lzMatch data level)
+        (by omega) henc
+        (lzMatch data level).size 0
+        (choose (lzMatch data level)) []
+        data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
+    exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
+
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -20,8 +20,10 @@ This composes:
 - `inflate_deflateRawBase` — the stored / fixed / dynamic base, in turn built
   from `inflate_deflateStoredPure`, `inflate_deflateFixedBlock`,
   `inflate_deflateDynamicBlock`
-- `inflate_deflateDynamicBlocksSC` / `inflate_deflateDynamicBlocksShared` — the
-  two block-split candidates (`Zip/Spec/DeflateBlockSplit.lean`)
+- `inflate_deflateDynamicBlocksSC` / `inflate_deflateDynamicBlocksSharedAt` — the
+  two block-split candidates (`Zip/Spec/DeflateBlockSplit.lean`); the shared-window
+  candidate holds for any boundary selector, so the entropy-divergence partition
+  (`chooseSplitsArbitrated`, #2528) needs no proof of its own
 - `inflate_pickSmaller` — selecting the smaller of two roundtripping candidates
 -/
 
@@ -115,7 +117,7 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
         (inflate_deflateRawBase data level _ hsize)
         (inflate_pickSmaller _ _ data maxOutputSize
           (inflate_deflateDynamicBlocksSC data splitChunkSize level _ hsize)
-          (inflate_deflateDynamicBlocksShared data sharedTokChunk level _ hsize))
+          (inflate_deflateDynamicBlocksSharedAt data chooseSplitsArbitrated level _ hsize))
     · exact inflate_deflateRawBase data level _ hsize
 
 /-- Padding decomposition for the compressed-block dispatch. -/
@@ -198,7 +200,7 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
           (P := fun bits => ∃ (contentBits padding : List Bool),
             bits = contentBits ++ padding ∧ padding.length < 8)
           _ _ (deflateDynamicBlocksSC_pad data splitChunkSize level)
-          (deflateDynamicBlocksShared_pad data sharedTokChunk level))
+          (deflateDynamicBlocksSharedAt_pad data chooseSplitsArbitrated level))
     · exact deflateRawBase_pad data level
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
@@ -354,7 +356,7 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
             Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
               remaining.length < 8)
           _ _ (deflateDynamicBlocksSC_goR_pad data splitChunkSize level)
-          (deflateDynamicBlocksShared_goR_pad data sharedTokChunk level))
+          (deflateDynamicBlocksSharedAt_goR_pad data chooseSplitsArbitrated level))
     · exact deflateRawBase_goR_pad data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/HuffmanEncode.lean
+++ b/Zip/Spec/HuffmanEncode.lean
@@ -123,10 +123,6 @@ def cappedBlCount (depths : List (Nat × Nat)) (maxBits : Nat) : Array Nat := Id
     bl := bl.set! dc ((bl.getD dc 0) + 1)
   return bl
 
-/-- How many natural code lengths exceed `maxBits` — the overflow to repair. -/
-def overflowCount (depths : List (Nat × Nat)) (maxBits : Nat) : Nat :=
-  (depths.filter (fun p => decide (p.2 > maxBits))).length
-
 /-- Largest length `≤ start` with a positive count in `bl` (0 if none). -/
 def findBelow (bl : Array Nat) (start : Nat) : Nat :=
   if start = 0 then 0
@@ -134,17 +130,36 @@ def findBelow (bl : Array Nat) (start : Nat) : Nat :=
   else findBelow bl (start - 1)
 termination_by start
 
+/-- Kraft sum of a `bl_count` histogram in units of `2^-maxBits`:
+    `Σ_l bl[l]·2^(maxBits−l)` over `l ∈ [1, maxBits]`. A complete code sums to
+    exactly `2^maxBits`; a capped histogram exceeds it by the overflow the
+    repair must remove. -/
+def blKraft (bl : Array Nat) (maxBits : Nat) : Nat :=
+  (List.range maxBits).foldl (fun acc i => acc + bl.getD (i + 1) 0 * 2 ^ (maxBits - (i + 1))) 0
+
 /-- Repair a capped `bl_count` so the code is complete (Kraft-exact) within
-    `maxBits`: pull one leaf up from the shallowest available depth and push the
-    overflowing pair down to `maxBits` (zlib `gen_bitlen`). Heuristic only. -/
-def repairBl (bl : Array Nat) (overflow maxBits : Nat) : Array Nat :=
-  if overflow < 2 then bl
-  else
+    `maxBits` (zlib `gen_bitlen`'s move): take the deepest depth `bits` below
+    `maxBits` with a leaf, move that leaf to `bits+1` and pair it with an
+    overflow leaf pulled up from `maxBits`. Each step lowers the Kraft sum by
+    exactly 1 (in `2^-maxBits` units) and preserves the leaf count, so calling
+    it with `excess = blKraft bl maxBits − 2^maxBits` lands exactly on a
+    complete code. The updates must be sequential `set!`s on the current
+    array: when `bits + 1 = maxBits` the `+2` and `−1` compose on the same
+    entry (a chained read of the *original* array here used to overwrite the
+    increment, silently dropping leaves and forcing the flat
+    `fixKraftList` fallback — emitting incomplete codes that zlib's inflate
+    rejects). Heuristic only. -/
+def repairBl (bl : Array Nat) (excess maxBits : Nat) : Array Nat :=
+  match excess with
+  | 0 => bl
+  | e + 1 =>
     let bits := findBelow bl (maxBits - 1)
-    let bl := ((bl.set! bits ((bl.getD bits 0) - 1)).set! (bits + 1)
-                ((bl.getD (bits + 1) 0) + 2)).set! maxBits ((bl.getD maxBits 0) - 1)
-    repairBl bl (overflow - 2) maxBits
-termination_by overflow
+    if bits == 0 then bl  -- defensive: unreachable while over-subscribed
+    else
+      let bl := bl.set! bits ((bl.getD bits 0) - 1)
+      let bl := bl.set! (bits + 1) ((bl.getD (bits + 1) 0) + 2)
+      let bl := bl.set! maxBits ((bl.getD maxBits 0) - 1)
+      repairBl bl e maxBits
 
 /-- The multiset of code lengths a `bl_count` histogram describes, ascending:
     `bl.getD l 0` copies of each `l ∈ [1, maxBits]`. Every element is in
@@ -161,7 +176,8 @@ def limitedPairs (nonzero : List (Nat × Nat)) (maxBits : Nat) : List (Nat × Na
   let leaves := (nonzero.map fun p => BuildTree.leaf p.2 p.1).mergeSort
                   (fun a b => a.weight ≤ b.weight)
   let depths := (buildHuffmanTree leaves).depths
-  let bl := repairBl (cappedBlCount depths maxBits) (overflowCount depths maxBits) maxBits
+  let capped := cappedBlCount depths maxBits
+  let bl := repairBl capped (blKraft capped maxBits - 2 ^ maxBits) maxBits
   let symsByFreq := (nonzero.mergeSort (fun a b => b.2 ≤ a.2)).map (·.1)
   symsByFreq.zip (expandBl bl maxBits ++ List.replicate symsByFreq.length maxBits)
 

--- a/ZipBenchReport.lean
+++ b/ZipBenchReport.lean
@@ -221,9 +221,7 @@ def runReport (outPath : String) : IO Unit := do
 
   -- Real-corpus rows only: the same timing matrix over every committed corpus
   -- (one single-size workload per file), so the dashboard rests entirely on
-  -- representative data. zopfli is the ratio ceiling (compress-only, very slow,
-  -- level-less) — run at one nominal level / single rep so it appears on the
-  -- ratio graphs without dominating wall-clock.
+  -- representative data.
   let corpora ← loadCorpora
   if corpora.isEmpty then
     IO.eprintln "  no corpora found — run bench/fetch_corpora.sh"
@@ -231,9 +229,13 @@ def runReport (outPath : String) : IO Unit := do
   for (corpus, files) in corpora do
     -- Every corpus is timed at all 9 levels (so the speed-vs-ratio scatter shows
     -- the full level sweep). Large corpora (Silesia, ~200 MB) use a single timing
-    -- pass — variance is low on big files — and skip zopfli (level-less and ~100×
-    -- slower than zlib), to keep the run tractable; small corpora (Canterbury)
-    -- keep the median-of-`reps` matrix plus the zopfli ratio-ceiling point.
+    -- pass — variance is low on big files — to keep the run tractable; small
+    -- corpora (Canterbury) keep the median-of-`reps` matrix.
+    --
+    -- zopfli is intentionally not benchmarked here: it is compress-only and
+    -- ~100× slower than zlib (default iteration count), so even at one
+    -- level/rep it dominated the wall-clock of the whole matrix. Its FFI binding
+    -- (`zopfliCompress`) is kept for ad-hoc ratio-ceiling checks.
     let big := corpus == "silesia"
     let lvls := levels
     let rps  := if big then 1 else reps
@@ -242,9 +244,7 @@ def runReport (outPath : String) : IO Unit := do
     let cz ← runWorkloads "zlib"        files zlibCompress       (some RawDeflate.decompress) (theLevels := lvls) (theReps := rps)
     let cm ← runWorkloads "miniz_oxide" files minizCompress      (some MinizOxide.decompress) (theLevels := lvls) (theReps := rps)
     let cl ← runWorkloads "libdeflate"  files libdeflateCompress (some Libdeflate.decompress) (theLevels := lvls) (theReps := rps)
-    let czo ← if big then pure [] else
-      runWorkloads "zopfli" files zopfliCompress none (theLevels := [6]) (theReps := 1)
-    rows := rows ++ cn ++ cz ++ cm ++ cl ++ czo
+    rows := rows ++ cn ++ cz ++ cm ++ cl
 
   let date ← shell "date" ["-u", "+%Y-%m-%dT%H:%M:%SZ"]
   let machine ← shell "uname" ["-mns"]

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -365,6 +365,29 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
       unless decomp == data do
         throw (IO.userError s!"deflateDynamicBlocksShared→FFI inflate mismatch on {name} (tokChunk={tokChunk})")
 
+  -- Cut-list shared-window splitting: deflateDynamicBlocksSharedAt clamps every
+  -- cut to (pos, toks.size], so ANY selector — empty, all-zero, out-of-range,
+  -- non-monotone, or exactly-at-the-end — must yield a valid partition. Verify
+  -- the roundtrip via both native and FFI inflate for adversarial cut lists.
+  let adversarialChoosers : List (String × (Array Zip.Native.Deflate.LZ77Token → List Nat)) :=
+    [("empty", fun _ => []),
+     ("zeros", fun _ => [0, 0, 0]),
+     ("huge", fun _ => [1000000000]),
+     ("nonmonotone", fun _ => [5, 3, 7]),
+     ("atEnd", fun toks => [toks.size]),
+     ("mixed", fun _ => [0, 7, 7, 100000])]
+  for (name, data) in [("empty", ByteArray.empty), ("hello", helloBytes), ("big", big),
+                        ("text", textRepeat), ("cyclic16K", mkCyclicData 16384)] do
+    for (cname, choose) in adversarialChoosers do
+      let sharedAt := Zip.Native.Deflate.deflateDynamicBlocksSharedAt data choose 9
+      match Zip.Native.Inflate.inflate sharedAt with
+      | .ok result => unless result == data do
+          throw (IO.userError s!"deflateDynamicBlocksSharedAt→native inflate mismatch on {name} (cuts={cname})")
+      | .error e => throw (IO.userError s!"deflateDynamicBlocksSharedAt→native inflate failed on {name} (cuts={cname}): {e}")
+      let decomp ← RawDeflate.decompress sharedAt
+      unless decomp == data do
+        throw (IO.userError s!"deflateDynamicBlocksSharedAt→FFI inflate mismatch on {name} (cuts={cname})")
+
   -- Stress the many-block cross-reference path: one token per block on a highly
   -- repetitive input, so almost every block references earlier blocks' output.
   let sharedTiny := Zip.Native.Deflate.deflateDynamicBlocksShared textRepeat 1 9

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -388,6 +388,20 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
       unless decomp == data do
         throw (IO.userError s!"deflateDynamicBlocksSharedAt→FFI inflate mismatch on {name} (cuts={cname})")
 
+  -- Regression: text followed by PRNG bytes in one dynamic block used to drive
+  -- the length-limiter's bl_count repair into losing leaves (chained stale
+  -- `set!` reads) and under-repairing (overflow-pair counting vs actual Kraft
+  -- excess), so `fixKraftList` flattened the CL tree to a uniform 7-bit code —
+  -- incomplete, which zlib's inflate rejects ("invalid code lengths set") even
+  -- though our native inflate tolerates it. Pin zlib (FFI) interop at the
+  -- default and max levels.
+  let textPrng := textRepeat ++ mkPrngData 4096
+  for level in [6, 9] do
+    let out := Zip.Native.Deflate.deflateRaw textPrng level.toUInt8
+    let decomp ← RawDeflate.decompress out
+    unless decomp == textPrng do
+      throw (IO.userError s!"deflateRaw({level}) text+prng→FFI inflate mismatch")
+
   -- Stress the many-block cross-reference path: one token per block on a highly
   -- repetitive input, so almost every block references earlier blocks' output.
   let sharedTiny := Zip.Native.Deflate.deflateDynamicBlocksShared textRepeat 1 9

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -402,6 +402,31 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
     unless decomp == textPrng do
       throw (IO.userError s!"deflateRaw({level}) text+prng→FFI inflate mismatch")
 
+  -- Entropy-divergence splitting (#2528): on a heterogeneous input whose symbol
+  -- statistics shift (prose, then PRNG bytes, then cyclic binary — each well
+  -- above the splitMinBlockBytes floor), the heuristic must propose at least one
+  -- cut, and the arbitrated shared-window stream must roundtrip via both
+  -- inflate implementations.
+  let hetero := String.toUTF8 (String.join (List.replicate 1600
+    "the quick brown fox jumps over the lazy dog. "))
+    ++ mkPrngData 65536 ++ mkCyclicData 65536
+  let heteroToks := Zip.Native.Deflate.lzMatch hetero 9
+  let heteroCuts := Zip.Native.Deflate.chooseSplitsHeuristic heteroToks
+  unless heteroCuts.length ≥ 1 do
+    throw (IO.userError s!"chooseSplitsHeuristic found no cuts on heterogeneous input \
+      ({heteroToks.size} tokens)")
+  for (name, data) in [("hetero", hetero), ("text", textRepeat),
+                        ("cyclic16K", mkCyclicData 16384), ("empty", ByteArray.empty)] do
+    let arb := Zip.Native.Deflate.deflateDynamicBlocksSharedAt data
+      Zip.Native.Deflate.chooseSplitsArbitrated 9
+    match Zip.Native.Inflate.inflate arb with
+    | .ok result => unless result == data do
+        throw (IO.userError s!"arbitrated shared split→native inflate mismatch on {name}")
+    | .error e => throw (IO.userError s!"arbitrated shared split→native inflate failed on {name}: {e}")
+    let decomp ← RawDeflate.decompress arb
+    unless decomp == data do
+      throw (IO.userError s!"arbitrated shared split→FFI inflate mismatch on {name}")
+
   -- Stress the many-block cross-reference path: one token per block on a highly
   -- repetitive input, so almost every block references earlier blocks' output.
   let sharedTiny := Zip.Native.Deflate.deflateDynamicBlocksShared textRepeat 1 9

--- a/ZipTest/SizeHelpers.lean
+++ b/ZipTest/SizeHelpers.lean
@@ -90,6 +90,56 @@ def tests : IO Unit := do
       unless back.beq data do
         throw (IO.userError s!"deflateRaw(6) roundtrip mismatch on {name}")
     | .error e => throw (IO.userError s!"deflateRaw(6) inflate failed on {name}: {e}")
+
+  -- 3. Shared-window partition cost model (`sharedPartitionBits`) equals the
+  -- emitted bit length of `emitSharedBlocksAt` for the same cuts — the invariant
+  -- that makes `chooseSplitsArbitrated`'s never-worse-than-fixed-cadence
+  -- guarantee trustworthy. Checked across adversarial, fixed-cadence, and
+  -- heuristic cut lists; the flushed byte size must be ⌈bits/8⌉.
+  for (name, data) in samples do
+    if data.size > 0 then
+      let toks := lzMatch data 9
+      let cutsLists : List (String × List Nat) :=
+        [ ("empty", []),
+          ("zeros", [0, 0, 0]),
+          ("huge", [1000000000]),
+          ("nonmonotone", [5, 3, 7]),
+          ("fixed", fixedCadenceCuts sharedTokChunk toks.size),
+          ("fixed-tiny", fixedCadenceCuts 3 toks.size),
+          ("heuristic", chooseSplitsHeuristic toks) ]
+      for (cname, cuts) in cutsLists do
+        let modelBits := sharedPartitionBits toks cuts 0
+        let bw := emitSharedBlocksAt data toks cuts 0 Zip.Native.BitWriter.empty
+        unless modelBits == bw.bitLength do
+          throw (IO.userError
+            s!"sharedPartitionBits mismatch on {name}/{cname}: \
+               model={modelBits} emitted={bw.bitLength}")
+        unless bw.flush.size == (modelBits + 7) / 8 do
+          throw (IO.userError
+            s!"flushed size mismatch on {name}/{cname}: \
+               bytes={bw.flush.size} bits={modelBits}")
+      -- 4. Arbitration never sizes worse than the fixed cadence, and the emitted
+      -- shared candidate never exceeds the old fixed-cadence emitter's output.
+      let fixedCuts := fixedCadenceCuts sharedTokChunk toks.size
+      let arbCuts := chooseSplitsArbitrated toks
+      unless sharedPartitionBits toks arbCuts 0 ≤ sharedPartitionBits toks fixedCuts 0 do
+        throw (IO.userError s!"chooseSplitsArbitrated sized worse than fixed on {name}")
+      let arbOut := deflateDynamicBlocksSharedAt data chooseSplitsArbitrated 9
+      let fixedOut := deflateDynamicBlocksShared data sharedTokChunk 9
+      unless arbOut.size ≤ fixedOut.size do
+        throw (IO.userError
+          s!"arbitrated shared output larger than fixed on {name}: \
+             {arbOut.size} > {fixedOut.size}")
+    -- 5. The cut-list emitter with fixed-cadence cuts is byte-identical to the
+    -- fixed-cadence emitter (also covers the empty input, where both emit the
+    -- single final block).
+    let viaCuts := deflateDynamicBlocksSharedAt data
+      (fun toks => fixedCadenceCuts sharedTokChunk toks.size) 9
+    let viaChunk := deflateDynamicBlocksShared data sharedTokChunk 9
+    unless viaCuts.beq viaChunk do
+      throw (IO.userError
+        s!"fixedCadenceCuts not byte-identical to fixed-cadence emitter on {name}: \
+           {viaCuts.size} vs {viaChunk.size}")
   IO.println "  SizeHelpers tests passed."
 
 end ZipTest.SizeHelpers

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="594pt" height="403.2pt" viewBox="0 0 594 403.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="594pt" height="367.2pt" viewBox="0 0 594 367.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -21,8 +21,8 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 403.2 
-L 594 403.2 
+   <path d="M 0 367.2 
+L 594 367.2 
 L 594 0 
 L 0 0 
 z
@@ -30,32 +30,32 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 95.67625 332.242309 
-L 527.435033 332.242309 
-L 527.435033 49.4355 
-L 95.67625 49.4355 
+    <path d="M 95.67625 297.322309 
+L 527.435033 297.322309 
+L 527.435033 47.9955 
+L 95.67625 47.9955 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p92d9436213)">
+   <g clip-path="url(#pf5d267a168)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJG0lEQVR4nO3YPY4l5RmGYU7PmUYgNMIDI0aIwGYHSE6deQdeihNStuA1WCJ06GAWQOrACUgkYFsIzSDc0+6/6T7lNdi6P72idF0reEp16jt31eH07y+3t/bocDa9YJ3ri+kF69zs89q2h/vpCcsc3vtwesIab787vWCdvZ6Pb26mF6yz03u2/fSP6QnL7POOAQAMElgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHj94efpzcscfNwOT1hmY/e//X0hGWebM+nJyxxuL6YnrDMV9dfT09Y4vn5B9MTlrk/3U1PWOLq4XZ6wjKnbZuesMRnTz6enrCML1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQO7y++8s2PWKFqzcX0xOWefbo6fSEdW4vpxes8Z+fphes8+Gn0wuWuNyupicsc32/z+fs2VtPpics86/t5fSEJT7++WZ6wjK+YAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEDs+PjsfHrDEu8c35uesM7VxfSCdS5+mF6wxHZ7Oz1hmcPT++kJSxzO9vv++fbx3ekJS7x8uJyesMyT49PpCUtsV19PT1hmvycIAMAQgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxw8Pfv9imR8DunU7TC9Y58572i3N2mF6wxmnHf2d7PUN2fH7s98oAAIYILACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2PGPr76f3rDEq+v76QnLfPXPi+kJy/z1D7+bnrDEs3c+mZ6wzG///OX0hCV+/5tfTU9Y5ptX19MTlni0408GL158Oz1hidd/+nx6wjI7/jkCAMwQWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAscP96cU2PWKFh9P99AT+D49vb6YnrHE8n16wzuXL6QVLPLz/fHrCMqftND1hicdn+33O7k77PBvPH6YXrOMLFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMSOZ9/9bXrDEmeH/bbj9uZuesIy292b6Qn8r47H6QVLPHr94/SEZR7t9Hzcbm+nJyxzfv54esIS29X19IRl9vmUAQAMElgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALH/AlWBh479fQOqAAAAAElFTkSuQmCC" id="image2edaf35e60" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAFbCAYAAAAJGvDvAAAIJElEQVR4nO3YQYpcVRiG4a5OJxoJMYqJEkRBN6G4AqduwbFT9+EmFAQnDnTgxIk4deJEZ4JBJITYlEl10l3lGiLv4YfieVbwwb116r1ns//nq8PJMdqcTi9YZ7edXrDO7nx6wRKHy2fTE5bZ3HpjesIaL70yvWCdYz0fn++mF6xzpM/s8PjB9IRljvOJAQAMElgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQO/tj82h6wxIXV0+mJyxz7/Y70xOWefX2vekJS2wuttMTlvlp++v0hCXu37g7PWGZq/3l9IQlnu530xOW2T6/mJ6wxIe33p2esIwbLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIhtzi++OUyPWOHp5XZ6wjJ3T+9MT1jn2ZPpBWv8+2h6wTpvvDe9YInt4UjfxZOTk38vz6cnLPHmyZ3pCcv8dTjOM+Stx8f7O3ODBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQO7tx7eXpDbyo3ZPpBes8fjC9YInDxcX0hGU2r19OT1hic3q83583z25NT1ji4dV2esIyt87uTE9Y4rD7e3rCMsd7ggAADBFYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxzWc/fnqYHrHC493V9IRlfv7zfHrCMt998tH0hCXu3nx7esIyH3z59fSEJT5+/7XpCcv8/mg3PWGJa6eb6QnLfPv9b9MTljj/4vPpCcu4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiG0u9z8cpkescLW/nJ7A/3D9Yjc9YY2zG9ML1tk+nF6wxP61+9MTljkc9tMTlrh2xHcGzw/H+Z92/ThfxZOTEzdYAAA5gQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxs9M/fpnesMTp5njb8fD82fSEZQ6XV9MT1tjvpxesc+P69IIlTrcPpyfwgo75bLx+djY9YYnDk6fTE5Y53goBABgisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYv8B101/NJrY3m0AAAAASUVORK5CYII=" id="imageff55acf5f6" transform="scale(1 -1) translate(0 -249.84)" x="95.67625" y="-47.482309" width="432" height="249.84"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me6ba856ea8" d="M 0 0 
+       <path id="m1f0d1d5455" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me6ba856ea8" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="115.301649" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- alice29.txt -->
-      <g transform="translate(84.144757 373.521078) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(84.144757 338.601078) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-61" d="M 2194 1759 
 Q 1497 1759 1228 1600 
@@ -271,12 +271,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me6ba856ea8" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="154.552448" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- asyoulik.txt -->
-      <g transform="translate(120.568012 376.348621) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(120.568012 341.428621) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -402,12 +402,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me6ba856ea8" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="193.803246" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- cp.html -->
-      <g transform="translate(171.243004 364.924428) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(171.243004 330.004428) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-70" d="M 1159 525 
 L 1159 -1331 
@@ -498,12 +498,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me6ba856ea8" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="233.054045" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- fields.c -->
-      <g transform="translate(211.816092 363.602138) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(211.816092 328.682138) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -567,12 +567,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me6ba856ea8" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="272.304843" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- grammar.lsp -->
-      <g transform="translate(235.541478 379.127551) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(235.541478 344.207551) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-67" d="M 2906 1791 
 Q 2906 2416 2648 2759 
@@ -643,12 +643,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me6ba856ea8" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="311.555641" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- kennedy.xls -->
-      <g transform="translate(277.379403 376.540424) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(277.379403 341.620424) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -687,12 +687,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me6ba856ea8" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="350.80644" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- lcet10.txt -->
-      <g transform="translate(322.470019 370.700606) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(322.470019 335.780606) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -746,12 +746,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me6ba856ea8" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="390.057238" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- plrabn12.txt -->
-      <g transform="translate(353.970044 378.45138) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(353.970044 343.53138) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -798,12 +798,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me6ba856ea8" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="429.308037" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- ptt5 -->
-      <g transform="translate(416.505868 355.166354) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(416.505868 320.246354) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -841,12 +841,12 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me6ba856ea8" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="468.558835" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- sum -->
-      <g transform="translate(455.340358 355.582663) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(455.340358 320.662663) rotate(-45) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-75" transform="translate(52.099609 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(115.478516 0)"/>
@@ -856,12 +856,12 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me6ba856ea8" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1f0d1d5455" x="507.809634" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- xargs.1 -->
-      <g transform="translate(485.656862 364.516957) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(485.656862 329.596957) rotate(-45) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-78"/>
        <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
        <use xlink:href="#DejaVuSans-72" transform="translate(120.458984 0)"/>
@@ -877,17 +877,17 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m974a565865" d="M 0 0 
+       <path id="mc0cf6b108b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m974a565865" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0cf6b108b" x="95.67625" y="65.804558" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- lean-zip (native) -->
-      <g transform="translate(23.39875 70.150301) scale(0.08 -0.08)">
+      <g transform="translate(23.39875 68.843933) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -970,12 +970,12 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m974a565865" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0cf6b108b" x="95.67625" y="101.422673" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- miniz_oxide -->
-      <g transform="translate(41.56625 105.501152) scale(0.08 -0.08)">
+      <g transform="translate(41.56625 104.462048) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1002,12 +1002,12 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m974a565865" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0cf6b108b" x="95.67625" y="137.040789" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- libdeflate -->
-      <g transform="translate(51.15125 140.852003) scale(0.08 -0.08)">
+      <g transform="translate(51.15125 140.080164) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-6c"/>
        <use xlink:href="#DejaVuSans-69" transform="translate(27.783203 0)"/>
        <use xlink:href="#DejaVuSans-62" transform="translate(55.566406 0)"/>
@@ -1024,30 +1024,12 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m974a565865" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0cf6b108b" x="95.67625" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <!-- zopfli -->
-      <g transform="translate(67.2425 176.202854) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-7a"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
-       <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
-       <use xlink:href="#DejaVuSans-66" transform="translate(177.148438 0)"/>
-       <use xlink:href="#DejaVuSans-6c" transform="translate(212.353516 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_16">
-      <g>
-       <use xlink:href="#m974a565865" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
       <!-- Go compress/flate -->
-      <g transform="translate(15.81375 211.553705) scale(0.08 -0.08)">
+      <g transform="translate(15.81375 175.69828) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1102,15 +1084,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_6">
-     <g id="line2d_17">
+    <g id="ytick_5">
+     <g id="line2d_16">
       <g>
-       <use xlink:href="#m974a565865" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0cf6b108b" x="95.67625" y="208.27702" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_17">
+     <g id="text_16">
       <!-- JS fflate -->
-      <g transform="translate(57.87875 246.904556) scale(0.08 -0.08)">
+      <g transform="translate(57.87875 211.316395) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1169,15 +1151,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_7">
-     <g id="line2d_18">
+    <g id="ytick_6">
+     <g id="line2d_17">
       <g>
-       <use xlink:href="#m974a565865" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0cf6b108b" x="95.67625" y="243.895136" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_18">
+     <g id="text_17">
       <!-- Zig std.flate -->
-      <g transform="translate(40.4275 282.255407) scale(0.08 -0.08)">
+      <g transform="translate(40.4275 246.934511) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1209,15 +1191,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_8">
-     <g id="line2d_19">
+    <g id="ytick_7">
+     <g id="line2d_18">
       <g>
-       <use xlink:href="#m974a565865" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0cf6b108b" x="95.67625" y="279.513251" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_19">
+     <g id="text_18">
       <!-- OCaml decompress -->
-      <g transform="translate(10.8 317.606259) scale(0.08 -0.08)">
+      <g transform="translate(10.8 282.552626) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1283,28 +1265,56 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 95.67625 332.242309 
-L 95.67625 49.4355 
+    <path d="M 95.67625 297.322309 
+L 95.67625 47.9955 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 527.435033 332.242309 
-L 527.435033 49.4355 
+    <path d="M 527.435033 297.322309 
+L 527.435033 47.9955 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 95.67625 332.242309 
-L 527.435033 332.242309 
+    <path d="M 95.67625 297.322309 
+L 527.435033 297.322309 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 95.67625 49.4355 
-L 527.435033 49.4355 
+    <path d="M 95.67625 47.9955 
+L 527.435033 47.9955 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
+   <g id="text_19">
+    <!-- -79 -->
+    <g transform="translate(109.993485 67.598152) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_20">
-    <!-- -80 -->
-    <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
+    <!-- -77 -->
+    <g transform="translate(149.244284 67.598152) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- -87 -->
+    <g transform="translate(188.495082 67.598152) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1348,40 +1358,12 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- -77 -->
-    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -87 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
     <!-- -94 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(227.74588 67.598152) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1408,9 +1390,9 @@ z
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_24">
+   <g id="text_23">
     <!-- -96 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(266.996679 67.598152) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1448,57 +1430,57 @@ z
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_25">
+   <g id="text_24">
     <!-- -87 -->
-    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(306.247477 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_26">
+   <g id="text_25">
     <!-- -78 -->
-    <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(345.498276 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
+   <g id="text_26">
     <!-- -76 -->
-    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(384.749074 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- -87 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+   <g id="text_27">
+    <!-- -88 -->
+    <g transform="translate(423.999873 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_29">
+   <g id="text_28">
     <!-- -79 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(463.250671 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_29">
     <!-- -96 -->
-    <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(502.50147 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- +4 -->
-    <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
+   <g id="text_30">
+    <!-- +5 -->
+    <g transform="translate(110.510438 103.216267) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1517,27 +1499,28 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_32">
-    <!-- +9 -->
-    <g transform="translate(149.761237 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
+   <g id="text_31">
     <!-- +10 -->
-    <g transform="translate(186.944223 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(147.693424 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_34">
+   <g id="text_32">
+    <!-- +11 -->
+    <g transform="translate(186.944223 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
     <!-- -23 -->
-    <g transform="translate(227.74588 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(227.74588 103.216267) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1577,629 +1560,537 @@ z
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- -14 -->
-    <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
+   <g id="text_34">
+    <!-- -13 -->
+    <g transform="translate(266.996679 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -45 -->
+    <g transform="translate(306.247477 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- -46 -->
-    <g transform="translate(306.247477 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    <!-- +6 -->
+    <g transform="translate(346.015229 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- +7 -->
-    <g transform="translate(346.015229 104.25537) scale(0.065 -0.065)">
+    <!-- +9 -->
+    <g transform="translate(385.266027 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- +10 -->
-    <g transform="translate(383.198215 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    <!-- -4 -->
+    <g transform="translate(426.067685 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- -2 -->
-    <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    <!-- +13 -->
+    <g transform="translate(461.699812 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- +14 -->
-    <g transform="translate(461.699812 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_41">
     <!-- -12 -->
-    <g transform="translate(502.50147 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(502.50147 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_42">
-    <!-- +226 -->
-    <g transform="translate(106.374813 139.606222) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- +247 -->
-    <g transform="translate(145.625612 139.606222) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_44">
-    <!-- +306 -->
-    <g transform="translate(184.87641 139.606222) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_45">
-    <!-- +75 -->
-    <g transform="translate(226.195021 139.606222) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_46">
-    <!-- +30 -->
-    <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_47">
-    <!-- +307 -->
-    <g transform="translate(302.628805 139.606222) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_48">
-    <!-- +234 -->
-    <g transform="translate(341.879604 139.606222) scale(0.065 -0.065)">
+   <g id="text_41">
+    <!-- +232 -->
+    <g transform="translate(106.374813 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
-   <g id="text_49">
-    <!-- +275 -->
-    <g transform="translate(381.130402 139.606222) scale(0.065 -0.065)">
+   <g id="text_42">
+    <!-- +251 -->
+    <g transform="translate(145.625612 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
-   <g id="text_50">
+   <g id="text_43">
+    <!-- +313 -->
+    <g transform="translate(184.87641 138.834383) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- +78 -->
+    <g transform="translate(226.195021 138.834383) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_45">
+    <!-- +32 -->
+    <g transform="translate(265.44582 138.834383) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_46">
+    <!-- +310 -->
+    <g transform="translate(302.628805 138.834383) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_47">
+    <!-- +231 -->
+    <g transform="translate(341.879604 138.834383) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_48">
     <!-- +272 -->
-    <g transform="translate(420.381201 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(381.130402 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
-   <g id="text_51">
-    <!-- +399 -->
-    <g transform="translate(459.631999 139.606222) scale(0.065 -0.065)">
+   <g id="text_49">
+    <!-- +268 -->
+    <g transform="translate(420.381201 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_50">
+    <!-- +406 -->
+    <g transform="translate(459.631999 138.834383) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- +26 -->
+    <g transform="translate(500.95061 138.834383) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_52">
-    <!-- +24 -->
-    <g transform="translate(500.95061 139.606222) scale(0.065 -0.065)">
+    <!-- +14 -->
+    <g transform="translate(108.442626 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_53">
-    <!-- -97 -->
-    <g transform="translate(109.993485 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_54">
-    <!-- -98 -->
-    <g transform="translate(149.244284 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_55">
-    <!-- -99 -->
-    <g transform="translate(188.495082 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_56">
-    <!-- -100 -->
-    <g transform="translate(225.678068 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(163.330078 0)"/>
-    </g>
-   </g>
-   <g id="text_57">
-    <!-- -100 -->
-    <g transform="translate(264.928866 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(163.330078 0)"/>
-    </g>
-   </g>
-   <g id="text_58">
-    <!-- -99 -->
-    <g transform="translate(306.247477 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_59">
-    <!-- -97 -->
-    <g transform="translate(345.498276 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_60">
-    <!-- -96 -->
-    <g transform="translate(384.749074 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_61">
-    <!-- -99 -->
-    <g transform="translate(423.999873 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_62">
-    <!-- -100 -->
-    <g transform="translate(461.182859 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(163.330078 0)"/>
-    </g>
-   </g>
-   <g id="text_63">
-    <!-- -100 -->
-    <g transform="translate(500.433657 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(163.330078 0)"/>
-    </g>
-   </g>
-   <g id="text_64">
-    <!-- +12 -->
-    <g transform="translate(108.442626 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_65">
-    <!-- +25 -->
-    <g transform="translate(147.693424 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_66">
-    <!-- -39 -->
-    <g transform="translate(188.495082 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_67">
-    <!-- -77 -->
-    <g transform="translate(227.74588 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_68">
-    <!-- -89 -->
-    <g transform="translate(266.996679 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_69">
-    <!-- -17 -->
-    <g transform="translate(306.247477 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_70">
-    <!-- +24 -->
-    <g transform="translate(343.947416 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_71">
-    <!-- +29 -->
-    <g transform="translate(383.198215 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_72">
-    <!-- +41 -->
-    <g transform="translate(422.449013 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_73">
-    <!-- +27 -->
-    <g transform="translate(461.699812 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_74">
-    <!-- -90 -->
-    <g transform="translate(502.50147 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_75">
-    <!-- +24 -->
-    <g transform="translate(108.442626 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_76">
-    <!-- +44 -->
-    <g transform="translate(147.693424 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_77">
-    <!-- -19 -->
-    <g transform="translate(188.495082 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_78">
-    <!-- -35 -->
-    <g transform="translate(227.74588 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_79">
-    <!-- -63 -->
-    <g transform="translate(266.996679 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_80">
-    <!-- -12 -->
-    <g transform="translate(306.247477 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_81">
     <!-- +28 -->
-    <g transform="translate(343.947416 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(147.693424 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_82">
-    <!-- +45 -->
-    <g transform="translate(383.198215 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_83">
-    <!-- -25 -->
-    <g transform="translate(423.999873 245.658775) scale(0.065 -0.065)">
+   <g id="text_54">
+    <!-- -37 -->
+    <g transform="translate(188.495082 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_84">
-    <!-- +54 -->
-    <g transform="translate(461.699812 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_85">
-    <!-- -69 -->
-    <g transform="translate(502.50147 245.658775) scale(0.065 -0.065)">
+   <g id="text_55">
+    <!-- -77 -->
+    <g transform="translate(227.74588 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_56">
+    <!-- -89 -->
+    <g transform="translate(266.996679 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_86">
-    <!-- +62 -->
-    <g transform="translate(108.442626 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_87">
-    <!-- +80 -->
-    <g transform="translate(147.693424 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_88">
-    <!-- +29 -->
-    <g transform="translate(186.944223 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_89">
+   <g id="text_57">
     <!-- -16 -->
-    <g transform="translate(227.74588 281.009626) scale(0.065 -0.065)">
+    <g transform="translate(306.247477 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_90">
-    <!-- -40 -->
-    <g transform="translate(266.996679 281.009626) scale(0.065 -0.065)">
+   <g id="text_58">
+    <!-- +25 -->
+    <g transform="translate(343.947416 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_59">
+    <!-- +30 -->
+    <g transform="translate(383.198215 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_60">
+    <!-- +42 -->
+    <g transform="translate(422.449013 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_61">
+    <!-- +28 -->
+    <g transform="translate(461.699812 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_62">
+    <!-- -89 -->
+    <g transform="translate(502.50147 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_63">
+    <!-- +28 -->
+    <g transform="translate(108.442626 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_64">
+    <!-- +47 -->
+    <g transform="translate(147.693424 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_65">
+    <!-- -21 -->
+    <g transform="translate(188.495082 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_66">
+    <!-- -35 -->
+    <g transform="translate(227.74588 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_67">
+    <!-- -65 -->
+    <g transform="translate(266.996679 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_68">
+    <!-- -10 -->
+    <g transform="translate(306.247477 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_91">
+   <g id="text_69">
+    <!-- +26 -->
+    <g transform="translate(343.947416 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_70">
+    <!-- +48 -->
+    <g transform="translate(383.198215 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_71">
+    <!-- -24 -->
+    <g transform="translate(423.999873 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_72">
+    <!-- +53 -->
+    <g transform="translate(461.699812 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_73">
+    <!-- -69 -->
+    <g transform="translate(502.50147 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_74">
+    <!-- +66 -->
+    <g transform="translate(108.442626 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_75">
+    <!-- +82 -->
+    <g transform="translate(147.693424 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_76">
+    <!-- +33 -->
+    <g transform="translate(186.944223 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_77">
+    <!-- -17 -->
+    <g transform="translate(227.74588 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_78">
+    <!-- -38 -->
+    <g transform="translate(266.996679 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_79">
+    <!-- +115 -->
+    <g transform="translate(302.628805 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_80">
+    <!-- +70 -->
+    <g transform="translate(343.947416 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_81">
+    <!-- +79 -->
+    <g transform="translate(383.198215 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_82">
+    <!-- +93 -->
+    <g transform="translate(422.449013 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_83">
     <!-- +112 -->
-    <g transform="translate(302.628805 281.009626) scale(0.065 -0.065)">
+    <g transform="translate(459.631999 245.68873) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
-   <g id="text_92">
-    <!-- +71 -->
-    <g transform="translate(343.947416 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_93">
-    <!-- +81 -->
-    <g transform="translate(383.198215 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_94">
-    <!-- +97 -->
-    <g transform="translate(422.449013 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_95">
-    <!-- +99 -->
-    <g transform="translate(461.699812 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_96">
-    <!-- -52 -->
-    <g transform="translate(502.50147 281.009626) scale(0.065 -0.065)">
+   <g id="text_84">
+    <!-- -51 -->
+    <g transform="translate(502.50147 245.68873) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_97">
-    <!-- -37 -->
-    <g transform="translate(109.993485 316.360477) scale(0.065 -0.065)">
+   <g id="text_85">
+    <!-- -36 -->
+    <g transform="translate(109.993485 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_98">
-    <!-- -34 -->
-    <g transform="translate(149.244284 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_99">
-    <!-- -55 -->
-    <g transform="translate(188.495082 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_100">
-    <!-- -75 -->
-    <g transform="translate(227.74588 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_101">
-    <!-- -84 -->
-    <g transform="translate(266.996679 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_102">
-    <!-- -52 -->
-    <g transform="translate(306.247477 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_103">
-    <!-- -37 -->
-    <g transform="translate(345.498276 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_104">
-    <!-- -33 -->
-    <g transform="translate(384.749074 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_105">
-    <!-- -46 -->
-    <g transform="translate(423.999873 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_106">
-    <!-- -43 -->
-    <g transform="translate(463.250671 316.360477) scale(0.065 -0.065)">
+   <g id="text_86">
+    <!-- -34 -->
+    <g transform="translate(149.244284 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_87">
+    <!-- -53 -->
+    <g transform="translate(188.495082 281.306845) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_107">
-    <!-- -85 -->
-    <g transform="translate(502.50147 316.360477) scale(0.065 -0.065)">
+   <g id="text_88">
+    <!-- -74 -->
+    <g transform="translate(227.74588 281.306845) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_89">
+    <!-- -83 -->
+    <g transform="translate(266.996679 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_90">
+    <!-- -51 -->
+    <g transform="translate(306.247477 281.306845) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_91">
+    <!-- -37 -->
+    <g transform="translate(345.498276 281.306845) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_92">
+    <!-- -33 -->
+    <g transform="translate(384.749074 281.306845) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_93">
+    <!-- -47 -->
+    <g transform="translate(423.999873 281.306845) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_94">
+    <!-- -42 -->
+    <g transform="translate(463.250671 281.306845) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_95">
+    <!-- -84 -->
+    <g transform="translate(502.50147 281.306845) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
   <g id="axes_2">
    <g id="patch_7">
-    <path d="M 536.477102 303.864764 
-L 547.779688 303.864764 
-L 547.779688 77.813045 
-L 536.477102 77.813045 
+    <path d="M 536.477102 285.684764 
+L 547.779688 285.684764 
+L 547.779688 59.633045 
+L 536.477102 59.633045 
 z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagedb2e8c33a1" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqUlEQVR4nO2aQW7EMAwD5azf0p/3mdn0ESNgGFd7t0APKS6CZP3Wz1Pgt6+LHK+CxxsUJAxYbMBATBhwggtrsSgOxIQBA7GhVMeFqn1Bint92AAOceEr2Ax8BR1RfjuDveA2NUTZD5LuAg1SQqH4Nup9QJeJM7hsF07ogwpQYLdy2dvIFVAbA0qV5iBgF45wAUeZ2qhD1LfRX6YGiAEM7FZOiDLcRr4LXIEe5dcz8K8wUY6AiF8P6Ax8G6dQGq4Q0QeTxFqUAR6AXbCvkODCQPSv0PDouz5Qwbjg78JAHIg9Ax76BcTzfNEA7sIXKthPwQG6ggSIdMCXusAV6FFOSOLtKmiAOEk8olD8XdCjnJBE9O1/Qh/wKxRmIEPEChJcsBngHASUaoML/oD3FwpP4vSBHqSBWLVvdj5AQYcLcMDNbcQK2IAjILI6aNkFNoC78P4kBrSynoMGBVDCGYWCFbweIu6Dm5cqVuD3wb+HiBU0uOBDtF0I+GvTg9ShAJ1vibIO0a60iFa2IdInloZ3bZRBwADqAlUwLgzEpgET5QMGHAHRTuK4UPUHHcJfH2HQndcAAAAASUVORK5CYII=" id="image6bc276483d" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-59.04" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
-    <g id="ytick_9">
-     <g id="line2d_20">
+    <g id="ytick_8">
+     <g id="line2d_19">
       <defs>
-       <path id="mb5a1d13107" d="M 0 0 
+       <path id="md8acf89999" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb5a1d13107" x="547.779688" y="275.764316" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8acf89999" x="547.779688" y="284.015266" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_108">
-      <!-- −3 -->
-      <g transform="translate(554.779688 279.563535) scale(0.1 -0.1)">
+     <g id="text_96">
+      <!-- −4 -->
+      <g transform="translate(554.779688 287.814485) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2210,6 +2101,20 @@ z
 " transform="scale(0.015625)"/>
        </defs>
        <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#md8acf89999" x="547.779688" y="256.176176" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_97">
+      <!-- −3 -->
+      <g transform="translate(554.779688 259.975394) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
       </g>
      </g>
@@ -2217,12 +2122,12 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mb5a1d13107" x="547.779688" y="247.455846" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8acf89999" x="547.779688" y="228.337085" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_109">
+     <g id="text_98">
       <!-- −2 -->
-      <g transform="translate(554.779688 251.255065) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 232.136304) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2231,12 +2136,12 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb5a1d13107" x="547.779688" y="219.147375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8acf89999" x="547.779688" y="200.497995" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_110">
+     <g id="text_99">
       <!-- −1 -->
-      <g transform="translate(554.779688 222.946594) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 204.297214) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2245,12 +2150,12 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mb5a1d13107" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8acf89999" x="547.779688" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_111">
+     <g id="text_100">
       <!-- 0 -->
-      <g transform="translate(554.779688 194.638123) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 176.458123) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
       </g>
      </g>
@@ -2258,12 +2163,12 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb5a1d13107" x="547.779688" y="162.530434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8acf89999" x="547.779688" y="144.819814" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_112">
+     <g id="text_101">
       <!-- 1 -->
-      <g transform="translate(554.779688 166.329653) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 148.619033) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2271,12 +2176,12 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mb5a1d13107" x="547.779688" y="134.221963" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8acf89999" x="547.779688" y="116.980724" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_113">
+     <g id="text_102">
       <!-- 2 -->
-      <g transform="translate(554.779688 138.021182) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 120.779943) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2284,19 +2189,32 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb5a1d13107" x="547.779688" y="105.913493" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8acf89999" x="547.779688" y="89.141634" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_114">
+     <g id="text_103">
       <!-- 3 -->
-      <g transform="translate(554.779688 109.712712) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 92.940852) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
     </g>
-    <g id="text_115">
+    <g id="ytick_16">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#md8acf89999" x="547.779688" y="61.302543" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_104">
+      <!-- 4 -->
+      <g transform="translate(554.779688 65.101762) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_105">
      <!-- % vs zlib (higher=faster) -->
-     <g transform="translate(581.120313 253.142811) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(581.120313 234.962811) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-25" d="M 4653 2053 
 Q 4381 2053 4226 1822 
@@ -2389,20 +2307,20 @@ z
    </g>
    <g id="LineCollection_1"/>
    <g id="patch_8">
-    <path d="M 536.477102 303.864764 
-L 542.128395 303.864764 
-L 547.779688 303.864764 
-L 547.779688 77.813045 
-L 542.128395 77.813045 
-L 536.477102 77.813045 
-L 536.477102 303.864764 
+    <path d="M 536.477102 285.684764 
+L 542.128395 285.684764 
+L 547.779688 285.684764 
+L 547.779688 59.633045 
+L 542.128395 59.633045 
+L 536.477102 59.633045 
+L 536.477102 285.684764 
 z
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
-  <g id="text_116">
+  <g id="text_106">
    <!-- Compression speed vs zlib  (canterbury, level 6, relative to zlib) -->
-   <g transform="translate(80.680313 17.182125) scale(0.12 -0.12)">
+   <g transform="translate(80.680313 16.462125) scale(0.12 -0.12)">
     <defs>
      <path id="DejaVuSans-Bold-43" d="M 4288 256 
 Q 3956 84 3597 -3 
@@ -2944,9 +2862,9 @@ z
     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3559.632812 0)"/>
    </g>
   </g>
-  <g id="text_117">
-   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(21.833828 401.184) scale(0.07 -0.07)">
+  <g id="text_107">
+   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.069922 365.364) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3016,12 +2934,12 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3061,109 +2979,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p92d9436213">
-   <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
+  <clipPath id="pf5d267a168">
+   <rect x="95.67625" y="47.9955" width="431.758783" height="249.326809"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 47.9955
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pf5d267a168)">
+   <g clip-path="url(#p6094c0f736)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAFbCAYAAAAJGvDvAAAIJElEQVR4nO3YQYpcVRiG4a5OJxoJMYqJEkRBN6G4AqduwbFT9+EmFAQnDnTgxIk4deJEZ4JBJITYlEl10l3lGiLv4YfieVbwwb116r1ns//nq8PJMdqcTi9YZ7edXrDO7nx6wRKHy2fTE5bZ3HpjesIaL70yvWCdYz0fn++mF6xzpM/s8PjB9IRljvOJAQAMElgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQO/tj82h6wxIXV0+mJyxz7/Y70xOWefX2vekJS2wuttMTlvlp++v0hCXu37g7PWGZq/3l9IQlnu530xOW2T6/mJ6wxIe33p2esIwbLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIhtzi++OUyPWOHp5XZ6wjJ3T+9MT1jn2ZPpBWv8+2h6wTpvvDe9YInt4UjfxZOTk38vz6cnLPHmyZ3pCcv8dTjOM+Stx8f7O3ODBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQO7tx7eXpDbyo3ZPpBes8fjC9YInDxcX0hGU2r19OT1hic3q83583z25NT1ji4dV2esIyt87uTE9Y4rD7e3rCMsd7ggAADBFYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxzWc/fnqYHrHC493V9IRlfv7zfHrCMt998tH0hCXu3nx7esIyH3z59fSEJT5+/7XpCcv8/mg3PWGJa6eb6QnLfPv9b9MTljj/4vPpCcu4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiG0u9z8cpkescLW/nJ7A/3D9Yjc9YY2zG9ML1tk+nF6wxP61+9MTljkc9tMTlrh2xHcGzw/H+Z92/ThfxZOTEzdYAAA5gQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACxs9M/fpnesMTp5njb8fD82fSEZQ6XV9MT1tjvpxesc+P69IIlTrcPpyfwgo75bLx+djY9YYnDk6fTE5Y53goBABgisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYv8B101/NJrY3m0AAAAASUVORK5CYII=" id="imageff55acf5f6" transform="scale(1 -1) translate(0 -249.84)" x="95.67625" y="-47.482309" width="432" height="249.84"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAFbCAYAAAAJGvDvAAAIIElEQVR4nO3YS4pdVRiG4dQlhZeIBk0UUTvqEGyKbUfgAGzbdR4OwkZwCOKl4wQEm4qgCMZgQqWsqpyqOscxCO/ix8PzjODbbPbi3etge/pgd4v/l8359IJ1Lk6nF6xxs5lesM6d16YXrHHywvSCdQ4OpxescXU5vWCdo+PpBWs8/n16wTJ7+pUBAMwRWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABA7/nX3cHrDEs9uzqcnLHP/xXemJyxz96X70xPWuDydXrDMD2c/TU9Y4o3jV6cnLLO5eTY9YYnL66vpCcuc/nMxPWGJj+68Pz1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEDt48uyr3fSIFS6uz6YnLPP60WvTE9bZnE8vWOPs0fSCde69N71gidPt6fSEZc6unkxPWOLNo/vTE5b57eqP6QlLvH16PT1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx45PD56Y3rHE8PWChZ+fTC9Z58sf0giV2m8vpCcscbK+nJyxxuMf/n88f3ZmesMSf27+nJyxz5/Yr0xOW2F3+Oj1hmf09QQAAhggsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYwWfff7qbHrHC0812esIyX//yeHrCMt998uH0hCXuPf/W9IRlPvjywfSEJT5+9+70hGV++utiegL/0bff/Dw9YYnTLz6fnrCMGywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjB9fbr3fSIFW6219MTltnd2k5PWObkak/f29HJ9IJ1zh5NL1ji5uX70xOW2e728wy5vdvfO4PNwX6ejSfb/X1n+/tkAABDBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEjg9/+3F6wxKHB/vbjrvrzfSEZXabq+kJ/Fcnt6cXLHH09OH0hGWO9vR83Oez8eToeHrCEruLi+kJy+znVwYAMEhgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE/gXbxn8J/6WTpwAAAABJRU5ErkJggg==" id="image3b7da9ad17" transform="scale(1 -1) translate(0 -249.84)" x="95.67625" y="-47.482309" width="432" height="249.84"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m1f0d1d5455" d="M 0 0 
+       <path id="mdfb4e38240" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1f0d1d5455" x="115.301649" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="115.301649" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="154.552448" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="154.552448" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="193.803246" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="193.803246" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="233.054045" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="233.054045" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="272.304843" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="272.304843" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="311.555641" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="311.555641" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="350.80644" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="350.80644" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="390.057238" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="390.057238" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="429.308037" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="429.308037" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="468.558835" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="468.558835" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m1f0d1d5455" x="507.809634" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdfb4e38240" x="507.809634" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mc0cf6b108b" d="M 0 0 
+       <path id="m27753eeec6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc0cf6b108b" x="95.67625" y="65.804558" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27753eeec6" x="95.67625" y="65.804558" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mc0cf6b108b" x="95.67625" y="101.422673" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27753eeec6" x="95.67625" y="101.422673" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc0cf6b108b" x="95.67625" y="137.040789" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27753eeec6" x="95.67625" y="137.040789" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc0cf6b108b" x="95.67625" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27753eeec6" x="95.67625" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1087,7 +1087,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc0cf6b108b" x="95.67625" y="208.27702" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27753eeec6" x="95.67625" y="208.27702" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1154,7 +1154,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc0cf6b108b" x="95.67625" y="243.895136" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27753eeec6" x="95.67625" y="243.895136" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1194,7 +1194,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc0cf6b108b" x="95.67625" y="279.513251" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m27753eeec6" x="95.67625" y="279.513251" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1305,15 +1305,47 @@ z
     </g>
    </g>
    <g id="text_20">
-    <!-- -77 -->
+    <!-- -76 -->
     <g transform="translate(149.244284 67.598152) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- -87 -->
+    <!-- -86 -->
     <g transform="translate(188.495082 67.598152) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1358,7 +1390,7 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1393,38 +1425,6 @@ z
    <g id="text_23">
     <!-- -96 -->
     <g transform="translate(266.996679 67.598152) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1447,27 +1447,27 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- -76 -->
+    <!-- -75 -->
     <g transform="translate(384.749074 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- -88 -->
+    <!-- -87 -->
     <g transform="translate(423.999873 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -79 -->
+    <!-- -78 -->
     <g transform="translate(463.250671 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -1503,24 +1503,16 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- +10 -->
-    <g transform="translate(147.693424 103.216267) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
     <!-- +11 -->
-    <g transform="translate(186.944223 103.216267) scale(0.065 -0.065)">
+    <g transform="translate(147.693424 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- -23 -->
-    <g transform="translate(227.74588 103.216267) scale(0.065 -0.065)">
+   <g id="text_32">
+    <!-- +13 -->
+    <g transform="translate(186.944223 103.216267) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1555,182 +1547,191 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -13 -->
-    <g transform="translate(266.996679 103.216267) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -45 -->
-    <g transform="translate(306.247477 103.216267) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- +6 -->
-    <g transform="translate(346.015229 103.216267) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- +9 -->
-    <g transform="translate(385.266027 103.216267) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- -4 -->
-    <g transform="translate(426.067685 103.216267) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- +13 -->
-    <g transform="translate(461.699812 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_40">
+   <g id="text_33">
+    <!-- -21 -->
+    <g transform="translate(227.74588 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
     <!-- -12 -->
-    <g transform="translate(502.50147 103.216267) scale(0.065 -0.065)">
+    <g transform="translate(266.996679 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_35">
+    <!-- -44 -->
+    <g transform="translate(306.247477 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- +8 -->
+    <g transform="translate(346.015229 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- +13 -->
+    <g transform="translate(383.198215 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- -7 -->
+    <g transform="translate(426.067685 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- +16 -->
+    <g transform="translate(461.699812 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- -10 -->
+    <g transform="translate(502.50147 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_41">
-    <!-- +232 -->
+    <!-- +237 -->
     <g transform="translate(106.374813 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- +251 -->
+    <!-- +255 -->
     <g transform="translate(145.625612 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- +313 -->
+    <!-- +329 -->
     <g transform="translate(184.87641 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- +78 -->
+    <!-- +80 -->
     <g transform="translate(226.195021 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +32 -->
+    <!-- +33 -->
     <g transform="translate(265.44582 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- +310 -->
+    <!-- +317 -->
     <g transform="translate(302.628805 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_47">
-    <!-- +231 -->
+    <!-- +239 -->
     <g transform="translate(341.879604 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_48">
-    <!-- +272 -->
+    <!-- +286 -->
     <g transform="translate(381.130402 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_49">
-    <!-- +268 -->
-    <g transform="translate(420.381201 138.834383) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_50">
-    <!-- +406 -->
-    <g transform="translate(459.631999 138.834383) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
-   <g id="text_51">
-    <!-- +26 -->
-    <g transform="translate(500.95061 138.834383) scale(0.065 -0.065)">
+   <g id="text_49">
+    <!-- +285 -->
+    <g transform="translate(420.381201 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
-   <g id="text_52">
-    <!-- +14 -->
-    <g transform="translate(108.442626 174.452498) scale(0.065 -0.065)">
+   <g id="text_50">
+    <!-- +413 -->
+    <g transform="translate(459.631999 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
-   <g id="text_53">
+   <g id="text_51">
     <!-- +28 -->
-    <g transform="translate(147.693424 174.452498) scale(0.065 -0.065)">
+    <g transform="translate(500.95061 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_52">
+    <!-- +17 -->
+    <g transform="translate(108.442626 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_53">
+    <!-- +30 -->
+    <g transform="translate(147.693424 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_54">
-    <!-- -37 -->
+    <!-- -34 -->
     <g transform="translate(188.495082 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_55">
@@ -1750,83 +1751,83 @@ z
     </g>
    </g>
    <g id="text_57">
-    <!-- -16 -->
+    <!-- -14 -->
     <g transform="translate(306.247477 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_58">
-    <!-- +25 -->
+    <!-- +29 -->
     <g transform="translate(343.947416 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_59">
-    <!-- +30 -->
+    <!-- +37 -->
     <g transform="translate(383.198215 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_60">
+    <!-- +49 -->
+    <g transform="translate(422.449013 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_61">
+    <!-- +36 -->
+    <g transform="translate(461.699812 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_62">
+    <!-- -88 -->
+    <g transform="translate(502.50147 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_63">
+    <!-- +30 -->
+    <g transform="translate(108.442626 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_60">
-    <!-- +42 -->
-    <g transform="translate(422.449013 174.452498) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_61">
-    <!-- +28 -->
-    <g transform="translate(461.699812 174.452498) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_62">
-    <!-- -89 -->
-    <g transform="translate(502.50147 174.452498) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_63">
-    <!-- +28 -->
-    <g transform="translate(108.442626 210.070614) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
    <g id="text_64">
-    <!-- +47 -->
+    <!-- +50 -->
     <g transform="translate(147.693424 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_65">
-    <!-- -21 -->
+    <!-- -18 -->
     <g transform="translate(188.495082 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_66">
-    <!-- -35 -->
+    <!-- -34 -->
     <g transform="translate(227.74588 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_67">
@@ -1838,173 +1839,173 @@ z
     </g>
    </g>
    <g id="text_68">
-    <!-- -10 -->
-    <g transform="translate(306.247477 210.070614) scale(0.065 -0.065)">
+    <!-- -9 -->
+    <g transform="translate(308.31529 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_69">
-    <!-- +26 -->
+    <!-- +30 -->
     <g transform="translate(343.947416 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_70">
-    <!-- +48 -->
+    <!-- +55 -->
     <g transform="translate(383.198215 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
-    <!-- -24 -->
+    <!-- -21 -->
     <g transform="translate(423.999873 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_72">
-    <!-- +53 -->
+    <!-- +62 -->
     <g transform="translate(461.699812 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_73">
-    <!-- -69 -->
-    <g transform="translate(502.50147 210.070614) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_74">
-    <!-- +66 -->
-    <g transform="translate(108.442626 245.68873) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_75">
-    <!-- +82 -->
-    <g transform="translate(147.693424 245.68873) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_76">
-    <!-- +33 -->
-    <g transform="translate(186.944223 245.68873) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_77">
-    <!-- -17 -->
-    <g transform="translate(227.74588 245.68873) scale(0.065 -0.065)">
+   <g id="text_73">
+    <!-- -68 -->
+    <g transform="translate(502.50147 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_78">
-    <!-- -38 -->
-    <g transform="translate(266.996679 245.68873) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_74">
+    <!-- +69 -->
+    <g transform="translate(108.442626 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_75">
+    <!-- +85 -->
+    <g transform="translate(147.693424 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_76">
+    <!-- +38 -->
+    <g transform="translate(186.944223 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_77">
+    <!-- -16 -->
+    <g transform="translate(227.74588 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_78">
+    <!-- -37 -->
+    <g transform="translate(266.996679 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_79">
-    <!-- +115 -->
+    <!-- +119 -->
     <g transform="translate(302.628805 245.68873) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_80">
-    <!-- +70 -->
+    <!-- +75 -->
     <g transform="translate(343.947416 245.68873) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_81">
-    <!-- +79 -->
+    <!-- +88 -->
     <g transform="translate(383.198215 245.68873) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_82">
-    <!-- +93 -->
-    <g transform="translate(422.449013 245.68873) scale(0.065 -0.065)">
+    <!-- +103 -->
+    <g transform="translate(420.381201 245.68873) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_83">
-    <!-- +112 -->
+    <!-- +125 -->
     <g transform="translate(459.631999 245.68873) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_84">
-    <!-- -51 -->
+    <!-- -50 -->
     <g transform="translate(502.50147 245.68873) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_85">
-    <!-- -36 -->
+    <!-- -34 -->
     <g transform="translate(109.993485 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_86">
-    <!-- -34 -->
+    <!-- -33 -->
     <g transform="translate(149.244284 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_87">
-    <!-- -53 -->
-    <g transform="translate(188.495082 281.306845) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_87">
+    <!-- -50 -->
+    <g transform="translate(188.495082 281.306845) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_88">
-    <!-- -74 -->
+    <!-- -73 -->
     <g transform="translate(227.74588 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_89">
@@ -2016,43 +2017,43 @@ z
     </g>
    </g>
    <g id="text_90">
-    <!-- -51 -->
+    <!-- -50 -->
     <g transform="translate(306.247477 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_91">
-    <!-- -37 -->
+    <!-- -35 -->
     <g transform="translate(345.498276 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_92">
-    <!-- -33 -->
+    <!-- -30 -->
     <g transform="translate(384.749074 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_93">
-    <!-- -47 -->
+    <!-- -44 -->
     <g transform="translate(423.999873 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_94">
-    <!-- -42 -->
+    <!-- -39 -->
     <g transform="translate(463.250671 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_95">
@@ -2074,23 +2075,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqUlEQVR4nO2aQW7EMAwD5azf0p/3mdn0ESNgGFd7t0APKS6CZP3Wz1Pgt6+LHK+CxxsUJAxYbMBATBhwggtrsSgOxIQBA7GhVMeFqn1Bint92AAOceEr2Ax8BR1RfjuDveA2NUTZD5LuAg1SQqH4Nup9QJeJM7hsF07ogwpQYLdy2dvIFVAbA0qV5iBgF45wAUeZ2qhD1LfRX6YGiAEM7FZOiDLcRr4LXIEe5dcz8K8wUY6AiF8P6Ax8G6dQGq4Q0QeTxFqUAR6AXbCvkODCQPSv0PDouz5Qwbjg78JAHIg9Ax76BcTzfNEA7sIXKthPwQG6ggSIdMCXusAV6FFOSOLtKmiAOEk8olD8XdCjnJBE9O1/Qh/wKxRmIEPEChJcsBngHASUaoML/oD3FwpP4vSBHqSBWLVvdj5AQYcLcMDNbcQK2IAjILI6aNkFNoC78P4kBrSynoMGBVDCGYWCFbweIu6Dm5cqVuD3wb+HiBU0uOBDtF0I+GvTg9ShAJ1vibIO0a60iFa2IdInloZ3bZRBwADqAlUwLgzEpgET5QMGHAHRTuK4UPUHHcJfH2HQndcAAAAASUVORK5CYII=" id="image6bc276483d" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-59.04" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqUlEQVR4nO2aQW7EMAwD5azf0p/3mdn0ESNgGFd7t0APKS6CZP3Wz1Pgt6+LHK+CxxsUJAxYbMBATBhwggtrsSgOxIQBA7GhVMeFqn1Bint92AAOceEr2Ax8BR1RfjuDveA2NUTZD5LuAg1SQqH4Nup9QJeJM7hsF07ogwpQYLdy2dvIFVAbA0qV5iBgF45wAUeZ2qhD1LfRX6YGiAEM7FZOiDLcRr4LXIEe5dcz8K8wUY6AiF8P6Ax8G6dQGq4Q0QeTxFqUAR6AXbCvkODCQPSv0PDouz5Qwbjg78JAHIg9Ax76BcTzfNEA7sIXKthPwQG6ggSIdMCXusAV6FFOSOLtKmiAOEk8olD8XdCjnJBE9O1/Qh/wKxRmIEPEChJcsBngHASUaoML/oD3FwpP4vSBHqSBWLVvdj5AQYcLcMDNbcQK2IAjILI6aNkFNoC78P4kBrSynoMGBVDCGYWCFbweIu6Dm5cqVuD3wb+HiBU0uOBDtF0I+GvTg9ShAJ1vibIO0a60iFa2IdInloZ3bZRBwADqAlUwLgzEpgET5QMGHAHRTuK4UPUHHcJfH2HQndcAAAAASUVORK5CYII=" id="imageb6396f6709" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-59.04" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_19">
       <defs>
-       <path id="md8acf89999" d="M 0 0 
+       <path id="md8f6805485" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md8acf89999" x="547.779688" y="284.015266" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8f6805485" x="547.779688" y="282.006329" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_96">
       <!-- −4 -->
-      <g transform="translate(554.779688 287.814485) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 285.805548) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2108,12 +2109,12 @@ z
     <g id="ytick_9">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md8acf89999" x="547.779688" y="256.176176" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8f6805485" x="547.779688" y="254.669473" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_97">
       <!-- −3 -->
-      <g transform="translate(554.779688 259.975394) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 258.468692) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
       </g>
@@ -2122,12 +2123,12 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#md8acf89999" x="547.779688" y="228.337085" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8f6805485" x="547.779688" y="227.332617" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_98">
       <!-- −2 -->
-      <g transform="translate(554.779688 232.136304) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 231.131836) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2136,12 +2137,12 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md8acf89999" x="547.779688" y="200.497995" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8f6805485" x="547.779688" y="199.995761" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_99">
       <!-- −1 -->
-      <g transform="translate(554.779688 204.297214) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 203.79498) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2150,7 +2151,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#md8acf89999" x="547.779688" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8f6805485" x="547.779688" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_100">
@@ -2163,12 +2164,12 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md8acf89999" x="547.779688" y="144.819814" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8f6805485" x="547.779688" y="145.322048" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_101">
       <!-- 1 -->
-      <g transform="translate(554.779688 148.619033) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 149.121267) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2176,12 +2177,12 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#md8acf89999" x="547.779688" y="116.980724" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8f6805485" x="547.779688" y="117.985192" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_102">
       <!-- 2 -->
-      <g transform="translate(554.779688 120.779943) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 121.784411) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2189,12 +2190,12 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md8acf89999" x="547.779688" y="89.141634" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8f6805485" x="547.779688" y="90.648336" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_103">
       <!-- 3 -->
-      <g transform="translate(554.779688 92.940852) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 94.447555) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2202,12 +2203,12 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#md8acf89999" x="547.779688" y="61.302543" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md8f6805485" x="547.779688" y="63.31148" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_104">
       <!-- 4 -->
-      <g transform="translate(554.779688 65.101762) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 67.110699) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-34"/>
       </g>
      </g>
@@ -2863,8 +2864,8 @@ z
    </g>
   </g>
   <g id="text_107">
-   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.069922 365.364) scale(0.07 -0.07)">
+   <!-- 2026-06-10T08:22:01Z  ·  Linux chungus x86_64  ·  commit 3050fc62  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.904453 365.364) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2934,13 +2935,13 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2979,109 +2980,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf5d267a168">
+  <clipPath id="p6094c0f736">
    <rect x="95.67625" y="47.9955" width="431.758783" height="249.326809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 122.006545 412.80375 
 L 122.006545 48.323125 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m8156b67f0e" d="M 0 0 
+       <path id="m52a60f6e47" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8156b67f0e" x="122.006545" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52a60f6e47" x="122.006545" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 218.120913 412.80375 
 L 218.120913 48.323125 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8156b67f0e" x="218.120913" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52a60f6e47" x="218.120913" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 314.235281 412.80375 
 L 314.235281 48.323125 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8156b67f0e" x="314.235281" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52a60f6e47" x="314.235281" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 410.349649 412.80375 
 L 410.349649 48.323125 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8156b67f0e" x="410.349649" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52a60f6e47" x="410.349649" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 506.464017 412.80375 
 L 506.464017 48.323125 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8156b67f0e" x="506.464017" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52a60f6e47" x="506.464017" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 602.578384 412.80375 
 L 602.578384 48.323125 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8156b67f0e" x="602.578384" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m52a60f6e47" x="602.578384" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -833,23 +833,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_13">
-      <path d="M 49.078125 283.533136 
-L 637.2 283.533136 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 278.630216 
+L 637.2 278.630216 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <defs>
-       <path id="m45f0f2329e" d="M 0 0 
+       <path id="m622e759740" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m45f0f2329e" x="49.078125" y="283.533136" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m622e759740" x="49.078125" y="278.630216" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 287.332354) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 282.429435) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -874,18 +874,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_15">
-      <path d="M 49.078125 146.255452 
-L 637.2 146.255452 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 143.599694 
+L 637.2 143.599694 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m45f0f2329e" x="49.078125" y="146.255452" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m622e759740" x="49.078125" y="143.599694" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 150.054671) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 147.398912) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -894,246 +894,246 @@ L 637.2 146.255452
     </g>
     <g id="ytick_3">
      <g id="line2d_17">
-      <path d="M 49.078125 379.486119 
-L 637.2 379.486119 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 373.012501 
+L 637.2 373.012501 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <defs>
-       <path id="m2541949ae3" d="M 0 0 
+       <path id="m30d8526d72" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="379.486119" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="373.012501" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_19">
-      <path d="M 49.078125 355.312719 
-L 637.2 355.312719 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 349.234806 
+L 637.2 349.234806 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="355.312719" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="349.234806" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_21">
-      <path d="M 49.078125 338.161418 
-L 637.2 338.161418 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 332.364264 
+L 637.2 332.364264 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="338.161418" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="332.364264" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_23">
-      <path d="M 49.078125 324.857836 
-L 637.2 324.857836 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 319.278454 
+L 637.2 319.278454 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="324.857836" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="319.278454" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_25">
-      <path d="M 49.078125 313.988018 
-L 637.2 313.988018 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 308.586569 
+L 637.2 308.586569 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="313.988018" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="308.586569" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_27">
-      <path d="M 49.078125 304.797718 
-L 637.2 304.797718 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 299.546709 
+L 637.2 299.546709 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="304.797718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="299.546709" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_29">
-      <path d="M 49.078125 296.836718 
-L 637.2 296.836718 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 291.716026 
+L 637.2 291.716026 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="296.836718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="291.716026" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_31">
-      <path d="M 49.078125 289.814618 
-L 637.2 289.814618 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 284.808874 
+L 637.2 284.808874 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="289.814618" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="284.808874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_33">
-      <path d="M 49.078125 242.208435 
-L 637.2 242.208435 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 237.981979 
+L 637.2 237.981979 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="242.208435" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="237.981979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_35">
-      <path d="M 49.078125 218.035035 
-L 637.2 218.035035 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 214.204284 
+L 637.2 214.204284 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="218.035035" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="214.204284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_37">
-      <path d="M 49.078125 200.883735 
-L 637.2 200.883735 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 197.333741 
+L 637.2 197.333741 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="200.883735" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="197.333741" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_39">
-      <path d="M 49.078125 187.580152 
-L 637.2 187.580152 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 184.247931 
+L 637.2 184.247931 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="187.580152" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="184.247931" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_41">
-      <path d="M 49.078125 176.710334 
-L 637.2 176.710334 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 173.556046 
+L 637.2 173.556046 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="176.710334" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="173.556046" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_43">
-      <path d="M 49.078125 167.520034 
-L 637.2 167.520034 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 164.516186 
+L 637.2 164.516186 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="167.520034" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="164.516186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_45">
-      <path d="M 49.078125 159.559034 
-L 637.2 159.559034 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 156.685503 
+L 637.2 156.685503 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="159.559034" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="156.685503" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_47">
-      <path d="M 49.078125 152.536934 
-L 637.2 152.536934 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 149.778352 
+L 637.2 149.778352 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="152.536934" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="149.778352" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_49">
-      <path d="M 49.078125 104.930751 
-L 637.2 104.930751 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 102.951456 
+L 637.2 102.951456 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="104.930751" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="102.951456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_51">
-      <path d="M 49.078125 80.757351 
-L 637.2 80.757351 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 79.173761 
+L 637.2 79.173761 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="80.757351" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="79.173761" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_53">
-      <path d="M 49.078125 63.606051 
-L 637.2 63.606051 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 62.303219 
+L 637.2 62.303219 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="63.606051" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="62.303219" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_55">
-      <path d="M 49.078125 50.302469 
-L 637.2 50.302469 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 49.217409 
+L 637.2 49.217409 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m2541949ae3" x="49.078125" y="50.302469" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m30d8526d72" x="49.078125" y="49.217409" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1255,7 +1255,7 @@ L 637.2 48.323125
    </g>
    <g id="text_11">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(266.388575 254.24444) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(236.977966 249.285636) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1287,7 +1287,7 @@ z
    </g>
    <g id="text_12">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(121.643128 391.236449) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(118.788393 391.236449) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1616,110 +1616,110 @@ z
     </g>
    </g>
    <g id="line2d_57">
-    <path d="M 329.937272 104.442368 
-L 278.002664 113.236337 
-L 237.248149 130.477884 
-L 178.503832 135.992401 
-L 133.66425 158.883767 
-L 118.044941 182.837351 
-L 115.691571 192.132267 
-L 108.238162 214.997174 
-L 105.622983 228.958594 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 329.937272 106.533843 
+L 278.002664 114.444954 
+L 237.248149 130.600066 
+L 178.503832 135.339621 
+L 133.66425 158.36631 
+L 118.044941 181.34241 
+L 115.691571 190.244123 
+L 108.238162 212.44155 
+L 105.622983 226.016623 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mce10842166" d="M -2.5 2.5 
+     <path id="m61e2f6e1fe" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8e93a1f5c)">
-     <use xlink:href="#mce10842166" x="329.937272" y="104.442368" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce10842166" x="278.002664" y="113.236337" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce10842166" x="237.248149" y="130.477884" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce10842166" x="178.503832" y="135.992401" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce10842166" x="133.66425" y="158.883767" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce10842166" x="118.044941" y="182.837351" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce10842166" x="115.691571" y="192.132267" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce10842166" x="108.238162" y="214.997174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mce10842166" x="105.622983" y="228.958594" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pde0927a43e)">
+     <use xlink:href="#m61e2f6e1fe" x="329.937272" y="106.533843" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61e2f6e1fe" x="278.002664" y="114.444954" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61e2f6e1fe" x="237.248149" y="130.600066" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61e2f6e1fe" x="178.503832" y="135.339621" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61e2f6e1fe" x="133.66425" y="158.36631" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61e2f6e1fe" x="118.044941" y="181.34241" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61e2f6e1fe" x="115.691571" y="190.244123" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61e2f6e1fe" x="108.238162" y="212.44155" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61e2f6e1fe" x="105.622983" y="226.016623" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_58">
-    <path d="M 523.75373 79.549583 
-L 250.990576 108.146695 
-L 179.656223 135.705829 
-L 145.072522 143.248726 
-L 132.855384 157.522019 
-L 118.236124 186.34059 
-L 117.307827 195.762894 
-L 114.109926 204.504766 
-L 112.448796 209.301605 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 523.75373 78.76837 
+L 250.990576 108.584637 
+L 179.656223 135.021703 
+L 145.072522 142.170421 
+L 132.855384 156.408244 
+L 118.236124 184.098054 
+L 117.307827 193.191168 
+L 114.109926 201.667529 
+L 112.448796 206.156253 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m3be9144ce4" d="M 0 -2.5 
+     <path id="m5af9016aeb" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8e93a1f5c)">
-     <use xlink:href="#m3be9144ce4" x="523.75373" y="79.549583" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3be9144ce4" x="250.990576" y="108.146695" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3be9144ce4" x="179.656223" y="135.705829" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3be9144ce4" x="145.072522" y="143.248726" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3be9144ce4" x="132.855384" y="157.522019" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3be9144ce4" x="118.236124" y="186.34059" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3be9144ce4" x="117.307827" y="195.762894" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3be9144ce4" x="114.109926" y="204.504766" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3be9144ce4" x="112.448796" y="209.301605" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pde0927a43e)">
+     <use xlink:href="#m5af9016aeb" x="523.75373" y="78.76837" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5af9016aeb" x="250.990576" y="108.584637" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5af9016aeb" x="179.656223" y="135.021703" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5af9016aeb" x="145.072522" y="142.170421" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5af9016aeb" x="132.855384" y="156.408244" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5af9016aeb" x="118.236124" y="184.098054" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5af9016aeb" x="117.307827" y="193.191168" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5af9016aeb" x="114.109926" y="201.667529" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5af9016aeb" x="112.448796" y="206.156253" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_59">
     <path d="M 215.607131 64.890426 
-L 163.03681 86.294771 
-L 144.561452 94.673077 
-L 136.63649 98.184501 
-L 112.246904 108.210313 
-L 102.468694 118.861595 
-L 97.700149 135.965688 
-L 78.648566 165.167747 
-L 75.810938 174.633982 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 163.03681 84.937106 
+L 144.561452 93.175003 
+L 136.63649 96.43828 
+L 112.246904 107.102999 
+L 102.468694 117.186628 
+L 97.700149 133.608096 
+L 78.648566 162.430966 
+L 75.810938 171.893941 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma75c70e9b3" d="M -0 3.535534 
+     <path id="me976ca8d44" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8e93a1f5c)">
-     <use xlink:href="#ma75c70e9b3" x="215.607131" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma75c70e9b3" x="163.03681" y="86.294771" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma75c70e9b3" x="144.561452" y="94.673077" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma75c70e9b3" x="136.63649" y="98.184501" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma75c70e9b3" x="112.246904" y="108.210313" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma75c70e9b3" x="102.468694" y="118.861595" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma75c70e9b3" x="97.700149" y="135.965688" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma75c70e9b3" x="78.648566" y="165.167747" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma75c70e9b3" x="75.810938" y="174.633982" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pde0927a43e)">
+     <use xlink:href="#me976ca8d44" x="215.607131" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me976ca8d44" x="163.03681" y="84.937106" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me976ca8d44" x="144.561452" y="93.175003" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me976ca8d44" x="136.63649" y="96.43828" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me976ca8d44" x="112.246904" y="107.102999" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me976ca8d44" x="102.468694" y="117.186628" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me976ca8d44" x="97.700149" y="133.608096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me976ca8d44" x="78.648566" y="162.430966" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me976ca8d44" x="75.810938" y="171.893941" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_60">
-    <path d="M 338.063322 167.866323 
-L 245.574267 169.924297 
-L 215.185478 176.004428 
-L 159.770378 179.689004 
-L 125.661082 196.980905 
-L 116.984485 210.132786 
-L 113.442444 218.912984 
-L 108.568337 233.00956 
-L 107.280778 247.743061 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 338.063322 164.856806 
+L 245.574267 166.881093 
+L 215.185478 172.861695 
+L 159.770378 176.485956 
+L 125.661082 193.494798 
+L 116.984485 206.431391 
+L 113.442444 215.067861 
+L 108.568337 228.933684 
+L 107.280778 243.426005 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mbc7d30f5c9" d="M -0.833333 2.5 
+     <path id="mb0178ab73c" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1734,31 +1734,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8e93a1f5c)">
-     <use xlink:href="#mbc7d30f5c9" x="338.063322" y="167.866323" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc7d30f5c9" x="245.574267" y="169.924297" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc7d30f5c9" x="215.185478" y="176.004428" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc7d30f5c9" x="159.770378" y="179.689004" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc7d30f5c9" x="125.661082" y="196.980905" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc7d30f5c9" x="116.984485" y="210.132786" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc7d30f5c9" x="113.442444" y="218.912984" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc7d30f5c9" x="108.568337" y="233.00956" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc7d30f5c9" x="107.280778" y="247.743061" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pde0927a43e)">
+     <use xlink:href="#mb0178ab73c" x="338.063322" y="164.856806" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0178ab73c" x="245.574267" y="166.881093" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0178ab73c" x="215.185478" y="172.861695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0178ab73c" x="159.770378" y="176.485956" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0178ab73c" x="125.661082" y="193.494798" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0178ab73c" x="116.984485" y="206.431391" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0178ab73c" x="113.442444" y="215.067861" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0178ab73c" x="108.568337" y="228.933684" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb0178ab73c" x="107.280778" y="243.426005" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_61">
-    <path d="M 270.681118 161.733425 
-L 214.151485 169.306799 
-L 186.847623 175.148256 
-L 172.446678 180.083547 
-L 168.817445 181.175779 
-L 156.184831 191.604471 
-L 153.183054 195.602244 
-L 151.316616 203.859202 
-L 150.959225 210.961016 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 270.681118 158.824301 
+L 214.151485 166.273703 
+L 186.847623 172.019538 
+L 172.446678 176.874041 
+L 168.817445 177.948394 
+L 156.184831 188.206374 
+L 153.183054 192.138706 
+L 151.316616 200.260502 
+L 150.959225 207.246063 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma6ce850076" d="M -1.25 2.5 
+     <path id="m022f16d15f" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1773,31 +1773,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8e93a1f5c)">
-     <use xlink:href="#ma6ce850076" x="270.681118" y="161.733425" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ce850076" x="214.151485" y="169.306799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ce850076" x="186.847623" y="175.148256" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ce850076" x="172.446678" y="180.083547" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ce850076" x="168.817445" y="181.175779" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ce850076" x="156.184831" y="191.604471" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ce850076" x="153.183054" y="195.602244" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ce850076" x="151.316616" y="203.859202" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma6ce850076" x="150.959225" y="210.961016" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pde0927a43e)">
+     <use xlink:href="#m022f16d15f" x="270.681118" y="158.824301" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m022f16d15f" x="214.151485" y="166.273703" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m022f16d15f" x="186.847623" y="172.019538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m022f16d15f" x="172.446678" y="176.874041" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m022f16d15f" x="168.817445" y="177.948394" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m022f16d15f" x="156.184831" y="188.206374" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m022f16d15f" x="153.183054" y="192.138706" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m022f16d15f" x="151.316616" y="200.260502" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m022f16d15f" x="150.959225" y="207.246063" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_62">
-    <path d="M 165.985197 132.031159 
-L 165.985197 131.802257 
-L 165.985197 132.12126 
-L 165.985197 132.136289 
-L 127.822126 151.176563 
-L 118.773575 165.003324 
-L 115.068253 172.450239 
-L 108.471992 195.534667 
-L 106.559215 207.889959 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 165.985197 129.608245 
+L 165.985197 129.38309 
+L 165.985197 129.69687 
+L 165.985197 129.711654 
+L 127.822126 148.440249 
+L 118.773575 162.040674 
+L 115.068253 169.365686 
+L 108.471992 192.072235 
+L 106.559215 204.225277 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m528b8b0d6d" d="M 0 -2.5 
+     <path id="m387a278d57" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1810,31 +1810,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pc8e93a1f5c)">
-     <use xlink:href="#m528b8b0d6d" x="165.985197" y="132.031159" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m528b8b0d6d" x="165.985197" y="131.802257" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m528b8b0d6d" x="165.985197" y="132.12126" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m528b8b0d6d" x="165.985197" y="132.136289" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m528b8b0d6d" x="127.822126" y="151.176563" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m528b8b0d6d" x="118.773575" y="165.003324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m528b8b0d6d" x="115.068253" y="172.450239" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m528b8b0d6d" x="108.471992" y="195.534667" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m528b8b0d6d" x="106.559215" y="207.889959" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pde0927a43e)">
+     <use xlink:href="#m387a278d57" x="165.985197" y="129.608245" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m387a278d57" x="165.985197" y="129.38309" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m387a278d57" x="165.985197" y="129.69687" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m387a278d57" x="165.985197" y="129.711654" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m387a278d57" x="127.822126" y="148.440249" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m387a278d57" x="118.773575" y="162.040674" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m387a278d57" x="115.068253" y="169.365686" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m387a278d57" x="108.471992" y="192.072235" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m387a278d57" x="106.559215" y="204.225277" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_63">
-    <path d="M 610.467188 201.124304 
-L 590.224255 202.798713 
-L 527.228879 210.981441 
-L 299.487126 205.220825 
-L 242.317135 218.720853 
-L 222.969117 233.520301 
-L 221.34725 239.999376 
-L 212.537951 257.407633 
-L 209.781734 269.898593 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467188 197.570372 
+L 590.224255 199.217372 
+L 527.228879 207.266153 
+L 299.487126 201.599836 
+L 242.317135 214.878876 
+L 222.969117 229.436065 
+L 221.34725 235.80908 
+L 212.537951 252.932374 
+L 209.781734 265.218864 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m14d3695f1a" d="M 0 -2.5 
+     <path id="m7cac5d40dd" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1843,16 +1843,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc8e93a1f5c)">
-     <use xlink:href="#m14d3695f1a" x="610.467188" y="201.124304" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14d3695f1a" x="590.224255" y="202.798713" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14d3695f1a" x="527.228879" y="210.981441" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14d3695f1a" x="299.487126" y="205.220825" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14d3695f1a" x="242.317135" y="218.720853" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14d3695f1a" x="222.969117" y="233.520301" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14d3695f1a" x="221.34725" y="239.999376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14d3695f1a" x="212.537951" y="257.407633" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14d3695f1a" x="209.781734" y="269.898593" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pde0927a43e)">
+     <use xlink:href="#m7cac5d40dd" x="610.467188" y="197.570372" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7cac5d40dd" x="590.224255" y="199.217372" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7cac5d40dd" x="527.228879" y="207.266153" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7cac5d40dd" x="299.487126" y="201.599836" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7cac5d40dd" x="242.317135" y="214.878876" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7cac5d40dd" x="222.969117" y="229.436065" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7cac5d40dd" x="221.34725" y="235.80908" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7cac5d40dd" x="212.537951" y="252.932374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7cac5d40dd" x="209.781734" y="265.218864" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1875,7 +1875,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m4f1ea31a70" d="M 0 3.5 
+      <path id="m8ebdba4b4c" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1888,7 +1888,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m4f1ea31a70" x="434.04625" y="365.69" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m8ebdba4b4c" x="434.04625" y="365.69" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_14">
@@ -1951,7 +1951,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mce10842166" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m61e2f6e1fe" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_15">
@@ -1969,7 +1969,7 @@ L 434.04625 389.175
 L 442.04625 389.175 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m3be9144ce4" x="434.04625" y="389.175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5af9016aeb" x="434.04625" y="389.175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2018,7 +2018,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma75c70e9b3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me976ca8d44" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2065,7 +2065,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mbc7d30f5c9" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb0178ab73c" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2123,7 +2123,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma6ce850076" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m022f16d15f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2192,7 +2192,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m528b8b0d6d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m387a278d57" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_20">
@@ -2234,7 +2234,7 @@ L 537.72375 400.9175
 L 545.72375 400.9175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m14d3695f1a" x="537.72375" y="400.9175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7cac5d40dd" x="537.72375" y="400.9175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2304,26 +2304,26 @@ z
     </g>
    </g>
    <g id="line2d_72">
-    <path d="M 261.388575 259.24444 
-L 240.315872 264.618253 
-L 224.06918 270.537473 
-L 196.664094 293.43124 
-L 137.766706 297.540776 
-L 131.5088 307.450017 
-L 119.290911 379.961032 
-L 117.237273 388.08972 
-L 116.643128 396.236449 
-" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pc8e93a1f5c)">
-     <use xlink:href="#m4f1ea31a70" x="261.388575" y="259.24444" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4f1ea31a70" x="240.315872" y="264.618253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4f1ea31a70" x="224.06918" y="270.537473" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4f1ea31a70" x="196.664094" y="293.43124" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4f1ea31a70" x="137.766706" y="297.540776" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4f1ea31a70" x="131.5088" y="307.450017" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4f1ea31a70" x="119.290911" y="379.961032" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4f1ea31a70" x="117.237273" y="388.08972" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4f1ea31a70" x="116.643128" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 231.977966 254.285636 
+L 206.8808 259.662706 
+L 191.355285 265.347283 
+L 141.730661 287.968985 
+L 137.766706 292.045681 
+L 131.5088 301.960132 
+L 116.430566 381.003528 
+L 114.344641 388.623249 
+L 113.788393 396.236449 
+" clip-path="url(#pde0927a43e)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pde0927a43e)">
+     <use xlink:href="#m8ebdba4b4c" x="231.977966" y="254.285636" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ebdba4b4c" x="206.8808" y="259.662706" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ebdba4b4c" x="191.355285" y="265.347283" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ebdba4b4c" x="141.730661" y="287.968985" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ebdba4b4c" x="137.766706" y="292.045681" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ebdba4b4c" x="131.5088" y="301.960132" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ebdba4b4c" x="116.430566" y="381.003528" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ebdba4b4c" x="114.344641" y="388.623249" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8ebdba4b4c" x="113.788393" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2734,8 +2734,8 @@ z
    </g>
   </g>
   <g id="text_23">
-   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.069922 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-10T08:22:01Z  ·  Linux chungus x86_64  ·  commit 3050fc62  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2746,16 +2746,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2769,31 +2759,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2853,34 +2818,29 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
@@ -2924,13 +2884,13 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2969,109 +2929,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc8e93a1f5c">
+  <clipPath id="pde0927a43e">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -40,23 +40,23 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 79.118387 412.80375 
-L 79.118387 48.323125 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 122.006545 412.80375 
+L 122.006545 48.323125 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m3efce1f8e4" d="M 0 0 
+       <path id="m8156b67f0e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3efce1f8e4" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8156b67f0e" x="122.006545" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
-      <!-- 0.28 -->
-      <g transform="translate(67.985575 427.402188) scale(0.1 -0.1)">
+      <!-- 0.30 -->
+      <g transform="translate(110.873733 427.402188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -86,6 +86,61 @@ L 684 0
 L 684 794 
 z
 " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 218.120913 412.80375 
+L 218.120913 48.323125 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8156b67f0e" x="218.120913" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.32 -->
+      <g transform="translate(206.988101 427.402188) scale(0.1 -0.1)">
+       <defs>
         <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
 L 3431 0 
@@ -110,6 +165,124 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 314.235281 412.80375 
+L 314.235281 48.323125 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m8156b67f0e" x="314.235281" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.34 -->
+      <g transform="translate(303.102468 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 410.349649 412.80375 
+L 410.349649 48.323125 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8156b67f0e" x="410.349649" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.36 -->
+      <g transform="translate(399.216836 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 506.464017 412.80375 
+L 506.464017 48.323125 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m8156b67f0e" x="506.464017" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.38 -->
+      <g transform="translate(495.331204 427.402188) scale(0.1 -0.1)">
+       <defs>
         <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -152,217 +325,25 @@ z
        </defs>
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
        <use xlink:href="#DejaVuSans-38" transform="translate(159.033203 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_2">
-     <g id="line2d_3">
-      <path d="M 166.481434 412.80375 
-L 166.481434 48.323125 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_4">
-      <g>
-       <use xlink:href="#m3efce1f8e4" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_2">
-      <!-- 0.30 -->
-      <g transform="translate(155.348622 427.402188) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_3">
-     <g id="line2d_5">
-      <path d="M 253.844481 412.80375 
-L 253.844481 48.323125 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_6">
-      <g>
-       <use xlink:href="#m3efce1f8e4" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_3">
-      <!-- 0.32 -->
-      <g transform="translate(242.711668 427.402188) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_4">
-     <g id="line2d_7">
-      <path d="M 341.207528 412.80375 
-L 341.207528 48.323125 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_8">
-      <g>
-       <use xlink:href="#m3efce1f8e4" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_4">
-      <!-- 0.34 -->
-      <g transform="translate(330.074715 427.402188) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_5">
-     <g id="line2d_9">
-      <path d="M 428.570575 412.80375 
-L 428.570575 48.323125 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_10">
-      <g>
-       <use xlink:href="#m3efce1f8e4" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_5">
-      <!-- 0.36 -->
-      <g transform="translate(417.437762 427.402188) scale(0.1 -0.1)">
-       <defs>
-        <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 515.933622 412.80375 
-L 515.933622 48.323125 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 602.578384 412.80375 
+L 602.578384 48.323125 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m3efce1f8e4" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8156b67f0e" x="602.578384" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
-      <!-- 0.38 -->
-      <g transform="translate(504.800809 427.402188) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(159.033203 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_7">
-     <g id="line2d_13">
-      <path d="M 603.296669 412.80375 
-L 603.296669 48.323125 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_14">
-      <g>
-       <use xlink:href="#m3efce1f8e4" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_7">
       <!-- 0.40 -->
-      <g transform="translate(592.163856 427.402188) scale(0.1 -0.1)">
+      <g transform="translate(591.445572 427.402188) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
@@ -370,7 +351,7 @@ L 603.296669 48.323125
       </g>
      </g>
     </g>
-    <g id="text_8">
+    <g id="text_7">
      <!-- compression ratio   (compressed / original  —  ← smaller is better) -->
      <g transform="translate(177.710156 441.080312) scale(0.1 -0.1)">
       <defs>
@@ -851,24 +832,24 @@ z
    </g>
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
-     <g id="line2d_15">
-      <path d="M 49.078125 348.811562 
-L 637.2 348.811562 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_13">
+      <path d="M 49.078125 283.533136 
+L 637.2 283.533136 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_16">
+     <g id="line2d_14">
       <defs>
-       <path id="m72d56f6285" d="M 0 0 
+       <path id="m45f0f2329e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m72d56f6285" x="49.078125" y="348.811562" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45f0f2329e" x="49.078125" y="283.533136" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_9">
-      <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 352.610781) scale(0.1 -0.1)">
+     <g id="text_8">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(24.478125 287.332354) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -885,382 +866,278 @@ L 794 531
 z
 " transform="scale(0.015625)"/>
        </defs>
-       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_2">
-     <g id="line2d_17">
-      <path d="M 49.078125 239.249643 
-L 637.2 239.249643 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_18">
-      <g>
-       <use xlink:href="#m72d56f6285" x="49.078125" y="239.249643" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_10">
-      <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 243.048862) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_3">
-     <g id="line2d_19">
-      <path d="M 49.078125 129.687723 
-L 637.2 129.687723 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+    <g id="ytick_2">
+     <g id="line2d_15">
+      <path d="M 49.078125 146.255452 
+L 637.2 146.255452 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_20">
+     <g id="line2d_16">
       <g>
-       <use xlink:href="#m72d56f6285" x="49.078125" y="129.687723" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m45f0f2329e" x="49.078125" y="146.255452" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_11">
+     <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 133.486942) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 150.054671) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
       </g>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_21">
-      <path d="M 49.078125 406.099161 
-L 637.2 406.099161 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+    <g id="ytick_3">
+     <g id="line2d_17">
+      <path d="M 49.078125 379.486119 
+L 637.2 379.486119 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_22">
+     <g id="line2d_18">
       <defs>
-       <path id="m4ff49485e5" d="M 0 0 
+       <path id="m2541949ae3" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="406.099161" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="379.486119" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_19">
+      <path d="M 49.078125 355.312719 
+L 637.2 355.312719 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="355.312719" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
-     <g id="line2d_23">
-      <path d="M 49.078125 392.410633 
-L 637.2 392.410633 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_21">
+      <path d="M 49.078125 338.161418 
+L 637.2 338.161418 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_24">
+     <g id="line2d_22">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="392.410633" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="338.161418" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
-     <g id="line2d_25">
-      <path d="M 49.078125 381.792986 
-L 637.2 381.792986 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_23">
+      <path d="M 49.078125 324.857836 
+L 637.2 324.857836 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_26">
+     <g id="line2d_24">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="381.792986" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="324.857836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
-     <g id="line2d_27">
-      <path d="M 49.078125 373.117737 
-L 637.2 373.117737 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_25">
+      <path d="M 49.078125 313.988018 
+L 637.2 313.988018 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_28">
+     <g id="line2d_26">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="373.117737" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="313.988018" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
-     <g id="line2d_29">
-      <path d="M 49.078125 365.782918 
-L 637.2 365.782918 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_27">
+      <path d="M 49.078125 304.797718 
+L 637.2 304.797718 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_30">
+     <g id="line2d_28">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="365.782918" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="304.797718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
-     <g id="line2d_31">
-      <path d="M 49.078125 359.429209 
-L 637.2 359.429209 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_29">
+      <path d="M 49.078125 296.836718 
+L 637.2 296.836718 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_32">
+     <g id="line2d_30">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="359.429209" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="296.836718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
-     <g id="line2d_33">
-      <path d="M 49.078125 353.824841 
-L 637.2 353.824841 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_31">
+      <path d="M 49.078125 289.814618 
+L 637.2 289.814618 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_34">
+     <g id="line2d_32">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="353.824841" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="289.814618" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
-     <g id="line2d_35">
-      <path d="M 49.078125 315.830138 
-L 637.2 315.830138 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_33">
+      <path d="M 49.078125 242.208435 
+L 637.2 242.208435 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_36">
+     <g id="line2d_34">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="315.830138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="242.208435" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
-     <g id="line2d_37">
-      <path d="M 49.078125 296.537242 
-L 637.2 296.537242 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_35">
+      <path d="M 49.078125 218.035035 
+L 637.2 218.035035 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_38">
+     <g id="line2d_36">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="296.537242" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="218.035035" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
-     <g id="line2d_39">
-      <path d="M 49.078125 282.848714 
-L 637.2 282.848714 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_37">
+      <path d="M 49.078125 200.883735 
+L 637.2 200.883735 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_40">
+     <g id="line2d_38">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="282.848714" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="200.883735" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
-     <g id="line2d_41">
-      <path d="M 49.078125 272.231067 
-L 637.2 272.231067 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_39">
+      <path d="M 49.078125 187.580152 
+L 637.2 187.580152 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_42">
+     <g id="line2d_40">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="272.231067" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="187.580152" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
-     <g id="line2d_43">
-      <path d="M 49.078125 263.555818 
-L 637.2 263.555818 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_41">
+      <path d="M 49.078125 176.710334 
+L 637.2 176.710334 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_44">
+     <g id="line2d_42">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="263.555818" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="176.710334" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
-     <g id="line2d_45">
-      <path d="M 49.078125 256.220999 
-L 637.2 256.220999 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_43">
+      <path d="M 49.078125 167.520034 
+L 637.2 167.520034 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_46">
+     <g id="line2d_44">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="256.220999" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="167.520034" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
-     <g id="line2d_47">
-      <path d="M 49.078125 249.86729 
-L 637.2 249.86729 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_45">
+      <path d="M 49.078125 159.559034 
+L 637.2 159.559034 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_48">
+     <g id="line2d_46">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="249.86729" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="159.559034" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
-     <g id="line2d_49">
-      <path d="M 49.078125 244.262921 
-L 637.2 244.262921 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_47">
+      <path d="M 49.078125 152.536934 
+L 637.2 152.536934 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_50">
+     <g id="line2d_48">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="244.262921" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="152.536934" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
-     <g id="line2d_51">
-      <path d="M 49.078125 206.268219 
-L 637.2 206.268219 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_49">
+      <path d="M 49.078125 104.930751 
+L 637.2 104.930751 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_52">
+     <g id="line2d_50">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="206.268219" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="104.930751" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
-     <g id="line2d_53">
-      <path d="M 49.078125 186.975322 
-L 637.2 186.975322 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_51">
+      <path d="M 49.078125 80.757351 
+L 637.2 80.757351 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_54">
+     <g id="line2d_52">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="186.975322" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="80.757351" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
-     <g id="line2d_55">
-      <path d="M 49.078125 173.286794 
-L 637.2 173.286794 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_53">
+      <path d="M 49.078125 63.606051 
+L 637.2 63.606051 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_56">
+     <g id="line2d_54">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="173.286794" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="63.606051" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
-     <g id="line2d_57">
-      <path d="M 49.078125 162.669147 
-L 637.2 162.669147 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     <g id="line2d_55">
+      <path d="M 49.078125 50.302469 
+L 637.2 50.302469 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
-     <g id="line2d_58">
+     <g id="line2d_56">
       <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="162.669147" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m2541949ae3" x="49.078125" y="50.302469" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
-    <g id="ytick_23">
-     <g id="line2d_59">
-      <path d="M 49.078125 153.993898 
-L 637.2 153.993898 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_60">
-      <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="153.993898" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_24">
-     <g id="line2d_61">
-      <path d="M 49.078125 146.659079 
-L 637.2 146.659079 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_62">
-      <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="146.659079" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_25">
-     <g id="line2d_63">
-      <path d="M 49.078125 140.30537 
-L 637.2 140.30537 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_64">
-      <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="140.30537" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_26">
-     <g id="line2d_65">
-      <path d="M 49.078125 134.701002 
-L 637.2 134.701002 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_66">
-      <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="134.701002" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_27">
-     <g id="line2d_67">
-      <path d="M 49.078125 96.706299 
-L 637.2 96.706299 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_68">
-      <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="96.706299" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_28">
-     <g id="line2d_69">
-      <path d="M 49.078125 77.413403 
-L 637.2 77.413403 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_70">
-      <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="77.413403" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_29">
-     <g id="line2d_71">
-      <path d="M 49.078125 63.724875 
-L 637.2 63.724875 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_72">
-      <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="63.724875" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_30">
-     <g id="line2d_73">
-      <path d="M 49.078125 53.107228 
-L 637.2 53.107228 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_74">
-      <g>
-       <use xlink:href="#m4ff49485e5" x="49.078125" y="53.107228" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_12">
+    <g id="text_10">
      <!-- compression speed   (MB/s, log) -->
      <g transform="translate(18.398438 310.461094) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -1376,9 +1253,9 @@ L 637.2 412.80375
 L 637.2 48.323125 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_13">
+   <g id="text_11">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(298.172574 215.105703) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(266.388575 254.24444) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1408,9 +1285,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-31" transform="translate(63.720703 0)"/>
     </g>
    </g>
-   <g id="text_14">
+   <g id="text_12">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(166.606362 324.081206) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(121.643128 391.236449) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1447,7 +1324,7 @@ z
      <use xlink:href="#DejaVuSans-Bold-39" transform="translate(63.720703 0)"/>
     </g>
    </g>
-   <g id="text_15">
+   <g id="text_13">
     <!-- ↖ fast &amp; small = best -->
     <g style="fill: #2a8a3a" transform="translate(57.899953 61.388772) scale(0.1 -0.1)">
      <defs>
@@ -1738,125 +1615,111 @@ z
      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1145.849609 0)"/>
     </g>
    </g>
-   <g id="line2d_75">
-    <path d="M 355.479835 96.221589 
-L 308.273931 103.086412 
-L 271.230161 117.04048 
-L 217.83458 120.951277 
-L 177.077692 139.538613 
-L 162.880539 158.700427 
-L 160.741445 166.116031 
-L 153.966678 184.325608 
-L 151.589614 195.420135 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_57">
+    <path d="M 329.937272 104.442368 
+L 278.002664 113.236337 
+L 237.248149 130.477884 
+L 178.503832 135.992401 
+L 133.66425 158.883767 
+L 118.044941 182.837351 
+L 115.691571 192.132267 
+L 108.238162 214.997174 
+L 105.622983 228.958594 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc312bf3a92" d="M -2.5 2.5 
+     <path id="mce10842166" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf1075ac3a9)">
-     <use xlink:href="#mc312bf3a92" x="355.479835" y="96.221589" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc312bf3a92" x="308.273931" y="103.086412" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc312bf3a92" x="271.230161" y="117.04048" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc312bf3a92" x="217.83458" y="120.951277" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc312bf3a92" x="177.077692" y="139.538613" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc312bf3a92" x="162.880539" y="158.700427" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc312bf3a92" x="160.741445" y="166.116031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc312bf3a92" x="153.966678" y="184.325608" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc312bf3a92" x="151.589614" y="195.420135" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8e93a1f5c)">
+     <use xlink:href="#mce10842166" x="329.937272" y="104.442368" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce10842166" x="278.002664" y="113.236337" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce10842166" x="237.248149" y="130.477884" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce10842166" x="178.503832" y="135.992401" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce10842166" x="133.66425" y="158.883767" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce10842166" x="118.044941" y="182.837351" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce10842166" x="115.691571" y="192.132267" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce10842166" x="108.238162" y="214.997174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mce10842166" x="105.622983" y="228.958594" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_76">
-    <path d="M 531.649087 75.715785 
-L 283.721324 98.745413 
-L 218.882044 120.970615 
-L 187.447228 126.936029 
-L 176.342474 138.381298 
-L 163.054314 161.530544 
-L 162.210539 169.028722 
-L 159.303811 176.032277 
-L 157.793928 179.841405 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_58">
+    <path d="M 523.75373 79.549583 
+L 250.990576 108.146695 
+L 179.656223 135.705829 
+L 145.072522 143.248726 
+L 132.855384 157.522019 
+L 118.236124 186.34059 
+L 117.307827 195.762894 
+L 114.109926 204.504766 
+L 112.448796 209.301605 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7666fc7968" d="M 0 -2.5 
+     <path id="m3be9144ce4" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf1075ac3a9)">
-     <use xlink:href="#m7666fc7968" x="531.649087" y="75.715785" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7666fc7968" x="283.721324" y="98.745413" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7666fc7968" x="218.882044" y="120.970615" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7666fc7968" x="187.447228" y="126.936029" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7666fc7968" x="176.342474" y="138.381298" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7666fc7968" x="163.054314" y="161.530544" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7666fc7968" x="162.210539" y="169.028722" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7666fc7968" x="159.303811" y="176.032277" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7666fc7968" x="157.793928" y="179.841405" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8e93a1f5c)">
+     <use xlink:href="#m3be9144ce4" x="523.75373" y="79.549583" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3be9144ce4" x="250.990576" y="108.146695" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3be9144ce4" x="179.656223" y="135.705829" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3be9144ce4" x="145.072522" y="143.248726" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3be9144ce4" x="132.855384" y="157.522019" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3be9144ce4" x="118.236124" y="186.34059" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3be9144ce4" x="117.307827" y="195.762894" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3be9144ce4" x="114.109926" y="204.504766" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3be9144ce4" x="112.448796" y="209.301605" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_77">
-    <path d="M 251.559581 64.890426 
-L 203.775848 81.551222 
-L 186.982691 88.690505 
-L 179.779306 91.223338 
-L 157.610419 99.570775 
-L 148.722526 108.024607 
-L 144.388162 121.351751 
-L 127.071247 144.983814 
-L 124.491988 152.570158 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_59">
+    <path d="M 215.607131 64.890426 
+L 163.03681 86.294771 
+L 144.561452 94.673077 
+L 136.63649 98.184501 
+L 112.246904 108.210313 
+L 102.468694 118.861595 
+L 97.700149 135.965688 
+L 78.648566 165.167747 
+L 75.810938 174.633982 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m8b3d44b508" d="M -0 3.535534 
+     <path id="ma75c70e9b3" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf1075ac3a9)">
-     <use xlink:href="#m8b3d44b508" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b3d44b508" x="203.775848" y="81.551222" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b3d44b508" x="186.982691" y="88.690505" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b3d44b508" x="179.779306" y="91.223338" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b3d44b508" x="157.610419" y="99.570775" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b3d44b508" x="148.722526" y="108.024607" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b3d44b508" x="144.388162" y="121.351751" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b3d44b508" x="127.071247" y="144.983814" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b3d44b508" x="124.491988" y="152.570158" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8e93a1f5c)">
+     <use xlink:href="#ma75c70e9b3" x="215.607131" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma75c70e9b3" x="163.03681" y="86.294771" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma75c70e9b3" x="144.561452" y="94.673077" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma75c70e9b3" x="136.63649" y="98.184501" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma75c70e9b3" x="112.246904" y="108.210313" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma75c70e9b3" x="102.468694" y="118.861595" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma75c70e9b3" x="97.700149" y="135.965688" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma75c70e9b3" x="78.648566" y="165.167747" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma75c70e9b3" x="75.810938" y="174.633982" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_78">
-    <path d="M 75.810937 396.236449 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_60">
+    <path d="M 338.063322 167.866323 
+L 245.574267 169.924297 
+L 215.185478 176.004428 
+L 159.770378 179.689004 
+L 125.661082 196.980905 
+L 116.984485 210.132786 
+L 113.442444 218.912984 
+L 108.568337 233.00956 
+L 107.280778 247.743061 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma943aa3ea2" d="M -0 2.5 
-L 2.5 -2.5 
-L -2.5 -2.5 
-z
-" style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#pf1075ac3a9)">
-     <use xlink:href="#ma943aa3ea2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_79">
-    <path d="M 362.865999 147.351516 
-L 278.798176 150.131517 
-L 251.17632 154.424374 
-L 200.806828 156.381038 
-L 169.803221 170.25855 
-L 161.916638 181.586606 
-L 158.697104 187.028572 
-L 154.26679 199.747456 
-L 153.096464 210.682045 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
-    <defs>
-     <path id="mc4ef4539f2" d="M -0.833333 2.5 
+     <path id="mbc7d30f5c9" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,31 +1734,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf1075ac3a9)">
-     <use xlink:href="#mc4ef4539f2" x="362.865999" y="147.351516" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4ef4539f2" x="278.798176" y="150.131517" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4ef4539f2" x="251.17632" y="154.424374" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4ef4539f2" x="200.806828" y="156.381038" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4ef4539f2" x="169.803221" y="170.25855" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4ef4539f2" x="161.916638" y="181.586606" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4ef4539f2" x="158.697104" y="187.028572" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4ef4539f2" x="154.26679" y="199.747456" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc4ef4539f2" x="153.096464" y="210.682045" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8e93a1f5c)">
+     <use xlink:href="#mbc7d30f5c9" x="338.063322" y="167.866323" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc7d30f5c9" x="245.574267" y="169.924297" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc7d30f5c9" x="215.185478" y="176.004428" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc7d30f5c9" x="159.770378" y="179.689004" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc7d30f5c9" x="125.661082" y="196.980905" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc7d30f5c9" x="116.984485" y="210.132786" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc7d30f5c9" x="113.442444" y="218.912984" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc7d30f5c9" x="108.568337" y="233.00956" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbc7d30f5c9" x="107.280778" y="247.743061" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_80">
-    <path d="M 301.619021 141.435532 
-L 250.236474 148.609921 
-L 225.418659 152.913765 
-L 212.328936 156.727542 
-L 209.030149 158.033477 
-L 197.547749 165.556179 
-L 194.819287 169.087077 
-L 193.12279 175.780925 
-L 192.79794 181.258909 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_61">
+    <path d="M 270.681118 161.733425 
+L 214.151485 169.306799 
+L 186.847623 175.148256 
+L 172.446678 180.083547 
+L 168.817445 181.175779 
+L 156.184831 191.604471 
+L 153.183054 195.602244 
+L 151.316616 203.859202 
+L 150.959225 210.961016 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc6afd3a75f" d="M -1.25 2.5 
+     <path id="ma6ce850076" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,31 +1773,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf1075ac3a9)">
-     <use xlink:href="#mc6afd3a75f" x="301.619021" y="141.435532" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6afd3a75f" x="250.236474" y="148.609921" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6afd3a75f" x="225.418659" y="152.913765" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6afd3a75f" x="212.328936" y="156.727542" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6afd3a75f" x="209.030149" y="158.033477" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6afd3a75f" x="197.547749" y="165.556179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6afd3a75f" x="194.819287" y="169.087077" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6afd3a75f" x="193.12279" y="175.780925" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6afd3a75f" x="192.79794" y="181.258909" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8e93a1f5c)">
+     <use xlink:href="#ma6ce850076" x="270.681118" y="161.733425" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6ce850076" x="214.151485" y="169.306799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6ce850076" x="186.847623" y="175.148256" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6ce850076" x="172.446678" y="180.083547" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6ce850076" x="168.817445" y="181.175779" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6ce850076" x="156.184831" y="191.604471" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6ce850076" x="153.183054" y="195.602244" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6ce850076" x="151.316616" y="203.859202" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma6ce850076" x="150.959225" y="210.961016" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_81">
-    <path d="M 206.45578 118.286977 
-L 206.45578 118.608382 
-L 206.45578 117.972989 
-L 206.45578 118.15015 
-L 171.767499 133.659276 
-L 163.54283 145.068039 
-L 160.174881 150.863312 
-L 154.179217 168.922986 
-L 152.4406 178.782394 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_62">
+    <path d="M 165.985197 132.031159 
+L 165.985197 131.802257 
+L 165.985197 132.12126 
+L 165.985197 132.136289 
+L 127.822126 151.176563 
+L 118.773575 165.003324 
+L 115.068253 172.450239 
+L 108.471992 195.534667 
+L 106.559215 207.889959 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc4f9d3e6f7" d="M 0 -2.5 
+     <path id="m528b8b0d6d" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,31 +1810,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pf1075ac3a9)">
-     <use xlink:href="#mc4f9d3e6f7" x="206.45578" y="118.286977" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4f9d3e6f7" x="206.45578" y="118.608382" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4f9d3e6f7" x="206.45578" y="117.972989" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4f9d3e6f7" x="206.45578" y="118.15015" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4f9d3e6f7" x="171.767499" y="133.659276" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4f9d3e6f7" x="163.54283" y="145.068039" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4f9d3e6f7" x="160.174881" y="150.863312" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4f9d3e6f7" x="154.179217" y="168.922986" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc4f9d3e6f7" x="152.4406" y="178.782394" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pc8e93a1f5c)">
+     <use xlink:href="#m528b8b0d6d" x="165.985197" y="132.031159" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m528b8b0d6d" x="165.985197" y="131.802257" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m528b8b0d6d" x="165.985197" y="132.12126" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m528b8b0d6d" x="165.985197" y="132.136289" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m528b8b0d6d" x="127.822126" y="151.176563" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m528b8b0d6d" x="118.773575" y="165.003324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m528b8b0d6d" x="115.068253" y="172.450239" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m528b8b0d6d" x="108.471992" y="195.534667" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m528b8b0d6d" x="106.559215" y="207.889959" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
-   <g id="line2d_82">
-    <path d="M 610.467188 173.38788 
-L 592.067397 175.261277 
-L 534.807821 181.990063 
-L 327.802209 177.159819 
-L 275.83761 188.03779 
-L 258.25125 200.068916 
-L 256.777056 204.613462 
-L 248.769854 218.966816 
-L 246.264594 228.560674 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_63">
+    <path d="M 610.467188 201.124304 
+L 590.224255 202.798713 
+L 527.228879 210.981441 
+L 299.487126 205.220825 
+L 242.317135 218.720853 
+L 222.969117 233.520301 
+L 221.34725 239.999376 
+L 212.537951 257.407633 
+L 209.781734 269.898593 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2210c7b763" d="M 0 -2.5 
+     <path id="m14d3695f1a" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1843,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pf1075ac3a9)">
-     <use xlink:href="#m2210c7b763" x="610.467188" y="173.38788" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2210c7b763" x="592.067397" y="175.261277" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2210c7b763" x="534.807821" y="181.990063" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2210c7b763" x="327.802209" y="177.159819" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2210c7b763" x="275.83761" y="188.03779" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2210c7b763" x="258.25125" y="200.068916" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2210c7b763" x="256.777056" y="204.613462" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2210c7b763" x="248.769854" y="218.966816" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2210c7b763" x="246.264594" y="228.560674" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc8e93a1f5c)">
+     <use xlink:href="#m14d3695f1a" x="610.467188" y="201.124304" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14d3695f1a" x="590.224255" y="202.798713" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14d3695f1a" x="527.228879" y="210.981441" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14d3695f1a" x="299.487126" y="205.220825" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14d3695f1a" x="242.317135" y="218.720853" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14d3695f1a" x="222.969117" y="233.520301" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14d3695f1a" x="221.34725" y="239.999376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14d3695f1a" x="212.537951" y="257.407633" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14d3695f1a" x="209.781734" y="269.898593" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1997,22 +1860,22 @@ z
      <path d="M 424.44625 408.80375 
 L 631.6 408.80375 
 Q 633.2 408.80375 633.2 407.20375 
-L 633.2 349.06875 
-Q 633.2 347.46875 631.6 347.46875 
-L 424.44625 347.46875 
-Q 422.84625 347.46875 422.84625 349.06875 
+L 633.2 360.81125 
+Q 633.2 359.21125 631.6 359.21125 
+L 424.44625 359.21125 
+Q 422.84625 359.21125 422.84625 360.81125 
 L 422.84625 407.20375 
 Q 422.84625 408.80375 424.44625 408.80375 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_83">
-     <path d="M 426.04625 353.9475 
-L 434.04625 353.9475 
-L 442.04625 353.9475 
+    <g id="line2d_64">
+     <path d="M 426.04625 365.69 
+L 434.04625 365.69 
+L 442.04625 365.69 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m9089e5bf19" d="M 0 3.5 
+      <path id="m4f1ea31a70" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,12 +1888,12 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m9089e5bf19" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m4f1ea31a70" x="434.04625" y="365.69" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
-    <g id="text_16">
+    <g id="text_14">
      <!-- lean-zip (native) -->
-     <g transform="translate(448.44625 356.7475) scale(0.08 -0.08)">
+     <g transform="translate(448.44625 368.49) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -2082,36 +1945,36 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
      </g>
     </g>
-    <g id="line2d_84">
-     <path d="M 426.04625 365.69 
-L 434.04625 365.69 
-L 442.04625 365.69 
+    <g id="line2d_65">
+     <path d="M 426.04625 377.4325 
+L 434.04625 377.4325 
+L 442.04625 377.4325 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc312bf3a92" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mce10842166" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_17">
+    <g id="text_15">
      <!-- zlib -->
-     <g transform="translate(448.44625 368.49) scale(0.08 -0.08)">
+     <g transform="translate(448.44625 380.2325) scale(0.08 -0.08)">
       <use xlink:href="#DejaVuSans-7a"/>
       <use xlink:href="#DejaVuSans-6c" transform="translate(52.490234 0)"/>
       <use xlink:href="#DejaVuSans-69" transform="translate(80.273438 0)"/>
       <use xlink:href="#DejaVuSans-62" transform="translate(108.056641 0)"/>
      </g>
     </g>
-    <g id="line2d_85">
-     <path d="M 426.04625 377.4325 
-L 434.04625 377.4325 
-L 442.04625 377.4325 
+    <g id="line2d_66">
+     <path d="M 426.04625 389.175 
+L 434.04625 389.175 
+L 442.04625 389.175 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7666fc7968" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3be9144ce4" x="434.04625" y="389.175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_18">
+    <g id="text_16">
      <!-- miniz_oxide -->
-     <g transform="translate(448.44625 380.2325) scale(0.08 -0.08)">
+     <g transform="translate(448.44625 391.975) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -2149,18 +2012,18 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
      </g>
     </g>
-    <g id="line2d_86">
-     <path d="M 426.04625 389.3975 
-L 434.04625 389.3975 
-L 442.04625 389.3975 
+    <g id="line2d_67">
+     <path d="M 426.04625 401.14 
+L 434.04625 401.14 
+L 442.04625 401.14 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m8b3d44b508" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma75c70e9b3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_19">
+    <g id="text_17">
      <!-- libdeflate -->
-     <g transform="translate(448.44625 392.1975) scale(0.08 -0.08)">
+     <g transform="translate(448.44625 403.94) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -2196,38 +2059,18 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
      </g>
     </g>
-    <g id="line2d_87">
-     <path d="M 426.04625 401.14 
-L 434.04625 401.14 
-L 442.04625 401.14 
-" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#ma943aa3ea2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_20">
-     <!-- zopfli -->
-     <g transform="translate(448.44625 403.94) scale(0.08 -0.08)">
-      <use xlink:href="#DejaVuSans-7a"/>
-      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
-      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(177.148438 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(212.353516 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
-     </g>
-    </g>
-    <g id="line2d_88">
-     <path d="M 529.72375 353.9475 
-L 537.72375 353.9475 
-L 545.72375 353.9475 
+    <g id="line2d_68">
+     <path d="M 529.72375 365.69 
+L 537.72375 365.69 
+L 545.72375 365.69 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc4ef4539f2" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbc7d30f5c9" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_21">
+    <g id="text_18">
      <!-- Go compress/flate -->
-     <g transform="translate(552.12375 356.7475) scale(0.08 -0.08)">
+     <g transform="translate(552.12375 368.49) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2274,18 +2117,18 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
      </g>
     </g>
-    <g id="line2d_89">
-     <path d="M 529.72375 365.69 
-L 537.72375 365.69 
-L 545.72375 365.69 
+    <g id="line2d_69">
+     <path d="M 529.72375 377.4325 
+L 537.72375 377.4325 
+L 545.72375 377.4325 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc6afd3a75f" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma6ce850076" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_22">
+    <g id="text_19">
      <!-- JS fflate -->
-     <g transform="translate(552.12375 368.49) scale(0.08 -0.08)">
+     <g transform="translate(552.12375 380.2325) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -2343,18 +2186,18 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
      </g>
     </g>
-    <g id="line2d_90">
-     <path d="M 529.72375 377.4325 
-L 537.72375 377.4325 
-L 545.72375 377.4325 
+    <g id="line2d_70">
+     <path d="M 529.72375 389.175 
+L 537.72375 389.175 
+L 545.72375 389.175 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc4f9d3e6f7" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m528b8b0d6d" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
-    <g id="text_23">
+    <g id="text_20">
      <!-- Zig std.flate -->
-     <g transform="translate(552.12375 380.2325) scale(0.08 -0.08)">
+     <g transform="translate(552.12375 391.975) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -2385,18 +2228,18 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(541.601562 0)"/>
      </g>
     </g>
-    <g id="line2d_91">
-     <path d="M 529.72375 389.175 
-L 537.72375 389.175 
-L 545.72375 389.175 
+    <g id="line2d_71">
+     <path d="M 529.72375 400.9175 
+L 537.72375 400.9175 
+L 545.72375 400.9175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2210c7b763" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m14d3695f1a" x="537.72375" y="400.9175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_24">
+    <g id="text_21">
      <!-- OCaml decompress -->
-     <g transform="translate(552.12375 391.975) scale(0.08 -0.08)">
+     <g transform="translate(552.12375 403.7175) scale(0.08 -0.08)">
       <defs>
        <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2460,31 +2303,31 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_92">
-    <path d="M 293.172574 220.105703 
-L 274.018564 224.410269 
-L 259.251152 228.874743 
-L 234.341329 247.170554 
-L 180.806615 250.531577 
-L 175.118498 258.372877 
-L 164.013061 316.198068 
-L 162.146409 322.605174 
-L 161.606362 329.081206 
-" clip-path="url(#pf1075ac3a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pf1075ac3a9)">
-     <use xlink:href="#m9089e5bf19" x="293.172574" y="220.105703" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9089e5bf19" x="274.018564" y="224.410269" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9089e5bf19" x="259.251152" y="228.874743" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9089e5bf19" x="234.341329" y="247.170554" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9089e5bf19" x="180.806615" y="250.531577" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9089e5bf19" x="175.118498" y="258.372877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9089e5bf19" x="164.013061" y="316.198068" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9089e5bf19" x="162.146409" y="322.605174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m9089e5bf19" x="161.606362" y="329.081206" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+   <g id="line2d_72">
+    <path d="M 261.388575 259.24444 
+L 240.315872 264.618253 
+L 224.06918 270.537473 
+L 196.664094 293.43124 
+L 137.766706 297.540776 
+L 131.5088 307.450017 
+L 119.290911 379.961032 
+L 117.237273 388.08972 
+L 116.643128 396.236449 
+" clip-path="url(#pc8e93a1f5c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pc8e93a1f5c)">
+     <use xlink:href="#m4f1ea31a70" x="261.388575" y="259.24444" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f1ea31a70" x="240.315872" y="264.618253" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f1ea31a70" x="224.06918" y="270.537473" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f1ea31a70" x="196.664094" y="293.43124" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f1ea31a70" x="137.766706" y="297.540776" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f1ea31a70" x="131.5088" y="307.450017" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f1ea31a70" x="119.290911" y="379.961032" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f1ea31a70" x="117.237273" y="388.08972" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4f1ea31a70" x="116.643128" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
-  <g id="text_25">
+  <g id="text_22">
    <!-- Compression speed vs ratio  (canterbury — geomean over 11 files; line = level sweep) -->
    <g transform="translate(7.704922 19.237969) scale(0.13 -0.13)">
     <defs>
@@ -2890,9 +2733,9 @@ z
     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(4820.361328 0)"/>
    </g>
   </g>
-  <g id="text_26">
-   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(48.833828 465.66) scale(0.07 -0.07)">
+  <g id="text_23">
+   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.069922 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2903,6 +2746,16 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -3000,6 +2853,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3041,12 +2924,12 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3086,108 +2969,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf1075ac3a9">
+  <clipPath id="pc8e93a1f5c">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 47.9955
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p61ece1236f)">
+   <g clip-path="url(#p36a630584a)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAFbCAYAAADWVIrwAAAH10lEQVR4nO3YsYqcVQCG4X92Z9eNYFAJUVJaW1hY2Vh7Q96E16HegGAh9tZiY2EjIinMKjEbNpPZf7yERDhy5H+f5wq+wzBn3jm79c8vT8vWPPtj9oKhTk+2dZ5lWZbfPv9m9oShfvnxZvaE4T796rPZE4bbffTx7Alj7c5mLxjv6ePZC8a7uj97wVBfv/fF7AnDbfCbBADw+sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0nYvjt+eZo8Y7bSssycMtdtgs16cXc6eMNRhvZ09YbiLn36YPWG444efzJ4w1HE9zJ4w3M3x6ewJwz3Y2PXw8v6D2ROG296vLADAvyCGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9hc3f83eMN6L57MXjHVaZy8Y79792QuGupw94D9wenoze8JwF39fz54w1MV6nD1huHtbvO9un81eMNTFfns3npchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBtd1y/O80eMdrptM6eMNS6sfMsy7JcnF3OnjDU3ek4e8Jw58+uZ08Y762HsxcM9XI9zJ4w3JPb32dPGO79F/vZE4Za33k0e8JwXoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQtj+d1tkbhjvc3c6eMNS93dXsCePdHWcvGOput63zLMuyXO8PsycM9+5pe5/T1pzv9rMnDPfz7vHsCUN9sD6cPWE4L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQNpuXb8/zR4B/A8dD7MXjLe/nL2AV7i9ez57wnBX52/OnsAreBkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANL2y+H57A3jHQ+zF4x1vp+9YLyzjZ1pt8H/Fde/zl4w3tuPZi8Ya2t33bIsyxuXsxeMd1pnLxhrg92wwRscAOD1iSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLR/ACPedSJJv3djAAAAAElFTkSuQmCC" id="image42420961df" transform="scale(1 -1) translate(0 -249.84)" x="95.67625" y="-47.482309" width="416.88" height="249.84"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAFbCAYAAADWVIrwAAAH10lEQVR4nO3YsYqcVQCG4X92Z9eNYFAJUVJaW1hY2Vh7Q96E16HegGAh9tZiY2EjIinMKjEbNpPZf7yERDhy5H+f5wq+wzBn3jm79c8vT8vWPPtj9oKhTk+2dZ5lWZbfPv9m9oShfvnxZvaE4T796rPZE4bbffTx7Alj7c5mLxjv6ePZC8a7uj97wVBfv/fF7AnDbfCbBADw+sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0nYvjt+eZo8Y7bSssycMtdtgs16cXc6eMNRhvZ09YbiLn36YPWG444efzJ4w1HE9zJ4w3M3x6ewJwz3Y2PXw8v6D2ROG296vLADAvyCGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9hc3f83eMN6L57MXjHVaZy8Y79792QuGupw94D9wenoze8JwF39fz54w1MV6nD1huHtbvO9un81eMNTFfns3npchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBtd1y/O80eMdrptM6eMNS6sfMsy7JcnF3OnjDU3ek4e8Jw58+uZ08Y762HsxcM9XI9zJ4w3JPb32dPGO79F/vZE4Za33k0e8JwXoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQtj+d1tkbhjvc3c6eMNS93dXsCePdHWcvGOput63zLMuyXO8PsycM9+5pe5/T1pzv9rMnDPfz7vHsCUN9sD6cPWE4L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQNpuXb8/zR4B/A8dD7MXjLe/nL2AV7i9ez57wnBX52/OnsAreBkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANL2y+H57A3jHQ+zF4x1vp+9YLyzjZ1pt8H/Fde/zl4w3tuPZi8Ya2t33bIsyxuXsxeMd1pnLxhrg92wwRscAOD1iSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLR/ACPedSJJv3djAAAAAElFTkSuQmCC" id="imagefc899c1e67" transform="scale(1 -1) translate(0 -249.84)" x="95.67625" y="-47.482309" width="416.88" height="249.84"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m21bfb6ecda" d="M 0 0 
+       <path id="m9de55103ee" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m21bfb6ecda" x="114.611309" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="114.611309" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="152.481427" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="152.481427" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="190.351545" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="190.351545" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="228.221663" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="228.221663" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="266.091781" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="266.091781" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="303.961899" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="303.961899" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="341.832017" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="341.832017" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="379.702135" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="379.702135" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="417.572253" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="417.572253" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="455.442371" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="455.442371" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m21bfb6ecda" x="493.312489" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9de55103ee" x="493.312489" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m48203c4df0" d="M 0 0 
+       <path id="mf96ca4251f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m48203c4df0" x="95.67625" y="65.804558" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf96ca4251f" x="95.67625" y="65.804558" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m48203c4df0" x="95.67625" y="101.422673" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf96ca4251f" x="95.67625" y="101.422673" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m48203c4df0" x="95.67625" y="137.040789" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf96ca4251f" x="95.67625" y="137.040789" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m48203c4df0" x="95.67625" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf96ca4251f" x="95.67625" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1087,7 +1087,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m48203c4df0" x="95.67625" y="208.27702" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf96ca4251f" x="95.67625" y="208.27702" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1154,7 +1154,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m48203c4df0" x="95.67625" y="243.895136" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf96ca4251f" x="95.67625" y="243.895136" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1194,7 +1194,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m48203c4df0" x="95.67625" y="279.513251" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf96ca4251f" x="95.67625" y="279.513251" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1962,18 +1962,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABg0lEQVR4nO2awa2FMAwEE6Cn39Lv/w55NcRzGK0c7ivbs7YTAXP8/61RfJ55zao2VXyVlWOMZ87EmmNpR9Yc2iQ9repIO7I9RdoXkD83oX0TYDByWcsiM6tM2mWt6DOk3Q+YN1W5g9FwDfUDxub5Ek8MIAY208jW6oVXKQ+Y2NtA7O0ws7dRZOAzqTl3DUnAmp4YiLYnrjOjaygTGCjbS5talVhz7GCMxJpPb2+L+/lMv9GRtMneZpGJeIK0xcEgacPIkU2iWnVrkaUmOWtoO3KoVZlraJZ//BnjGesrixltEtkUf4lpm1ZFAhNpr/XWxQ1pm4PRkTaoOfbEQD5/9QPapB1Zc2ja1KpI2muF0k7ssNC0j1X74nraIu31ItpETCIvKzK06iVWabSRz6TDzDUU2Z5e2mcwdsXmYCBgkVahyJ5VKO3PA2bdSUTa6CrFfG7Y26ZV1n3bO5+1DgsdydQ1hHwGcyGK4WCQr8CZwEzakTUzMXpde6xKEZu0zw7bepBVP2R4KzX/wzi8AAAAAElFTkSuQmCC" id="image499e267726" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-62.64" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABg0lEQVR4nO2awa2FMAwEE6Cn39Lv/w55NcRzGK0c7ivbs7YTAXP8/61RfJ55zao2VXyVlWOMZ87EmmNpR9Yc2iQ9repIO7I9RdoXkD83oX0TYDByWcsiM6tM2mWt6DOk3Q+YN1W5g9FwDfUDxub5Ek8MIAY208jW6oVXKQ+Y2NtA7O0ws7dRZOAzqTl3DUnAmp4YiLYnrjOjaygTGCjbS5talVhz7GCMxJpPb2+L+/lMv9GRtMneZpGJeIK0xcEgacPIkU2iWnVrkaUmOWtoO3KoVZlraJZ//BnjGesrixltEtkUf4lpm1ZFAhNpr/XWxQ1pm4PRkTaoOfbEQD5/9QPapB1Zc2ja1KpI2muF0k7ssNC0j1X74nraIu31ItpETCIvKzK06iVWabSRz6TDzDUU2Z5e2mcwdsXmYCBgkVahyJ5VKO3PA2bdSUTa6CrFfG7Y26ZV1n3bO5+1DgsdydQ1hHwGcyGK4WCQr8CZwEzakTUzMXpde6xKEZu0zw7bepBVP2R4KzX/wzi8AAAAAElFTkSuQmCC" id="imageb74c6f5e05" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-62.64" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_19">
       <defs>
-       <path id="m6645a15df5" d="M 0 0 
+       <path id="m167485ecf7" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6645a15df5" x="531.876562" y="278.678375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m167485ecf7" x="531.876562" y="278.678375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_96">
@@ -1999,7 +1999,7 @@ z
     <g id="ytick_9">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6645a15df5" x="531.876562" y="252.173507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m167485ecf7" x="531.876562" y="252.173507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_97">
@@ -2016,7 +2016,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m6645a15df5" x="531.876562" y="225.66864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m167485ecf7" x="531.876562" y="225.66864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_98">
@@ -2033,7 +2033,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6645a15df5" x="531.876562" y="199.163772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m167485ecf7" x="531.876562" y="199.163772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_99">
@@ -2050,7 +2050,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m6645a15df5" x="531.876562" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m167485ecf7" x="531.876562" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_100">
@@ -2066,7 +2066,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6645a15df5" x="531.876562" y="146.154037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m167485ecf7" x="531.876562" y="146.154037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_101">
@@ -2082,7 +2082,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m6645a15df5" x="531.876562" y="119.649169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m167485ecf7" x="531.876562" y="119.649169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_102">
@@ -2098,7 +2098,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6645a15df5" x="531.876562" y="93.144302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m167485ecf7" x="531.876562" y="93.144302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_103">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m6645a15df5" x="531.876562" y="66.639434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m167485ecf7" x="531.876562" y="66.639434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_104">
@@ -2752,8 +2752,8 @@ z
    </g>
   </g>
   <g id="text_107">
-   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.069922 365.364) scale(0.07 -0.07)">
+   <!-- 2026-06-10T08:22:01Z  ·  Linux chungus x86_64  ·  commit 3050fc62  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.904453 365.364) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -2853,13 +2853,13 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2898,109 +2898,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p61ece1236f">
+  <clipPath id="p36a630584a">
    <rect x="95.67625" y="47.9955" width="416.571298" height="249.326809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="594pt" height="403.2pt" viewBox="0 0 594 403.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="594pt" height="367.2pt" viewBox="0 0 594 367.2" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -21,8 +21,8 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 403.2 
-L 594 403.2 
+   <path d="M 0 367.2 
+L 594 367.2 
 L 594 0 
 L 0 0 
 z
@@ -30,32 +30,32 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 95.67625 332.242309 
-L 512.247548 332.242309 
-L 512.247548 49.4355 
-L 95.67625 49.4355 
+    <path d="M 95.67625 297.322309 
+L 512.247548 297.322309 
+L 512.247548 47.9955 
+L 95.67625 47.9955 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p1198597a54)">
+   <g clip-path="url(#p61ece1236f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+UlEQVR4nO3YwYqkVx2H4aqe7rYnwUFlEsMshewkuHDjbLL2TnIFWYp7r8PkBgQRMZugZONG3IkbEQkhmSSTmaG7p/orL2ESOPKXep/nCn5nUafe7+y3L3973J2aZ59PL1jq+MVpnWe32+3+/f7vpics9c+/PZ+esNy7H/xyesJy+5/9fHrCWvuz6QXrPf10esF6Vw+mFyz14Y9/Mz1huRP8JQEAfHtiCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbX9z+P1xesRqx902PWGp/Qk268XZ5fSEpW636+kJy138/ZPpCcsdfvp4esJSh+12esJyzw9Ppycs9/DEroeXDx5OT1ju9P5lAQC+AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvH8q+kN6928mF6w1nGbXrDe/QfTC5a6nB7wP3B8+nx6wnIX3zyZnrDUxXaYnrDc/VO8766fTS9Y6uL89G48L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2Px6nR6x2PG7TE5baTuw8u91ud3F2OT1hqbvjYXrCcveePZmesN7335xesNTL7XZ6wnJfXP9nesJyb92cT09Yavvho+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSzv/62Z+nNyx3tttPT1jqjdceTk9Y7m47TE9Y6vLe1fSE5d776OPpCcv9+hdvT09Y6nDcpics96u//GN6wnKPH70+PWGp9955PD1hOS9DAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASNu/vPvDcXrEard319MTlrq/v5qewCvc7g/TE5b7+ubz6QnL/ejqrekJS23HbXrCcl/dfDY9YbknN59OT1jqJw/emZ6wnJchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO237U/H6RHA/6HD7fSC9c4vpxfwCtd3L6YnLHd177XpCbyClyEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkne9uX0xvWO9wO71grXvn0wvWOzuxM+1P8Lviyb+mF6z3g0fTC9Y6tbtut9vtvnc5vWC94za9YK0T7IYTvMEBAL49MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfwb+IB8PIhC4AAAAASUVORK5CYII=" id="image6408d19398" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAFbCAYAAADWVIrwAAAH10lEQVR4nO3YsYqcVQCG4X92Z9eNYFAJUVJaW1hY2Vh7Q96E16HegGAh9tZiY2EjIinMKjEbNpPZf7yERDhy5H+f5wq+wzBn3jm79c8vT8vWPPtj9oKhTk+2dZ5lWZbfPv9m9oShfvnxZvaE4T796rPZE4bbffTx7Alj7c5mLxjv6ePZC8a7uj97wVBfv/fF7AnDbfCbBADw+sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0nYvjt+eZo8Y7bSssycMtdtgs16cXc6eMNRhvZ09YbiLn36YPWG444efzJ4w1HE9zJ4w3M3x6ewJwz3Y2PXw8v6D2ROG296vLADAvyCGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDS9hc3f83eMN6L57MXjHVaZy8Y79792QuGupw94D9wenoze8JwF39fz54w1MV6nD1huHtbvO9un81eMNTFfns3npchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBtd1y/O80eMdrptM6eMNS6sfMsy7JcnF3OnjDU3ek4e8Jw58+uZ08Y762HsxcM9XI9zJ4w3JPb32dPGO79F/vZE4Za33k0e8JwXoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQtj+d1tkbhjvc3c6eMNS93dXsCePdHWcvGOput63zLMuyXO8PsycM9+5pe5/T1pzv9rMnDPfz7vHsCUN9sD6cPWE4L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQNpuXb8/zR4B/A8dD7MXjLe/nL2AV7i9ez57wnBX52/OnsAreBkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANL2y+H57A3jHQ+zF4x1vp+9YLyzjZ1pt8H/Fde/zl4w3tuPZi8Ya2t33bIsyxuXsxeMd1pnLxhrg92wwRscAOD1iSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLR/ACPedSJJv3djAAAAAElFTkSuQmCC" id="image42420961df" transform="scale(1 -1) translate(0 -249.84)" x="95.67625" y="-47.482309" width="416.88" height="249.84"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc27b46c688" d="M 0 0 
+       <path id="m21bfb6ecda" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc27b46c688" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="114.611309" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- alice29.txt -->
-      <g transform="translate(83.454416 373.521078) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(83.454416 338.601078) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-61" d="M 2194 1759 
 Q 1497 1759 1228 1600 
@@ -271,12 +271,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc27b46c688" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="152.481427" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- asyoulik.txt -->
-      <g transform="translate(118.496991 376.348621) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(118.496991 341.428621) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-73" d="M 2834 3397 
 L 2834 2853 
@@ -402,12 +402,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc27b46c688" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="190.351545" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- cp.html -->
-      <g transform="translate(167.791303 364.924428) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(167.791303 330.004428) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-70" d="M 1159 525 
 L 1159 -1331 
@@ -498,12 +498,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc27b46c688" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="228.221663" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- fields.c -->
-      <g transform="translate(206.983711 363.602138) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(206.983711 328.682138) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -567,12 +567,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc27b46c688" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="266.091781" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- grammar.lsp -->
-      <g transform="translate(229.328416 379.127551) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(229.328416 344.207551) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-67" d="M 2906 1791 
 Q 2906 2416 2648 2759 
@@ -643,12 +643,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc27b46c688" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="303.961899" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- kennedy.xls -->
-      <g transform="translate(269.785661 376.540424) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(269.785661 341.620424) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -687,12 +687,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc27b46c688" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="341.832017" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- lcet10.txt -->
-      <g transform="translate(313.495597 370.700606) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(313.495597 335.780606) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -746,12 +746,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc27b46c688" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="379.702135" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- plrabn12.txt -->
-      <g transform="translate(343.614941 378.45138) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(343.614941 343.53138) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -798,12 +798,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc27b46c688" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="417.572253" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- ptt5 -->
-      <g transform="translate(404.770085 355.166354) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(404.770085 320.246354) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -841,12 +841,12 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc27b46c688" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="455.442371" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- sum -->
-      <g transform="translate(442.223894 355.582663) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(442.223894 320.662663) rotate(-45) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-75" transform="translate(52.099609 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(115.478516 0)"/>
@@ -856,12 +856,12 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc27b46c688" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m21bfb6ecda" x="493.312489" y="297.322309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- xargs.1 -->
-      <g transform="translate(471.159718 364.516957) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(471.159718 329.596957) rotate(-45) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-78"/>
        <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
        <use xlink:href="#DejaVuSans-72" transform="translate(120.458984 0)"/>
@@ -877,17 +877,17 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m1334f2885b" d="M 0 0 
+       <path id="m48203c4df0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1334f2885b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48203c4df0" x="95.67625" y="65.804558" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- lean-zip (native) -->
-      <g transform="translate(23.39875 70.150301) scale(0.08 -0.08)">
+      <g transform="translate(23.39875 68.843933) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -970,12 +970,12 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m1334f2885b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48203c4df0" x="95.67625" y="101.422673" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- miniz_oxide -->
-      <g transform="translate(41.56625 105.501152) scale(0.08 -0.08)">
+      <g transform="translate(41.56625 104.462048) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-5f" d="M 3263 -1063 
 L 3263 -1509 
@@ -1002,12 +1002,12 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1334f2885b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48203c4df0" x="95.67625" y="137.040789" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- libdeflate -->
-      <g transform="translate(51.15125 140.852003) scale(0.08 -0.08)">
+      <g transform="translate(51.15125 140.080164) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-6c"/>
        <use xlink:href="#DejaVuSans-69" transform="translate(27.783203 0)"/>
        <use xlink:href="#DejaVuSans-62" transform="translate(55.566406 0)"/>
@@ -1024,30 +1024,12 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m1334f2885b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48203c4df0" x="95.67625" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <!-- zopfli -->
-      <g transform="translate(67.2425 176.202854) scale(0.08 -0.08)">
-       <use xlink:href="#DejaVuSans-7a"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
-       <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
-       <use xlink:href="#DejaVuSans-66" transform="translate(177.148438 0)"/>
-       <use xlink:href="#DejaVuSans-6c" transform="translate(212.353516 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_5">
-     <g id="line2d_16">
-      <g>
-       <use xlink:href="#m1334f2885b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_16">
       <!-- Go compress/flate -->
-      <g transform="translate(15.81375 211.553705) scale(0.08 -0.08)">
+      <g transform="translate(15.81375 175.69828) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1102,15 +1084,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_6">
-     <g id="line2d_17">
+    <g id="ytick_5">
+     <g id="line2d_16">
       <g>
-       <use xlink:href="#m1334f2885b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48203c4df0" x="95.67625" y="208.27702" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_17">
+     <g id="text_16">
       <!-- JS fflate -->
-      <g transform="translate(57.87875 246.904556) scale(0.08 -0.08)">
+      <g transform="translate(57.87875 211.316395) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1169,15 +1151,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_7">
-     <g id="line2d_18">
+    <g id="ytick_6">
+     <g id="line2d_17">
       <g>
-       <use xlink:href="#m1334f2885b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48203c4df0" x="95.67625" y="243.895136" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_18">
+     <g id="text_17">
       <!-- Zig std.flate -->
-      <g transform="translate(40.4275 282.255407) scale(0.08 -0.08)">
+      <g transform="translate(40.4275 246.934511) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1209,15 +1191,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_8">
-     <g id="line2d_19">
+    <g id="ytick_7">
+     <g id="line2d_18">
       <g>
-       <use xlink:href="#m1334f2885b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48203c4df0" x="95.67625" y="279.513251" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_19">
+     <g id="text_18">
       <!-- OCaml decompress -->
-      <g transform="translate(10.8 317.606259) scale(0.08 -0.08)">
+      <g transform="translate(10.8 282.552626) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1283,28 +1265,28 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 95.67625 332.242309 
-L 95.67625 49.4355 
+    <path d="M 95.67625 297.322309 
+L 95.67625 47.9955 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 512.247548 332.242309 
-L 512.247548 49.4355 
+    <path d="M 512.247548 297.322309 
+L 512.247548 47.9955 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 95.67625 332.242309 
-L 512.247548 332.242309 
+    <path d="M 95.67625 297.322309 
+L 512.247548 297.322309 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 95.67625 49.4355 
-L 512.247548 49.4355 
+    <path d="M 95.67625 47.9955 
+L 512.247548 47.9955 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_20">
+   <g id="text_19">
     <!-- +1 -->
-    <g transform="translate(109.820098 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(109.820098 67.598152) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1326,37 +1308,37 @@ z
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
+   <g id="text_20">
+    <!-- +1 -->
+    <g transform="translate(147.690216 67.598152) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
    <g id="text_21">
     <!-- +1 -->
-    <g transform="translate(147.690216 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(185.560334 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
     <!-- +1 -->
-    <g transform="translate(185.560334 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(223.430452 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_23">
     <!-- +1 -->
-    <g transform="translate(223.430452 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(261.30057 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- +1 -->
-    <g transform="translate(261.30057 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
     <!-- +3 -->
-    <g transform="translate(299.170688 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(299.170688 67.598152) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1395,184 +1377,184 @@ z
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
+   <g id="text_25">
+    <!-- +1 -->
+    <g transform="translate(337.040806 67.598152) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
    <g id="text_26">
     <!-- +1 -->
-    <g transform="translate(337.040806 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(374.910924 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +1 -->
-    <g transform="translate(374.910924 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
     <!-- -1 -->
-    <g transform="translate(414.331902 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(414.331902 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_29">
+   <g id="text_28">
     <!-- +0 -->
-    <g transform="translate(450.65116 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(450.65116 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_29">
     <!-- +1 -->
-    <g transform="translate(488.521278 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(488.521278 67.598152) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
+   <g id="text_30">
+    <!-- +0 -->
+    <g transform="translate(109.820098 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
    <g id="text_31">
     <!-- +0 -->
-    <g transform="translate(109.820098 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(147.690216 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- +0 -->
-    <g transform="translate(147.690216 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(187.111194 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- -0 -->
-    <g transform="translate(187.111194 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(224.981312 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- -0 -->
-    <g transform="translate(224.981312 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
     <!-- +0 -->
-    <g transform="translate(261.30057 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(261.30057 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_36">
+   <g id="text_35">
     <!-- +1 -->
-    <g transform="translate(299.170688 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(299.170688 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
+   <g id="text_36">
+    <!-- +0 -->
+    <g transform="translate(337.040806 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
    <g id="text_37">
     <!-- +0 -->
-    <g transform="translate(337.040806 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(374.910924 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- +0 -->
-    <g transform="translate(374.910924 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_39">
     <!-- -1 -->
-    <g transform="translate(414.331902 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(414.331902 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
+   <g id="text_39">
+    <!-- +0 -->
+    <g transform="translate(450.65116 103.216267) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
    <g id="text_40">
     <!-- +0 -->
-    <g transform="translate(450.65116 104.25537) scale(0.065 -0.065)">
+    <g transform="translate(488.521278 103.216267) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- +0 -->
-    <g transform="translate(488.521278 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_42">
     <!-- -0 -->
-    <g transform="translate(111.370957 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(111.370957 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_43">
+   <g id="text_42">
     <!-- -1 -->
-    <g transform="translate(149.241075 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(149.241075 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
+   <g id="text_43">
+    <!-- +0 -->
+    <g transform="translate(185.560334 138.834383) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
    <g id="text_44">
     <!-- +0 -->
-    <g transform="translate(185.560334 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(223.430452 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +0 -->
-    <g transform="translate(223.430452 139.606222) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_46">
     <!-- -1 -->
-    <g transform="translate(262.85143 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(262.85143 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_47">
+   <g id="text_46">
     <!-- -2 -->
-    <g transform="translate(300.721548 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(300.721548 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_48">
+   <g id="text_47">
     <!-- -0 -->
-    <g transform="translate(338.591666 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(338.591666 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_49">
+   <g id="text_48">
     <!-- -1 -->
-    <g transform="translate(376.461784 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(376.461784 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_50">
+   <g id="text_49">
     <!-- -2 -->
-    <g transform="translate(414.331902 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(414.331902 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_51">
+   <g id="text_50">
     <!-- -4 -->
-    <g transform="translate(452.20202 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(452.20202 138.834383) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1598,240 +1580,128 @@ z
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_52">
+   <g id="text_51">
     <!-- -1 -->
-    <g transform="translate(490.072138 139.606222) scale(0.065 -0.065)">
+    <g transform="translate(490.072138 138.834383) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_52">
+    <!-- -0 -->
+    <g transform="translate(111.370957 174.452498) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_53">
-    <!-- -5 -->
-    <g transform="translate(111.370957 174.957073) scale(0.065 -0.065)">
+    <!-- -0 -->
+    <g transform="translate(149.241075 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_54">
-    <!-- -5 -->
-    <g transform="translate(149.241075 174.957073) scale(0.065 -0.065)">
+    <!-- -0 -->
+    <g transform="translate(187.111194 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_55">
-    <!-- -3 -->
-    <g transform="translate(187.111194 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_56">
-    <!-- -4 -->
-    <g transform="translate(224.981312 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_57">
-    <!-- -3 -->
-    <g transform="translate(262.85143 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_58">
-    <!-- -14 -->
-    <g transform="translate(298.653735 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_59">
-    <!-- -5 -->
-    <g transform="translate(338.591666 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_60">
-    <!-- -6 -->
-    <g transform="translate(376.461784 174.957073) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_61">
-    <!-- -14 -->
-    <g transform="translate(412.264089 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_62">
-    <!-- -11 -->
-    <g transform="translate(450.134207 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_63">
-    <!-- -2 -->
-    <g transform="translate(490.072138 174.957073) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_64">
-    <!-- -0 -->
-    <g transform="translate(111.370957 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_65">
-    <!-- -0 -->
-    <g transform="translate(149.241075 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_66">
-    <!-- -0 -->
-    <g transform="translate(187.111194 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_67">
     <!-- +0 -->
-    <g transform="translate(223.430452 210.307924) scale(0.065 -0.065)">
+    <g transform="translate(223.430452 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_68">
+   <g id="text_56">
     <!-- -0 -->
-    <g transform="translate(262.85143 210.307924) scale(0.065 -0.065)">
+    <g transform="translate(262.85143 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_69">
+   <g id="text_57">
     <!-- +2 -->
-    <g transform="translate(299.170688 210.307924) scale(0.065 -0.065)">
+    <g transform="translate(299.170688 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_70">
+   <g id="text_58">
     <!-- -0 -->
-    <g transform="translate(338.591666 210.307924) scale(0.065 -0.065)">
+    <g transform="translate(338.591666 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_71">
+   <g id="text_59">
     <!-- -1 -->
-    <g transform="translate(376.461784 210.307924) scale(0.065 -0.065)">
+    <g transform="translate(376.461784 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_72">
+   <g id="text_60">
     <!-- -3 -->
-    <g transform="translate(414.331902 210.307924) scale(0.065 -0.065)">
+    <g transform="translate(414.331902 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_73">
+   <g id="text_61">
     <!-- +2 -->
-    <g transform="translate(450.65116 210.307924) scale(0.065 -0.065)">
+    <g transform="translate(450.65116 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_74">
+   <g id="text_62">
     <!-- -0 -->
-    <g transform="translate(490.072138 210.307924) scale(0.065 -0.065)">
+    <g transform="translate(490.072138 174.452498) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_75">
+   <g id="text_63">
     <!-- +2 -->
-    <g transform="translate(109.820098 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(109.820098 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_76">
+   <g id="text_64">
     <!-- +3 -->
-    <g transform="translate(147.690216 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(147.690216 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_77">
+   <g id="text_65">
     <!-- +3 -->
-    <g transform="translate(185.560334 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(185.560334 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_78">
+   <g id="text_66">
     <!-- +2 -->
-    <g transform="translate(223.430452 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(223.430452 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_79">
+   <g id="text_67">
     <!-- +2 -->
-    <g transform="translate(261.30057 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(261.30057 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_80">
+   <g id="text_68">
     <!-- +7 -->
-    <g transform="translate(299.170688 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(299.170688 210.070614) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1848,150 +1718,150 @@ z
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_81">
+   <g id="text_69">
     <!-- +2 -->
-    <g transform="translate(337.040806 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(337.040806 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_82">
+   <g id="text_70">
     <!-- +2 -->
-    <g transform="translate(374.910924 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(374.910924 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_83">
+   <g id="text_71">
     <!-- +3 -->
-    <g transform="translate(412.781042 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(412.781042 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_84">
+   <g id="text_72">
     <!-- +4 -->
-    <g transform="translate(450.65116 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(450.65116 210.070614) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
+   <g id="text_73">
+    <!-- +2 -->
+    <g transform="translate(488.521278 210.070614) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_74">
+    <!-- -1 -->
+    <g transform="translate(111.370957 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_75">
+    <!-- -1 -->
+    <g transform="translate(149.241075 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_76">
+    <!-- -0 -->
+    <g transform="translate(187.111194 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_77">
+    <!-- -0 -->
+    <g transform="translate(224.981312 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_78">
+    <!-- -1 -->
+    <g transform="translate(262.85143 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_79">
+    <!-- +5 -->
+    <g transform="translate(299.170688 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_80">
+    <!-- -1 -->
+    <g transform="translate(338.591666 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_81">
+    <!-- -1 -->
+    <g transform="translate(376.461784 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_82">
+    <!-- -2 -->
+    <g transform="translate(414.331902 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_83">
+    <!-- +2 -->
+    <g transform="translate(450.65116 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_84">
+    <!-- -1 -->
+    <g transform="translate(490.072138 245.68873) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
    <g id="text_85">
     <!-- +2 -->
-    <g transform="translate(488.521278 245.658775) scale(0.065 -0.065)">
+    <g transform="translate(109.820098 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_86">
-    <!-- -1 -->
-    <g transform="translate(111.370957 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_87">
-    <!-- -1 -->
-    <g transform="translate(149.241075 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_88">
-    <!-- -0 -->
-    <g transform="translate(187.111194 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_89">
-    <!-- -0 -->
-    <g transform="translate(224.981312 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_90">
-    <!-- -1 -->
-    <g transform="translate(262.85143 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_91">
-    <!-- +5 -->
-    <g transform="translate(299.170688 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_92">
-    <!-- -1 -->
-    <g transform="translate(338.591666 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_93">
-    <!-- -1 -->
-    <g transform="translate(376.461784 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_94">
-    <!-- -2 -->
-    <g transform="translate(414.331902 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_95">
-    <!-- +2 -->
-    <g transform="translate(450.65116 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_96">
-    <!-- -1 -->
-    <g transform="translate(490.072138 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_97">
-    <!-- +2 -->
-    <g transform="translate(109.820098 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_98">
     <!-- +4 -->
-    <g transform="translate(147.690216 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(147.690216 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_99">
+   <g id="text_87">
     <!-- +5 -->
-    <g transform="translate(185.560334 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(185.560334 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_100">
+   <g id="text_88">
     <!-- +15 -->
-    <g transform="translate(221.36264 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(221.36264 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_101">
+   <g id="text_89">
     <!-- +18 -->
-    <g transform="translate(259.232758 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(259.232758 281.306845) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -2038,44 +1908,44 @@ z
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_102">
+   <g id="text_90">
     <!-- +7 -->
-    <g transform="translate(299.170688 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(299.170688 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_103">
+   <g id="text_91">
     <!-- +2 -->
-    <g transform="translate(337.040806 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(337.040806 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_104">
+   <g id="text_92">
     <!-- +2 -->
-    <g transform="translate(374.910924 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(374.910924 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_105">
+   <g id="text_93">
     <!-- +4 -->
-    <g transform="translate(412.781042 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(412.781042 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_106">
+   <g id="text_94">
     <!-- +3 -->
-    <g transform="translate(450.65116 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(450.65116 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_107">
+   <g id="text_95">
     <!-- +21 -->
-    <g transform="translate(486.453466 316.360477) scale(0.065 -0.065)">
+    <g transform="translate(486.453466 281.306845) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
@@ -2084,31 +1954,31 @@ z
   </g>
   <g id="axes_2">
    <g id="patch_7">
-    <path d="M 520.971555 299.888983 
-L 531.876562 299.888983 
-L 531.876562 81.788826 
-L 520.971555 81.788826 
+    <path d="M 520.971555 281.708983 
+L 531.876562 281.708983 
+L 531.876562 63.608826 
+L 520.971555 63.608826 
 z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagefaa2c31e1e" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABg0lEQVR4nO2awa2FMAwEE6Cn39Lv/w55NcRzGK0c7ivbs7YTAXP8/61RfJ55zao2VXyVlWOMZ87EmmNpR9Yc2iQ9repIO7I9RdoXkD83oX0TYDByWcsiM6tM2mWt6DOk3Q+YN1W5g9FwDfUDxub5Ek8MIAY208jW6oVXKQ+Y2NtA7O0ws7dRZOAzqTl3DUnAmp4YiLYnrjOjaygTGCjbS5talVhz7GCMxJpPb2+L+/lMv9GRtMneZpGJeIK0xcEgacPIkU2iWnVrkaUmOWtoO3KoVZlraJZ//BnjGesrixltEtkUf4lpm1ZFAhNpr/XWxQ1pm4PRkTaoOfbEQD5/9QPapB1Zc2ja1KpI2muF0k7ssNC0j1X74nraIu31ItpETCIvKzK06iVWabSRz6TDzDUU2Z5e2mcwdsXmYCBgkVahyJ5VKO3PA2bdSUTa6CrFfG7Y26ZV1n3bO5+1DgsdydQ1hHwGcyGK4WCQr8CZwEzakTUzMXpde6xKEZu0zw7bepBVP2R4KzX/wzi8AAAAAElFTkSuQmCC" id="image499e267726" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-62.64" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
-    <g id="ytick_9">
-     <g id="line2d_20">
+    <g id="ytick_8">
+     <g id="line2d_19">
       <defs>
-       <path id="m94cedb4080" d="M 0 0 
+       <path id="m6645a15df5" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m94cedb4080" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6645a15df5" x="531.876562" y="278.678375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_108">
+     <g id="text_96">
       <!-- −0.20 -->
-      <g transform="translate(538.876562 300.657594) scale(0.1 -0.1)">
+      <g transform="translate(538.876562 282.477594) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2126,15 +1996,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_10">
-     <g id="line2d_21">
+    <g id="ytick_9">
+     <g id="line2d_20">
       <g>
-       <use xlink:href="#m94cedb4080" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6645a15df5" x="531.876562" y="252.173507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_109">
+     <g id="text_97">
       <!-- −0.15 -->
-      <g transform="translate(538.876562 274.152726) scale(0.1 -0.1)">
+      <g transform="translate(538.876562 255.972726) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
@@ -2143,15 +2013,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_11">
-     <g id="line2d_22">
+    <g id="ytick_10">
+     <g id="line2d_21">
       <g>
-       <use xlink:href="#m94cedb4080" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6645a15df5" x="531.876562" y="225.66864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_110">
+     <g id="text_98">
       <!-- −0.10 -->
-      <g transform="translate(538.876562 247.647858) scale(0.1 -0.1)">
+      <g transform="translate(538.876562 229.467858) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
@@ -2160,15 +2030,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_12">
-     <g id="line2d_23">
+    <g id="ytick_11">
+     <g id="line2d_22">
       <g>
-       <use xlink:href="#m94cedb4080" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6645a15df5" x="531.876562" y="199.163772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_111">
+     <g id="text_99">
       <!-- −0.05 -->
-      <g transform="translate(538.876562 221.142991) scale(0.1 -0.1)">
+      <g transform="translate(538.876562 202.962991) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
@@ -2177,47 +2047,47 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_13">
-     <g id="line2d_24">
+    <g id="ytick_12">
+     <g id="line2d_23">
       <g>
-       <use xlink:href="#m94cedb4080" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6645a15df5" x="531.876562" y="172.658905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_112">
+     <g id="text_100">
       <!-- 0.00 -->
-      <g transform="translate(538.876562 194.638123) scale(0.1 -0.1)">
+      <g transform="translate(538.876562 176.458123) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m6645a15df5" x="531.876562" y="146.154037" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_101">
+      <!-- 0.05 -->
+      <g transform="translate(538.876562 149.953256) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m94cedb4080" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6645a15df5" x="531.876562" y="119.649169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_113">
-      <!-- 0.05 -->
-      <g transform="translate(538.876562 168.133256) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_15">
-     <g id="line2d_26">
-      <g>
-       <use xlink:href="#m94cedb4080" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_114">
+     <g id="text_102">
       <!-- 0.10 -->
-      <g transform="translate(538.876562 141.628388) scale(0.1 -0.1)">
+      <g transform="translate(538.876562 123.448388) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
@@ -2225,15 +2095,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_16">
-     <g id="line2d_27">
+    <g id="ytick_15">
+     <g id="line2d_26">
       <g>
-       <use xlink:href="#m94cedb4080" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6645a15df5" x="531.876562" y="93.144302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_115">
+     <g id="text_103">
       <!-- 0.15 -->
-      <g transform="translate(538.876562 115.123521) scale(0.1 -0.1)">
+      <g transform="translate(538.876562 96.943521) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
@@ -2241,15 +2111,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_17">
-     <g id="line2d_28">
+    <g id="ytick_16">
+     <g id="line2d_27">
       <g>
-       <use xlink:href="#m94cedb4080" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6645a15df5" x="531.876562" y="66.639434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_116">
+     <g id="text_104">
       <!-- 0.20 -->
-      <g transform="translate(538.876562 88.618653) scale(0.1 -0.1)">
+      <g transform="translate(538.876562 70.438653) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2257,9 +2127,9 @@ z
       </g>
      </g>
     </g>
-    <g id="text_117">
+    <g id="text_105">
      <!-- % vs zlib (higher=bigger) -->
-     <g transform="translate(581.120313 254.665467) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(581.120313 236.485467) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-25" d="M 4653 2053 
 Q 4381 2053 4226 1822 
@@ -2352,20 +2222,20 @@ z
    </g>
    <g id="LineCollection_1"/>
    <g id="patch_8">
-    <path d="M 520.971555 299.888983 
-L 526.424059 299.888983 
-L 531.876562 299.888983 
-L 531.876562 81.788826 
-L 526.424059 81.788826 
-L 520.971555 81.788826 
-L 520.971555 299.888983 
+    <path d="M 520.971555 281.708983 
+L 526.424059 281.708983 
+L 531.876562 281.708983 
+L 531.876562 63.608826 
+L 526.424059 63.608826 
+L 520.971555 63.608826 
+L 520.971555 281.708983 
 z
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
-  <g id="text_118">
+  <g id="text_106">
    <!-- Compression ratio vs zlib  (canterbury, level 6, relative to zlib) -->
-   <g transform="translate(84.925313 17.182125) scale(0.12 -0.12)">
+   <g transform="translate(84.925313 16.462125) scale(0.12 -0.12)">
     <defs>
      <path id="DejaVuSans-Bold-43" d="M 4288 256 
 Q 3956 84 3597 -3 
@@ -2881,10 +2751,40 @@ z
     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3488.880859 0)"/>
    </g>
   </g>
-  <g id="text_119">
-   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(21.833828 401.184) scale(0.07 -0.07)">
+  <g id="text_107">
+   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.069922 365.364) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2953,12 +2853,12 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2998,109 +2898,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1198597a54">
-   <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
+  <clipPath id="p61ece1236f">
+   <rect x="95.67625" y="47.9955" width="416.571298" height="249.326809"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.732344pt" height="386.202469pt" viewBox="0 0 564.732344 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.260156pt" height="354.774469pt" viewBox="0 0 570.260156 354.774469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -21,233 +21,209 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 386.202469 
-L 564.732344 386.202469 
-L 564.732344 0 
+   <path d="M 0 354.774469 
+L 570.260156 354.774469 
+L 570.260156 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 184.491172 104.1264 
-L 289.116172 104.1264 
-L 289.116172 74.7432 
-L 184.491172 74.7432 
+    <path d="M 187.255078 101.872 
+L 291.880078 101.872 
+L 291.880078 71.996 
+L 187.255078 71.996 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 289.116172 104.1264 
-L 393.741172 104.1264 
-L 393.741172 74.7432 
-L 289.116172 74.7432 
+    <path d="M 291.880078 101.872 
+L 396.505078 101.872 
+L 396.505078 71.996 
+L 291.880078 71.996 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 393.741172 104.1264 
-L 498.366172 104.1264 
-L 498.366172 74.7432 
-L 393.741172 74.7432 
+    <path d="M 396.505078 101.872 
+L 501.130078 101.872 
+L 501.130078 71.996 
+L 396.505078 71.996 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 184.491172 133.5096 
-L 289.116172 133.5096 
-L 289.116172 104.1264 
-L 184.491172 104.1264 
+    <path d="M 187.255078 131.748 
+L 291.880078 131.748 
+L 291.880078 101.872 
+L 187.255078 101.872 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #82c966; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 289.116172 133.5096 
-L 393.741172 133.5096 
-L 393.741172 104.1264 
-L 289.116172 104.1264 
+    <path d="M 291.880078 131.748 
+L 396.505078 131.748 
+L 396.505078 101.872 
+L 291.880078 101.872 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #fff1a8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 393.741172 133.5096 
-L 498.366172 133.5096 
-L 498.366172 104.1264 
-L 393.741172 104.1264 
+    <path d="M 396.505078 131.748 
+L 501.130078 131.748 
+L 501.130078 101.872 
+L 396.505078 101.872 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #fdaf62; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #fdaf62; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 184.491172 162.8928 
-L 289.116172 162.8928 
-L 289.116172 133.5096 
-L 184.491172 133.5096 
+    <path d="M 187.255078 161.624 
+L 291.880078 161.624 
+L 291.880078 131.748 
+L 187.255078 131.748 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #7fc866; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 289.116172 162.8928 
-L 393.741172 162.8928 
-L 393.741172 133.5096 
-L 289.116172 133.5096 
+    <path d="M 291.880078 161.624 
+L 396.505078 161.624 
+L 396.505078 131.748 
+L 291.880078 131.748 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #feda86; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 393.741172 162.8928 
-L 498.366172 162.8928 
-L 498.366172 133.5096 
-L 393.741172 133.5096 
+    <path d="M 396.505078 161.624 
+L 501.130078 161.624 
+L 501.130078 131.748 
+L 396.505078 131.748 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #c5e67e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #c3e67d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 184.491172 192.276 
-L 289.116172 192.276 
-L 289.116172 162.8928 
-L 184.491172 162.8928 
+    <path d="M 187.255078 191.5 
+L 291.880078 191.5 
+L 291.880078 161.624 
+L 187.255078 161.624 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #7fc866; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 289.116172 192.276 
-L 393.741172 192.276 
-L 393.741172 162.8928 
-L 289.116172 162.8928 
+    <path d="M 291.880078 191.5 
+L 396.505078 191.5 
+L 396.505078 161.624 
+L 291.880078 161.624 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 393.741172 192.276 
-L 498.366172 192.276 
-L 498.366172 162.8928 
-L 393.741172 162.8928 
+    <path d="M 396.505078 191.5 
+L 501.130078 191.5 
+L 501.130078 161.624 
+L 396.505078 161.624 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #b7e075; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #b3df72; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 184.491172 221.6592 
-L 289.116172 221.6592 
-L 289.116172 192.276 
-L 184.491172 192.276 
+    <path d="M 187.255078 221.376 
+L 291.880078 221.376 
+L 291.880078 191.5 
+L 187.255078 191.5 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #f1f9ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 289.116172 221.6592 
-L 393.741172 221.6592 
-L 393.741172 192.276 
-L 289.116172 192.276 
+    <path d="M 291.880078 221.376 
+L 396.505078 221.376 
+L 396.505078 191.5 
+L 291.880078 191.5 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 393.741172 221.6592 
-L 498.366172 221.6592 
-L 498.366172 192.276 
-L 393.741172 192.276 
+    <path d="M 396.505078 221.376 
+L 501.130078 221.376 
+L 501.130078 191.5 
+L 396.505078 191.5 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 184.491172 251.0424 
-L 289.116172 251.0424 
-L 289.116172 221.6592 
-L 184.491172 221.6592 
+    <path d="M 187.255078 251.252 
+L 291.880078 251.252 
+L 291.880078 221.376 
+L 187.255078 221.376 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #7ac665; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 289.116172 251.0424 
-L 393.741172 251.0424 
-L 393.741172 221.6592 
-L 289.116172 221.6592 
+    <path d="M 291.880078 251.252 
+L 396.505078 251.252 
+L 396.505078 221.376 
+L 291.880078 221.376 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #fdad60; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 393.741172 251.0424 
-L 498.366172 251.0424 
-L 498.366172 221.6592 
-L 393.741172 221.6592 
+    <path d="M 396.505078 251.252 
+L 501.130078 251.252 
+L 501.130078 221.376 
+L 396.505078 221.376 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 184.491172 280.4256 
-L 289.116172 280.4256 
-L 289.116172 251.0424 
-L 184.491172 251.0424 
+    <path d="M 187.255078 281.128 
+L 291.880078 281.128 
+L 291.880078 251.252 
+L 187.255078 251.252 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 289.116172 280.4256 
-L 393.741172 280.4256 
-L 393.741172 251.0424 
-L 289.116172 251.0424 
+    <path d="M 291.880078 281.128 
+L 396.505078 281.128 
+L 396.505078 251.252 
+L 291.880078 251.252 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #f67c4a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 393.741172 280.4256 
-L 498.366172 280.4256 
-L 498.366172 251.0424 
-L 393.741172 251.0424 
+    <path d="M 396.505078 281.128 
+L 501.130078 281.128 
+L 501.130078 251.252 
+L 396.505078 251.252 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 184.491172 309.8088 
-L 289.116172 309.8088 
-L 289.116172 280.4256 
-L 184.491172 280.4256 
+    <path d="M 187.255078 311.004 
+L 291.880078 311.004 
+L 291.880078 281.128 
+L 187.255078 281.128 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #afdd70; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 289.116172 309.8088 
-L 393.741172 309.8088 
-L 393.741172 280.4256 
-L 289.116172 280.4256 
+    <path d="M 291.880078 311.004 
+L 396.505078 311.004 
+L 396.505078 281.128 
+L 291.880078 281.128 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #ed5f3c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 393.741172 309.8088 
-L 498.366172 309.8088 
-L 498.366172 280.4256 
-L 393.741172 280.4256 
+    <path d="M 396.505078 311.004 
+L 501.130078 311.004 
+L 501.130078 281.128 
+L 396.505078 281.128 
 z
-" clip-path="url(#p6a1a8887d1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_26">
-    <path d="M 184.491172 339.192 
-L 289.116172 339.192 
-L 289.116172 309.8088 
-L 184.491172 309.8088 
-z
-" clip-path="url(#p6a1a8887d1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 289.116172 339.192 
-L 393.741172 339.192 
-L 393.741172 309.8088 
-L 289.116172 309.8088 
-z
-" clip-path="url(#p6a1a8887d1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 393.741172 339.192 
-L 498.366172 339.192 
-L 498.366172 309.8088 
-L 393.741172 309.8088 
-z
-" clip-path="url(#p6a1a8887d1)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc99e894f1c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(117.478438 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.242344 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +328,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(224.762656 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.526563 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +424,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(303.334766 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.098672 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +589,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(401.686484 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.450391 59.541437) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +609,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(113.416172 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.180078 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +798,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(225.352422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +922,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(333.793672 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.557578 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1033,16 +1009,37 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 958 -->
-    <g transform="translate(438.418672 91.6423) scale(0.08 -0.08)">
+    <!-- 946 -->
+    <g transform="translate(441.182578 89.1415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(108.054297 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.818203 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1138,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(225.352422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 119.0175) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1150,8 +1147,8 @@ z
     </g>
    </g>
    <g id="text_11">
-    <!-- 72 -->
-    <g transform="translate(336.338672 121.0255) scale(0.08 -0.08)">
+    <!-- 73 -->
+    <g transform="translate(339.102578 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1163,14 +1160,46 @@ L 525 4134
 L 525 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_12">
     <!-- 282 -->
-    <g transform="translate(438.418672 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.182578 119.0175) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1178,7 +1207,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(125.317422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.081328 148.8935) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1202,7 +1231,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(225.352422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1212,43 +1241,22 @@ z
    </g>
    <g id="text_15">
     <!-- 54 -->
-    <g transform="translate(336.338672 150.4087) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(339.102578 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 697 -->
-    <g transform="translate(438.418672 150.4087) scale(0.08 -0.08)">
+    <!-- 692 -->
+    <g transform="translate(441.182578 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(108.623672 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.387578 178.65825) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1358,7 +1366,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(225.352422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1368,22 +1376,22 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(336.338672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 729 -->
-    <g transform="translate(438.418672 179.7919) scale(0.08 -0.08)">
+    <!-- 733 -->
+    <g transform="translate(441.182578 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(116.779922 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.543828 208.6455) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1443,41 +1451,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(225.352422 209.1751) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(228.116328 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1487,22 +1461,22 @@ z
    </g>
    <g id="text_23">
     <!-- 47 -->
-    <g transform="translate(336.338672 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 154 -->
-    <g transform="translate(438.418672 209.1751) scale(0.08 -0.08)">
+    <!-- 151 -->
+    <g transform="translate(441.182578 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- Go compress/flate -->
-    <g transform="translate(95.747422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(98.511328 238.5215) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1622,7 +1596,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.299 -->
-    <g transform="translate(225.352422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1632,22 +1606,22 @@ z
    </g>
    <g id="text_27">
     <!-- 34 -->
-    <g transform="translate(336.338672 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 227 -->
-    <g transform="translate(438.418672 238.5583) scale(0.08 -0.08)">
+    <!-- 235 -->
+    <g transform="translate(441.182578 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(93.240547 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.004453 268.3975) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1712,7 +1686,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(225.352422 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1722,22 +1696,22 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(336.338672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 116 -->
-    <g transform="translate(438.418672 267.9415) scale(0.08 -0.08)">
+    <!-- 117 -->
+    <g transform="translate(441.182578 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(95.125547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.889453 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1846,7 +1820,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.302 -->
-    <g transform="translate(224.151797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(226.915703 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1940,7 +1914,7 @@ z
    </g>
    <g id="text_35">
     <!-- 7 -->
-    <g transform="translate(338.645547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.409453 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
@@ -1957,8 +1931,8 @@ z
     </g>
    </g>
    <g id="text_36">
-    <!-- 93 -->
-    <g transform="translate(440.487422 297.3247) scale(0.08 -0.08)">
+    <!-- 94 -->
+    <g transform="translate(443.251328 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1990,57 +1964,34 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-39"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- zopfli -->
-    <g transform="translate(121.461797 326.7079) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-7a"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(212.353516 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- 0.279 -->
-    <g transform="translate(225.352422 326.7079) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- 0 -->
-    <g transform="translate(338.883672 326.7079) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- — -->
-    <g transform="translate(442.053672 326.7079) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-2014" d="M 313 1978 
-L 6088 1978 
-L 6088 1528 
-L 313 1528 
-L 313 1978 
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2014"/>
+     <use xlink:href="#DejaVuSans-Bold-39"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
     </g>
    </g>
   </g>
-  <g id="text_41">
+  <g id="text_37">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(131.874922 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.638828 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2252,9 +2203,9 @@ z
     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(2245.654297 0)"/>
    </g>
   </g>
-  <g id="text_42">
-   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
+  <g id="text_38">
+   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(7.2 345.924) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -2395,12 +2346,12 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2440,109 +2391,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p6a1a8887d1">
-   <rect x="79.866172" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pc99e894f1c">
+   <rect x="82.630078" y="42.12" width="418.5" height="268.884"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.260156pt" height="354.774469pt" viewBox="0 0 570.260156 354.774469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.591094pt" height="354.774469pt" viewBox="0 0 568.591094 354.774469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,208 +22,208 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 354.774469 
-L 570.260156 354.774469 
-L 570.260156 0 
+L 568.591094 354.774469 
+L 568.591094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.255078 101.872 
-L 291.880078 101.872 
-L 291.880078 71.996 
-L 187.255078 71.996 
+    <path d="M 186.420547 101.872 
+L 291.045547 101.872 
+L 291.045547 71.996 
+L 186.420547 71.996 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.880078 101.872 
-L 396.505078 101.872 
-L 396.505078 71.996 
-L 291.880078 71.996 
+    <path d="M 291.045547 101.872 
+L 395.670547 101.872 
+L 395.670547 71.996 
+L 291.045547 71.996 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.505078 101.872 
-L 501.130078 101.872 
-L 501.130078 71.996 
-L 396.505078 71.996 
+    <path d="M 395.670547 101.872 
+L 500.295547 101.872 
+L 500.295547 71.996 
+L 395.670547 71.996 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.255078 131.748 
-L 291.880078 131.748 
-L 291.880078 101.872 
-L 187.255078 101.872 
+    <path d="M 186.420547 131.748 
+L 291.045547 131.748 
+L 291.045547 101.872 
+L 186.420547 101.872 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #82c966; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #82c966; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.880078 131.748 
-L 396.505078 131.748 
-L 396.505078 101.872 
-L 291.880078 101.872 
+    <path d="M 291.045547 131.748 
+L 395.670547 131.748 
+L 395.670547 101.872 
+L 291.045547 101.872 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #fff1a8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #fff2aa; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.505078 131.748 
-L 501.130078 131.748 
-L 501.130078 101.872 
-L 396.505078 101.872 
+    <path d="M 395.670547 131.748 
+L 500.295547 131.748 
+L 500.295547 101.872 
+L 395.670547 101.872 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #fdaf62; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #fdb163; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.255078 161.624 
-L 291.880078 161.624 
-L 291.880078 131.748 
-L 187.255078 131.748 
+    <path d="M 186.420547 161.624 
+L 291.045547 161.624 
+L 291.045547 131.748 
+L 186.420547 131.748 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #7fc866; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #7fc866; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.880078 161.624 
-L 396.505078 161.624 
-L 396.505078 131.748 
-L 291.880078 131.748 
+    <path d="M 291.045547 161.624 
+L 395.670547 161.624 
+L 395.670547 131.748 
+L 291.045547 131.748 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.505078 161.624 
-L 501.130078 161.624 
-L 501.130078 131.748 
-L 396.505078 131.748 
+    <path d="M 395.670547 161.624 
+L 500.295547 161.624 
+L 500.295547 131.748 
+L 395.670547 131.748 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #c3e67d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #c5e67e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.255078 191.5 
-L 291.880078 191.5 
-L 291.880078 161.624 
-L 187.255078 161.624 
+    <path d="M 186.420547 191.5 
+L 291.045547 191.5 
+L 291.045547 161.624 
+L 186.420547 161.624 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #7fc866; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #7fc866; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.880078 191.5 
-L 396.505078 191.5 
-L 396.505078 161.624 
-L 291.880078 161.624 
+    <path d="M 291.045547 191.5 
+L 395.670547 191.5 
+L 395.670547 161.624 
+L 291.045547 161.624 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.505078 191.5 
-L 501.130078 191.5 
-L 501.130078 161.624 
-L 396.505078 161.624 
+    <path d="M 395.670547 191.5 
+L 500.295547 191.5 
+L 500.295547 161.624 
+L 395.670547 161.624 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #b3df72; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #b7e075; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.255078 221.376 
-L 291.880078 221.376 
-L 291.880078 191.5 
-L 187.255078 191.5 
+    <path d="M 186.420547 221.376 
+L 291.045547 221.376 
+L 291.045547 191.5 
+L 186.420547 191.5 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #f1f9ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #f1f9ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.880078 221.376 
-L 396.505078 221.376 
-L 396.505078 191.5 
-L 291.880078 191.5 
+    <path d="M 291.045547 221.376 
+L 395.670547 221.376 
+L 395.670547 191.5 
+L 291.045547 191.5 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #fdc171; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.505078 221.376 
-L 501.130078 221.376 
-L 501.130078 191.5 
-L 396.505078 191.5 
+    <path d="M 395.670547 221.376 
+L 500.295547 221.376 
+L 500.295547 191.5 
+L 395.670547 191.5 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.255078 251.252 
-L 291.880078 251.252 
-L 291.880078 221.376 
-L 187.255078 221.376 
+    <path d="M 186.420547 251.252 
+L 291.045547 251.252 
+L 291.045547 221.376 
+L 186.420547 221.376 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #7ac665; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #7ac665; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.880078 251.252 
-L 396.505078 251.252 
-L 396.505078 221.376 
-L 291.880078 221.376 
+    <path d="M 291.045547 251.252 
+L 395.670547 251.252 
+L 395.670547 221.376 
+L 291.045547 221.376 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #fba05b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.505078 251.252 
-L 501.130078 251.252 
-L 501.130078 221.376 
-L 396.505078 221.376 
+    <path d="M 395.670547 251.252 
+L 500.295547 251.252 
+L 500.295547 221.376 
+L 395.670547 221.376 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.255078 281.128 
-L 291.880078 281.128 
-L 291.880078 251.252 
-L 187.255078 251.252 
+    <path d="M 186.420547 281.128 
+L 291.045547 281.128 
+L 291.045547 251.252 
+L 186.420547 251.252 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.880078 281.128 
-L 396.505078 281.128 
-L 396.505078 251.252 
-L 291.880078 251.252 
+    <path d="M 291.045547 281.128 
+L 395.670547 281.128 
+L 395.670547 251.252 
+L 291.045547 251.252 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #f67c4a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #f67c4a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.505078 281.128 
-L 501.130078 281.128 
-L 501.130078 251.252 
-L 396.505078 251.252 
+    <path d="M 395.670547 281.128 
+L 500.295547 281.128 
+L 500.295547 251.252 
+L 395.670547 251.252 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.255078 311.004 
-L 291.880078 311.004 
-L 291.880078 281.128 
-L 187.255078 281.128 
+    <path d="M 186.420547 311.004 
+L 291.045547 311.004 
+L 291.045547 281.128 
+L 186.420547 281.128 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #afdd70; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #afdd70; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.880078 311.004 
-L 396.505078 311.004 
-L 396.505078 281.128 
-L 291.880078 281.128 
+    <path d="M 291.045547 311.004 
+L 395.670547 311.004 
+L 395.670547 281.128 
+L 291.045547 281.128 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.505078 311.004 
-L 501.130078 311.004 
-L 501.130078 281.128 
-L 396.505078 281.128 
+    <path d="M 395.670547 311.004 
+L 500.295547 311.004 
+L 500.295547 281.128 
+L 395.670547 281.128 
 z
-" clip-path="url(#pc99e894f1c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8f0c2efaf6)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.242344 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(119.407813 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -328,7 +328,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.526563 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(226.692031 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -424,7 +424,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.098672 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(305.264141 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -589,7 +589,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.450391 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(403.615859 59.541437) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -609,7 +609,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.180078 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(115.345547 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -798,7 +798,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.116328 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -921,8 +921,8 @@ z
     </g>
    </g>
    <g id="text_7">
-    <!-- 158 -->
-    <g transform="translate(336.557578 89.1415) scale(0.08 -0.08)">
+    <!-- 157 -->
+    <g transform="translate(335.723047 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -963,54 +963,25 @@ Q 953 2441 691 2322
 L 691 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_8">
-    <!-- 946 -->
-    <g transform="translate(441.182578 89.1415) scale(0.08 -0.08)">
+    <!-- 941 -->
+    <g transform="translate(440.348047 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1034,12 +1005,12 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.818203 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(109.983672 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1138,7 +1109,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.116328 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 119.0175) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1148,18 +1119,8 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.102578 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 119.0175) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1199,7 +1160,48 @@ z
    </g>
    <g id="text_12">
     <!-- 282 -->
-    <g transform="translate(441.182578 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 119.0175) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1207,7 +1209,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.081328 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(127.246797 148.8935) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1231,7 +1233,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.116328 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1240,23 +1242,23 @@ z
     </g>
    </g>
    <g id="text_15">
-    <!-- 54 -->
-    <g transform="translate(339.102578 148.8935) scale(0.08 -0.08)">
+    <!-- 53 -->
+    <g transform="translate(338.268047 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 692 -->
-    <g transform="translate(441.182578 148.8935) scale(0.08 -0.08)">
+    <!-- 684 -->
+    <g transform="translate(440.348047 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.387578 178.65825) scale(0.08 -0.08)">
+    <g transform="translate(110.553047 178.65825) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1366,7 +1368,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.116328 178.7695) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1375,23 +1377,23 @@ z
     </g>
    </g>
    <g id="text_19">
-    <!-- 51 -->
-    <g transform="translate(339.102578 178.7695) scale(0.08 -0.08)">
+    <!-- 50 -->
+    <g transform="translate(338.268047 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 733 -->
-    <g transform="translate(441.182578 178.7695) scale(0.08 -0.08)">
+    <!-- 718 -->
+    <g transform="translate(440.348047 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.543828 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(118.709297 208.6455) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1451,7 +1453,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.116328 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1461,14 +1463,14 @@ z
    </g>
    <g id="text_23">
     <!-- 47 -->
-    <g transform="translate(339.102578 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 151 -->
-    <g transform="translate(441.182578 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1476,7 +1478,7 @@ z
    </g>
    <g id="text_25">
     <!-- Go compress/flate -->
-    <g transform="translate(98.511328 238.5215) scale(0.08 -0.08)">
+    <g transform="translate(97.676797 238.5215) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1596,7 +1598,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.299 -->
-    <g transform="translate(228.116328 238.5215) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1606,14 +1608,14 @@ z
    </g>
    <g id="text_27">
     <!-- 34 -->
-    <g transform="translate(339.102578 238.5215) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 235 -->
-    <g transform="translate(441.182578 238.5215) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1621,7 +1623,7 @@ z
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.004453 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(95.169922 268.3975) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1686,7 +1688,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(228.116328 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1696,14 +1698,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(339.102578 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(441.182578 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1711,7 +1713,7 @@ z
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.889453 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(97.054922 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1820,7 +1822,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.302 -->
-    <g transform="translate(226.915703 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(226.081172 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1914,7 +1916,7 @@ z
    </g>
    <g id="text_35">
     <!-- 7 -->
-    <g transform="translate(341.409453 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(340.574922 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
@@ -1932,7 +1934,7 @@ z
    </g>
    <g id="text_36">
     <!-- 94 -->
-    <g transform="translate(443.251328 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(442.416797 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1991,7 +1993,7 @@ z
   </g>
   <g id="text_37">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.638828 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(133.804297 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2204,7 +2206,7 @@ z
    </g>
   </g>
   <g id="text_38">
-   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-10T08:22:01Z  ·  Linux chungus x86_64  ·  commit 3050fc62  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 345.924) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2346,13 +2348,13 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2391,110 +2393,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc99e894f1c">
-   <rect x="82.630078" y="42.12" width="418.5" height="268.884"/>
+  <clipPath id="p8f0c2efaf6">
+   <rect x="81.795547" y="42.12" width="418.5" height="268.884"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 47.90175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p13ee7ccf25)">
+   <g clip-path="url(#p88cd8f9553)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAFrCAYAAAAO+zsvAAAI8klEQVR4nO3YPY5k5RmGYXdP9Y97EMNPC1tAAoETJCMW4JDAkTdCzhII2IEzS96DSYjtzJYtWSIACYMsI4ZgrKaZqampZhGj735HR9e1gufonDrnru/k+MOf7n6xZfvb6QVrnZxOL1jreJhewPN4tvH7d/XK9IK1ntxML+B5nO6mF6y19e/72eX0gqU2Xi8AALxoBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAavev47fTG5Y6v9hNT1jqZv94esJSb7389vSEpb65+WZ6wlKPj0+nJyz13tX19ISlHl+cT09Y6uv/b/v399bVr6YnLLW/OE5PWGp3epiesJQTUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILV74+rN6Q1LXV9u+/r+++NX0xOW+vXt9IK1rl59b3rCUvdOdtMTlnp2d5iesNSb916bnrDU2YPz6QlLPbi4np6w1NPjfnrCUvefbfuMcNtXBwDAC0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKR290520xuWerR/OD1hqftnL09PWOr40hvTE5b67tE/picsdfv0yfSEpd5/8MH0hKX2p8fpCUt9e/Of6QlLPbi4np6w1D8f/n16wlK/vd72+8UJKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkDp5/dPf302PWOl0t+3G/v6Lh9MTlvrjRx9MT1jqk79+Nz1hqQ/ffW16wlJ//vzL6QlLffyH30xPWOqzrx5NT1jqnVd+OT1hqf/d7KcnLPW7t+9PT1hq23UGAMALR4ACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJA6eXL4y930iJXODofpCWudXU4vWGt/O71grfOr6QVrnWz8P+7dcXrBWof99IK1tv58bvz69ifb/r6fH7b9ftn20wkAwAtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkdrt//216w1J3h2fTE9ba3ZtesNbt4+kFa11dTi/geWz9/XI8Ti9Y6/JiesFa+6fTC5Y6Oz+bnrDU3e1P0xOWcgIKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkfgYqq3IH+y5bzAAAAABJRU5ErkJggg==" id="image5e6c7ce4ae" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="483.84" height="261.36"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAFrCAYAAAAO+zsvAAAI8UlEQVR4nO3YP46dBxWHYWY8M7YHxyBDCEkIBYSOBgVEh4ToKGAjtCyDDdDRUdKmpaACpYECUCQLuUBJbInIsifz77IIdN6DRs+zgt/Vvfq+956j2+e/O3zpLru62F7A/+L2envBrHtn2wtmXb7aXjDry0+2F8y668/Pw+32gllHx9sLZn3xcnvBrLPz7QWj7vivEwCA/zcCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACB18perp9sbRp2f3t+eMOrl1cX2hFHvvPH29oRRf33+j+0Jox6fPdyeMOo79x9vTxj14vB8e8KoZy9fbE8Y9b2vvrc9YdTrky+2J4w6Ob7enjDKBRQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEidvP3one0No956+O3tCaP+/erp9oRR774+2Z4w6uzN729PGHV++nh7wqibw/X2hFHvf+Wb2xNGPTp9uj1h1Fvnd/v9d3HzanvCqMeHB9sTRrmAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqZOz4wfbG0b95/Kz7QmjHp482p4w6urJk+0Jo549//P2hFHXh5vtCaN+9OTH2xNGvbh6sT1h1NPPn21PGPXmw29tTxj10ScfbU8Y9cE3PtieMMoFFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASB19/Tc/P2yPmHR0fLQ9YdSnf/9se8Ko3/7qB9sTRv36Dx9vTxj1ix++uz1h1O8//Of2hFG//Nl3tyeM+uPHL7YnjPrp+1/bnjDqX59fbE8Y9ZP33tieMMoFFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACB1dHXz4WF7xKR7lxfbE2adPNheMOv6bn9/t/fPtyeMOvYfF/bcXG8vGHV5dLc/39nN9oJZ3g4AAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDq5Phvf9reMOpwfbM9YdbJve0Fs15dbC8YdfTofHvCqMPt7faEWXf9+XLXPTjbXjDr4nJ7wajTs9PtCaMOr15vTxjlAgoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT+Cz22dBWvSUOMAAAAAElFTkSuQmCC" id="imagefd4d61e65e" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="483.84" height="261.36"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m5fd7607b96" d="M 0 0 
+       <path id="m802fba23f5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5fd7607b96" x="115.814949" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="115.814949" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m5fd7607b96" x="156.092348" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="156.092348" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m5fd7607b96" x="196.369746" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="196.369746" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5fd7607b96" x="236.647145" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="236.647145" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m5fd7607b96" x="276.924544" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="276.924544" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5fd7607b96" x="317.201942" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="317.201942" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m5fd7607b96" x="357.479341" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="357.479341" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5fd7607b96" x="397.756739" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="397.756739" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m5fd7607b96" x="438.034138" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="438.034138" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5fd7607b96" x="478.311536" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="478.311536" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m5fd7607b96" x="518.588935" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="518.588935" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5fd7607b96" x="558.866334" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m802fba23f5" x="558.866334" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m8f260b4034" d="M 0 0 
+       <path id="m9167bcb843" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8f260b4034" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9167bcb843" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8f260b4034" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9167bcb843" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m8f260b4034" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9167bcb843" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m8f260b4034" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9167bcb843" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -881,7 +881,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m8f260b4034" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9167bcb843" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -948,7 +948,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8f260b4034" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9167bcb843" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1029,7 +1029,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m8f260b4034" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9167bcb843" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1120,7 +1120,7 @@ L 579.005033 47.90175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -78 -->
+    <!-- -77 -->
     <g transform="translate(110.506785 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
@@ -1133,6 +1133,16 @@ L 525 4134
 L 525 4666 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- -82 -->
+    <g transform="translate(150.784184 68.352934) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1172,16 +1182,6 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- -82 -->
-    <g transform="translate(150.784184 68.352934) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
 L 3431 0 
@@ -1282,8 +1282,37 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- -76 -->
+    <!-- -74 -->
     <g transform="translate(271.616379 68.352934) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -76 -->
+    <g transform="translate(311.893778 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1321,17 +1350,25 @@ z
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- -76 -->
-    <g transform="translate(311.893778 68.352934) scale(0.065 -0.065)">
+   <g id="text_26">
+    <!-- -82 -->
+    <g transform="translate(352.171177 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- -83 -->
-    <g transform="translate(352.171177 68.352934) scale(0.065 -0.065)">
+   <g id="text_27">
+    <!-- -82 -->
+    <g transform="translate(392.448575 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -73 -->
+    <g transform="translate(432.725974 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1367,13 +1404,21 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- -85 -->
-    <g transform="translate(392.448575 68.352934) scale(0.065 -0.065)">
+   <g id="text_29">
+    <!-- -82 -->
+    <g transform="translate(473.003372 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -75 -->
+    <g transform="translate(513.280771 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1402,44 +1447,20 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -75 -->
-    <g transform="translate(432.725974 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -83 -->
-    <g transform="translate(473.003372 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -75 -->
-    <g transform="translate(513.280771 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- -87 -->
+    <!-- -86 -->
     <g transform="translate(553.558169 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- +7 -->
+    <!-- +6 -->
     <g transform="translate(111.023738 105.668114) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1459,11 +1480,11 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- -13 -->
+    <!-- -14 -->
     <g transform="translate(150.784184 105.668114) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
@@ -1483,7 +1504,7 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_34">
@@ -1502,31 +1523,10 @@ z
     </g>
    </g>
    <g id="text_36">
-    <!-- -4 -->
-    <g transform="translate(273.684192 105.668114) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    <!-- +3 -->
+    <g transform="translate(272.133333 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_37">
@@ -1537,25 +1537,24 @@ z
     </g>
    </g>
    <g id="text_38">
-    <!-- -3 -->
+    <!-- -2 -->
     <g transform="translate(354.238989 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- -12 -->
-    <g transform="translate(392.448575 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    <!-- +2 -->
+    <g transform="translate(392.965528 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- -9 -->
+    <!-- -2 -->
     <g transform="translate(434.793786 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_41">
@@ -1566,28 +1565,28 @@ z
     </g>
    </g>
    <g id="text_42">
-    <!-- +10 -->
+    <!-- +11 -->
     <g transform="translate(511.729912 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- -12 -->
+    <!-- -11 -->
     <g transform="translate(553.558169 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- +258 -->
+    <!-- +255 -->
     <g transform="translate(106.888113 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_45">
@@ -1600,12 +1599,12 @@ z
     </g>
    </g>
    <g id="text_46">
-    <!-- +304 -->
+    <!-- +303 -->
     <g transform="translate(187.44291 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_47">
@@ -1618,91 +1617,91 @@ z
     </g>
    </g>
    <g id="text_48">
-    <!-- +236 -->
+    <!-- +267 -->
     <g transform="translate(267.997708 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +182 -->
+    <!-- +188 -->
     <g transform="translate(308.275106 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +280 -->
+    <!-- +289 -->
     <g transform="translate(348.552505 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +155 -->
+    <!-- +195 -->
     <g transform="translate(388.829903 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
-    <!-- +218 -->
+    <!-- +249 -->
     <g transform="translate(429.107302 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_53">
-    <!-- +191 -->
+    <!-- +193 -->
     <g transform="translate(469.3847 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_54">
-    <!-- +210 -->
+    <!-- +217 -->
     <g transform="translate(509.662099 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_55">
-    <!-- +159 -->
+    <!-- +165 -->
     <g transform="translate(549.939498 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_56">
-    <!-- +33 -->
+    <!-- +31 -->
     <g transform="translate(108.955926 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_57">
-    <!-- +29 -->
+    <!-- +30 -->
     <g transform="translate(149.233324 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_58">
@@ -1714,82 +1713,81 @@ z
     </g>
    </g>
    <g id="text_59">
-    <!-- +5 -->
+    <!-- +9 -->
     <g transform="translate(231.855934 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_60">
-    <!-- +60 -->
+    <!-- +75 -->
     <g transform="translate(270.06552 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_61">
-    <!-- +72 -->
+    <!-- +79 -->
     <g transform="translate(310.342919 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_62">
-    <!-- -11 -->
-    <g transform="translate(352.171177 180.298474) scale(0.065 -0.065)">
+    <!-- -9 -->
+    <g transform="translate(354.238989 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_63">
-    <!-- +11 -->
+    <!-- +30 -->
     <g transform="translate(390.897716 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_64">
-    <!-- +75 -->
-    <g transform="translate(431.175114 180.298474) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_65">
-    <!-- +10 -->
-    <g transform="translate(471.452513 180.298474) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_66">
-    <!-- +85 -->
-    <g transform="translate(511.729912 180.298474) scale(0.065 -0.065)">
+   <g id="text_64">
+    <!-- +88 -->
+    <g transform="translate(431.175114 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_65">
+    <!-- +13 -->
+    <g transform="translate(471.452513 180.298474) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_66">
+    <!-- +91 -->
+    <g transform="translate(511.729912 180.298474) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_67">
-    <!-- +17 -->
+    <!-- +20 -->
     <g transform="translate(552.00731 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_68">
-    <!-- +37 -->
+    <!-- +40 -->
     <g transform="translate(108.955926 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_69">
@@ -1800,11 +1798,11 @@ z
     </g>
    </g>
    <g id="text_70">
-    <!-- +46 -->
+    <!-- +44 -->
     <g transform="translate(189.510723 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
@@ -1816,11 +1814,11 @@ z
     </g>
    </g>
    <g id="text_72">
-    <!-- +23 -->
+    <!-- +35 -->
     <g transform="translate(270.06552 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_73">
@@ -1832,26 +1830,26 @@ z
     </g>
    </g>
    <g id="text_74">
-    <!-- +22 -->
+    <!-- +23 -->
     <g transform="translate(350.620317 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_75">
-    <!-- -9 -->
-    <g transform="translate(394.516388 217.613655) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    <!-- +9 -->
+    <g transform="translate(392.965528 217.613655) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_76">
-    <!-- +34 -->
+    <!-- +46 -->
     <g transform="translate(431.175114 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_77">
@@ -1863,123 +1861,124 @@ z
     </g>
    </g>
    <g id="text_78">
-    <!-- +19 -->
+    <!-- +23 -->
     <g transform="translate(511.729912 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_79">
-    <!-- -16 -->
-    <g transform="translate(553.558169 217.613655) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_80">
-    <!-- +71 -->
-    <g transform="translate(108.955926 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_81">
-    <!-- +63 -->
-    <g transform="translate(149.233324 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_82">
+   <g id="text_79">
+    <!-- -14 -->
+    <g transform="translate(553.558169 217.613655) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_80">
     <!-- +78 -->
-    <g transform="translate(189.510723 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(108.955926 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_83">
-    <!-- +40 -->
-    <g transform="translate(229.788122 254.928835) scale(0.065 -0.065)">
+   <g id="text_81">
+    <!-- +64 -->
+    <g transform="translate(149.233324 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_84">
-    <!-- +80 -->
-    <g transform="translate(270.06552 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_85">
-    <!-- +89 -->
-    <g transform="translate(310.342919 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_86">
-    <!-- +31 -->
-    <g transform="translate(350.620317 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_87">
-    <!-- +42 -->
-    <g transform="translate(390.897716 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_88">
-    <!-- +84 -->
-    <g transform="translate(431.175114 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_89">
-    <!-- +49 -->
-    <g transform="translate(471.452513 254.928835) scale(0.065 -0.065)">
+   <g id="text_82">
+    <!-- +79 -->
+    <g transform="translate(189.510723 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_83">
+    <!-- +45 -->
+    <g transform="translate(229.788122 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_84">
+    <!-- +100 -->
+    <g transform="translate(267.997708 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_85">
+    <!-- +85 -->
+    <g transform="translate(310.342919 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_86">
+    <!-- +37 -->
+    <g transform="translate(350.620317 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_87">
+    <!-- +64 -->
+    <g transform="translate(390.897716 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_88">
+    <!-- +98 -->
+    <g transform="translate(431.175114 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_89">
+    <!-- +50 -->
+    <g transform="translate(471.452513 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_90">
-    <!-- +59 -->
+    <!-- +64 -->
     <g transform="translate(511.729912 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_91">
-    <!-- +51 -->
+    <!-- +60 -->
     <g transform="translate(552.00731 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_92">
-    <!-- -35 -->
+    <!-- -34 -->
     <g transform="translate(110.506785 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_93">
@@ -1991,11 +1990,11 @@ z
     </g>
    </g>
    <g id="text_94">
-    <!-- -44 -->
+    <!-- -43 -->
     <g transform="translate(191.061582 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_95">
@@ -2007,67 +2006,67 @@ z
     </g>
    </g>
    <g id="text_96">
-    <!-- -48 -->
+    <!-- -43 -->
     <g transform="translate(271.616379 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_97">
-    <!-- -54 -->
+    <!-- -52 -->
     <g transform="translate(311.893778 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_98">
-    <!-- -33 -->
+    <!-- -32 -->
     <g transform="translate(352.171177 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_99">
-    <!-- -49 -->
+    <!-- -41 -->
     <g transform="translate(392.448575 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_100">
-    <!-- -48 -->
-    <g transform="translate(432.725974 292.244015) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_101">
     <!-- -43 -->
-    <g transform="translate(473.003372 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(432.725974 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_101">
+    <!-- -41 -->
+    <g transform="translate(473.003372 292.244015) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_102">
-    <!-- -56 -->
+    <!-- -55 -->
     <g transform="translate(513.280771 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_103">
-    <!-- -46 -->
+    <!-- -45 -->
     <g transform="translate(553.558169 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2081,23 +2080,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB10lEQVR4nO2b223EMAwEKVu1pPOUeVZKoD8GwRyxLGDhHXIp3cPrt35OAXURIlVV+4KkfEJGRosRMlqzCYVRX0JGazEZEVrTCYVRX4MZgdagc200I84aQ3uv27ZqF2YNEgKtQbBBRrr2c5M9l9GC9ojSWtrfVCLSl88aFlohoyvt74V0t5GyWdt12yJStjkSWtPNERkR6qJlgz14jQit1dwLe9ZIW9wa8aVft9iwgRR+7YOtER8j0NrYO2QYvREKo17IZ426H0G/HE9mNHqOBltL+5sKo752LYoRJGRs/2BGmDUbbCMjm5Awa2vdiFDa35ew/ZMZ2Vat0ZpNSMjoUH+sPOdBhDhGD/RE+1SsdULUE3GMqIHcD8UoEWlLae3DCCUivVAi0tZga4nICyFjRJBXjo3t56wVxogREq4RcI7CqCnQGjfZcxnZJnv0quV2dhg1pbSWNfJvQh9Gx8jIaA0S+nBzhOiAjKiu+WCDc8QsyETkjdDoiGTVdkJCa5A336pNRPoiGVHWoONIaQ1rv+0SQXXNB1s5R4iO0trk9lNCk9fI3APS1jVl+ymhyWuE+ihKwT46RtQTGa1R7Z/MyGYtjPoyWrNlzcjIJjSYkdFaIvJ9QhijP3Z3X2u76gsSAAAAAElFTkSuQmCC" id="imagecda760947f" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-51.12" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB10lEQVR4nO2b223EMAwEKVu1pPOUeVZKoD8GwRyxLGDhHXIp3cPrt35OAXURIlVV+4KkfEJGRosRMlqzCYVRX0JGazEZEVrTCYVRX4MZgdagc200I84aQ3uv27ZqF2YNEgKtQbBBRrr2c5M9l9GC9ojSWtrfVCLSl88aFlohoyvt74V0t5GyWdt12yJStjkSWtPNERkR6qJlgz14jQit1dwLe9ZIW9wa8aVft9iwgRR+7YOtER8j0NrYO2QYvREKo17IZ426H0G/HE9mNHqOBltL+5sKo752LYoRJGRs/2BGmDUbbCMjm5Awa2vdiFDa35ew/ZMZ2Vat0ZpNSMjoUH+sPOdBhDhGD/RE+1SsdULUE3GMqIHcD8UoEWlLae3DCCUivVAi0tZga4nICyFjRJBXjo3t56wVxogREq4RcI7CqCnQGjfZcxnZJnv0quV2dhg1pbSWNfJvQh9Gx8jIaA0S+nBzhOiAjKiu+WCDc8QsyETkjdDoiGTVdkJCa5A336pNRPoiGVHWoONIaQ1rv+0SQXXNB1s5R4iO0trk9lNCk9fI3APS1jVl+ymhyWuE+ihKwT46RtQTGa1R7Z/MyGYtjPoyWrNlzcjIJjSYkdFaIvJ9QhijP3Z3X2u76gsSAAAAAElFTkSuQmCC" id="imageb9993a5324" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-51.12" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_20">
       <defs>
-       <path id="m40b64c4be4" d="M 0 0 
+       <path id="m29fb8c7050" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m40b64c4be4" x="601.779688" y="303.401516" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29fb8c7050" x="601.779688" y="303.771221" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_104">
       <!-- −3 -->
-      <g transform="translate(608.779688 307.200735) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 307.57044) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2115,12 +2114,12 @@ z
     <g id="ytick_9">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m40b64c4be4" x="601.779688" y="261.769304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29fb8c7050" x="601.779688" y="262.015774" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_105">
       <!-- −2 -->
-      <g transform="translate(608.779688 265.568523) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 265.814993) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2129,12 +2128,12 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m40b64c4be4" x="601.779688" y="220.137093" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29fb8c7050" x="601.779688" y="220.260328" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_106">
       <!-- −1 -->
-      <g transform="translate(608.779688 223.936311) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 224.059546) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2143,7 +2142,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m40b64c4be4" x="601.779688" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29fb8c7050" x="601.779688" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_107">
@@ -2156,12 +2155,12 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m40b64c4be4" x="601.779688" y="136.872669" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29fb8c7050" x="601.779688" y="136.749434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
       <!-- 1 -->
-      <g transform="translate(608.779688 140.671888) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 140.548653) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2169,12 +2168,12 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m40b64c4be4" x="601.779688" y="95.240457" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29fb8c7050" x="601.779688" y="94.993987" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
       <!-- 2 -->
-      <g transform="translate(608.779688 99.039676) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 98.793206) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2182,12 +2181,12 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m40b64c4be4" x="601.779688" y="53.608245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m29fb8c7050" x="601.779688" y="53.23854" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
       <!-- 3 -->
-      <g transform="translate(608.779688 57.407464) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 57.037759) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2798,8 +2797,8 @@ z
    </g>
   </g>
   <g id="text_113">
-   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(48.833828 365.364) scale(0.07 -0.07)">
+   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.069922 365.364) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2891,12 +2890,12 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2936,108 +2935,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p13ee7ccf25">
+  <clipPath id="p88cd8f9553">
    <rect x="95.67625" y="47.90175" width="483.328783" height="261.206261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 47.90175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p88cd8f9553)">
+   <g clip-path="url(#p4d60667d3b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAFrCAYAAAAO+zsvAAAI8UlEQVR4nO3YP46dBxWHYWY8M7YHxyBDCEkIBYSOBgVEh4ToKGAjtCyDDdDRUdKmpaACpYECUCQLuUBJbInIsifz77IIdN6DRs+zgt/Vvfq+956j2+e/O3zpLru62F7A/+L2envBrHtn2wtmXb7aXjDry0+2F8y668/Pw+32gllHx9sLZn3xcnvBrLPz7QWj7vivEwCA/zcCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACB18perp9sbRp2f3t+eMOrl1cX2hFHvvPH29oRRf33+j+0Jox6fPdyeMOo79x9vTxj14vB8e8KoZy9fbE8Y9b2vvrc9YdTrky+2J4w6Ob7enjDKBRQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEidvP3one0No956+O3tCaP+/erp9oRR774+2Z4w6uzN729PGHV++nh7wqibw/X2hFHvf+Wb2xNGPTp9uj1h1Fvnd/v9d3HzanvCqMeHB9sTRrmAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqZOz4wfbG0b95/Kz7QmjHp482p4w6urJk+0Jo549//P2hFHXh5vtCaN+9OTH2xNGvbh6sT1h1NPPn21PGPXmw29tTxj10ScfbU8Y9cE3PtieMMoFFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASB19/Tc/P2yPmHR0fLQ9YdSnf/9se8Ko3/7qB9sTRv36Dx9vTxj1ix++uz1h1O8//Of2hFG//Nl3tyeM+uPHL7YnjPrp+1/bnjDqX59fbE8Y9ZP33tieMMoFFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACB1dHXz4WF7xKR7lxfbE2adPNheMOv6bn9/t/fPtyeMOvYfF/bcXG8vGHV5dLc/39nN9oJZ3g4AAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDq5Phvf9reMOpwfbM9YdbJve0Fs15dbC8YdfTofHvCqMPt7faEWXf9+XLXPTjbXjDr4nJ7wajTs9PtCaMOr15vTxjlAgoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT+Cz22dBWvSUOMAAAAAElFTkSuQmCC" id="imagefd4d61e65e" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="483.84" height="261.36"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAFrCAYAAAAO+zsvAAAI/0lEQVR4nO3Yz47dZR3H8TnTM8P0DwhVKCHWxJjggg0r6sqtbrgPEi+DFWsugUswxjU73RgXpokJRptCAqEBWtvJzHR6xoswz/tbTl6vK/ic/M7zO+/zbHbffXZ1sM8uTqcXrLU5nF6w1u5yesFa+/78Li+mF6x14/XpBWudP51esNa+n7/D7fSCtfb9+3l0Mr1gqT0/fQAAvGwEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBq+9fzL6Y3LHXr6GR6wlKnl+fTE5a6c/PN6QlL/euHB9MTltoeXpuesNS7r9yanrDU+XY3PWGpB0++nJ6w1N1X356esNR/N0+nJyx1fXs5PWEpN6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBq+/Nb70xvWOqt67+YnrDU16f/mZ6w1N2Lk+kJS9342XvTE5Y6uXZjesJSu4Pd9ISl7uz5+/P4cL/fL7dP3p6esNSz4yfTE5Z6Y3NresJSbkABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU9vjwZHrDUo8vHk1PWOrm0WvTE5Y6u77fn++bx/+YnrDU0+dn0xOWuvfT30xPWOrZ5ZPpCUs9fPpwesJSr7/y1vSEpf727d+nJyx1784H0xOWcgMKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkNrc/+f3V9IiVrh1fm56w1Lf/fDQ9YalPP3p/esJSH3/+1fSEpX77q9vTE5b64+f/np6w1B8+/PX0hKX+9MX30xOW+uCdV6cnLHX/0en0hKV+98ufTE9Yyg0oAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGpzfvnnq+kRKx292E1PWGt7PL1gredn0wvWOr4xvWCp3cF+n7/DvX57HhwcvLicXrDWxh3Mj9nFZr+/n8cvphes5fQBAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp7fb+X6Y3LHW1201PWOtwz/9DnJ5NL1jrtZvTC5ba7K6mJyx1dfF8egL/j5Pj6QVrnV1ML1jqaM+f39We//7teb0AAPCyEaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqf8B84lvM6PyISwAAAAASUVORK5CYII=" id="image6be2c63cc3" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="483.84" height="261.36"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m802fba23f5" d="M 0 0 
+       <path id="m473f637789" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m802fba23f5" x="115.814949" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="115.814949" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m802fba23f5" x="156.092348" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="156.092348" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m802fba23f5" x="196.369746" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="196.369746" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m802fba23f5" x="236.647145" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="236.647145" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m802fba23f5" x="276.924544" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="276.924544" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m802fba23f5" x="317.201942" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="317.201942" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m802fba23f5" x="357.479341" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="357.479341" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m802fba23f5" x="397.756739" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="397.756739" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m802fba23f5" x="438.034138" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="438.034138" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m802fba23f5" x="478.311536" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="478.311536" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m802fba23f5" x="518.588935" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="518.588935" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m802fba23f5" x="558.866334" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m473f637789" x="558.866334" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m9167bcb843" d="M 0 0 
+       <path id="madb3831b72" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9167bcb843" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#madb3831b72" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9167bcb843" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#madb3831b72" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m9167bcb843" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#madb3831b72" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m9167bcb843" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#madb3831b72" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -881,7 +881,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m9167bcb843" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#madb3831b72" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -948,7 +948,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m9167bcb843" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#madb3831b72" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1029,7 +1029,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m9167bcb843" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#madb3831b72" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1140,7 +1140,7 @@ z
     </g>
    </g>
    <g id="text_21">
-    <!-- -82 -->
+    <!-- -81 -->
     <g transform="translate(150.784184 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1182,46 +1182,36 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -78 -->
+    <!-- -77 -->
     <g transform="translate(191.061582 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -90 -->
+    <!-- -89 -->
     <g transform="translate(231.338981 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
@@ -1254,31 +1244,10 @@ Q 1038 2656 1286 2365
 Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1311,8 +1280,109 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- -76 -->
+    <!-- -75 -->
     <g transform="translate(311.893778 68.352934) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -82 -->
+    <g transform="translate(352.171177 68.352934) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -84 -->
+    <g transform="translate(392.448575 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -74 -->
+    <g transform="translate(432.725974 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -82 -->
+    <g transform="translate(473.003372 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -74 -->
+    <g transform="translate(513.280771 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -86 -->
+    <g transform="translate(553.558169 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1346,29 +1416,52 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- -82 -->
-    <g transform="translate(352.171177 68.352934) scale(0.065 -0.065)">
+   <g id="text_32">
+    <!-- +9 -->
+    <g transform="translate(111.023738 105.668114) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- -12 -->
+    <g transform="translate(150.784184 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- -82 -->
-    <g transform="translate(392.448575 68.352934) scale(0.065 -0.065)">
+   <g id="text_34">
+    <!-- -4 -->
+    <g transform="translate(193.129395 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- -73 -->
-    <g transform="translate(432.725974 68.352934) scale(0.065 -0.065)">
+   <g id="text_35">
+    <!-- -13 -->
+    <g transform="translate(231.338981 105.668114) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1404,136 +1497,22 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- -82 -->
-    <g transform="translate(473.003372 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -75 -->
-    <g transform="translate(513.280771 68.352934) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -86 -->
-    <g transform="translate(553.558169 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- +6 -->
-    <g transform="translate(111.023738 105.668114) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- -14 -->
-    <g transform="translate(150.784184 105.668114) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -5 -->
-    <g transform="translate(193.129395 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -16 -->
-    <g transform="translate(231.338981 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
    <g id="text_36">
-    <!-- +3 -->
-    <g transform="translate(272.133333 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    <!-- -1 -->
+    <g transform="translate(273.684192 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- +1 -->
+    <!-- +3 -->
     <g transform="translate(312.410731 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_38">
@@ -1544,17 +1523,17 @@ z
     </g>
    </g>
    <g id="text_39">
-    <!-- +2 -->
-    <g transform="translate(392.965528 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+    <!-- -7 -->
+    <g transform="translate(394.516388 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- -2 -->
+    <!-- -7 -->
     <g transform="translate(434.793786 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_41">
@@ -1573,64 +1552,87 @@ z
     </g>
    </g>
    <g id="text_43">
-    <!-- -11 -->
+    <!-- -12 -->
     <g transform="translate(553.558169 105.668114) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- +255 -->
+    <!-- +264 -->
     <g transform="translate(106.888113 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +253 -->
+    <!-- +256 -->
     <g transform="translate(147.165512 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- +303 -->
+    <!-- +307 -->
     <g transform="translate(187.44291 142.983294) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_47">
-    <!-- +132 -->
-    <g transform="translate(227.720309 142.983294) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_48">
-    <!-- +267 -->
-    <g transform="translate(267.997708 142.983294) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
+   <g id="text_47">
+    <!-- +141 -->
+    <g transform="translate(227.720309 142.983294) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_48">
+    <!-- +253 -->
+    <g transform="translate(267.997708 142.983294) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
    <g id="text_49">
-    <!-- +188 -->
+    <!-- +198 -->
     <g transform="translate(308.275106 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
     </g>
    </g>
@@ -1644,95 +1646,96 @@ z
     </g>
    </g>
    <g id="text_51">
-    <!-- +195 -->
+    <!-- +171 -->
     <g transform="translate(388.829903 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
-    <!-- +249 -->
+    <!-- +234 -->
     <g transform="translate(429.107302 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_53">
-    <!-- +193 -->
+    <!-- +191 -->
     <g transform="translate(469.3847 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_54">
-    <!-- +217 -->
+    <!-- +226 -->
     <g transform="translate(509.662099 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_55">
-    <!-- +165 -->
+    <!-- +164 -->
     <g transform="translate(549.939498 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_56">
-    <!-- +31 -->
+    <!-- +35 -->
     <g transform="translate(108.955926 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_57">
-    <!-- +30 -->
+    <!-- +33 -->
     <g transform="translate(149.233324 180.298474) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_58">
+    <!-- +30 -->
+    <g transform="translate(189.510723 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_58">
-    <!-- +29 -->
-    <g transform="translate(189.510723 180.298474) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
    <g id="text_59">
-    <!-- +9 -->
-    <g transform="translate(231.855934 180.298474) scale(0.065 -0.065)">
+    <!-- +13 -->
+    <g transform="translate(229.788122 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_60">
-    <!-- +75 -->
+    <!-- +70 -->
     <g transform="translate(270.06552 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_61">
-    <!-- +79 -->
+    <!-- +83 -->
     <g transform="translate(310.342919 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_62">
@@ -1743,35 +1746,35 @@ z
     </g>
    </g>
    <g id="text_63">
-    <!-- +30 -->
+    <!-- +18 -->
     <g transform="translate(390.897716 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_64">
-    <!-- +88 -->
-    <g transform="translate(431.175114 180.298474) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_64">
+    <!-- +81 -->
+    <g transform="translate(431.175114 180.298474) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_65">
-    <!-- +13 -->
+    <!-- +14 -->
     <g transform="translate(471.452513 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_66">
-    <!-- +91 -->
+    <!-- +97 -->
     <g transform="translate(511.729912 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_67">
@@ -1783,50 +1786,50 @@ z
     </g>
    </g>
    <g id="text_68">
-    <!-- +40 -->
-    <g transform="translate(108.955926 217.613655) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_69">
-    <!-- +6 -->
-    <g transform="translate(151.301137 217.613655) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_70">
     <!-- +44 -->
-    <g transform="translate(189.510723 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(108.955926 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_69">
+    <!-- +9 -->
+    <g transform="translate(151.301137 217.613655) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_70">
+    <!-- +46 -->
+    <g transform="translate(189.510723 217.613655) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_71">
-    <!-- -39 -->
+    <!-- -36 -->
     <g transform="translate(231.338981 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_72">
-    <!-- +35 -->
+    <!-- +31 -->
     <g transform="translate(270.06552 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_73">
-    <!-- +18 -->
+    <!-- +21 -->
     <g transform="translate(310.342919 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_74">
@@ -1838,34 +1841,34 @@ z
     </g>
    </g>
    <g id="text_75">
-    <!-- +9 -->
-    <g transform="translate(392.965528 217.613655) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(394.516388 217.613655) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_76">
-    <!-- +46 -->
+    <!-- +41 -->
     <g transform="translate(431.175114 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_77">
-    <!-- +11 -->
-    <g transform="translate(471.452513 217.613655) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_77">
+    <!-- +12 -->
+    <g transform="translate(471.452513 217.613655) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_78">
-    <!-- +23 -->
+    <!-- +27 -->
     <g transform="translate(511.729912 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_79">
@@ -1877,52 +1880,51 @@ z
     </g>
    </g>
    <g id="text_80">
-    <!-- +78 -->
+    <!-- +82 -->
     <g transform="translate(108.955926 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_81">
-    <!-- +64 -->
+    <!-- +68 -->
     <g transform="translate(149.233324 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_82">
-    <!-- +79 -->
+    <!-- +81 -->
     <g transform="translate(189.510723 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_83">
-    <!-- +45 -->
+    <!-- +50 -->
     <g transform="translate(229.788122 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_84">
-    <!-- +100 -->
-    <g transform="translate(267.997708 254.928835) scale(0.065 -0.065)">
+    <!-- +95 -->
+    <g transform="translate(270.06552 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_85">
-    <!-- +85 -->
+    <!-- +89 -->
     <g transform="translate(310.342919 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_86">
@@ -1934,35 +1936,35 @@ z
     </g>
    </g>
    <g id="text_87">
-    <!-- +64 -->
-    <g transform="translate(390.897716 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_88">
-    <!-- +98 -->
-    <g transform="translate(431.175114 254.928835) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_89">
     <!-- +50 -->
-    <g transform="translate(471.452513 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(390.897716 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_88">
+    <!-- +91 -->
+    <g transform="translate(431.175114 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_89">
+    <!-- +51 -->
+    <g transform="translate(471.452513 254.928835) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_90">
-    <!-- +64 -->
+    <!-- +70 -->
     <g transform="translate(511.729912 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_91">
@@ -1974,19 +1976,19 @@ z
     </g>
    </g>
    <g id="text_92">
-    <!-- -34 -->
+    <!-- -32 -->
     <g transform="translate(110.506785 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_93">
-    <!-- -45 -->
+    <!-- -44 -->
     <g transform="translate(150.784184 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_94">
@@ -1998,27 +2000,27 @@ z
     </g>
    </g>
    <g id="text_95">
-    <!-- -48 -->
+    <!-- -46 -->
     <g transform="translate(231.338981 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_96">
-    <!-- -43 -->
+    <!-- -44 -->
     <g transform="translate(271.616379 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_97">
-    <!-- -52 -->
+    <!-- -51 -->
     <g transform="translate(311.893778 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_98">
@@ -2030,35 +2032,35 @@ z
     </g>
    </g>
    <g id="text_99">
-    <!-- -41 -->
+    <!-- -46 -->
     <g transform="translate(392.448575 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_100">
-    <!-- -43 -->
+    <!-- -45 -->
     <g transform="translate(432.725974 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_101">
-    <!-- -41 -->
+    <!-- -40 -->
     <g transform="translate(473.003372 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_102">
-    <!-- -55 -->
+    <!-- -53 -->
     <g transform="translate(513.280771 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_103">
@@ -2080,23 +2082,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB10lEQVR4nO2b223EMAwEKVu1pPOUeVZKoD8GwRyxLGDhHXIp3cPrt35OAXURIlVV+4KkfEJGRosRMlqzCYVRX0JGazEZEVrTCYVRX4MZgdagc200I84aQ3uv27ZqF2YNEgKtQbBBRrr2c5M9l9GC9ojSWtrfVCLSl88aFlohoyvt74V0t5GyWdt12yJStjkSWtPNERkR6qJlgz14jQit1dwLe9ZIW9wa8aVft9iwgRR+7YOtER8j0NrYO2QYvREKo17IZ426H0G/HE9mNHqOBltL+5sKo752LYoRJGRs/2BGmDUbbCMjm5Awa2vdiFDa35ew/ZMZ2Vat0ZpNSMjoUH+sPOdBhDhGD/RE+1SsdULUE3GMqIHcD8UoEWlLae3DCCUivVAi0tZga4nICyFjRJBXjo3t56wVxogREq4RcI7CqCnQGjfZcxnZJnv0quV2dhg1pbSWNfJvQh9Gx8jIaA0S+nBzhOiAjKiu+WCDc8QsyETkjdDoiGTVdkJCa5A336pNRPoiGVHWoONIaQ1rv+0SQXXNB1s5R4iO0trk9lNCk9fI3APS1jVl+ymhyWuE+ihKwT46RtQTGa1R7Z/MyGYtjPoyWrNlzcjIJjSYkdFaIvJ9QhijP3Z3X2u76gsSAAAAAElFTkSuQmCC" id="imageb9993a5324" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-51.12" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB10lEQVR4nO2b223EMAwEKVu1pPOUeVZKoD8GwRyxLGDhHXIp3cPrt35OAXURIlVV+4KkfEJGRosRMlqzCYVRX0JGazEZEVrTCYVRX4MZgdagc200I84aQ3uv27ZqF2YNEgKtQbBBRrr2c5M9l9GC9ojSWtrfVCLSl88aFlohoyvt74V0t5GyWdt12yJStjkSWtPNERkR6qJlgz14jQit1dwLe9ZIW9wa8aVft9iwgRR+7YOtER8j0NrYO2QYvREKo17IZ426H0G/HE9mNHqOBltL+5sKo752LYoRJGRs/2BGmDUbbCMjm5Awa2vdiFDa35ew/ZMZ2Vat0ZpNSMjoUH+sPOdBhDhGD/RE+1SsdULUE3GMqIHcD8UoEWlLae3DCCUivVAi0tZga4nICyFjRJBXjo3t56wVxogREq4RcI7CqCnQGjfZcxnZJnv0quV2dhg1pbSWNfJvQh9Gx8jIaA0S+nBzhOiAjKiu+WCDc8QsyETkjdDoiGTVdkJCa5A336pNRPoiGVHWoONIaQ1rv+0SQXXNB1s5R4iO0trk9lNCk9fI3APS1jVl+ymhyWuE+ihKwT46RtQTGa1R7Z/MyGYtjPoyWrNlzcjIJjSYkdFaIvJ9QhijP3Z3X2u76gsSAAAAAElFTkSuQmCC" id="image761b2d281a" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-51.12" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_20">
       <defs>
-       <path id="m29fb8c7050" d="M 0 0 
+       <path id="m807ea16ad8" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m29fb8c7050" x="601.779688" y="303.771221" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m807ea16ad8" x="601.779688" y="301.989406" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_104">
       <!-- −3 -->
-      <g transform="translate(608.779688 307.57044) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 305.788625) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2114,12 +2116,12 @@ z
     <g id="ytick_9">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m29fb8c7050" x="601.779688" y="262.015774" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m807ea16ad8" x="601.779688" y="260.827898" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_105">
       <!-- −2 -->
-      <g transform="translate(608.779688 265.814993) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 264.627116) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2128,12 +2130,12 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m29fb8c7050" x="601.779688" y="220.260328" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m807ea16ad8" x="601.779688" y="219.666389" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_106">
       <!-- −1 -->
-      <g transform="translate(608.779688 224.059546) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 223.465608) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2142,7 +2144,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m29fb8c7050" x="601.779688" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m807ea16ad8" x="601.779688" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_107">
@@ -2155,12 +2157,12 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m29fb8c7050" x="601.779688" y="136.749434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m807ea16ad8" x="601.779688" y="137.343372" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
       <!-- 1 -->
-      <g transform="translate(608.779688 140.548653) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 141.142591) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2168,12 +2170,12 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m29fb8c7050" x="601.779688" y="94.993987" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m807ea16ad8" x="601.779688" y="96.181864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
       <!-- 2 -->
-      <g transform="translate(608.779688 98.793206) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 99.981083) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2181,12 +2183,12 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m29fb8c7050" x="601.779688" y="53.23854" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m807ea16ad8" x="601.779688" y="55.020355" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
       <!-- 3 -->
-      <g transform="translate(608.779688 57.037759) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 58.819574) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2797,8 +2799,8 @@ z
    </g>
   </g>
   <g id="text_113">
-   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.069922 365.364) scale(0.07 -0.07)">
+   <!-- 2026-06-10T08:22:01Z  ·  Linux chungus x86_64  ·  commit 3050fc62  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 365.364) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2890,13 +2892,13 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2935,109 +2937,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p88cd8f9553">
+  <clipPath id="p4d60667d3b">
    <rect x="95.67625" y="47.90175" width="483.328783" height="261.206261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 100.798569 412.80375 
 L 100.798569 48.323125 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m2dc11e37be" d="M 0 0 
+       <path id="m4e6ea543a3" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2dc11e37be" x="100.798569" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e6ea543a3" x="100.798569" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -154,11 +154,11 @@ z
      <g id="line2d_3">
       <path d="M 193.031172 412.80375 
 L 193.031172 48.323125 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2dc11e37be" x="193.031172" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e6ea543a3" x="193.031172" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -196,11 +196,11 @@ z
      <g id="line2d_5">
       <path d="M 285.263775 412.80375 
 L 285.263775 48.323125 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2dc11e37be" x="285.263775" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e6ea543a3" x="285.263775" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -249,11 +249,11 @@ z
      <g id="line2d_7">
       <path d="M 377.496378 412.80375 
 L 377.496378 48.323125 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2dc11e37be" x="377.496378" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e6ea543a3" x="377.496378" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -311,11 +311,11 @@ z
      <g id="line2d_9">
       <path d="M 469.72898 412.80375 
 L 469.72898 48.323125 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2dc11e37be" x="469.72898" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e6ea543a3" x="469.72898" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ L 469.72898 48.323125
      <g id="line2d_11">
       <path d="M 561.961583 412.80375 
 L 561.961583 48.323125 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2dc11e37be" x="561.961583" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e6ea543a3" x="561.961583" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -831,23 +831,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_13">
-      <path d="M 49.078125 275.17508 
-L 637.2 275.17508 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 275.154665 
+L 637.2 275.154665 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <defs>
-       <path id="mdfdb3c54cb" d="M 0 0 
+       <path id="m85b1e1c010" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdfdb3c54cb" x="49.078125" y="275.17508" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85b1e1c010" x="49.078125" y="275.154665" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 278.974298) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 278.953883) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -872,18 +872,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_15">
-      <path d="M 49.078125 128.33751 
-L 637.2 128.33751 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 128.329042 
+L 637.2 128.329042 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdfdb3c54cb" x="49.078125" y="128.33751" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85b1e1c010" x="49.078125" y="128.329042" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 132.136729) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 132.128261) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -892,222 +892,222 @@ L 637.2 128.33751
     </g>
     <g id="ytick_3">
      <g id="line2d_17">
-      <path d="M 49.078125 377.810136 
-L 637.2 377.810136 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 377.781371 
+L 637.2 377.781371 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <defs>
-       <path id="m809a69971e" d="M 0 0 
+       <path id="mdfc8f6ae0f" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="377.810136" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="377.781371" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_19">
-      <path d="M 49.078125 351.953324 
-L 637.2 351.953324 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 351.926662 
+L 637.2 351.926662 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="351.953324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="351.926662" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_21">
-      <path d="M 49.078125 333.607623 
-L 637.2 333.607623 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 333.582454 
+L 637.2 333.582454 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="333.607623" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="333.582454" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_23">
-      <path d="M 49.078125 319.377593 
-L 637.2 319.377593 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 319.353581 
+L 637.2 319.353581 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="319.377593" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="319.353581" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_25">
-      <path d="M 49.078125 307.750811 
-L 637.2 307.750811 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 307.727745 
+L 637.2 307.727745 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="307.750811" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="307.727745" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_27">
-      <path d="M 49.078125 297.920507 
-L 637.2 297.920507 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 297.898241 
+L 637.2 297.898241 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="297.920507" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="297.898241" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_29">
-      <path d="M 49.078125 289.405111 
-L 637.2 289.405111 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 289.383538 
+L 637.2 289.383538 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="289.405111" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="289.383538" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_31">
-      <path d="M 49.078125 281.893998 
-L 637.2 281.893998 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 281.873037 
+L 637.2 281.873037 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="281.893998" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="281.873037" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_33">
-      <path d="M 49.078125 230.972567 
-L 637.2 230.972567 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 230.955748 
+L 637.2 230.955748 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="230.972567" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="230.955748" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_35">
-      <path d="M 49.078125 205.115754 
-L 637.2 205.115754 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.101039 
+L 637.2 205.101039 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="205.115754" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="205.101039" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_37">
-      <path d="M 49.078125 186.770054 
-L 637.2 186.770054 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 186.756831 
+L 637.2 186.756831 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="186.770054" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="186.756831" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_39">
-      <path d="M 49.078125 172.540023 
-L 637.2 172.540023 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 172.527958 
+L 637.2 172.527958 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="172.540023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="172.527958" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_41">
-      <path d="M 49.078125 160.913241 
-L 637.2 160.913241 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 160.902123 
+L 637.2 160.902123 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="160.913241" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="160.902123" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_43">
-      <path d="M 49.078125 151.082938 
-L 637.2 151.082938 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 151.072619 
+L 637.2 151.072619 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="151.082938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="151.072619" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_45">
-      <path d="M 49.078125 142.567541 
-L 637.2 142.567541 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 142.557915 
+L 637.2 142.557915 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="142.567541" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="142.557915" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_47">
-      <path d="M 49.078125 135.056429 
-L 637.2 135.056429 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 135.047414 
+L 637.2 135.047414 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="135.056429" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="135.047414" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_49">
-      <path d="M 49.078125 84.134997 
-L 637.2 84.134997 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 84.130125 
+L 637.2 84.130125 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="84.134997" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="84.130125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_51">
-      <path d="M 49.078125 58.278185 
-L 637.2 58.278185 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 58.275416 
+L 637.2 58.275416 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m809a69971e" x="49.078125" y="58.278185" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="58.275416" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1229,7 +1229,7 @@ L 637.2 48.323125
    </g>
    <g id="text_11">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(472.789269 230.426768) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(472.789269 230.216035) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1590,110 +1590,110 @@ z
     </g>
    </g>
    <g id="line2d_53">
-    <path d="M 354.801917 111.776119 
-L 296.396877 118.38239 
-L 240.372732 137.302009 
-L 199.2912 139.4363 
-L 145.672036 164.396936 
-L 115.077361 190.555326 
-L 105.421184 203.209875 
-L 95.641458 227.103078 
-L 93.912266 235.121278 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 354.801917 114.660939 
+L 296.396877 123.10881 
+L 240.372732 140.381931 
+L 199.2912 141.623331 
+L 145.672036 166.804274 
+L 115.077361 192.626714 
+L 105.421184 205.604533 
+L 95.641458 230.54475 
+L 93.912266 237.379416 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m766ca61a5c" d="M -2.5 2.5 
+     <path id="md300d03360" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9d887ab682)">
-     <use xlink:href="#m766ca61a5c" x="354.801917" y="111.776119" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m766ca61a5c" x="296.396877" y="118.38239" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m766ca61a5c" x="240.372732" y="137.302009" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m766ca61a5c" x="199.2912" y="139.4363" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m766ca61a5c" x="145.672036" y="164.396936" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m766ca61a5c" x="115.077361" y="190.555326" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m766ca61a5c" x="105.421184" y="203.209875" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m766ca61a5c" x="95.641458" y="227.103078" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m766ca61a5c" x="93.912266" y="235.121278" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6d5f4c5531)">
+     <use xlink:href="#md300d03360" x="354.801917" y="114.660939" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md300d03360" x="296.396877" y="123.10881" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md300d03360" x="240.372732" y="140.381931" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md300d03360" x="199.2912" y="141.623331" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md300d03360" x="145.672036" y="166.804274" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md300d03360" x="115.077361" y="192.626714" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md300d03360" x="105.421184" y="205.604533" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md300d03360" x="95.641458" y="230.54475" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md300d03360" x="93.912266" y="237.379416" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_54">
-    <path d="M 610.467187 73.587747 
-L 292.101608 107.421391 
-L 172.024432 140.7311 
-L 156.692445 145.272459 
-L 134.525595 161.569513 
-L 108.348473 194.034785 
-L 102.387102 208.080833 
-L 99.4003 219.556513 
-L 97.945363 224.106407 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467187 74.197484 
+L 292.101608 108.523762 
+L 172.024432 141.80691 
+L 156.692445 146.604189 
+L 134.525595 163.089425 
+L 108.348473 194.594672 
+L 102.387102 208.686989 
+L 99.4003 219.91743 
+L 97.945363 224.466317 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m321fec97a4" d="M 0 -2.5 
+     <path id="m6ff3ff7ad5" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9d887ab682)">
-     <use xlink:href="#m321fec97a4" x="610.467187" y="73.587747" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m321fec97a4" x="292.101608" y="107.421391" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m321fec97a4" x="172.024432" y="140.7311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m321fec97a4" x="156.692445" y="145.272459" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m321fec97a4" x="134.525595" y="161.569513" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m321fec97a4" x="108.348473" y="194.034785" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m321fec97a4" x="102.387102" y="208.080833" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m321fec97a4" x="99.4003" y="219.556513" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m321fec97a4" x="97.945363" y="224.106407" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6d5f4c5531)">
+     <use xlink:href="#m6ff3ff7ad5" x="610.467187" y="74.197484" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ff3ff7ad5" x="292.101608" y="108.523762" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ff3ff7ad5" x="172.024432" y="141.80691" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ff3ff7ad5" x="156.692445" y="146.604189" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ff3ff7ad5" x="134.525595" y="163.089425" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ff3ff7ad5" x="108.348473" y="194.594672" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ff3ff7ad5" x="102.387102" y="208.686989" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ff3ff7ad5" x="99.4003" y="219.91743" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6ff3ff7ad5" x="97.945363" y="224.466317" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_55">
     <path d="M 261.591835 64.890426 
-L 207.694789 83.472682 
-L 180.75628 89.86461 
-L 158.366417 94.727656 
-L 123.924526 105.030385 
-L 101.412222 118.289132 
-L 89.106563 136.68356 
-L 77.579551 164.162689 
-L 75.810938 173.8635 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 207.694789 83.383093 
+L 180.75628 89.79303 
+L 158.366417 94.548929 
+L 123.924526 104.681036 
+L 101.412222 118.154763 
+L 89.106563 136.75714 
+L 77.579551 163.947027 
+L 75.810938 173.47315 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf78ccb86eb" d="M -0 3.535534 
+     <path id="m4707d373f2" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9d887ab682)">
-     <use xlink:href="#mf78ccb86eb" x="261.591835" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf78ccb86eb" x="207.694789" y="83.472682" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf78ccb86eb" x="180.75628" y="89.86461" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf78ccb86eb" x="158.366417" y="94.727656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf78ccb86eb" x="123.924526" y="105.030385" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf78ccb86eb" x="101.412222" y="118.289132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf78ccb86eb" x="89.106563" y="136.68356" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf78ccb86eb" x="77.579551" y="164.162689" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf78ccb86eb" x="75.810938" y="173.8635" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6d5f4c5531)">
+     <use xlink:href="#m4707d373f2" x="261.591835" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4707d373f2" x="207.694789" y="83.383093" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4707d373f2" x="180.75628" y="89.79303" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4707d373f2" x="158.366417" y="94.548929" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4707d373f2" x="123.924526" y="104.681036" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4707d373f2" x="101.412222" y="118.154763" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4707d373f2" x="89.106563" y="136.75714" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4707d373f2" x="77.579551" y="163.947027" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4707d373f2" x="75.810938" y="173.47315" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_56">
-    <path d="M 415.481577 102.520757 
-L 271.002054 122.79617 
-L 234.129884 132.37151 
-L 189.290714 133.833688 
-L 139.928317 156.903538 
-L 121.802872 173.16502 
-L 114.483714 183.899882 
-L 107.370838 199.718544 
-L 106.338791 207.421577 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 415.481577 102.17095 
+L 271.002054 122.446936 
+L 234.129884 131.998442 
+L 189.290714 133.537601 
+L 139.928317 157.005693 
+L 121.802872 172.645763 
+L 114.483714 183.682981 
+L 107.370838 199.464786 
+L 106.338791 207.208091 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma4d347ce34" d="M -0.833333 2.5 
+     <path id="me731f8b662" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1708,31 +1708,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9d887ab682)">
-     <use xlink:href="#ma4d347ce34" x="415.481577" y="102.520757" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma4d347ce34" x="271.002054" y="122.79617" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma4d347ce34" x="234.129884" y="132.37151" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma4d347ce34" x="189.290714" y="133.833688" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma4d347ce34" x="139.928317" y="156.903538" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma4d347ce34" x="121.802872" y="173.16502" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma4d347ce34" x="114.483714" y="183.899882" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma4d347ce34" x="107.370838" y="199.718544" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma4d347ce34" x="106.338791" y="207.421577" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6d5f4c5531)">
+     <use xlink:href="#me731f8b662" x="415.481577" y="102.17095" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me731f8b662" x="271.002054" y="122.446936" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me731f8b662" x="234.129884" y="131.998442" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me731f8b662" x="189.290714" y="133.537601" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me731f8b662" x="139.928317" y="157.005693" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me731f8b662" x="121.802872" y="172.645763" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me731f8b662" x="114.483714" y="183.682981" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me731f8b662" x="107.370838" y="199.464786" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me731f8b662" x="106.338791" y="207.208091" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_57">
-    <path d="M 319.655788 147.083464 
-L 241.138751 155.60659 
-L 205.372997 162.276322 
-L 184.155683 169.100406 
-L 168.571516 171.586622 
-L 140.014958 184.606525 
-L 138.061909 188.001389 
-L 136.349672 195.436076 
-L 136.267068 201.851274 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 319.655788 147.167243 
+L 241.138751 155.690965 
+L 205.372997 162.507465 
+L 184.155683 168.694757 
+L 168.571516 171.337808 
+L 140.014958 184.22147 
+L 138.061909 188.478882 
+L 136.349672 195.027957 
+L 136.267068 201.360628 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc6a459cc91" d="M -1.25 2.5 
+     <path id="m14429c6ded" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1747,31 +1747,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9d887ab682)">
-     <use xlink:href="#mc6a459cc91" x="319.655788" y="147.083464" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6a459cc91" x="241.138751" y="155.60659" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6a459cc91" x="205.372997" y="162.276322" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6a459cc91" x="184.155683" y="169.100406" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6a459cc91" x="168.571516" y="171.586622" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6a459cc91" x="140.014958" y="184.606525" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6a459cc91" x="138.061909" y="188.001389" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6a459cc91" x="136.349672" y="195.436076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc6a459cc91" x="136.267068" y="201.851274" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6d5f4c5531)">
+     <use xlink:href="#m14429c6ded" x="319.655788" y="147.167243" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14429c6ded" x="241.138751" y="155.690965" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14429c6ded" x="205.372997" y="162.507465" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14429c6ded" x="184.155683" y="168.694757" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14429c6ded" x="168.571516" y="171.337808" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14429c6ded" x="140.014958" y="184.22147" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14429c6ded" x="138.061909" y="188.478882" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14429c6ded" x="136.349672" y="195.027957" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m14429c6ded" x="136.267068" y="201.360628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_58">
-    <path d="M 190.200149 122.027753 
-L 190.200149 122.569211 
-L 190.200149 121.713741 
-L 190.200149 121.458056 
-L 136.403453 144.935929 
-L 117.347293 160.509091 
-L 110.358201 168.098667 
-L 102.810747 186.030199 
-L 101.457483 194.986364 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 190.200149 121.788005 
+L 190.200149 121.751716 
+L 190.200149 121.718717 
+L 190.200149 122.221614 
+L 136.403453 143.872287 
+L 117.347293 159.673906 
+L 110.358201 168.063198 
+L 102.810747 186.066803 
+L 101.457483 194.246981 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md888c81323" d="M 0 -2.5 
+     <path id="md0fb35b5de" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1784,31 +1784,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p9d887ab682)">
-     <use xlink:href="#md888c81323" x="190.200149" y="122.027753" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md888c81323" x="190.200149" y="122.569211" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md888c81323" x="190.200149" y="121.713741" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md888c81323" x="190.200149" y="121.458056" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md888c81323" x="136.403453" y="144.935929" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md888c81323" x="117.347293" y="160.509091" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md888c81323" x="110.358201" y="168.098667" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md888c81323" x="102.810747" y="186.030199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md888c81323" x="101.457483" y="194.986364" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p6d5f4c5531)">
+     <use xlink:href="#md0fb35b5de" x="190.200149" y="121.788005" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md0fb35b5de" x="190.200149" y="121.751716" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md0fb35b5de" x="190.200149" y="121.718717" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md0fb35b5de" x="190.200149" y="122.221614" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md0fb35b5de" x="136.403453" y="143.872287" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md0fb35b5de" x="117.347293" y="159.673906" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md0fb35b5de" x="110.358201" y="168.063198" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md0fb35b5de" x="102.810747" y="186.066803" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#md0fb35b5de" x="101.457483" y="194.246981" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_59">
-    <path d="M 583.298166 193.951199 
-L 519.179151 196.566985 
-L 442.700778 206.25977 
-L 261.692068 199.557248 
-L 208.012723 213.429972 
-L 175.596233 229.929448 
-L 165.747429 238.98927 
-L 156.224637 258.199348 
-L 154.208481 264.671077 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 583.298166 193.564162 
+L 519.179151 196.095066 
+L 442.700778 205.893071 
+L 261.692068 198.930695 
+L 208.012723 212.911134 
+L 175.596233 229.383885 
+L 165.747429 238.561879 
+L 156.224637 257.822324 
+L 154.208481 264.385674 
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m4a5b9e5fd3" d="M 0 -2.5 
+     <path id="mb4eab45ddb" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1817,16 +1817,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p9d887ab682)">
-     <use xlink:href="#m4a5b9e5fd3" x="583.298166" y="193.951199" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a5b9e5fd3" x="519.179151" y="196.566985" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a5b9e5fd3" x="442.700778" y="206.25977" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a5b9e5fd3" x="261.692068" y="199.557248" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a5b9e5fd3" x="208.012723" y="213.429972" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a5b9e5fd3" x="175.596233" y="229.929448" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a5b9e5fd3" x="165.747429" y="238.98927" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a5b9e5fd3" x="156.224637" y="258.199348" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a5b9e5fd3" x="154.208481" y="264.671077" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6d5f4c5531)">
+     <use xlink:href="#mb4eab45ddb" x="583.298166" y="193.564162" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb4eab45ddb" x="519.179151" y="196.095066" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb4eab45ddb" x="442.700778" y="205.893071" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb4eab45ddb" x="261.692068" y="198.930695" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb4eab45ddb" x="208.012723" y="212.911134" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb4eab45ddb" x="175.596233" y="229.383885" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb4eab45ddb" x="165.747429" y="238.561879" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb4eab45ddb" x="156.224637" y="257.822324" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb4eab45ddb" x="154.208481" y="264.385674" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1849,7 +1849,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m260cccae68" d="M 0 3.5 
+      <path id="m4ec57b821e" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1862,7 +1862,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m260cccae68" x="434.04625" y="365.69" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m4ec57b821e" x="434.04625" y="365.69" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_14">
@@ -1925,7 +1925,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m766ca61a5c" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md300d03360" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_15">
@@ -1943,7 +1943,7 @@ L 434.04625 389.175
 L 442.04625 389.175 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m321fec97a4" x="434.04625" y="389.175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6ff3ff7ad5" x="434.04625" y="389.175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -1992,7 +1992,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf78ccb86eb" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4707d373f2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2039,7 +2039,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma4d347ce34" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me731f8b662" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2097,7 +2097,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc6a459cc91" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m14429c6ded" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2166,7 +2166,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md888c81323" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#md0fb35b5de" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_20">
@@ -2208,7 +2208,7 @@ L 537.72375 400.9175
 L 545.72375 400.9175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m4a5b9e5fd3" x="537.72375" y="400.9175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb4eab45ddb" x="537.72375" y="400.9175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2278,26 +2278,26 @@ z
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 467.789269 235.426768 
-L 418.340522 242.330896 
-L 358.158195 249.618552 
-L 302.416526 278.723991 
-L 296.217965 284.329677 
-L 286.657165 297.51306 
-L 119.684757 381.191793 
-L 117.697993 389.814346 
+    <path d="M 467.789269 235.216035 
+L 418.340522 241.488151 
+L 358.158195 248.891571 
+L 302.416526 278.321187 
+L 296.217965 283.956497 
+L 286.657165 297.273879 
+L 119.684757 380.932447 
+L 117.697993 390.171583 
 L 116.602636 396.236449 
-" clip-path="url(#p9d887ab682)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p9d887ab682)">
-     <use xlink:href="#m260cccae68" x="467.789269" y="235.426768" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m260cccae68" x="418.340522" y="242.330896" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m260cccae68" x="358.158195" y="249.618552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m260cccae68" x="302.416526" y="278.723991" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m260cccae68" x="296.217965" y="284.329677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m260cccae68" x="286.657165" y="297.51306" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m260cccae68" x="119.684757" y="381.191793" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m260cccae68" x="117.697993" y="389.814346" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m260cccae68" x="116.602636" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p6d5f4c5531)">
+     <use xlink:href="#m4ec57b821e" x="467.789269" y="235.216035" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4ec57b821e" x="418.340522" y="241.488151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4ec57b821e" x="358.158195" y="248.891571" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4ec57b821e" x="302.416526" y="278.321187" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4ec57b821e" x="296.217965" y="283.956497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4ec57b821e" x="286.657165" y="297.273879" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4ec57b821e" x="119.684757" y="380.932447" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4ec57b821e" x="117.697993" y="390.171583" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4ec57b821e" x="116.602636" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2666,8 +2666,8 @@ z
    </g>
   </g>
   <g id="text_23">
-   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(48.833828 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.069922 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2678,6 +2678,16 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2775,6 +2785,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -2816,12 +2856,12 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2861,108 +2901,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9d887ab682">
+  <clipPath id="p6d5f4c5531">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 100.798569 412.80375 
 L 100.798569 48.323125 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m4e6ea543a3" d="M 0 0 
+       <path id="m8c1d2eeb15" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4e6ea543a3" x="100.798569" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c1d2eeb15" x="100.798569" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -154,11 +154,11 @@ z
      <g id="line2d_3">
       <path d="M 193.031172 412.80375 
 L 193.031172 48.323125 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4e6ea543a3" x="193.031172" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c1d2eeb15" x="193.031172" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -196,11 +196,11 @@ z
      <g id="line2d_5">
       <path d="M 285.263775 412.80375 
 L 285.263775 48.323125 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4e6ea543a3" x="285.263775" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c1d2eeb15" x="285.263775" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -249,11 +249,11 @@ z
      <g id="line2d_7">
       <path d="M 377.496378 412.80375 
 L 377.496378 48.323125 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4e6ea543a3" x="377.496378" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c1d2eeb15" x="377.496378" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -311,11 +311,11 @@ z
      <g id="line2d_9">
       <path d="M 469.72898 412.80375 
 L 469.72898 48.323125 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4e6ea543a3" x="469.72898" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c1d2eeb15" x="469.72898" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ L 469.72898 48.323125
      <g id="line2d_11">
       <path d="M 561.961583 412.80375 
 L 561.961583 48.323125 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m4e6ea543a3" x="561.961583" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c1d2eeb15" x="561.961583" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -831,23 +831,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_13">
-      <path d="M 49.078125 275.154665 
-L 637.2 275.154665 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 272.685074 
+L 637.2 272.685074 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <defs>
-       <path id="m85b1e1c010" d="M 0 0 
+       <path id="m17a467e07c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m85b1e1c010" x="49.078125" y="275.154665" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17a467e07c" x="49.078125" y="272.685074" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 278.953883) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 276.484292) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -872,18 +872,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_15">
-      <path d="M 49.078125 128.329042 
-L 637.2 128.329042 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 127.360927 
+L 637.2 127.360927 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m85b1e1c010" x="49.078125" y="128.329042" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m17a467e07c" x="49.078125" y="127.360927" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 132.128261) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 131.160146) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -892,222 +892,222 @@ L 637.2 128.329042
     </g>
     <g id="ytick_3">
      <g id="line2d_17">
-      <path d="M 49.078125 377.781371 
-L 637.2 377.781371 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 374.262293 
+L 637.2 374.262293 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <defs>
-       <path id="mdfc8f6ae0f" d="M 0 0 
+       <path id="m83ec301f9f" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="377.781371" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="374.262293" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_19">
-      <path d="M 49.078125 351.926662 
-L 637.2 351.926662 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 348.671981 
+L 637.2 348.671981 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="351.926662" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="348.671981" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_21">
-      <path d="M 49.078125 333.582454 
-L 637.2 333.582454 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.515366 
+L 637.2 330.515366 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="333.582454" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="330.515366" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_23">
-      <path d="M 49.078125 319.353581 
-L 637.2 319.353581 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 316.432001 
+L 637.2 316.432001 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="319.353581" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="316.432001" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_25">
-      <path d="M 49.078125 307.727745 
-L 637.2 307.727745 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 304.925054 
+L 637.2 304.925054 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="307.727745" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="304.925054" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_27">
-      <path d="M 49.078125 297.898241 
-L 637.2 297.898241 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 295.196069 
+L 637.2 295.196069 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="297.898241" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="295.196069" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_29">
-      <path d="M 49.078125 289.383538 
-L 637.2 289.383538 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 286.768439 
+L 637.2 286.768439 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="289.383538" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="286.768439" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_31">
-      <path d="M 49.078125 281.873037 
-L 637.2 281.873037 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 279.334742 
+L 637.2 279.334742 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="281.873037" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="279.334742" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_33">
-      <path d="M 49.078125 230.955748 
-L 637.2 230.955748 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 228.938146 
+L 637.2 228.938146 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="230.955748" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="228.938146" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_35">
-      <path d="M 49.078125 205.101039 
-L 637.2 205.101039 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 203.347835 
+L 637.2 203.347835 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="205.101039" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="203.347835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_37">
-      <path d="M 49.078125 186.756831 
-L 637.2 186.756831 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 185.191219 
+L 637.2 185.191219 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="186.756831" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="185.191219" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_39">
-      <path d="M 49.078125 172.527958 
-L 637.2 172.527958 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 171.107854 
+L 637.2 171.107854 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="172.527958" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="171.107854" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_41">
-      <path d="M 49.078125 160.902123 
-L 637.2 160.902123 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 159.600907 
+L 637.2 159.600907 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="160.902123" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="159.600907" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_43">
-      <path d="M 49.078125 151.072619 
-L 637.2 151.072619 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 149.871922 
+L 637.2 149.871922 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="151.072619" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="149.871922" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_45">
-      <path d="M 49.078125 142.557915 
-L 637.2 142.557915 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 141.444292 
+L 637.2 141.444292 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="142.557915" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="141.444292" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_47">
-      <path d="M 49.078125 135.047414 
-L 637.2 135.047414 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 134.010595 
+L 637.2 134.010595 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="135.047414" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="134.010595" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_49">
-      <path d="M 49.078125 84.130125 
-L 637.2 84.130125 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 83.614 
+L 637.2 83.614 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="84.130125" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="83.614" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_51">
-      <path d="M 49.078125 58.275416 
-L 637.2 58.275416 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 58.023688 
+L 637.2 58.023688 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mdfc8f6ae0f" x="49.078125" y="58.275416" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m83ec301f9f" x="49.078125" y="58.023688" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1229,7 +1229,7 @@ L 637.2 48.323125
    </g>
    <g id="text_11">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(472.789269 230.216035) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(261.764598 227.291344) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1261,7 +1261,7 @@ z
    </g>
    <g id="text_12">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(121.602636 391.236449) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(114.014951 391.236449) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1590,110 +1590,110 @@ z
     </g>
    </g>
    <g id="line2d_53">
-    <path d="M 354.801917 114.660939 
-L 296.396877 123.10881 
-L 240.372732 140.381931 
-L 199.2912 141.623331 
-L 145.672036 166.804274 
-L 115.077361 192.626714 
-L 105.421184 205.604533 
-L 95.641458 230.54475 
-L 93.912266 237.379416 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 354.801917 115.668816 
+L 296.396877 121.768825 
+L 240.372732 138.757083 
+L 199.2912 141.36985 
+L 145.672036 165.958793 
+L 115.077361 191.011707 
+L 105.421184 203.262551 
+L 95.641458 226.476087 
+L 93.912266 234.420319 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md300d03360" d="M -2.5 2.5 
+     <path id="macb5709087" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6d5f4c5531)">
-     <use xlink:href="#md300d03360" x="354.801917" y="114.660939" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md300d03360" x="296.396877" y="123.10881" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md300d03360" x="240.372732" y="140.381931" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md300d03360" x="199.2912" y="141.623331" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md300d03360" x="145.672036" y="166.804274" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md300d03360" x="115.077361" y="192.626714" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md300d03360" x="105.421184" y="205.604533" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md300d03360" x="95.641458" y="230.54475" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md300d03360" x="93.912266" y="237.379416" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p39aa087fb5)">
+     <use xlink:href="#macb5709087" x="354.801917" y="115.668816" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macb5709087" x="296.396877" y="121.768825" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macb5709087" x="240.372732" y="138.757083" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macb5709087" x="199.2912" y="141.36985" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macb5709087" x="145.672036" y="165.958793" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macb5709087" x="115.077361" y="191.011707" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macb5709087" x="105.421184" y="203.262551" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macb5709087" x="95.641458" y="226.476087" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macb5709087" x="93.912266" y="234.420319" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_54">
-    <path d="M 610.467187 74.197484 
-L 292.101608 108.523762 
-L 172.024432 141.80691 
-L 156.692445 146.604189 
-L 134.525595 163.089425 
-L 108.348473 194.594672 
-L 102.387102 208.686989 
-L 99.4003 219.91743 
-L 97.945363 224.466317 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467187 75.205728 
+L 292.101608 108.501362 
+L 172.024432 140.895549 
+L 156.692445 145.523233 
+L 134.525595 161.56111 
+L 108.348473 193.316593 
+L 102.387102 206.989777 
+L 99.4003 218.259212 
+L 97.945363 222.65663 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6ff3ff7ad5" d="M 0 -2.5 
+     <path id="m9d13b061e8" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6d5f4c5531)">
-     <use xlink:href="#m6ff3ff7ad5" x="610.467187" y="74.197484" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ff3ff7ad5" x="292.101608" y="108.523762" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ff3ff7ad5" x="172.024432" y="141.80691" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ff3ff7ad5" x="156.692445" y="146.604189" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ff3ff7ad5" x="134.525595" y="163.089425" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ff3ff7ad5" x="108.348473" y="194.594672" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ff3ff7ad5" x="102.387102" y="208.686989" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ff3ff7ad5" x="99.4003" y="219.91743" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6ff3ff7ad5" x="97.945363" y="224.466317" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p39aa087fb5)">
+     <use xlink:href="#m9d13b061e8" x="610.467187" y="75.205728" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d13b061e8" x="292.101608" y="108.501362" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d13b061e8" x="172.024432" y="140.895549" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d13b061e8" x="156.692445" y="145.523233" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d13b061e8" x="134.525595" y="161.56111" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d13b061e8" x="108.348473" y="193.316593" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d13b061e8" x="102.387102" y="206.989777" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d13b061e8" x="99.4003" y="218.259212" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d13b061e8" x="97.945363" y="222.65663" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_55">
     <path d="M 261.591835 64.890426 
-L 207.694789 83.383093 
-L 180.75628 89.79303 
-L 158.366417 94.548929 
-L 123.924526 104.681036 
-L 101.412222 118.154763 
-L 89.106563 136.75714 
-L 77.579551 163.947027 
-L 75.810938 173.47315 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 207.694789 83.097627 
+L 180.75628 89.414711 
+L 158.366417 94.024245 
+L 123.924526 104.096441 
+L 101.412222 117.516055 
+L 89.106563 135.543431 
+L 77.579551 162.686441 
+L 75.810938 172.051819 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m4707d373f2" d="M -0 3.535534 
+     <path id="md3cc8e6fca" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6d5f4c5531)">
-     <use xlink:href="#m4707d373f2" x="261.591835" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4707d373f2" x="207.694789" y="83.383093" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4707d373f2" x="180.75628" y="89.79303" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4707d373f2" x="158.366417" y="94.548929" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4707d373f2" x="123.924526" y="104.681036" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4707d373f2" x="101.412222" y="118.154763" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4707d373f2" x="89.106563" y="136.75714" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4707d373f2" x="77.579551" y="163.947027" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4707d373f2" x="75.810938" y="173.47315" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p39aa087fb5)">
+     <use xlink:href="#md3cc8e6fca" x="261.591835" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md3cc8e6fca" x="207.694789" y="83.097627" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md3cc8e6fca" x="180.75628" y="89.414711" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md3cc8e6fca" x="158.366417" y="94.024245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md3cc8e6fca" x="123.924526" y="104.096441" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md3cc8e6fca" x="101.412222" y="117.516055" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md3cc8e6fca" x="89.106563" y="135.543431" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md3cc8e6fca" x="77.579551" y="162.686441" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md3cc8e6fca" x="75.810938" y="172.051819" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_56">
-    <path d="M 415.481577 102.17095 
-L 271.002054 122.446936 
-L 234.129884 131.998442 
-L 189.290714 133.537601 
-L 139.928317 157.005693 
-L 121.802872 172.645763 
-L 114.483714 183.682981 
-L 107.370838 199.464786 
-L 106.338791 207.208091 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 415.481577 101.470335 
+L 271.002054 121.538973 
+L 234.129884 130.992803 
+L 189.290714 132.516222 
+L 139.928317 155.744323 
+L 121.802872 171.224454 
+L 114.483714 182.148803 
+L 107.370838 197.769219 
+L 106.338791 205.433339 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me731f8b662" d="M -0.833333 2.5 
+     <path id="m471ad54816" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1708,31 +1708,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6d5f4c5531)">
-     <use xlink:href="#me731f8b662" x="415.481577" y="102.17095" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me731f8b662" x="271.002054" y="122.446936" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me731f8b662" x="234.129884" y="131.998442" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me731f8b662" x="189.290714" y="133.537601" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me731f8b662" x="139.928317" y="157.005693" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me731f8b662" x="121.802872" y="172.645763" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me731f8b662" x="114.483714" y="183.682981" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me731f8b662" x="107.370838" y="199.464786" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me731f8b662" x="106.338791" y="207.208091" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p39aa087fb5)">
+     <use xlink:href="#m471ad54816" x="415.481577" y="101.470335" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ad54816" x="271.002054" y="121.538973" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ad54816" x="234.129884" y="130.992803" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ad54816" x="189.290714" y="132.516222" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ad54816" x="139.928317" y="155.744323" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ad54816" x="121.802872" y="171.224454" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ad54816" x="114.483714" y="182.148803" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ad54816" x="107.370838" y="197.769219" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m471ad54816" x="106.338791" y="205.433339" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_57">
-    <path d="M 319.655788 147.167243 
-L 241.138751 155.690965 
-L 205.372997 162.507465 
-L 184.155683 168.694757 
-L 168.571516 171.337808 
-L 140.014958 184.22147 
-L 138.061909 188.478882 
-L 136.349672 195.027957 
-L 136.267068 201.360628 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 319.655788 146.006484 
+L 241.138751 154.443041 
+L 205.372997 161.189834 
+L 184.155683 167.313852 
+L 168.571516 169.929874 
+L 140.014958 182.681785 
+L 138.061909 186.89566 
+L 136.349672 193.377762 
+L 136.267068 199.645674 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m14429c6ded" d="M -1.25 2.5 
+     <path id="m6333e19c78" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1747,31 +1747,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6d5f4c5531)">
-     <use xlink:href="#m14429c6ded" x="319.655788" y="147.167243" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14429c6ded" x="241.138751" y="155.690965" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14429c6ded" x="205.372997" y="162.507465" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14429c6ded" x="184.155683" y="168.694757" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14429c6ded" x="168.571516" y="171.337808" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14429c6ded" x="140.014958" y="184.22147" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14429c6ded" x="138.061909" y="188.478882" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14429c6ded" x="136.349672" y="195.027957" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m14429c6ded" x="136.267068" y="201.360628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p39aa087fb5)">
+     <use xlink:href="#m6333e19c78" x="319.655788" y="146.006484" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6333e19c78" x="241.138751" y="154.443041" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6333e19c78" x="205.372997" y="161.189834" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6333e19c78" x="184.155683" y="167.313852" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6333e19c78" x="168.571516" y="169.929874" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6333e19c78" x="140.014958" y="182.681785" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6333e19c78" x="138.061909" y="186.89566" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6333e19c78" x="136.349672" y="193.377762" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6333e19c78" x="136.267068" y="199.645674" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_58">
-    <path d="M 190.200149 121.788005 
-L 190.200149 121.751716 
-L 190.200149 121.718717 
-L 190.200149 122.221614 
-L 136.403453 143.872287 
-L 117.347293 159.673906 
-L 110.358201 168.063198 
-L 102.810747 186.066803 
-L 101.457483 194.246981 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 190.200149 120.886781 
+L 190.200149 120.850863 
+L 190.200149 120.818201 
+L 190.200149 121.315956 
+L 136.403453 142.745223 
+L 117.347293 158.385251 
+L 110.358201 166.688752 
+L 102.810747 184.508247 
+L 101.457483 192.604773 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md0fb35b5de" d="M 0 -2.5 
+     <path id="m9e065584cd" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1784,31 +1784,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p6d5f4c5531)">
-     <use xlink:href="#md0fb35b5de" x="190.200149" y="121.788005" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md0fb35b5de" x="190.200149" y="121.751716" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md0fb35b5de" x="190.200149" y="121.718717" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md0fb35b5de" x="190.200149" y="122.221614" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md0fb35b5de" x="136.403453" y="143.872287" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md0fb35b5de" x="117.347293" y="159.673906" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md0fb35b5de" x="110.358201" y="168.063198" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md0fb35b5de" x="102.810747" y="186.066803" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#md0fb35b5de" x="101.457483" y="194.246981" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p39aa087fb5)">
+     <use xlink:href="#m9e065584cd" x="190.200149" y="120.886781" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065584cd" x="190.200149" y="120.850863" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065584cd" x="190.200149" y="120.818201" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065584cd" x="190.200149" y="121.315956" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065584cd" x="136.403453" y="142.745223" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065584cd" x="117.347293" y="158.385251" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065584cd" x="110.358201" y="166.688752" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065584cd" x="102.810747" y="184.508247" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9e065584cd" x="101.457483" y="192.604773" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_59">
-    <path d="M 583.298166 193.564162 
-L 519.179151 196.095066 
-L 442.700778 205.893071 
-L 261.692068 198.930695 
-L 208.012723 212.911134 
-L 175.596233 229.383885 
-L 165.747429 238.561879 
-L 156.224637 257.822324 
-L 154.208481 264.385674 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 583.298166 191.928937 
+L 519.179151 194.433958 
+L 442.700778 204.131767 
+L 261.692068 197.24059 
+L 208.012723 211.078062 
+L 175.596233 227.382358 
+L 165.747429 236.466495 
+L 156.224637 255.529978 
+L 154.208481 262.02621 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb4eab45ddb" d="M 0 -2.5 
+     <path id="m498f6725b3" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1817,16 +1817,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p6d5f4c5531)">
-     <use xlink:href="#mb4eab45ddb" x="583.298166" y="193.564162" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4eab45ddb" x="519.179151" y="196.095066" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4eab45ddb" x="442.700778" y="205.893071" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4eab45ddb" x="261.692068" y="198.930695" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4eab45ddb" x="208.012723" y="212.911134" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4eab45ddb" x="175.596233" y="229.383885" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4eab45ddb" x="165.747429" y="238.561879" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4eab45ddb" x="156.224637" y="257.822324" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4eab45ddb" x="154.208481" y="264.385674" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p39aa087fb5)">
+     <use xlink:href="#m498f6725b3" x="583.298166" y="191.928937" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m498f6725b3" x="519.179151" y="194.433958" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m498f6725b3" x="442.700778" y="204.131767" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m498f6725b3" x="261.692068" y="197.24059" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m498f6725b3" x="208.012723" y="211.078062" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m498f6725b3" x="175.596233" y="227.382358" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m498f6725b3" x="165.747429" y="236.466495" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m498f6725b3" x="156.224637" y="255.529978" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m498f6725b3" x="154.208481" y="262.02621" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1849,7 +1849,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m4ec57b821e" d="M 0 3.5 
+      <path id="m612503b398" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1862,7 +1862,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m4ec57b821e" x="434.04625" y="365.69" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m612503b398" x="434.04625" y="365.69" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_14">
@@ -1925,7 +1925,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md300d03360" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#macb5709087" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_15">
@@ -1943,7 +1943,7 @@ L 434.04625 389.175
 L 442.04625 389.175 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6ff3ff7ad5" x="434.04625" y="389.175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9d13b061e8" x="434.04625" y="389.175" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -1992,7 +1992,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m4707d373f2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md3cc8e6fca" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2039,7 +2039,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me731f8b662" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m471ad54816" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2097,7 +2097,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m14429c6ded" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6333e19c78" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2166,7 +2166,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md0fb35b5de" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m9e065584cd" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_20">
@@ -2208,7 +2208,7 @@ L 537.72375 400.9175
 L 545.72375 400.9175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb4eab45ddb" x="537.72375" y="400.9175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m498f6725b3" x="537.72375" y="400.9175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2278,26 +2278,26 @@ z
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 467.789269 235.216035 
-L 418.340522 241.488151 
-L 358.158195 248.891571 
-L 302.416526 278.321187 
-L 296.217965 283.956497 
-L 286.657165 297.273879 
-L 119.684757 380.932447 
-L 117.697993 390.171583 
-L 116.602636 396.236449 
-" clip-path="url(#p6d5f4c5531)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p6d5f4c5531)">
-     <use xlink:href="#m4ec57b821e" x="467.789269" y="235.216035" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4ec57b821e" x="418.340522" y="241.488151" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4ec57b821e" x="358.158195" y="248.891571" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4ec57b821e" x="302.416526" y="278.321187" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4ec57b821e" x="296.217965" y="283.956497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4ec57b821e" x="286.657165" y="297.273879" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4ec57b821e" x="119.684757" y="380.932447" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4ec57b821e" x="117.697993" y="390.171583" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4ec57b821e" x="116.602636" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 256.764598 232.291344 
+L 219.55202 238.747552 
+L 193.74997 246.429681 
+L 155.651841 275.706698 
+L 150.401662 280.609953 
+L 141.959526 293.940507 
+L 111.986472 381.350843 
+L 110.046078 391.740432 
+L 109.014951 396.236449 
+" clip-path="url(#p39aa087fb5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p39aa087fb5)">
+     <use xlink:href="#m612503b398" x="256.764598" y="232.291344" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m612503b398" x="219.55202" y="238.747552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m612503b398" x="193.74997" y="246.429681" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m612503b398" x="155.651841" y="275.706698" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m612503b398" x="150.401662" y="280.609953" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m612503b398" x="141.959526" y="293.940507" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m612503b398" x="111.986472" y="381.350843" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m612503b398" x="110.046078" y="391.740432" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m612503b398" x="109.014951" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2666,8 +2666,8 @@ z
    </g>
   </g>
   <g id="text_23">
-   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.069922 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-10T08:22:01Z  ·  Linux chungus x86_64  ·  commit 3050fc62  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2678,16 +2678,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2701,31 +2691,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2785,34 +2750,29 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
@@ -2856,13 +2816,13 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2901,109 +2861,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p6d5f4c5531">
+  <clipPath id="p39aa087fb5">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -31,31 +31,31 @@ z
   <g id="axes_1">
    <g id="patch_2">
     <path d="M 95.67625 309.108011 
-L 569.893736 309.108011 
-L 569.893736 47.90175 
+L 557.741361 309.108011 
+L 557.741361 47.90175 
 L 95.67625 47.90175 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p1d91901854)">
+   <g clip-path="url(#p87118765f3)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAApMAAAFrCAYAAACNPwIUAAAI4ElEQVR4nO3YPY5kVx2H4arudqm6DcaWPwJkeWQHpJMQQeDImWMkAhIkQidO2AAZYgdOHbAAImdOHZA6wgNMYOGRP8Y9nmamu4o18KKjvyg9zwp+V/fq3Fdne3j85+PmRB0//+v0hGW2b709PWGdq5enFyxzfPRgesIy21ffmp6wxvOb6QXLHD/9dHrCMttf/mJ6wjqXL00vWOf22fSCZY5ffjE9YZmz6QEAAPz/EpMAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCAbHtz+5fj9IhVdj9cT09Y5sl+Nz1hmWd3N9MTlnnl5jA9YZmbH700PWGJ4/F039nl+dX0hHWefD29YJmby9N9b/uvv5yesM7r70wvWMbNJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZBe7J4+nN6yzu5pesMzxeDs9YZmX//nF9IR17t2fXrDM/vrb6QlrHA/TC9bZne45sjnfTS9YZn99uv/tp6+8MT1hmctvHk5PWMbNJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZNvbwyfH6RGrnH3/aHrCMo/3F9MTlvn37Q/TE5Z5/fHpPtvdG+9MT1ji2d3N9IRlLs+vpies8+jB9IJlnr/65vSEZV7419+mJyzz/ETPyM3GzSQAAP8DMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDItreHT47TI1Z5ens9PWGZ3dl+esIyX908nJ6wzGv7n05P4L+0u5tesM53x9M9I3+ye216wjLPD8+mJyxz3BymJyxzvr2YnrCMm0kAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAdnF2wj354vZqesI6ZxfTC5bZn5/ue9ud7acnLHPYHKYnrHF2umfkjze76QkEZ9vT/Sbvjid6jmw2m6e319MTljndLxIAgOXEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACDbfrz52XF6xCq/fvjB9IRl/v6bj6YnLPPVP55OT1jm/of3pycs88Lvfjs9YYkH7/1+esIy9/70/vSEZbb3352esMznPz/df9u9z/44PWGZ7371h+kJy7iZBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCA7D9fMX3Yj4e/igAAAABJRU5ErkJggg==" id="image245185f7d0" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="474.48" height="261.36"/>
+iVBORw0KGgoAAAANSUhEUgAAAoIAAAFrCAYAAABFU+jCAAAJGklEQVR4nO3YT6vmdR3H4fuMxzMWoaOZM9lUUhLUqkWRi/5thGpRLVv1AIKgZfQA7GG0KRJ3/Y9a1aIihKBNIZYiRy2bMWfQGT1zztw9hRbfHx84r+t6BG+4f/eXF5+Ds+e/v9+dM8ffemZ6wiaufucz0xPW+9iHpxds4uSZP05PWO7o65+anrCN129ML1ju6c/+bHrCJr7xmyenJ6z3+IemF2zj5pvTC5a7/YPz967vdrvdhekBAADMEIIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAg6uD67R/vp0esdunlF6cnbOL4kUvTE5a7efLG9IRNfOKVt6cnLHftox+ZnrCJs/3p9ITlrhw9Oj1hE/vjv05PWO76lfP5W733T89OT1ju7he+Mj1hEy6CAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBEHZw999R+esRqB5cuT0/YxIsXb01PWO7yUz+fnrCJd333m9MTltu//Pz0hG2c3JlesNzBI+fzDdwdHk0vWG5/7V/TEzbx6mOPTk9Y7v1/f2F6wiZcBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiDp45/RX++kRqx3+8y/TEzbxj/ddnJ6w3H9u35iesIknnn11esJy73z5q9MTNnHj5Nr0hOUu33tlesIm9r//5fSE5d763BenJ2zi3T/56fSE5W597Xy+gS6CAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBEHbx9+ov99IjV/n3rpekJm3jg4sPTE5b73fEfpids4vMfeGJ6wnJn+9PpCZt46M7h9ITl/nbnhekJm/j4g5+enrDcW6c3pyds4vTuyfSE5Q4vHE1P2ISLIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIg6PLpw3/SG5T54dHV6wjYuHE0vWO7qex6anrCJB44enp6w3J27J9MTNnH34uH0hOUev3v/9AT+T/ccnL/vb7fb7U535++9eO3WS9MTNuEiCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABA1OHuv8fTG5Y7+/Vvpyds4p4vPTk9YblPXt9PT9jG/W9OL1ju3tOT6QnbeOOV6QXLvfbtH05P2MSVH31vesJy952dz//V6xduTk9Y7rE/Pzc9YRMuggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARAlBAIAoIQgAECUEAQCihCAAQJQQBACIEoIAAFFCEAAgSggCAEQJQQCAKCEIABAlBAEAooQgAECUEAQAiBKCAABRQhAAIEoIAgBECUEAgCghCAAQJQQBAKKEIABAlBAEAIgSggAAUUIQACBKCAIARP0P3b+K382qWVkAAAAASUVORK5CYII=" id="image47392caf66" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="462.24" height="261.36"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m705417b5e1" d="M 0 0 
+       <path id="m390e84cdee" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m705417b5e1" x="115.435312" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="114.928963" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- dickens -->
-      <g transform="translate(92.90247 341.762729) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(92.396121 341.762729) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-64" d="M 2906 2969 
 L 2906 4863 
@@ -220,12 +220,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m705417b5e1" x="154.953436" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="153.434389" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- mozilla -->
-      <g transform="translate(133.655379 340.527944) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(132.136333 340.527944) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -345,12 +345,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m705417b5e1" x="194.47156" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="191.939815" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- mr -->
-      <g transform="translate(185.459484 328.241964) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(182.927739 328.241964) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-72" d="M 2631 2963 
 Q 2534 3019 2420 3045 
@@ -378,12 +378,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m705417b5e1" x="233.989683" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="230.445241" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- nci -->
-      <g transform="translate(224.546272 328.673299) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(221.00183 328.673299) rotate(-45) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-6e"/>
        <use xlink:href="#DejaVuSans-63" transform="translate(63.378906 0)"/>
        <use xlink:href="#DejaVuSans-69" transform="translate(118.359375 0)"/>
@@ -393,12 +393,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m705417b5e1" x="273.507807" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="268.950667" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- ooffice -->
-      <g transform="translate(253.26334 339.474355) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(248.706199 339.474355) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-66" d="M 2375 4863 
 L 2375 4384 
@@ -435,12 +435,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m705417b5e1" x="313.025931" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="307.456093" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- osdb -->
-      <g transform="translate(298.25889 333.996929) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(292.689051 333.996929) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-62" d="M 3116 1747 
 Q 3116 2381 2855 2742 
@@ -479,12 +479,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m705417b5e1" x="352.544055" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="345.961518" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- reymont -->
-      <g transform="translate(327.566392 344.207551) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(320.983855 344.207551) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-79" d="M 2059 -325 
 Q 1816 -950 1584 -1140 
@@ -538,12 +538,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m705417b5e1" x="392.062179" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="384.466944" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- samba -->
-      <g transform="translate(371.904332 339.387734) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(364.309098 339.387734) rotate(-45) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-61" transform="translate(52.099609 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(113.378906 0)"/>
@@ -555,12 +555,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m705417b5e1" x="431.580303" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="422.97237" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- sao -->
-      <g transform="translate(420.529107 330.281083) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(411.921175 330.281083) rotate(-45) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-73"/>
        <use xlink:href="#DejaVuSans-61" transform="translate(52.099609 0)"/>
        <use xlink:href="#DejaVuSans-6f" transform="translate(113.378906 0)"/>
@@ -570,12 +570,12 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m705417b5e1" x="471.098426" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="461.477796" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- webster -->
-      <g transform="translate(447.253018 343.075296) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(437.632388 343.075296) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-77" d="M 269 3500 
 L 844 3500 
@@ -607,12 +607,12 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m705417b5e1" x="510.61655" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="499.983222" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- x-ray -->
-      <g transform="translate(494.910825 334.935613) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(484.277497 334.935613) rotate(-45) scale(0.08 -0.08)">
        <defs>
         <path id="DejaVuSans-78" d="M 3513 3500 
 L 2247 1797 
@@ -648,12 +648,12 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m705417b5e1" x="550.134674" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m390e84cdee" x="538.488648" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- xml -->
-      <g transform="translate(538.5284 330.836162) rotate(-45) scale(0.08 -0.08)">
+      <g transform="translate(526.882374 330.836162) rotate(-45) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-78"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(59.179688 0)"/>
        <use xlink:href="#DejaVuSans-6c" transform="translate(156.591797 0)"/>
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m66e8757376" d="M 0 0 
+       <path id="m7f1be09e7e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m66e8757376" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f1be09e7e" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m66e8757376" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f1be09e7e" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m66e8757376" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f1be09e7e" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m66e8757376" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f1be09e7e" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -881,7 +881,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m66e8757376" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f1be09e7e" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -948,7 +948,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m66e8757376" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f1be09e7e" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1029,7 +1029,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m66e8757376" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7f1be09e7e" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1105,23 +1105,23 @@ L 95.67625 47.90175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 569.893736 309.108011 
-L 569.893736 47.90175 
+    <path d="M 557.741361 309.108011 
+L 557.741361 47.90175 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
     <path d="M 95.67625 309.108011 
-L 569.893736 309.108011 
+L 557.741361 309.108011 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
     <path d="M 95.67625 47.90175 
-L 569.893736 47.90175 
+L 557.741361 47.90175 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +25 -->
-    <g transform="translate(108.576288 68.352934) scale(0.065 -0.065)">
+    <!-- +1 -->
+    <g transform="translate(110.137752 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1138,64 +1138,28 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- +4 -->
-    <g transform="translate(150.162225 68.352934) scale(0.065 -0.065)">
+    <g transform="translate(148.643178 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1222,160 +1186,48 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- +18 -->
-    <g transform="translate(187.612536 68.352934) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- +1 -->
+    <g transform="translate(187.148604 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- +21 -->
-    <g transform="translate(227.13066 68.352934) scale(0.065 -0.065)">
+    <!-- +2 -->
+    <g transform="translate(225.65403 68.352934) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- +12 -->
-    <g transform="translate(266.648784 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +1 -->
-    <g transform="translate(308.23472 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- +19 -->
-    <g transform="translate(345.685031 68.352934) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +7 -->
-    <g transform="translate(387.270968 68.352934) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- +1 -->
-    <g transform="translate(426.789092 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +20 -->
-    <g transform="translate(464.239403 68.352934) scale(0.065 -0.065)">
+    <!-- +0 -->
+    <g transform="translate(264.159456 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -1400,133 +1252,66 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +1 -->
+    <g transform="translate(302.664882 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +2 -->
+    <g transform="translate(341.170307 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +7 -->
+    <g transform="translate(379.675733 68.352934) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- +1 -->
+    <g transform="translate(418.181159 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +1 -->
+    <g transform="translate(456.686585 68.352934) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_30">
     <!-- -1 -->
-    <g transform="translate(507.376199 68.352934) scale(0.065 -0.065)">
+    <g transform="translate(496.742871 68.352934) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- +17 -->
-    <g transform="translate(543.275651 68.352934) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- +0 -->
-    <g transform="translate(110.644101 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +0 -->
-    <g transform="translate(150.162225 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- +0 -->
-    <g transform="translate(189.680349 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -2 -->
-    <g transform="translate(230.749332 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -0 -->
-    <g transform="translate(270.267456 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- -0 -->
-    <g transform="translate(309.785579 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- -0 -->
-    <g transform="translate(349.303703 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- -0 -->
-    <g transform="translate(388.821827 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- -0 -->
-    <g transform="translate(428.339951 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- -0 -->
-    <g transform="translate(467.858075 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- -1 -->
-    <g transform="translate(507.376199 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- -2 -->
-    <g transform="translate(546.894322 105.668114) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_44">
-    <!-- -0 -->
-    <g transform="translate(112.19496 142.983294) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_45">
-    <!-- -2 -->
-    <g transform="translate(151.713084 142.983294) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_46">
-    <!-- -1 -->
-    <g transform="translate(191.231208 142.983294) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_47">
-    <!-- -3 -->
-    <g transform="translate(230.749332 142.983294) scale(0.065 -0.065)">
+    <!-- +3 -->
+    <g transform="translate(533.697437 68.352934) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1561,174 +1346,286 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- +0 -->
+    <g transform="translate(110.137752 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +0 -->
+    <g transform="translate(148.643178 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- +0 -->
+    <g transform="translate(187.148604 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -2 -->
+    <g transform="translate(227.204889 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -0 -->
+    <g transform="translate(265.710315 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- -0 -->
+    <g transform="translate(304.215741 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- -0 -->
+    <g transform="translate(342.721167 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- -0 -->
+    <g transform="translate(381.226593 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- -0 -->
+    <g transform="translate(419.732019 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- -0 -->
+    <g transform="translate(458.237445 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- -1 -->
+    <g transform="translate(496.742871 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- -2 -->
+    <g transform="translate(535.248296 105.668114) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- -0 -->
+    <g transform="translate(111.688611 142.983294) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_45">
+    <!-- -2 -->
+    <g transform="translate(150.194037 142.983294) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_46">
+    <!-- -1 -->
+    <g transform="translate(188.699463 142.983294) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_47">
+    <!-- -3 -->
+    <g transform="translate(227.204889 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_48">
     <!-- -1 -->
-    <g transform="translate(270.267456 142.983294) scale(0.065 -0.065)">
+    <g transform="translate(265.710315 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_49">
     <!-- -1 -->
-    <g transform="translate(309.785579 142.983294) scale(0.065 -0.065)">
+    <g transform="translate(304.215741 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_50">
     <!-- +1 -->
-    <g transform="translate(347.752844 142.983294) scale(0.065 -0.065)">
+    <g transform="translate(341.170307 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_51">
     <!-- -2 -->
-    <g transform="translate(388.821827 142.983294) scale(0.065 -0.065)">
+    <g transform="translate(381.226593 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_52">
     <!-- +0 -->
-    <g transform="translate(426.789092 142.983294) scale(0.065 -0.065)">
+    <g transform="translate(418.181159 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_53">
     <!-- -1 -->
-    <g transform="translate(467.858075 142.983294) scale(0.065 -0.065)">
+    <g transform="translate(458.237445 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_54">
     <!-- -1 -->
-    <g transform="translate(507.376199 142.983294) scale(0.065 -0.065)">
+    <g transform="translate(496.742871 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_55">
     <!-- -1 -->
-    <g transform="translate(546.894322 142.983294) scale(0.065 -0.065)">
+    <g transform="translate(535.248296 142.983294) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_56">
     <!-- -0 -->
-    <g transform="translate(112.19496 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(111.688611 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_57">
     <!-- +2 -->
-    <g transform="translate(150.162225 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(148.643178 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_58">
     <!-- -2 -->
-    <g transform="translate(191.231208 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(188.699463 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_59">
     <!-- -3 -->
-    <g transform="translate(230.749332 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(227.204889 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_60">
     <!-- +4 -->
-    <g transform="translate(268.716596 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(264.159456 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_61">
     <!-- -0 -->
-    <g transform="translate(309.785579 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(304.215741 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_62">
     <!-- -1 -->
-    <g transform="translate(349.303703 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(342.721167 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_63">
     <!-- +0 -->
-    <g transform="translate(387.270968 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(379.675733 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_64">
     <!-- +3 -->
-    <g transform="translate(426.789092 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(418.181159 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_65">
     <!-- -1 -->
-    <g transform="translate(467.858075 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(458.237445 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_66">
     <!-- +4 -->
-    <g transform="translate(505.825339 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(495.192011 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_67">
     <!-- -1 -->
-    <g transform="translate(546.894322 180.298474) scale(0.065 -0.065)">
+    <g transform="translate(535.248296 180.298474) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_68">
     <!-- +2 -->
-    <g transform="translate(110.644101 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(110.137752 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_69">
     <!-- +1 -->
-    <g transform="translate(150.162225 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(148.643178 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_70">
     <!-- -2 -->
-    <g transform="translate(191.231208 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(188.699463 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_71">
     <!-- +6 -->
-    <g transform="translate(229.198472 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(225.65403 217.613655) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1767,196 +1664,223 @@ z
    </g>
    <g id="text_72">
     <!-- +1 -->
-    <g transform="translate(268.716596 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(264.159456 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_73">
     <!-- +2 -->
-    <g transform="translate(308.23472 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(302.664882 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_74">
     <!-- +3 -->
-    <g transform="translate(347.752844 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(341.170307 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_75">
     <!-- +2 -->
-    <g transform="translate(387.270968 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(379.675733 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_76">
     <!-- +1 -->
-    <g transform="translate(426.789092 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(418.181159 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_77">
     <!-- +2 -->
-    <g transform="translate(466.307215 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(456.686585 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_78">
     <!-- -1 -->
-    <g transform="translate(507.376199 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(496.742871 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_79">
     <!-- +3 -->
-    <g transform="translate(545.343463 217.613655) scale(0.065 -0.065)">
+    <g transform="translate(533.697437 217.613655) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_80">
     <!-- -1 -->
-    <g transform="translate(112.19496 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(111.688611 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_81">
     <!-- +2 -->
-    <g transform="translate(150.162225 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(148.643178 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_82">
     <!-- -1 -->
-    <g transform="translate(191.231208 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(188.699463 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_83">
     <!-- -2 -->
-    <g transform="translate(230.749332 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(227.204889 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_84">
     <!-- +2 -->
-    <g transform="translate(268.716596 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(264.159456 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_85">
     <!-- -1 -->
-    <g transform="translate(309.785579 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(304.215741 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_86">
     <!-- -1 -->
-    <g transform="translate(349.303703 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(342.721167 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_87">
     <!-- +0 -->
-    <g transform="translate(387.270968 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(379.675733 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_88">
     <!-- +2 -->
-    <g transform="translate(426.789092 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(418.181159 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_89">
     <!-- -1 -->
-    <g transform="translate(467.858075 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(458.237445 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_90">
     <!-- +3 -->
-    <g transform="translate(505.825339 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(495.192011 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_91">
     <!-- -0 -->
-    <g transform="translate(546.894322 254.928835) scale(0.065 -0.065)">
+    <g transform="translate(535.248296 254.928835) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_92">
     <!-- +2 -->
-    <g transform="translate(110.644101 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(110.137752 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_93">
     <!-- +7 -->
-    <g transform="translate(150.162225 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(148.643178 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_94">
     <!-- +4 -->
-    <g transform="translate(189.680349 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(187.148604 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_95">
     <!-- +2 -->
-    <g transform="translate(229.198472 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(225.65403 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_96">
     <!-- +5 -->
-    <g transform="translate(268.716596 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(264.159456 292.244015) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_97">
     <!-- +2 -->
-    <g transform="translate(308.23472 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(302.664882 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_98">
     <!-- +3 -->
-    <g transform="translate(347.752844 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(341.170307 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_99">
     <!-- +10 -->
-    <g transform="translate(385.203155 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(377.607921 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -1964,28 +1888,28 @@ z
    </g>
    <g id="text_100">
     <!-- +3 -->
-    <g transform="translate(426.789092 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(418.181159 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_101">
     <!-- +2 -->
-    <g transform="translate(466.307215 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(456.686585 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_102">
     <!-- +3 -->
-    <g transform="translate(505.825339 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(495.192011 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_103">
     <!-- +6 -->
-    <g transform="translate(545.343463 292.244015) scale(0.065 -0.065)">
+    <g transform="translate(533.697437 292.244015) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
@@ -1993,31 +1917,31 @@ z
   </g>
   <g id="axes_2">
    <g id="patch_7">
-    <path d="M 579.824992 302.645584 
-L 592.239063 302.645584 
-L 592.239063 54.364178 
-L 579.824992 54.364178 
+    <path d="M 567.418117 299.464334 
+L 579.514063 299.464334 
+L 579.514063 57.545428 
+L 567.418117 57.545428 
 z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFYCAYAAABeeqzpAAAB0klEQVR4nO2b0Y0DIQwFYZeerqXr/3+XlOB8jNDEehQwwoOfIUoyx//fHsBa85oEhwNdCGUYS1tzxtEpUBzVy+goETkGiqN6tXaUrB0DcY4uCLVu6PjXrXMEloZwuB0pHVEghkM64kqTySb7iAIJS/MdP8JROrJljRwjFMgmW9lHCEfZR9SovbjBhnDI5zF2HWGyhVmDQDrZZB8lIhUIm9nUjowR6Xsd6dKv7CNZRJTzSDZqsR0JHYEgprrejnR9BLGMpdk6u7cjmWwyInFUrPRRvcDSbA1JOpKN2jV9fURd2VRpwqxN7llDyYZ2JMxaIlKDjBG5GVAiUoO4PtI50kWkdR/Z7jVhH03knxBjrLFfBMQ5onbkA4GO3r6l2U4Nk93aka6P9n4YULL2g6DGo9boyDZq4+grEPOINGYtjo6ByNIY2Tn+k6C946gGxVENiqMaFEc1qK2j/WAXpM4RVdruW9p4qD5q7Ih6Q1JZE46RZO0gyOhINkYw2cKPoq2v7PRRsbjSsD7yzaO3b2lb9/IXOrKVtt44OgZSOpKFVngdURHp7EgX2s6OfDMbmiIcyFga9TPGzo5soDiql9AR9T1tZ0c6UBzVC3Rku46MjmylfQB5PCuHsIxBxQAAAABJRU5ErkJggg==" id="imagee920bbf744" transform="scale(1 -1) translate(0 -247.68)" x="579.6" y="-54" width="12.96" height="247.68"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFQCAYAAABZHpWHAAAB20lEQVR4nO2aQY7EIAwEIeFP+6X9/z0w95CbC6lkmQe03EU3MJr09v+3WnCNfvWoRrvCCg2axCMCMekSOyYmFjvF5EvEkth0YIvJERETk+rOGZELMMQwuYktvgkm0CRhDRVYy+5QTAgRS9ggJowdyST5uhPWUDGxdKfAHpqEOpQIEabF8UkYJpfFzgCyZrrQL8sNSOUEEIFyUmDfIsihlK6AyCSWy8tUwLiI6JGjAZvvQkd2x1NAxE58mHxMCBHAUTomQNjyMfF0hzgKmoRJhe1TJBcTS9hMBUT+TPTkBNBB7Ii60wkmSNg0k1CfXSE3oCSxokOpt9sxSboCaphoYl85MU8iOqh7+Cvq1kZbMyzCMCEm8YhATKbEjokJYscC1sSEEFnrASYBdicb2GxhqwIeEqnu7CIeJjP+aIO6w4jE7ZheSsXkQ0SSWBGTtYrJLlJMdhEJExXYYvJaIibr8VxeBBPAzlieC52w0x4iJ8mYEGEjumM6lCzdQSbJx8SSE80Wi355QUdB5eQt4img56WE2JkWsBQTyWPYxMRiZ8xickRExaQK+FpI7LMx0djJxgQJG1BirDsaEeCzq3RMLCIFdl8iJsgfZ8mYaESKyb4gJsSXuhomJrDAJD+Cbyt3uPJFXwAAAABJRU5ErkJggg==" id="image6fb7255018" transform="scale(1 -1) translate(0 -241.92)" x="567.36" y="-56.88" width="12.24" height="241.92"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_20">
       <defs>
-       <path id="m2f05f111a7" d="M 0 0 
+       <path id="m3cc3bc5c25" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2f05f111a7" x="592.239063" y="278.634505" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc3bc5c25" x="579.514063" y="270.797431" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_104">
-      <!-- −0.2 -->
-      <g transform="translate(599.239063 282.433724) scale(0.1 -0.1)">
+      <!-- −0.075 -->
+      <g transform="translate(586.514063 274.59665) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2030,72 +1954,117 @@ z
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(242.822266 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(306.445312 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m2f05f111a7" x="592.239063" y="228.569693" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc3bc5c25" x="579.514063" y="240.033248" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_105">
-      <!-- −0.1 -->
-      <g transform="translate(599.239063 232.368912) scale(0.1 -0.1)">
+      <!-- −0.050 -->
+      <g transform="translate(586.514063 243.832466) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(242.822266 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(306.445312 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2f05f111a7" x="592.239063" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc3bc5c25" x="579.514063" y="209.269064" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_106">
-      <!-- 0.0 -->
-      <g transform="translate(599.239063 182.304099) scale(0.1 -0.1)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      <!-- −0.025 -->
+      <g transform="translate(586.514063 213.068283) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-2212"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(179.199219 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(242.822266 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(306.445312 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m2f05f111a7" x="592.239063" y="128.440069" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc3bc5c25" x="579.514063" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_107">
-      <!-- 0.1 -->
-      <g transform="translate(599.239063 132.239287) scale(0.1 -0.1)">
+      <!-- 0.000 -->
+      <g transform="translate(586.514063 182.304099) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2f05f111a7" x="592.239063" y="78.375256" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc3bc5c25" x="579.514063" y="147.740697" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
-      <!-- 0.2 -->
-      <g transform="translate(599.239063 82.174475) scale(0.1 -0.1)">
+      <!-- 0.025 -->
+      <g transform="translate(586.514063 151.539916) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
       </g>
      </g>
     </g>
-    <g id="text_109">
+    <g id="ytick_13">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m3cc3bc5c25" x="579.514063" y="116.976514" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_109">
+      <!-- 0.050 -->
+      <g transform="translate(586.514063 120.775733) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m3cc3bc5c25" x="579.514063" y="86.21233" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_110">
+      <!-- 0.075 -->
+      <g transform="translate(586.514063 90.011549) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_111">
      <!-- % vs zlib (higher=bigger) -->
      <g transform="translate(635.120313 242.331443) rotate(-90) scale(0.1 -0.1)">
       <defs>
@@ -2209,18 +2178,18 @@ z
    </g>
    <g id="LineCollection_1"/>
    <g id="patch_8">
-    <path d="M 579.824992 302.645584 
-L 586.032027 302.645584 
-L 592.239063 302.645584 
-L 592.239063 54.364178 
-L 586.032027 54.364178 
-L 579.824992 54.364178 
-L 579.824992 302.645584 
+    <path d="M 567.418117 299.464334 
+L 573.46609 299.464334 
+L 579.514063 299.464334 
+L 579.514063 57.545428 
+L 573.46609 57.545428 
+L 567.418117 57.545428 
+L 567.418117 299.464334 
 z
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
-  <g id="text_110">
+  <g id="text_112">
    <!-- Compression ratio vs zlib  (silesia, level 6, relative to zlib) -->
    <g transform="translate(127.238438 16.462125) scale(0.12 -0.12)">
     <defs>
@@ -2674,9 +2643,9 @@ z
     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3233.642578 0)"/>
    </g>
   </g>
-  <g id="text_111">
-   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.069922 365.364) scale(0.07 -0.07)">
+  <g id="text_113">
+   <!-- 2026-06-10T08:22:01Z  ·  Linux chungus x86_64  ·  commit 3050fc62  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 365.364) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2687,6 +2656,45 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2768,13 +2776,13 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2813,110 +2821,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1d91901854">
-   <rect x="95.67625" y="47.90175" width="474.217486" height="261.206261"/>
+  <clipPath id="p87118765f3">
+   <rect x="95.67625" y="47.90175" width="462.065111" height="261.206261"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 47.90175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p54edbd7140)">
+   <g clip-path="url(#p1d91901854)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAApMAAAFrCAYAAACNPwIUAAAI4ElEQVR4nO3YPY5kVx2H4arudqm6DcaWPwJkeWQHpJMQQeDImWMkAhIkQidO2AAZYgdOHbAAImdOHZA6wgNMYOGRP8Y9nmamu4o18KKjvyg9zwp+V/fq3Fdne3j85+PmRB0//+v0hGW2b709PWGdq5enFyxzfPRgesIy21ffmp6wxvOb6QXLHD/9dHrCMttf/mJ6wjqXL00vWOf22fSCZY5ffjE9YZmz6QEAAPz/EpMAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCAbHtz+5fj9IhVdj9cT09Y5sl+Nz1hmWd3N9MTlnnl5jA9YZmbH700PWGJ4/F039nl+dX0hHWefD29YJmby9N9b/uvv5yesM7r70wvWMbNJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZBe7J4+nN6yzu5pesMzxeDs9YZmX//nF9IR17t2fXrDM/vrb6QlrHA/TC9bZne45sjnfTS9YZn99uv/tp6+8MT1hmctvHk5PWMbNJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZNvbwyfH6RGrnH3/aHrCMo/3F9MTlvn37Q/TE5Z5/fHpPtvdG+9MT1ji2d3N9IRlLs+vpies8+jB9IJlnr/65vSEZV7419+mJyzz/ETPyM3GzSQAAP8DMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDItreHT47TI1Z5ens9PWGZ3dl+esIyX908nJ6wzGv7n05P4L+0u5tesM53x9M9I3+ye216wjLPD8+mJyxz3BymJyxzvr2YnrCMm0kAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAdnF2wj354vZqesI6ZxfTC5bZn5/ue9ud7acnLHPYHKYnrHF2umfkjze76QkEZ9vT/Sbvjid6jmw2m6e319MTljndLxIAgOXEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACDbfrz52XF6xCq/fvjB9IRl/v6bj6YnLPPVP55OT1jm/of3pycs88Lvfjs9YYkH7/1+esIy9/70/vSEZbb3352esMznPz/df9u9z/44PWGZ7371h+kJy7iZBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCA7D9fMX3Yj4e/igAAAABJRU5ErkJggg==" id="image3d9f99833f" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="474.48" height="261.36"/>
+iVBORw0KGgoAAAANSUhEUgAAApMAAAFrCAYAAACNPwIUAAAI4ElEQVR4nO3YPY5kVx2H4arudqm6DcaWPwJkeWQHpJMQQeDImWMkAhIkQidO2AAZYgdOHbAAImdOHZA6wgNMYOGRP8Y9nmamu4o18KKjvyg9zwp+V/fq3Fdne3j85+PmRB0//+v0hGW2b709PWGdq5enFyxzfPRgesIy21ffmp6wxvOb6QXLHD/9dHrCMttf/mJ6wjqXL00vWOf22fSCZY5ffjE9YZmz6QEAAPz/EpMAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCAbHtz+5fj9IhVdj9cT09Y5sl+Nz1hmWd3N9MTlnnl5jA9YZmbH700PWGJ4/F039nl+dX0hHWefD29YJmby9N9b/uvv5yesM7r70wvWMbNJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZBe7J4+nN6yzu5pesMzxeDs9YZmX//nF9IR17t2fXrDM/vrb6QlrHA/TC9bZne45sjnfTS9YZn99uv/tp6+8MT1hmctvHk5PWMbNJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZNvbwyfH6RGrnH3/aHrCMo/3F9MTlvn37Q/TE5Z5/fHpPtvdG+9MT1ji2d3N9IRlLs+vpies8+jB9IJlnr/65vSEZV7419+mJyzz/ETPyM3GzSQAAP8DMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDItreHT47TI1Z5ens9PWGZ3dl+esIyX908nJ6wzGv7n05P4L+0u5tesM53x9M9I3+ye216wjLPD8+mJyxz3BymJyxzvr2YnrCMm0kAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAdnF2wj354vZqesI6ZxfTC5bZn5/ue9ud7acnLHPYHKYnrHF2umfkjze76QkEZ9vT/Sbvjid6jmw2m6e319MTljndLxIAgOXEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACDbfrz52XF6xCq/fvjB9IRl/v6bj6YnLPPVP55OT1jm/of3pycs88Lvfjs9YYkH7/1+esIy9/70/vSEZbb3352esMznPz/df9u9z/44PWGZ7371h+kJy7iZBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCATEwCAJCJSQAAMjEJAEAmJgEAyMQkAACZmAQAIBOTAABkYhIAgExMAgCQiUkAADIxCQBAJiYBAMjEJAAAmZgEACATkwAAZGISAIBMTAIAkIlJAAAyMQkAQCYmAQDIxCQAAJmYBAAgE5MAAGRiEgCA7D9fMX3Yj4e/igAAAABJRU5ErkJggg==" id="image245185f7d0" transform="scale(1 -1) translate(0 -261.36)" x="95.67625" y="-47.748011" width="474.48" height="261.36"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m609212f498" d="M 0 0 
+       <path id="m705417b5e1" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m609212f498" x="115.435312" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="115.435312" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m609212f498" x="154.953436" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="154.953436" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m609212f498" x="194.47156" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="194.47156" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m609212f498" x="233.989683" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="233.989683" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m609212f498" x="273.507807" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="273.507807" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m609212f498" x="313.025931" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="313.025931" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m609212f498" x="352.544055" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="352.544055" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m609212f498" x="392.062179" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="392.062179" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m609212f498" x="431.580303" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="431.580303" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m609212f498" x="471.098426" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="471.098426" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m609212f498" x="510.61655" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="510.61655" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m609212f498" x="550.134674" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m705417b5e1" x="550.134674" y="309.108011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m2aab4d4024" d="M 0 0 
+       <path id="m66e8757376" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2aab4d4024" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66e8757376" x="95.67625" y="66.55934" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2aab4d4024" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66e8757376" x="95.67625" y="103.87452" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m2aab4d4024" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66e8757376" x="95.67625" y="141.189701" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m2aab4d4024" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66e8757376" x="95.67625" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -881,7 +881,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m2aab4d4024" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66e8757376" x="95.67625" y="215.820061" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -948,7 +948,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m2aab4d4024" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66e8757376" x="95.67625" y="253.135241" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1029,7 +1029,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m2aab4d4024" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66e8757376" x="95.67625" y="290.450421" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2001,18 +2001,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFYCAYAAABeeqzpAAAB0klEQVR4nO2b0Y0DIQwFYZeerqXr/3+XlOB8jNDEehQwwoOfIUoyx//fHsBa85oEhwNdCGUYS1tzxtEpUBzVy+goETkGiqN6tXaUrB0DcY4uCLVu6PjXrXMEloZwuB0pHVEghkM64kqTySb7iAIJS/MdP8JROrJljRwjFMgmW9lHCEfZR9SovbjBhnDI5zF2HWGyhVmDQDrZZB8lIhUIm9nUjowR6Xsd6dKv7CNZRJTzSDZqsR0JHYEgprrejnR9BLGMpdk6u7cjmWwyInFUrPRRvcDSbA1JOpKN2jV9fURd2VRpwqxN7llDyYZ2JMxaIlKDjBG5GVAiUoO4PtI50kWkdR/Z7jVhH03knxBjrLFfBMQ5onbkA4GO3r6l2U4Nk93aka6P9n4YULL2g6DGo9boyDZq4+grEPOINGYtjo6ByNIY2Tn+k6C946gGxVENiqMaFEc1qK2j/WAXpM4RVdruW9p4qD5q7Ih6Q1JZE46RZO0gyOhINkYw2cKPoq2v7PRRsbjSsD7yzaO3b2lb9/IXOrKVtt44OgZSOpKFVngdURHp7EgX2s6OfDMbmiIcyFga9TPGzo5soDiql9AR9T1tZ0c6UBzVC3Rku46MjmylfQB5PCuHsIxBxQAAAABJRU5ErkJggg==" id="image2f5b70a509" transform="scale(1 -1) translate(0 -247.68)" x="579.6" y="-54" width="12.96" height="247.68"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFYCAYAAABeeqzpAAAB0klEQVR4nO2b0Y0DIQwFYZeerqXr/3+XlOB8jNDEehQwwoOfIUoyx//fHsBa85oEhwNdCGUYS1tzxtEpUBzVy+goETkGiqN6tXaUrB0DcY4uCLVu6PjXrXMEloZwuB0pHVEghkM64kqTySb7iAIJS/MdP8JROrJljRwjFMgmW9lHCEfZR9SovbjBhnDI5zF2HWGyhVmDQDrZZB8lIhUIm9nUjowR6Xsd6dKv7CNZRJTzSDZqsR0JHYEgprrejnR9BLGMpdk6u7cjmWwyInFUrPRRvcDSbA1JOpKN2jV9fURd2VRpwqxN7llDyYZ2JMxaIlKDjBG5GVAiUoO4PtI50kWkdR/Z7jVhH03knxBjrLFfBMQ5onbkA4GO3r6l2U4Nk93aka6P9n4YULL2g6DGo9boyDZq4+grEPOINGYtjo6ByNIY2Tn+k6C946gGxVENiqMaFEc1qK2j/WAXpM4RVdruW9p4qD5q7Ih6Q1JZE46RZO0gyOhINkYw2cKPoq2v7PRRsbjSsD7yzaO3b2lb9/IXOrKVtt44OgZSOpKFVngdURHp7EgX2s6OfDMbmiIcyFga9TPGzo5soDiql9AR9T1tZ0c6UBzVC3Rku46MjmylfQB5PCuHsIxBxQAAAABJRU5ErkJggg==" id="imagee920bbf744" transform="scale(1 -1) translate(0 -247.68)" x="579.6" y="-54" width="12.96" height="247.68"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_20">
       <defs>
-       <path id="m3b8090dfb4" d="M 0 0 
+       <path id="m2f05f111a7" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3b8090dfb4" x="592.239063" y="278.634505" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f05f111a7" x="592.239063" y="278.634505" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_104">
@@ -2037,7 +2037,7 @@ z
     <g id="ytick_9">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m3b8090dfb4" x="592.239063" y="228.569693" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f05f111a7" x="592.239063" y="228.569693" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_105">
@@ -2053,7 +2053,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3b8090dfb4" x="592.239063" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f05f111a7" x="592.239063" y="178.504881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_106">
@@ -2068,7 +2068,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3b8090dfb4" x="592.239063" y="128.440069" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f05f111a7" x="592.239063" y="128.440069" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_107">
@@ -2083,7 +2083,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3b8090dfb4" x="592.239063" y="78.375256" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f05f111a7" x="592.239063" y="78.375256" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2675,8 +2675,8 @@ z
    </g>
   </g>
   <g id="text_111">
-   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(48.833828 365.364) scale(0.07 -0.07)">
+   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.069922 365.364) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2768,12 +2768,12 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2813,108 +2813,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p54edbd7140">
+  <clipPath id="p1d91901854">
    <rect x="95.67625" y="47.90175" width="474.217486" height="261.206261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.732344pt" height="354.774469pt" viewBox="0 0 564.732344 354.774469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.260156pt" height="354.774469pt" viewBox="0 0 570.260156 354.774469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,208 +22,208 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 354.774469 
-L 564.732344 354.774469 
-L 564.732344 0 
+L 570.260156 354.774469 
+L 570.260156 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 184.491172 101.872 
-L 289.116172 101.872 
-L 289.116172 71.996 
-L 184.491172 71.996 
+    <path d="M 187.255078 101.872 
+L 291.880078 101.872 
+L 291.880078 71.996 
+L 187.255078 71.996 
 z
-" clip-path="url(#p96f300d071)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 289.116172 101.872 
-L 393.741172 101.872 
-L 393.741172 71.996 
-L 289.116172 71.996 
+    <path d="M 291.880078 101.872 
+L 396.505078 101.872 
+L 396.505078 71.996 
+L 291.880078 71.996 
 z
-" clip-path="url(#p96f300d071)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 393.741172 101.872 
-L 498.366172 101.872 
-L 498.366172 71.996 
-L 393.741172 71.996 
+    <path d="M 396.505078 101.872 
+L 501.130078 101.872 
+L 501.130078 71.996 
+L 396.505078 71.996 
 z
-" clip-path="url(#p96f300d071)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 184.491172 131.748 
-L 289.116172 131.748 
-L 289.116172 101.872 
-L 184.491172 101.872 
+    <path d="M 187.255078 131.748 
+L 291.880078 131.748 
+L 291.880078 101.872 
+L 187.255078 101.872 
 z
-" clip-path="url(#p96f300d071)" style="fill: #6bbf64; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #6bbf64; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 289.116172 131.748 
-L 393.741172 131.748 
-L 393.741172 101.872 
-L 289.116172 101.872 
+    <path d="M 291.880078 131.748 
+L 396.505078 131.748 
+L 396.505078 101.872 
+L 291.880078 101.872 
 z
-" clip-path="url(#p96f300d071)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 393.741172 131.748 
-L 498.366172 131.748 
-L 498.366172 101.872 
-L 393.741172 101.872 
+    <path d="M 396.505078 131.748 
+L 501.130078 131.748 
+L 501.130078 101.872 
+L 396.505078 101.872 
 z
-" clip-path="url(#p96f300d071)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 184.491172 161.624 
-L 289.116172 161.624 
-L 289.116172 131.748 
-L 184.491172 131.748 
+    <path d="M 187.255078 161.624 
+L 291.880078 161.624 
+L 291.880078 131.748 
+L 187.255078 131.748 
 z
-" clip-path="url(#p96f300d071)" style="fill: #78c565; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #78c565; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 289.116172 161.624 
-L 393.741172 161.624 
-L 393.741172 131.748 
-L 289.116172 131.748 
+    <path d="M 291.880078 161.624 
+L 396.505078 161.624 
+L 396.505078 131.748 
+L 291.880078 131.748 
 z
-" clip-path="url(#p96f300d071)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #fee797; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 393.741172 161.624 
-L 498.366172 161.624 
-L 498.366172 131.748 
-L 393.741172 131.748 
+    <path d="M 396.505078 161.624 
+L 501.130078 161.624 
+L 501.130078 131.748 
+L 396.505078 131.748 
 z
-" clip-path="url(#p96f300d071)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #fdbb6c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 184.491172 191.5 
-L 289.116172 191.5 
-L 289.116172 161.624 
-L 184.491172 161.624 
+    <path d="M 187.255078 191.5 
+L 291.880078 191.5 
+L 291.880078 161.624 
+L 187.255078 161.624 
 z
-" clip-path="url(#p96f300d071)" style="fill: #a2d76a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #a2d76a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 289.116172 191.5 
-L 393.741172 191.5 
-L 393.741172 161.624 
-L 289.116172 161.624 
+    <path d="M 291.880078 191.5 
+L 396.505078 191.5 
+L 396.505078 161.624 
+L 291.880078 161.624 
 z
-" clip-path="url(#p96f300d071)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 393.741172 191.5 
-L 498.366172 191.5 
-L 498.366172 161.624 
-L 393.741172 161.624 
+    <path d="M 396.505078 191.5 
+L 501.130078 191.5 
+L 501.130078 161.624 
+L 396.505078 161.624 
 z
-" clip-path="url(#p96f300d071)" style="fill: #fba35c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 184.491172 221.376 
-L 289.116172 221.376 
-L 289.116172 191.5 
-L 184.491172 191.5 
+    <path d="M 187.255078 221.376 
+L 291.880078 221.376 
+L 291.880078 191.5 
+L 187.255078 191.5 
 z
-" clip-path="url(#p96f300d071)" style="fill: #66bd63; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #66bd63; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 289.116172 221.376 
-L 393.741172 221.376 
-L 393.741172 191.5 
-L 289.116172 191.5 
+    <path d="M 291.880078 221.376 
+L 396.505078 221.376 
+L 396.505078 191.5 
+L 291.880078 191.5 
 z
-" clip-path="url(#p96f300d071)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #fdc171; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 393.741172 221.376 
-L 498.366172 221.376 
-L 498.366172 191.5 
-L 393.741172 191.5 
+    <path d="M 396.505078 221.376 
+L 501.130078 221.376 
+L 501.130078 191.5 
+L 396.505078 191.5 
 z
-" clip-path="url(#p96f300d071)" style="fill: #fff5ae; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #fff2aa; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 184.491172 251.252 
-L 289.116172 251.252 
-L 289.116172 221.376 
-L 184.491172 221.376 
+    <path d="M 187.255078 251.252 
+L 291.880078 251.252 
+L 291.880078 221.376 
+L 187.255078 221.376 
 z
-" clip-path="url(#p96f300d071)" style="fill: #54b45f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #54b45f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 289.116172 251.252 
-L 393.741172 251.252 
-L 393.741172 221.376 
-L 289.116172 221.376 
+    <path d="M 291.880078 251.252 
+L 396.505078 251.252 
+L 396.505078 221.376 
+L 291.880078 221.376 
 z
-" clip-path="url(#p96f300d071)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 393.741172 251.252 
-L 498.366172 251.252 
-L 498.366172 221.376 
-L 393.741172 221.376 
+    <path d="M 396.505078 251.252 
+L 501.130078 251.252 
+L 501.130078 221.376 
+L 396.505078 221.376 
 z
-" clip-path="url(#p96f300d071)" style="fill: #eef8a8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #e9f6a1; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 184.491172 281.128 
-L 289.116172 281.128 
-L 289.116172 251.252 
-L 184.491172 251.252 
+    <path d="M 187.255078 281.128 
+L 291.880078 281.128 
+L 291.880078 251.252 
+L 187.255078 251.252 
 z
-" clip-path="url(#p96f300d071)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 289.116172 281.128 
-L 393.741172 281.128 
-L 393.741172 251.252 
-L 289.116172 251.252 
+    <path d="M 291.880078 281.128 
+L 396.505078 281.128 
+L 396.505078 251.252 
+L 291.880078 251.252 
 z
-" clip-path="url(#p96f300d071)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 393.741172 281.128 
-L 498.366172 281.128 
-L 498.366172 251.252 
-L 393.741172 251.252 
+    <path d="M 396.505078 281.128 
+L 501.130078 281.128 
+L 501.130078 251.252 
+L 396.505078 251.252 
 z
-" clip-path="url(#p96f300d071)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 184.491172 311.004 
-L 289.116172 311.004 
-L 289.116172 281.128 
-L 184.491172 281.128 
+    <path d="M 187.255078 311.004 
+L 291.880078 311.004 
+L 291.880078 281.128 
+L 187.255078 281.128 
 z
-" clip-path="url(#p96f300d071)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 289.116172 311.004 
-L 393.741172 311.004 
-L 393.741172 281.128 
-L 289.116172 281.128 
+    <path d="M 291.880078 311.004 
+L 396.505078 311.004 
+L 396.505078 281.128 
+L 291.880078 281.128 
 z
-" clip-path="url(#p96f300d071)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 393.741172 311.004 
-L 498.366172 311.004 
-L 498.366172 281.128 
-L 393.741172 281.128 
+    <path d="M 396.505078 311.004 
+L 501.130078 311.004 
+L 501.130078 281.128 
+L 396.505078 281.128 
 z
-" clip-path="url(#p96f300d071)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb13371865f)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(117.478438 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(120.242344 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -328,7 +328,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(224.762656 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(227.526563 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -424,7 +424,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(303.334766 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(306.098672 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -589,7 +589,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(401.686484 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(404.450391 59.541437) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -609,7 +609,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(113.416172 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(116.180078 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -798,7 +798,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(225.352422 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -894,7 +894,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(333.793672 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(336.557578 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -927,73 +927,57 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 905 -->
-    <g transform="translate(438.418672 89.1415) scale(0.08 -0.08)">
+    <!-- 877 -->
+    <g transform="translate(441.182578 89.1415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
 z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
 z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(108.054297 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(110.818203 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1092,7 +1076,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(225.352422 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1122,8 +1106,8 @@ z
     </g>
    </g>
    <g id="text_11">
-    <!-- 60 -->
-    <g transform="translate(336.338672 119.0175) scale(0.08 -0.08)">
+    <!-- 61 -->
+    <g transform="translate(339.102578 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1157,20 +1141,20 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_12">
-    <!-- 310 -->
-    <g transform="translate(438.418672 119.0175) scale(0.08 -0.08)">
+    <!-- 311 -->
+    <g transform="translate(441.182578 119.0175) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(95.747422 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(98.511328 148.8935) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1341,7 +1325,34 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(225.352422 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 148.8935) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1351,22 +1362,22 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(336.338672 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 272 -->
-    <g transform="translate(438.418672 148.8935) scale(0.08 -0.08)">
+    <!-- 273 -->
+    <g transform="translate(441.182578 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(116.779922 178.7695) scale(0.08 -0.08)">
+    <g transform="translate(119.543828 178.7695) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1426,7 +1437,39 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(225.352422 178.7695) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 178.7695) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1435,64 +1478,23 @@ z
     </g>
    </g>
    <g id="text_19">
-    <!-- 41 -->
-    <g transform="translate(336.338672 178.7695) scale(0.08 -0.08)">
+    <!-- 42 -->
+    <g transform="translate(339.102578 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 228 -->
-    <g transform="translate(438.418672 178.7695) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 226 -->
+    <g transform="translate(441.182578 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(125.317422 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(128.081328 208.6455) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1516,7 +1518,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(225.352422 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1525,23 +1527,23 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- 38 -->
-    <g transform="translate(336.338672 208.6455) scale(0.08 -0.08)">
+    <!-- 36 -->
+    <g transform="translate(339.102578 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 447 -->
-    <g transform="translate(438.418672 208.6455) scale(0.08 -0.08)">
+    <!-- 423 -->
+    <g transform="translate(441.182578 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(108.623672 238.41025) scale(0.08 -0.08)">
+    <g transform="translate(111.387578 238.41025) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1600,7 +1602,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(225.352422 238.5215) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,23 +1611,23 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 36 -->
-    <g transform="translate(336.338672 238.5215) scale(0.08 -0.08)">
+    <!-- 35 -->
+    <g transform="translate(339.102578 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 539 -->
-    <g transform="translate(438.418672 238.5215) scale(0.08 -0.08)">
+    <!-- 540 -->
+    <g transform="translate(441.182578 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(93.240547 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(96.004453 268.3975) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1690,7 +1692,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.336 -->
-    <g transform="translate(225.352422 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(228.116328 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1700,21 +1702,21 @@ z
    </g>
    <g id="text_31">
     <!-- 20 -->
-    <g transform="translate(336.338672 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(339.102578 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 68 -->
-    <g transform="translate(440.963672 268.3975) scale(0.08 -0.08)">
+    <!-- 69 -->
+    <g transform="translate(443.727578 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(95.125547 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(97.889453 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1823,7 +1825,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.360 -->
-    <g transform="translate(224.151797 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(226.915703 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1925,7 +1927,7 @@ z
    </g>
    <g id="text_35">
     <!-- 7 -->
-    <g transform="translate(338.645547 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(341.409453 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
@@ -1943,7 +1945,7 @@ z
    </g>
    <g id="text_36">
     <!-- 105 -->
-    <g transform="translate(437.704297 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(440.468203 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1993,7 +1995,7 @@ z
   </g>
   <g id="text_37">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(148.967891 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.731797 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2107,7 +2109,7 @@ z
    </g>
   </g>
   <g id="text_38">
-   <!-- 2026-06-10T02:01:55Z  ·  Linux chungus x86_64  ·  commit 52df143  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 345.924) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2249,12 +2251,12 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2294,109 +2296,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.802734 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p96f300d071">
-   <rect x="79.866172" y="42.12" width="418.5" height="268.884"/>
+  <clipPath id="pb13371865f">
+   <rect x="82.630078" y="42.12" width="418.5" height="268.884"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.260156pt" height="354.774469pt" viewBox="0 0 570.260156 354.774469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.591094pt" height="354.774469pt" viewBox="0 0 568.591094 354.774469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,208 +22,208 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 354.774469 
-L 570.260156 354.774469 
-L 570.260156 0 
+L 568.591094 354.774469 
+L 568.591094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.255078 101.872 
-L 291.880078 101.872 
-L 291.880078 71.996 
-L 187.255078 71.996 
+    <path d="M 186.420547 101.872 
+L 291.045547 101.872 
+L 291.045547 71.996 
+L 186.420547 71.996 
 z
-" clip-path="url(#pb13371865f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.880078 101.872 
-L 396.505078 101.872 
-L 396.505078 71.996 
-L 291.880078 71.996 
+    <path d="M 291.045547 101.872 
+L 395.670547 101.872 
+L 395.670547 71.996 
+L 291.045547 71.996 
 z
-" clip-path="url(#pb13371865f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.505078 101.872 
-L 501.130078 101.872 
-L 501.130078 71.996 
-L 396.505078 71.996 
+    <path d="M 395.670547 101.872 
+L 500.295547 101.872 
+L 500.295547 71.996 
+L 395.670547 71.996 
 z
-" clip-path="url(#pb13371865f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.255078 131.748 
-L 291.880078 131.748 
-L 291.880078 101.872 
-L 187.255078 101.872 
+    <path d="M 186.420547 131.748 
+L 291.045547 131.748 
+L 291.045547 101.872 
+L 186.420547 101.872 
 z
-" clip-path="url(#pb13371865f)" style="fill: #6bbf64; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #a5d86a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.880078 131.748 
-L 396.505078 131.748 
-L 396.505078 101.872 
-L 291.880078 101.872 
+    <path d="M 291.045547 131.748 
+L 395.670547 131.748 
+L 395.670547 101.872 
+L 291.045547 101.872 
 z
-" clip-path="url(#pb13371865f)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.505078 131.748 
-L 501.130078 131.748 
-L 501.130078 101.872 
-L 396.505078 101.872 
+    <path d="M 395.670547 131.748 
+L 500.295547 131.748 
+L 500.295547 101.872 
+L 395.670547 101.872 
 z
-" clip-path="url(#pb13371865f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.255078 161.624 
-L 291.880078 161.624 
-L 291.880078 131.748 
-L 187.255078 131.748 
+    <path d="M 186.420547 161.624 
+L 291.045547 161.624 
+L 291.045547 131.748 
+L 186.420547 131.748 
 z
-" clip-path="url(#pb13371865f)" style="fill: #78c565; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.880078 161.624 
-L 396.505078 161.624 
-L 396.505078 131.748 
-L 291.880078 131.748 
+    <path d="M 291.045547 161.624 
+L 395.670547 161.624 
+L 395.670547 131.748 
+L 291.045547 131.748 
 z
-" clip-path="url(#pb13371865f)" style="fill: #fee797; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fee797; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.505078 161.624 
-L 501.130078 161.624 
-L 501.130078 131.748 
-L 396.505078 131.748 
+    <path d="M 395.670547 161.624 
+L 500.295547 161.624 
+L 500.295547 131.748 
+L 395.670547 131.748 
 z
-" clip-path="url(#pb13371865f)" style="fill: #fdbb6c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.255078 191.5 
-L 291.880078 191.5 
-L 291.880078 161.624 
-L 187.255078 161.624 
+    <path d="M 186.420547 191.5 
+L 291.045547 191.5 
+L 291.045547 161.624 
+L 186.420547 161.624 
 z
-" clip-path="url(#pb13371865f)" style="fill: #a2d76a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fffbb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.880078 191.5 
-L 396.505078 191.5 
-L 396.505078 161.624 
-L 291.880078 161.624 
+    <path d="M 291.045547 191.5 
+L 395.670547 191.5 
+L 395.670547 161.624 
+L 291.045547 161.624 
 z
-" clip-path="url(#pb13371865f)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.505078 191.5 
-L 501.130078 191.5 
-L 501.130078 161.624 
-L 396.505078 161.624 
+    <path d="M 395.670547 191.5 
+L 500.295547 191.5 
+L 500.295547 161.624 
+L 395.670547 161.624 
 z
-" clip-path="url(#pb13371865f)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.255078 221.376 
-L 291.880078 221.376 
-L 291.880078 191.5 
-L 187.255078 191.5 
+    <path d="M 186.420547 221.376 
+L 291.045547 221.376 
+L 291.045547 191.5 
+L 186.420547 191.5 
 z
-" clip-path="url(#pb13371865f)" style="fill: #66bd63; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #98d368; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.880078 221.376 
-L 396.505078 221.376 
-L 396.505078 191.5 
-L 291.880078 191.5 
+    <path d="M 291.045547 221.376 
+L 395.670547 221.376 
+L 395.670547 191.5 
+L 291.045547 191.5 
 z
-" clip-path="url(#pb13371865f)" style="fill: #fdc171; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fdc171; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.505078 221.376 
-L 501.130078 221.376 
-L 501.130078 191.5 
-L 396.505078 191.5 
+    <path d="M 395.670547 221.376 
+L 500.295547 221.376 
+L 500.295547 191.5 
+L 395.670547 191.5 
 z
-" clip-path="url(#pb13371865f)" style="fill: #fff2aa; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fff8b4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.255078 251.252 
-L 291.880078 251.252 
-L 291.880078 221.376 
-L 187.255078 221.376 
+    <path d="M 186.420547 251.252 
+L 291.045547 251.252 
+L 291.045547 221.376 
+L 186.420547 221.376 
 z
-" clip-path="url(#pb13371865f)" style="fill: #54b45f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #70c164; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.880078 251.252 
-L 396.505078 251.252 
-L 396.505078 221.376 
-L 291.880078 221.376 
+    <path d="M 291.045547 251.252 
+L 395.670547 251.252 
+L 395.670547 221.376 
+L 291.045547 221.376 
 z
-" clip-path="url(#pb13371865f)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.505078 251.252 
-L 501.130078 251.252 
-L 501.130078 221.376 
-L 396.505078 221.376 
+    <path d="M 395.670547 251.252 
+L 500.295547 251.252 
+L 500.295547 221.376 
+L 395.670547 221.376 
 z
-" clip-path="url(#pb13371865f)" style="fill: #e9f6a1; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.255078 281.128 
-L 291.880078 281.128 
-L 291.880078 251.252 
-L 187.255078 251.252 
+    <path d="M 186.420547 281.128 
+L 291.045547 281.128 
+L 291.045547 251.252 
+L 186.420547 251.252 
 z
-" clip-path="url(#pb13371865f)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.880078 281.128 
-L 396.505078 281.128 
-L 396.505078 251.252 
-L 291.880078 251.252 
+    <path d="M 291.045547 281.128 
+L 395.670547 281.128 
+L 395.670547 251.252 
+L 291.045547 251.252 
 z
-" clip-path="url(#pb13371865f)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.505078 281.128 
-L 501.130078 281.128 
-L 501.130078 251.252 
-L 396.505078 251.252 
+    <path d="M 395.670547 281.128 
+L 500.295547 281.128 
+L 500.295547 251.252 
+L 395.670547 251.252 
 z
-" clip-path="url(#pb13371865f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.255078 311.004 
-L 291.880078 311.004 
-L 291.880078 281.128 
-L 187.255078 281.128 
+    <path d="M 186.420547 311.004 
+L 291.045547 311.004 
+L 291.045547 281.128 
+L 186.420547 281.128 
 z
-" clip-path="url(#pb13371865f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #fff5ae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.880078 311.004 
-L 396.505078 311.004 
-L 396.505078 281.128 
-L 291.880078 281.128 
+    <path d="M 291.045547 311.004 
+L 395.670547 311.004 
+L 395.670547 281.128 
+L 291.045547 281.128 
 z
-" clip-path="url(#pb13371865f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.505078 311.004 
-L 501.130078 311.004 
-L 501.130078 281.128 
-L 396.505078 281.128 
+    <path d="M 395.670547 311.004 
+L 500.295547 311.004 
+L 500.295547 281.128 
+L 395.670547 281.128 
 z
-" clip-path="url(#pb13371865f)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pd88c432162)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.242344 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(119.407813 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -328,7 +328,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.526563 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(226.692031 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -424,7 +424,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.098672 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(305.264141 59.541437) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -589,7 +589,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.450391 59.541437) scale(0.09 -0.09)">
+    <g transform="translate(403.615859 59.541437) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -609,7 +609,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.180078 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(115.345547 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -798,7 +798,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.116328 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -894,7 +894,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.557578 89.1415) scale(0.08 -0.08)">
+    <g transform="translate(335.723047 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -927,8 +927,8 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 877 -->
-    <g transform="translate(441.182578 89.1415) scale(0.08 -0.08)">
+    <!-- 856 -->
+    <g transform="translate(440.348047 89.1415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -969,15 +969,70 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.818203 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(109.983672 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1076,7 +1131,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.116328 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 119.0175) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1107,46 +1162,14 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.102578 119.0175) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(338.268047 119.0175) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.182578 119.0175) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 119.0175) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1154,7 +1177,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.511328 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(97.676797 148.8935) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1325,34 +1348,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.116328 148.8935) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(227.281797 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1362,14 +1358,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(339.102578 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 273 -->
-    <g transform="translate(441.182578 148.8935) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 148.8935) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1377,7 +1373,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.543828 178.7695) scale(0.08 -0.08)">
+    <g transform="translate(118.709297 178.7695) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1437,7 +1433,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.116328 178.7695) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 178.7695) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1479,14 +1475,14 @@ z
    </g>
    <g id="text_19">
     <!-- 42 -->
-    <g transform="translate(339.102578 178.7695) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 226 -->
-    <g transform="translate(441.182578 178.7695) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 178.7695) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
@@ -1494,7 +1490,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.081328 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(127.246797 208.6455) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1518,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.116328 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1528,22 +1524,22 @@ z
    </g>
    <g id="text_23">
     <!-- 36 -->
-    <g transform="translate(339.102578 208.6455) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 423 -->
-    <g transform="translate(441.182578 208.6455) scale(0.08 -0.08)">
+    <!-- 438 -->
+    <g transform="translate(440.348047 208.6455) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.387578 238.41025) scale(0.08 -0.08)">
+    <g transform="translate(110.553047 238.41025) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1602,7 +1598,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.116328 238.5215) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1612,22 +1608,22 @@ z
    </g>
    <g id="text_27">
     <!-- 35 -->
-    <g transform="translate(339.102578 238.5215) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 540 -->
-    <g transform="translate(441.182578 238.5215) scale(0.08 -0.08)">
+    <!-- 531 -->
+    <g transform="translate(440.348047 238.5215) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.004453 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(95.169922 268.3975) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1692,7 +1688,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.336 -->
-    <g transform="translate(228.116328 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1702,21 +1698,21 @@ z
    </g>
    <g id="text_31">
     <!-- 20 -->
-    <g transform="translate(339.102578 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 69 -->
-    <g transform="translate(443.727578 268.3975) scale(0.08 -0.08)">
+    <g transform="translate(442.893047 268.3975) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.889453 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(97.054922 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1824,8 +1820,8 @@ z
     </g>
    </g>
    <g id="text_34">
-    <!-- 0.360 -->
-    <g transform="translate(226.915703 298.2735) scale(0.08 -0.08)">
+    <!-- 0.329 -->
+    <g transform="translate(226.081172 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1887,47 +1883,69 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
 z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-30"/>
      <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(246.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(246.728516 0)"/>
     </g>
    </g>
    <g id="text_35">
     <!-- 7 -->
-    <g transform="translate(341.409453 298.2735) scale(0.08 -0.08)">
+    <g transform="translate(340.574922 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
@@ -1944,8 +1962,8 @@ z
     </g>
    </g>
    <g id="text_36">
-    <!-- 105 -->
-    <g transform="translate(440.468203 298.2735) scale(0.08 -0.08)">
+    <!-- 104 -->
+    <g transform="translate(439.633672 298.2735) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1961,41 +1979,35 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
     </g>
    </g>
   </g>
   <g id="text_37">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.731797 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(150.897266 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2068,6 +2080,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2109,7 +2151,7 @@ z
    </g>
   </g>
   <g id="text_38">
-   <!-- 2026-06-10T07:53:15Z  ·  Linux chungus x86_64  ·  commit e94ac0d2  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-10T08:22:01Z  ·  Linux chungus x86_64  ·  commit 3050fc62  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 345.924) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2251,13 +2293,13 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2296,110 +2338,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3440.380859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3504.003906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.791016 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.578125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.365234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.152344 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.939453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.722656 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.525391 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.904297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.380859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.244141 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.605469 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4161.128906 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.933594 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.716797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.519531 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.898438 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.521484 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.212891 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.392578 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4670.015625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.802734 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4829.048828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.835938 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.542969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.40625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.386719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5118.009766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.796875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.583984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.371094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.158203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.945312 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.154297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.533203 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.396484 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.578125 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.957031 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.433594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.8125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.289062 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.876953 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.664062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.453125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.240234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.652344 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.175781 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.652344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.435547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.714844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6358.09375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.980469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.359375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.638672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6630.115234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.214844 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.59375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.775391 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.984375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.675781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.576172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.855469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7053.064453 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.847656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.816406 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.599609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.699219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.962891 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.486328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.695312 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.582031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.994141 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.777344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.15625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.939453 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7819.039062 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.248047 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7886.03125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb13371865f">
-   <rect x="82.630078" y="42.12" width="418.5" height="268.884"/>
+  <clipPath id="pd88c432162">
+   <rect x="81.795547" y="42.12" width="418.5" height="268.884"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,16681 +1,16571 @@
 {
-"meta": {
-"date": "2026-06-10T02:01:55Z",
-"machine": "Linux chungus x86_64",
-"git_commit": "52df143",
-"toolchain": "leanprover/lean4:v4.30.0-rc2",
-"note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
-},
-"results": [
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 59545,
-"ratio": 0.3915,
-"compress_mbps": 14.04,
-"decompress_mbps": 85.77
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 57936,
-"ratio": 0.3809,
-"compress_mbps": 12.39,
-"decompress_mbps": 92.41
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 56891,
-"ratio": 0.3741,
-"compress_mbps": 10.82,
-"decompress_mbps": 101.69
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 55541,
-"ratio": 0.3652,
-"compress_mbps": 6.63,
-"decompress_mbps": 102.17
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 55282,
-"ratio": 0.3635,
-"compress_mbps": 6.1,
-"decompress_mbps": 104.39
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54902,
-"ratio": 0.361,
-"compress_mbps": 5.13,
-"decompress_mbps": 108.64
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54758,
-"ratio": 0.36,
-"compress_mbps": 1.63,
-"decompress_mbps": 109.07
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54717,
-"ratio": 0.3598,
-"compress_mbps": 1.54,
-"decompress_mbps": 109.85
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54716,
-"ratio": 0.3598,
-"compress_mbps": 1.51,
-"decompress_mbps": 109.61
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 52768,
-"ratio": 0.4215,
-"compress_mbps": 13.23,
-"decompress_mbps": 81.32
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 51760,
-"ratio": 0.4135,
-"compress_mbps": 11.75,
-"decompress_mbps": 85.47
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51056,
-"ratio": 0.4079,
-"compress_mbps": 10.35,
-"decompress_mbps": 91.98
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 49963,
-"ratio": 0.3991,
-"compress_mbps": 6.5,
-"decompress_mbps": 93.95
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 49779,
-"ratio": 0.3977,
-"compress_mbps": 5.96,
-"decompress_mbps": 97.38
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 49540,
-"ratio": 0.3958,
-"compress_mbps": 5.19,
-"decompress_mbps": 97.79
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 49419,
-"ratio": 0.3948,
-"compress_mbps": 1.71,
-"decompress_mbps": 98.31
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 49409,
-"ratio": 0.3947,
-"compress_mbps": 1.67,
-"decompress_mbps": 99.72
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 49409,
-"ratio": 0.3947,
-"compress_mbps": 1.67,
-"decompress_mbps": 99.02
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8430,
-"ratio": 0.3426,
-"compress_mbps": 15.9,
-"decompress_mbps": 85.33
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8297,
-"ratio": 0.3372,
-"compress_mbps": 14.97,
-"decompress_mbps": 89.11
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8218,
-"ratio": 0.334,
-"compress_mbps": 14.01,
-"decompress_mbps": 90.67
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8055,
-"ratio": 0.3274,
-"compress_mbps": 10.22,
-"decompress_mbps": 90.61
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8049,
-"ratio": 0.3272,
-"compress_mbps": 9.66,
-"decompress_mbps": 92.63
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 8043,
-"ratio": 0.3269,
-"compress_mbps": 8.71,
-"decompress_mbps": 92.27
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 8038,
-"ratio": 0.3267,
-"compress_mbps": 2.85,
-"decompress_mbps": 93.84
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 8038,
-"ratio": 0.3267,
-"compress_mbps": 2.83,
-"decompress_mbps": 93.52
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 8038,
-"ratio": 0.3267,
-"compress_mbps": 2.83,
-"decompress_mbps": 92.89
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3325,
-"ratio": 0.2982,
-"compress_mbps": 13.42,
-"decompress_mbps": 75.15
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3251,
-"ratio": 0.2916,
-"compress_mbps": 12.85,
-"decompress_mbps": 77.53
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3202,
-"ratio": 0.2872,
-"compress_mbps": 12.19,
-"decompress_mbps": 77.89
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3150,
-"ratio": 0.2825,
-"compress_mbps": 9.4,
-"decompress_mbps": 81.05
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3141,
-"ratio": 0.2817,
-"compress_mbps": 9.1,
-"decompress_mbps": 82.36
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3136,
-"ratio": 0.2813,
-"compress_mbps": 8.48,
-"decompress_mbps": 82.49
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3134,
-"ratio": 0.2811,
-"compress_mbps": 2.76,
-"decompress_mbps": 82.59
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3134,
-"ratio": 0.2811,
-"compress_mbps": 2.73,
-"decompress_mbps": 82.99
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3134,
-"ratio": 0.2811,
-"compress_mbps": 2.72,
-"decompress_mbps": 82.93
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1251,
-"ratio": 0.3362,
-"compress_mbps": 8.51,
-"decompress_mbps": 42.05
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1241,
-"ratio": 0.3335,
-"compress_mbps": 8.32,
-"decompress_mbps": 42.59
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1241,
-"ratio": 0.3335,
-"compress_mbps": 8.11,
-"decompress_mbps": 42.85
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1225,
-"ratio": 0.3292,
-"compress_mbps": 7.23,
-"decompress_mbps": 43.33
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1224,
-"ratio": 0.3289,
-"compress_mbps": 7.16,
-"decompress_mbps": 43.55
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1224,
-"ratio": 0.3289,
-"compress_mbps": 7.11,
-"decompress_mbps": 43.49
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1224,
-"ratio": 0.3289,
-"compress_mbps": 2.47,
-"decompress_mbps": 43.51
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1224,
-"ratio": 0.3289,
-"compress_mbps": 2.47,
-"decompress_mbps": 43.68
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1224,
-"ratio": 0.3289,
-"compress_mbps": 2.47,
-"decompress_mbps": 43.67
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 248840,
-"ratio": 0.2417,
-"compress_mbps": 24.55,
-"decompress_mbps": 128.32
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 247429,
-"ratio": 0.2403,
-"compress_mbps": 21.97,
-"decompress_mbps": 149.77
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 246442,
-"ratio": 0.2393,
-"compress_mbps": 20.63,
-"decompress_mbps": 157.98
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 213851,
-"ratio": 0.2077,
-"compress_mbps": 10.64,
-"decompress_mbps": 163.82
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 212782,
-"ratio": 0.2066,
-"compress_mbps": 9.33,
-"decompress_mbps": 131.2
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 210061,
-"ratio": 0.204,
-"compress_mbps": 6.27,
-"decompress_mbps": 131.16
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 199322,
-"ratio": 0.1936,
-"compress_mbps": 1.3,
-"decompress_mbps": 121.13
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 199462,
-"ratio": 0.1937,
-"compress_mbps": 0.8,
-"decompress_mbps": 119.84
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 199644,
-"ratio": 0.1939,
-"compress_mbps": 0.48,
-"decompress_mbps": 118.9
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 194388,
-"ratio": 0.4555,
-"compress_mbps": 15.29,
-"decompress_mbps": 90.57
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 153708,
-"ratio": 0.3602,
-"compress_mbps": 13.21,
-"decompress_mbps": 96.67
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 150718,
-"ratio": 0.3532,
-"compress_mbps": 11.52,
-"decompress_mbps": 106.59
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 177586,
-"ratio": 0.4161,
-"compress_mbps": 7.18,
-"decompress_mbps": 107.71
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 146857,
-"ratio": 0.3441,
-"compress_mbps": 6.61,
-"decompress_mbps": 111.83
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 146118,
-"ratio": 0.3424,
-"compress_mbps": 5.63,
-"decompress_mbps": 113.71
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 145876,
-"ratio": 0.3418,
-"compress_mbps": 1.81,
-"decompress_mbps": 113.96
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 145803,
-"ratio": 0.3417,
-"compress_mbps": 1.73,
-"decompress_mbps": 113.8
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 145799,
-"ratio": 0.3416,
-"compress_mbps": 1.71,
-"decompress_mbps": 114.36
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 212305,
-"ratio": 0.4406,
-"compress_mbps": 12.71,
-"decompress_mbps": 79.05
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 263152,
-"ratio": 0.5461,
-"compress_mbps": 11.23,
-"decompress_mbps": 85.54
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 257812,
-"ratio": 0.535,
-"compress_mbps": 9.78,
-"decompress_mbps": 90.97
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 249343,
-"ratio": 0.5175,
-"compress_mbps": 5.97,
-"decompress_mbps": 91.41
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 199229,
-"ratio": 0.4135,
-"compress_mbps": 5.5,
-"decompress_mbps": 94.63
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 198023,
-"ratio": 0.411,
-"compress_mbps": 4.62,
-"decompress_mbps": 97.21
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 197532,
-"ratio": 0.4099,
-"compress_mbps": 1.46,
-"decompress_mbps": 97.34
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 197364,
-"ratio": 0.4096,
-"compress_mbps": 1.32,
-"decompress_mbps": 97.35
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 197347,
-"ratio": 0.4096,
-"compress_mbps": 1.27,
-"decompress_mbps": 97.24
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 60352,
-"ratio": 0.1176,
-"compress_mbps": 42.65,
-"decompress_mbps": 242.28
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 59696,
-"ratio": 0.1163,
-"compress_mbps": 35.44,
-"decompress_mbps": 256.01
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 59069,
-"ratio": 0.1151,
-"compress_mbps": 28.44,
-"decompress_mbps": 270.46
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 56435,
-"ratio": 0.11,
-"compress_mbps": 16.14,
-"decompress_mbps": 247.79
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 56350,
-"ratio": 0.1098,
-"compress_mbps": 14.04,
-"decompress_mbps": 261.24
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 56014,
-"ratio": 0.1091,
-"compress_mbps": 9.58,
-"decompress_mbps": 275.92
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 54781,
-"ratio": 0.1067,
-"compress_mbps": 2.17,
-"decompress_mbps": 282.72
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 54031,
-"ratio": 0.1053,
-"compress_mbps": 1.39,
-"decompress_mbps": 296.66
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 53850,
-"ratio": 0.1049,
-"compress_mbps": 0.82,
-"decompress_mbps": 301.07
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 13725,
-"ratio": 0.3589,
-"compress_mbps": 13.9,
-"decompress_mbps": 66.21
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13615,
-"ratio": 0.356,
-"compress_mbps": 13.24,
-"decompress_mbps": 69.77
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13548,
-"ratio": 0.3543,
-"compress_mbps": 12.41,
-"decompress_mbps": 72.39
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13080,
-"ratio": 0.3421,
-"compress_mbps": 9.09,
-"decompress_mbps": 70.36
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13060,
-"ratio": 0.3415,
-"compress_mbps": 8.44,
-"decompress_mbps": 74.15
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13015,
-"ratio": 0.3404,
-"compress_mbps": 6.88,
-"decompress_mbps": 74.8
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12923,
-"ratio": 0.3379,
-"compress_mbps": 1.67,
-"decompress_mbps": 75.41
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12905,
-"ratio": 0.3375,
-"compress_mbps": 1.23,
-"decompress_mbps": 77.96
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12887,
-"ratio": 0.337,
-"compress_mbps": 0.84,
-"decompress_mbps": 77.69
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1781,
-"ratio": 0.4213,
-"compress_mbps": 8.76,
-"decompress_mbps": 41.75
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1764,
-"ratio": 0.4173,
-"compress_mbps": 8.67,
-"decompress_mbps": 42.78
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1765,
-"ratio": 0.4176,
-"compress_mbps": 8.65,
-"decompress_mbps": 42.71
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 8.0,
-"decompress_mbps": 43.74
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 8.01,
-"decompress_mbps": 43.73
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 8.0,
-"decompress_mbps": 43.69
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 2.79,
-"decompress_mbps": 43.65
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 2.79,
-"decompress_mbps": 43.59
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 2.78,
-"decompress_mbps": 43.56
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 65130,
-"ratio": 0.4282,
-"compress_mbps": 117.93,
-"decompress_mbps": 409.61
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 62270,
-"ratio": 0.4094,
-"compress_mbps": 102.2,
-"decompress_mbps": 427.14
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 59488,
-"ratio": 0.3911,
-"compress_mbps": 67.17,
-"decompress_mbps": 441.45
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 57679,
-"ratio": 0.3792,
-"compress_mbps": 71.3,
-"decompress_mbps": 419.65
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 55616,
-"ratio": 0.3657,
-"compress_mbps": 41.75,
-"decompress_mbps": 411.55
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54398,
-"ratio": 0.3577,
-"compress_mbps": 25.53,
-"decompress_mbps": 426.15
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54253,
-"ratio": 0.3567,
-"compress_mbps": 21.46,
-"decompress_mbps": 425.45
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54164,
-"ratio": 0.3561,
-"compress_mbps": 17.04,
-"decompress_mbps": 427.29
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54164,
-"ratio": 0.3561,
-"compress_mbps": 17.02,
-"decompress_mbps": 425.23
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 56791,
-"ratio": 0.4537,
-"compress_mbps": 115.56,
-"decompress_mbps": 398.4
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 54652,
-"ratio": 0.4366,
-"compress_mbps": 98.47,
-"decompress_mbps": 412.81
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 52663,
-"ratio": 0.4207,
-"compress_mbps": 62.64,
-"decompress_mbps": 436.38
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 51266,
-"ratio": 0.4095,
-"compress_mbps": 67.0,
-"decompress_mbps": 406.84
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 49622,
-"ratio": 0.3964,
-"compress_mbps": 37.32,
-"decompress_mbps": 393.59
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48891,
-"ratio": 0.3906,
-"compress_mbps": 22.84,
-"decompress_mbps": 402.28
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48801,
-"ratio": 0.3898,
-"compress_mbps": 20.04,
-"decompress_mbps": 402.51
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48772,
-"ratio": 0.3896,
-"compress_mbps": 18.17,
-"decompress_mbps": 401.32
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48772,
-"ratio": 0.3896,
-"compress_mbps": 18.17,
-"decompress_mbps": 404.13
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 9028,
-"ratio": 0.3669,
-"compress_mbps": 398.57,
-"decompress_mbps": 1056.86
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8811,
-"ratio": 0.3581,
-"compress_mbps": 224.34,
-"decompress_mbps": 1068.65
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8616,
-"ratio": 0.3502,
-"compress_mbps": 153.67,
-"decompress_mbps": 1101.25
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8219,
-"ratio": 0.3341,
-"compress_mbps": 115.6,
-"decompress_mbps": 1122.05
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8001,
-"ratio": 0.3252,
-"compress_mbps": 83.8,
-"decompress_mbps": 1147.85
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7955,
-"ratio": 0.3233,
-"compress_mbps": 68.29,
-"decompress_mbps": 1152.25
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7933,
-"ratio": 0.3224,
-"compress_mbps": 62.39,
-"decompress_mbps": 1155.6
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7934,
-"ratio": 0.3225,
-"compress_mbps": 57.63,
-"decompress_mbps": 1149.03
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7934,
-"ratio": 0.3225,
-"compress_mbps": 57.65,
-"decompress_mbps": 1155.26
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3647,
-"ratio": 0.3271,
-"compress_mbps": 413.46,
-"decompress_mbps": 1069.34
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3501,
-"ratio": 0.314,
-"compress_mbps": 398.75,
-"decompress_mbps": 1111.82
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3393,
-"ratio": 0.3043,
-"compress_mbps": 332.56,
-"decompress_mbps": 1137.03
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3215,
-"ratio": 0.2883,
-"compress_mbps": 267.89,
-"decompress_mbps": 1172.12
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3140,
-"ratio": 0.2816,
-"compress_mbps": 200.05,
-"decompress_mbps": 1198.27
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 151.03,
-"decompress_mbps": 1212.76
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 129.48,
-"decompress_mbps": 1216.92
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3109,
-"ratio": 0.2788,
-"compress_mbps": 109.5,
-"decompress_mbps": 1216.23
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3109,
-"ratio": 0.2788,
-"compress_mbps": 109.01,
-"decompress_mbps": 1216.09
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1326,
-"ratio": 0.3564,
-"compress_mbps": 308.12,
-"decompress_mbps": 772.78
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1306,
-"ratio": 0.351,
-"compress_mbps": 303.02,
-"decompress_mbps": 777.01
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1301,
-"ratio": 0.3496,
-"compress_mbps": 285.95,
-"decompress_mbps": 782.5
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1228,
-"ratio": 0.33,
-"compress_mbps": 227.16,
-"decompress_mbps": 806.51
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 191.07,
-"decompress_mbps": 812.97
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 171.75,
-"decompress_mbps": 811.86
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 164.88,
-"decompress_mbps": 811.67
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 162.17,
-"decompress_mbps": 811.3
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 162.56,
-"decompress_mbps": 810.93
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 242293,
-"ratio": 0.2353,
-"compress_mbps": 258.39,
-"decompress_mbps": 843.91
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 233553,
-"ratio": 0.2268,
-"compress_mbps": 247.81,
-"decompress_mbps": 997.79
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 228222,
-"ratio": 0.2216,
-"compress_mbps": 196.18,
-"decompress_mbps": 1058.35
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 223668,
-"ratio": 0.2172,
-"compress_mbps": 176.7,
-"decompress_mbps": 1087.34
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 205994,
-"ratio": 0.2,
-"compress_mbps": 109.6,
-"decompress_mbps": 1043.08
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 203986,
-"ratio": 0.1981,
-"compress_mbps": 49.98,
-"decompress_mbps": 1044.15
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 207681,
-"ratio": 0.2017,
-"compress_mbps": 36.94,
-"decompress_mbps": 1035.1
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 206827,
-"ratio": 0.2009,
-"compress_mbps": 7.28,
-"decompress_mbps": 1010.23
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 207023,
-"ratio": 0.201,
-"compress_mbps": 3.42,
-"decompress_mbps": 1006.36
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 174124,
-"ratio": 0.408,
-"compress_mbps": 122.72,
-"decompress_mbps": 394.72
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 166150,
-"ratio": 0.3893,
-"compress_mbps": 104.19,
-"decompress_mbps": 403.73
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 158784,
-"ratio": 0.3721,
-"compress_mbps": 69.75,
-"decompress_mbps": 423.34
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 152782,
-"ratio": 0.358,
-"compress_mbps": 72.52,
-"decompress_mbps": 410.75
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 147196,
-"ratio": 0.3449,
-"compress_mbps": 42.79,
-"decompress_mbps": 404.52
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144898,
-"ratio": 0.3395,
-"compress_mbps": 26.12,
-"decompress_mbps": 414.24
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144589,
-"ratio": 0.3388,
-"compress_mbps": 22.68,
-"decompress_mbps": 416.65
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144436,
-"ratio": 0.3385,
-"compress_mbps": 19.51,
-"decompress_mbps": 415.99
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 144433,
-"ratio": 0.3384,
-"compress_mbps": 19.45,
-"decompress_mbps": 417.23
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 228883,
-"ratio": 0.475,
-"compress_mbps": 107.18,
-"decompress_mbps": 367.93
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 219047,
-"ratio": 0.4546,
-"compress_mbps": 90.23,
-"decompress_mbps": 388.32
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 209408,
-"ratio": 0.4346,
-"compress_mbps": 55.01,
-"decompress_mbps": 402.18
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 205916,
-"ratio": 0.4273,
-"compress_mbps": 61.06,
-"decompress_mbps": 378.11
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 199188,
-"ratio": 0.4134,
-"compress_mbps": 32.51,
-"decompress_mbps": 357.49
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 195255,
-"ratio": 0.4052,
-"compress_mbps": 19.19,
-"decompress_mbps": 365.87
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 194657,
-"ratio": 0.404,
-"compress_mbps": 16.26,
-"decompress_mbps": 370.27
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 194326,
-"ratio": 0.4033,
-"compress_mbps": 12.87,
-"decompress_mbps": 369.51
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 194326,
-"ratio": 0.4033,
-"compress_mbps": 12.86,
-"decompress_mbps": 368.77
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 65553,
-"ratio": 0.1277,
-"compress_mbps": 270.76,
-"decompress_mbps": 887.65
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 63891,
-"ratio": 0.1245,
-"compress_mbps": 244.47,
-"decompress_mbps": 914.86
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 62515,
-"ratio": 0.1218,
-"compress_mbps": 192.65,
-"decompress_mbps": 975.16
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 58451,
-"ratio": 0.1139,
-"compress_mbps": 165.93,
-"decompress_mbps": 700.13
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 57410,
-"ratio": 0.1119,
-"compress_mbps": 127.99,
-"decompress_mbps": 729.11
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 56459,
-"ratio": 0.11,
-"compress_mbps": 76.24,
-"decompress_mbps": 776.91
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 55358,
-"ratio": 0.1079,
-"compress_mbps": 59.79,
-"decompress_mbps": 811.68
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 52991,
-"ratio": 0.1033,
-"compress_mbps": 27.34,
-"decompress_mbps": 869.38
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 52215,
-"ratio": 0.1017,
-"compress_mbps": 9.78,
-"decompress_mbps": 885.29
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14112,
-"ratio": 0.369,
-"compress_mbps": 126.86,
-"decompress_mbps": 938.48
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13815,
-"ratio": 0.3613,
-"compress_mbps": 108.59,
-"decompress_mbps": 972.73
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13795,
-"ratio": 0.3607,
-"compress_mbps": 78.26,
-"decompress_mbps": 1006.69
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13375,
-"ratio": 0.3498,
-"compress_mbps": 78.79,
-"decompress_mbps": 1002.93
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13062,
-"ratio": 0.3416,
-"compress_mbps": 54.73,
-"decompress_mbps": 1036.92
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 12984,
-"ratio": 0.3395,
-"compress_mbps": 32.66,
-"decompress_mbps": 1055.99
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12949,
-"ratio": 0.3386,
-"compress_mbps": 25.15,
-"decompress_mbps": 1058.41
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12894,
-"ratio": 0.3372,
-"compress_mbps": 11.0,
-"decompress_mbps": 1075.8
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12832,
-"ratio": 0.3356,
-"compress_mbps": 5.07,
-"decompress_mbps": 1079.24
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1846,
-"ratio": 0.4367,
-"compress_mbps": 283.59,
-"decompress_mbps": 702.3
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1820,
-"ratio": 0.4306,
-"compress_mbps": 277.73,
-"decompress_mbps": 715.13
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1808,
-"ratio": 0.4277,
-"compress_mbps": 266.72,
-"decompress_mbps": 727.13
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1749,
-"ratio": 0.4138,
-"compress_mbps": 219.22,
-"decompress_mbps": 738.04
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 192.41,
-"decompress_mbps": 738.99
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 189.68,
-"decompress_mbps": 742.8
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 187.57,
-"decompress_mbps": 744.31
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 187.65,
-"decompress_mbps": 743.49
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 187.65,
-"decompress_mbps": 743.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 76470,
-"ratio": 0.5028,
-"compress_mbps": 158.4,
-"decompress_mbps": 441.68
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 62765,
-"ratio": 0.4127,
-"compress_mbps": 134.17,
-"decompress_mbps": 493.24
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 57162,
-"ratio": 0.3758,
-"compress_mbps": 72.41,
-"decompress_mbps": 551.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56826,
-"ratio": 0.3736,
-"compress_mbps": 64.46,
-"decompress_mbps": 541.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 55696,
-"ratio": 0.3662,
-"compress_mbps": 46.93,
-"decompress_mbps": 530.39
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54440,
-"ratio": 0.3579,
-"compress_mbps": 26.6,
-"decompress_mbps": 545.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54283,
-"ratio": 0.3569,
-"compress_mbps": 22.45,
-"decompress_mbps": 543.55
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54221,
-"ratio": 0.3565,
-"compress_mbps": 19.76,
-"decompress_mbps": 543.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54217,
-"ratio": 0.3565,
-"compress_mbps": 19.53,
-"decompress_mbps": 544.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 64926,
-"ratio": 0.5187,
-"compress_mbps": 152.25,
-"decompress_mbps": 420.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 54985,
-"ratio": 0.4393,
-"compress_mbps": 125.92,
-"decompress_mbps": 469.17
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51148,
-"ratio": 0.4086,
-"compress_mbps": 67.29,
-"decompress_mbps": 535.86
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50599,
-"ratio": 0.4042,
-"compress_mbps": 59.25,
-"decompress_mbps": 522.61
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 49775,
-"ratio": 0.3976,
-"compress_mbps": 42.72,
-"decompress_mbps": 511.1
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48967,
-"ratio": 0.3912,
-"compress_mbps": 25.0,
-"decompress_mbps": 524.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48870,
-"ratio": 0.3904,
-"compress_mbps": 22.19,
-"decompress_mbps": 521.5
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48845,
-"ratio": 0.3902,
-"compress_mbps": 20.94,
-"decompress_mbps": 523.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48845,
-"ratio": 0.3902,
-"compress_mbps": 20.94,
-"decompress_mbps": 521.37
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 10024,
-"ratio": 0.4074,
-"compress_mbps": 568.12,
-"decompress_mbps": 903.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8577,
-"ratio": 0.3486,
-"compress_mbps": 258.71,
-"decompress_mbps": 925.17
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8168,
-"ratio": 0.332,
-"compress_mbps": 156.4,
-"decompress_mbps": 944.88
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8069,
-"ratio": 0.328,
-"compress_mbps": 115.51,
-"decompress_mbps": 964.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7997,
-"ratio": 0.325,
-"compress_mbps": 100.83,
-"decompress_mbps": 996.36
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7952,
-"ratio": 0.3232,
-"compress_mbps": 75.23,
-"decompress_mbps": 1002.32
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7947,
-"ratio": 0.323,
-"compress_mbps": 72.08,
-"decompress_mbps": 1006.79
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7947,
-"ratio": 0.323,
-"compress_mbps": 71.45,
-"decompress_mbps": 1004.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7947,
-"ratio": 0.323,
-"compress_mbps": 71.03,
-"decompress_mbps": 1007.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 4061,
-"ratio": 0.3642,
-"compress_mbps": 504.75,
-"decompress_mbps": 855.19
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3446,
-"ratio": 0.3091,
-"compress_mbps": 305.07,
-"decompress_mbps": 896.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3201,
-"ratio": 0.2871,
-"compress_mbps": 231.97,
-"decompress_mbps": 926.66
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 194.23,
-"decompress_mbps": 954.53
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3139,
-"ratio": 0.2815,
-"compress_mbps": 162.92,
-"decompress_mbps": 966.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3115,
-"ratio": 0.2794,
-"compress_mbps": 115.76,
-"decompress_mbps": 981.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 106.21,
-"decompress_mbps": 982.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 103.08,
-"decompress_mbps": 982.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 102.7,
-"decompress_mbps": 984.12
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1410,
-"ratio": 0.3789,
-"compress_mbps": 365.54,
-"decompress_mbps": 589.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1262,
-"ratio": 0.3392,
-"compress_mbps": 232.57,
-"decompress_mbps": 596.51
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1238,
-"ratio": 0.3327,
-"compress_mbps": 207.41,
-"decompress_mbps": 598.02
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1219,
-"ratio": 0.3276,
-"compress_mbps": 177.25,
-"decompress_mbps": 615.87
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 162.53,
-"decompress_mbps": 619.52
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 147.56,
-"decompress_mbps": 626.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 147.05,
-"decompress_mbps": 628.3
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 146.41,
-"decompress_mbps": 623.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 146.72,
-"decompress_mbps": 626.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 274412,
-"ratio": 0.2665,
-"compress_mbps": 451.96,
-"decompress_mbps": 792.76
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 213239,
-"ratio": 0.2071,
-"compress_mbps": 276.99,
-"decompress_mbps": 896.16
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 232107,
-"ratio": 0.2254,
-"compress_mbps": 137.1,
-"decompress_mbps": 940.9
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 202733,
-"ratio": 0.1969,
-"compress_mbps": 129.88,
-"decompress_mbps": 947.59
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 207803,
-"ratio": 0.2018,
-"compress_mbps": 84.12,
-"decompress_mbps": 955.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 205270,
-"ratio": 0.1993,
-"compress_mbps": 27.21,
-"decompress_mbps": 983.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 209951,
-"ratio": 0.2039,
-"compress_mbps": 19.28,
-"decompress_mbps": 995.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 209656,
-"ratio": 0.2036,
-"compress_mbps": 12.21,
-"decompress_mbps": 1007.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 209189,
-"ratio": 0.2031,
-"compress_mbps": 8.94,
-"decompress_mbps": 1011.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 208640,
-"ratio": 0.4889,
-"compress_mbps": 155.63,
-"decompress_mbps": 425.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 167329,
-"ratio": 0.3921,
-"compress_mbps": 139.25,
-"decompress_mbps": 466.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 151097,
-"ratio": 0.3541,
-"compress_mbps": 73.66,
-"decompress_mbps": 512.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 150035,
-"ratio": 0.3516,
-"compress_mbps": 66.53,
-"decompress_mbps": 512.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 147375,
-"ratio": 0.3453,
-"compress_mbps": 48.17,
-"decompress_mbps": 508.36
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144908,
-"ratio": 0.3396,
-"compress_mbps": 28.07,
-"decompress_mbps": 519.9
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144562,
-"ratio": 0.3387,
-"compress_mbps": 24.64,
-"decompress_mbps": 519.53
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144449,
-"ratio": 0.3385,
-"compress_mbps": 22.41,
-"decompress_mbps": 518.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 144438,
-"ratio": 0.3385,
-"compress_mbps": 22.31,
-"decompress_mbps": 520.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 264549,
-"ratio": 0.549,
-"compress_mbps": 134.75,
-"decompress_mbps": 378.48
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 223724,
-"ratio": 0.4643,
-"compress_mbps": 119.83,
-"decompress_mbps": 423.57
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 204825,
-"ratio": 0.4251,
-"compress_mbps": 60.68,
-"decompress_mbps": 479.4
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 203945,
-"ratio": 0.4232,
-"compress_mbps": 54.03,
-"decompress_mbps": 473.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 199780,
-"ratio": 0.4146,
-"compress_mbps": 37.91,
-"decompress_mbps": 457.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 195417,
-"ratio": 0.4055,
-"compress_mbps": 21.17,
-"decompress_mbps": 468.52
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 194796,
-"ratio": 0.4043,
-"compress_mbps": 17.87,
-"decompress_mbps": 468.56
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 194543,
-"ratio": 0.4037,
-"compress_mbps": 15.69,
-"decompress_mbps": 466.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 194460,
-"ratio": 0.4036,
-"compress_mbps": 15.02,
-"decompress_mbps": 468.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 67436,
-"ratio": 0.1314,
-"compress_mbps": 624.79,
-"decompress_mbps": 1014.95
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 59257,
-"ratio": 0.1155,
-"compress_mbps": 280.41,
-"decompress_mbps": 1070.32
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 58316,
-"ratio": 0.1136,
-"compress_mbps": 181.54,
-"decompress_mbps": 1155.66
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 56291,
-"ratio": 0.1097,
-"compress_mbps": 185.33,
-"decompress_mbps": 1156.45
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 56220,
-"ratio": 0.1095,
-"compress_mbps": 146.23,
-"decompress_mbps": 1221.77
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55972,
-"ratio": 0.1091,
-"compress_mbps": 74.43,
-"decompress_mbps": 1279.83
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 55121,
-"ratio": 0.1074,
-"compress_mbps": 52.02,
-"decompress_mbps": 1313.02
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 54124,
-"ratio": 0.1055,
-"compress_mbps": 36.63,
-"decompress_mbps": 1384.59
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 53699,
-"ratio": 0.1046,
-"compress_mbps": 28.6,
-"decompress_mbps": 1419.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 15612,
-"ratio": 0.4083,
-"compress_mbps": 513.22,
-"decompress_mbps": 851.77
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 14133,
-"ratio": 0.3696,
-"compress_mbps": 147.1,
-"decompress_mbps": 887.42
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13341,
-"ratio": 0.3489,
-"compress_mbps": 89.31,
-"decompress_mbps": 908.8
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13289,
-"ratio": 0.3475,
-"compress_mbps": 84.3,
-"decompress_mbps": 936.07
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13052,
-"ratio": 0.3413,
-"compress_mbps": 67.06,
-"decompress_mbps": 977.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 12996,
-"ratio": 0.3399,
-"compress_mbps": 37.22,
-"decompress_mbps": 989.22
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12972,
-"ratio": 0.3392,
-"compress_mbps": 27.24,
-"decompress_mbps": 991.21
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12951,
-"ratio": 0.3387,
-"compress_mbps": 19.02,
-"decompress_mbps": 997.52
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12933,
-"ratio": 0.3382,
-"compress_mbps": 14.85,
-"decompress_mbps": 995.65
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1988,
-"ratio": 0.4703,
-"compress_mbps": 341.39,
-"decompress_mbps": 537.63
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1802,
-"ratio": 0.4263,
-"compress_mbps": 216.2,
-"decompress_mbps": 543.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 205.95,
-"decompress_mbps": 551.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1732,
-"ratio": 0.4097,
-"compress_mbps": 170.53,
-"decompress_mbps": 569.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 166.21,
-"decompress_mbps": 575.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 165.97,
-"decompress_mbps": 573.59
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 166.38,
-"decompress_mbps": 573.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 166.6,
-"decompress_mbps": 574.98
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 165.5,
-"decompress_mbps": 573.92
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 59790,
-"ratio": 0.3931,
-"compress_mbps": 262.44,
-"decompress_mbps": 995.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 57173,
-"ratio": 0.3759,
-"compress_mbps": 180.16,
-"decompress_mbps": 1085.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 56189,
-"ratio": 0.3694,
-"compress_mbps": 150.25,
-"decompress_mbps": 1161.44
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 55816,
-"ratio": 0.367,
-"compress_mbps": 137.76,
-"decompress_mbps": 1193.82
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54758,
-"ratio": 0.36,
-"compress_mbps": 108.39,
-"decompress_mbps": 1248.74
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54220,
-"ratio": 0.3565,
-"compress_mbps": 83.3,
-"decompress_mbps": 1295.46
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 53801,
-"ratio": 0.3537,
-"compress_mbps": 60.28,
-"decompress_mbps": 1295.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 53573,
-"ratio": 0.3522,
-"compress_mbps": 39.0,
-"decompress_mbps": 1301.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 53546,
-"ratio": 0.3521,
-"compress_mbps": 34.47,
-"decompress_mbps": 1304.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 52276,
-"ratio": 0.4176,
-"compress_mbps": 243.11,
-"decompress_mbps": 954.22
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 50534,
-"ratio": 0.4037,
-"compress_mbps": 167.92,
-"decompress_mbps": 1003.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 49919,
-"ratio": 0.3988,
-"compress_mbps": 141.26,
-"decompress_mbps": 1069.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 49715,
-"ratio": 0.3972,
-"compress_mbps": 131.37,
-"decompress_mbps": 1107.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48735,
-"ratio": 0.3893,
-"compress_mbps": 100.57,
-"decompress_mbps": 1154.14
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48422,
-"ratio": 0.3868,
-"compress_mbps": 79.35,
-"decompress_mbps": 1182.43
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48249,
-"ratio": 0.3854,
-"compress_mbps": 61.02,
-"decompress_mbps": 1185.24
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 47977,
-"ratio": 0.3833,
-"compress_mbps": 42.89,
-"decompress_mbps": 1178.17
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 47971,
-"ratio": 0.3832,
-"compress_mbps": 41.02,
-"decompress_mbps": 1176.31
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8385,
-"ratio": 0.3408,
-"compress_mbps": 688.37,
-"decompress_mbps": 933.56
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8380,
-"ratio": 0.3406,
-"compress_mbps": 436.65,
-"decompress_mbps": 968.92
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8286,
-"ratio": 0.3368,
-"compress_mbps": 402.96,
-"decompress_mbps": 1002.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8163,
-"ratio": 0.3318,
-"compress_mbps": 374.46,
-"decompress_mbps": 1038.24
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8053,
-"ratio": 0.3273,
-"compress_mbps": 333.9,
-"decompress_mbps": 1053.39
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7986,
-"ratio": 0.3246,
-"compress_mbps": 277.12,
-"decompress_mbps": 1062.21
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7954,
-"ratio": 0.3233,
-"compress_mbps": 190.83,
-"decompress_mbps": 1075.41
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7916,
-"ratio": 0.3217,
-"compress_mbps": 128.54,
-"decompress_mbps": 1081.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7916,
-"ratio": 0.3217,
-"compress_mbps": 124.64,
-"decompress_mbps": 1081.41
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3401,
-"ratio": 0.305,
-"compress_mbps": 584.35,
-"decompress_mbps": 759.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3307,
-"ratio": 0.2966,
-"compress_mbps": 397.36,
-"decompress_mbps": 835.64
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3242,
-"ratio": 0.2908,
-"compress_mbps": 368.54,
-"decompress_mbps": 856.36
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3205,
-"ratio": 0.2874,
-"compress_mbps": 350.5,
-"decompress_mbps": 885.53
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3150,
-"ratio": 0.2825,
-"compress_mbps": 312.13,
-"decompress_mbps": 895.9
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3126,
-"ratio": 0.2804,
-"compress_mbps": 263.64,
-"decompress_mbps": 898.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3106,
-"ratio": 0.2786,
-"compress_mbps": 207.09,
-"decompress_mbps": 903.44
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3102,
-"ratio": 0.2782,
-"compress_mbps": 146.67,
-"decompress_mbps": 910.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3102,
-"ratio": 0.2782,
-"compress_mbps": 139.8,
-"decompress_mbps": 893.34
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1251,
-"ratio": 0.3362,
-"compress_mbps": 380.55,
-"decompress_mbps": 458.72
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1228,
-"ratio": 0.33,
-"compress_mbps": 267.03,
-"decompress_mbps": 427.44
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1219,
-"ratio": 0.3276,
-"compress_mbps": 260.16,
-"decompress_mbps": 492.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1220,
-"ratio": 0.3279,
-"compress_mbps": 254.05,
-"decompress_mbps": 442.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 240.05,
-"decompress_mbps": 485.85
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 222.61,
-"decompress_mbps": 475.43
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 202.79,
-"decompress_mbps": 485.98
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1204,
-"ratio": 0.3236,
-"compress_mbps": 166.06,
-"decompress_mbps": 487.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1204,
-"ratio": 0.3236,
-"compress_mbps": 165.63,
-"decompress_mbps": 485.85
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 221813,
-"ratio": 0.2154,
-"compress_mbps": 588.25,
-"decompress_mbps": 1014.19
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 199825,
-"ratio": 0.1941,
-"compress_mbps": 409.13,
-"decompress_mbps": 1475.95
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 195675,
-"ratio": 0.19,
-"compress_mbps": 282.82,
-"decompress_mbps": 1547.08
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 195664,
-"ratio": 0.19,
-"compress_mbps": 279.93,
-"decompress_mbps": 1557.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 198900,
-"ratio": 0.1932,
-"compress_mbps": 238.25,
-"decompress_mbps": 1138.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 199347,
-"ratio": 0.1936,
-"compress_mbps": 203.38,
-"decompress_mbps": 1137.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 199777,
-"ratio": 0.194,
-"compress_mbps": 123.06,
-"decompress_mbps": 1199.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 182094,
-"ratio": 0.1768,
-"compress_mbps": 25.58,
-"decompress_mbps": 1183.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 181451,
-"ratio": 0.1762,
-"compress_mbps": 13.6,
-"decompress_mbps": 1190.57
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 159063,
-"ratio": 0.3727,
-"compress_mbps": 263.48,
-"decompress_mbps": 1034.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 152115,
-"ratio": 0.3564,
-"compress_mbps": 186.89,
-"decompress_mbps": 1118.79
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 149162,
-"ratio": 0.3495,
-"compress_mbps": 156.66,
-"decompress_mbps": 1200.34
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 148359,
-"ratio": 0.3476,
-"compress_mbps": 142.85,
-"decompress_mbps": 1057.83
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145353,
-"ratio": 0.3406,
-"compress_mbps": 112.92,
-"decompress_mbps": 1024.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144209,
-"ratio": 0.3379,
-"compress_mbps": 87.37,
-"decompress_mbps": 1060.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 143604,
-"ratio": 0.3365,
-"compress_mbps": 66.48,
-"decompress_mbps": 1068.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 142086,
-"ratio": 0.3329,
-"compress_mbps": 44.17,
-"decompress_mbps": 1056.99
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 142027,
-"ratio": 0.3328,
-"compress_mbps": 40.43,
-"decompress_mbps": 1069.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 210662,
-"ratio": 0.4372,
-"compress_mbps": 229.19,
-"decompress_mbps": 879.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 202881,
-"ratio": 0.421,
-"compress_mbps": 158.88,
-"decompress_mbps": 948.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 200409,
-"ratio": 0.4159,
-"compress_mbps": 133.25,
-"decompress_mbps": 1027.43
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 199678,
-"ratio": 0.4144,
-"compress_mbps": 123.52,
-"decompress_mbps": 863.69
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 195798,
-"ratio": 0.4063,
-"compress_mbps": 93.63,
-"decompress_mbps": 814.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 194029,
-"ratio": 0.4027,
-"compress_mbps": 71.92,
-"decompress_mbps": 839.22
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 192773,
-"ratio": 0.4001,
-"compress_mbps": 51.4,
-"decompress_mbps": 844.46
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 191739,
-"ratio": 0.3979,
-"compress_mbps": 33.65,
-"decompress_mbps": 833.43
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 191676,
-"ratio": 0.3978,
-"compress_mbps": 31.03,
-"decompress_mbps": 842.91
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 58079,
-"ratio": 0.1132,
-"compress_mbps": 373.41,
-"decompress_mbps": 1709.49
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 57838,
-"ratio": 0.1127,
-"compress_mbps": 414.45,
-"decompress_mbps": 1817.42
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 57554,
-"ratio": 0.1121,
-"compress_mbps": 393.38,
-"decompress_mbps": 1908.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 57064,
-"ratio": 0.1112,
-"compress_mbps": 373.3,
-"decompress_mbps": 1753.82
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 55743,
-"ratio": 0.1086,
-"compress_mbps": 342.67,
-"decompress_mbps": 1804.91
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55102,
-"ratio": 0.1074,
-"compress_mbps": 283.74,
-"decompress_mbps": 1901.37
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 54742,
-"ratio": 0.1067,
-"compress_mbps": 191.84,
-"decompress_mbps": 1927.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 53133,
-"ratio": 0.1035,
-"compress_mbps": 102.41,
-"decompress_mbps": 2011.92
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 52186,
-"ratio": 0.1017,
-"compress_mbps": 72.07,
-"decompress_mbps": 2064.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14122,
-"ratio": 0.3693,
-"compress_mbps": 644.49,
-"decompress_mbps": 829.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13374,
-"ratio": 0.3497,
-"compress_mbps": 376.73,
-"decompress_mbps": 889.98
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13293,
-"ratio": 0.3476,
-"compress_mbps": 269.35,
-"decompress_mbps": 978.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13259,
-"ratio": 0.3467,
-"compress_mbps": 259.3,
-"decompress_mbps": 977.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 12641,
-"ratio": 0.3306,
-"compress_mbps": 187.51,
-"decompress_mbps": 1014.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 12432,
-"ratio": 0.3251,
-"compress_mbps": 163.06,
-"decompress_mbps": 1033.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12439,
-"ratio": 0.3253,
-"compress_mbps": 123.56,
-"decompress_mbps": 1039.91
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12579,
-"ratio": 0.3289,
-"compress_mbps": 67.21,
-"decompress_mbps": 1052.88
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12574,
-"ratio": 0.3288,
-"compress_mbps": 47.27,
-"decompress_mbps": 1058.65
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1777,
-"ratio": 0.4204,
-"compress_mbps": 383.7,
-"decompress_mbps": 407.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1756,
-"ratio": 0.4154,
-"compress_mbps": 256.0,
-"decompress_mbps": 398.65
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1746,
-"ratio": 0.4131,
-"compress_mbps": 254.7,
-"decompress_mbps": 434.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1740,
-"ratio": 0.4116,
-"compress_mbps": 252.15,
-"decompress_mbps": 439.56
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1722,
-"ratio": 0.4074,
-"compress_mbps": 239.28,
-"decompress_mbps": 452.69
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1721,
-"ratio": 0.4071,
-"compress_mbps": 235.38,
-"decompress_mbps": 450.46
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 233.8,
-"decompress_mbps": 448.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1717,
-"ratio": 0.4062,
-"compress_mbps": 212.53,
-"decompress_mbps": 448.66
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1717,
-"ratio": 0.4062,
-"compress_mbps": 212.57,
-"decompress_mbps": 455.96
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 51455,
-"ratio": 0.3383,
-"compress_mbps": 0.69,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 46328,
-"ratio": 0.3701,
-"compress_mbps": 0.42,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7697,
-"ratio": 0.3128,
-"compress_mbps": 0.68,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3002,
-"ratio": 0.2692,
-"compress_mbps": 0.58,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1179,
-"ratio": 0.3169,
-"compress_mbps": 0.07,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 176105,
-"ratio": 0.171,
-"compress_mbps": 0.25,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 137229,
-"ratio": 0.3216,
-"compress_mbps": 0.79,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 184475,
-"ratio": 0.3828,
-"compress_mbps": 0.77,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 48558,
-"ratio": 0.0946,
-"compress_mbps": 0.39,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 11587,
-"ratio": 0.303,
-"compress_mbps": 0.05,
-"decompress_mbps": null
-},
-{
-"compressor": "zopfli",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1688,
-"ratio": 0.3993,
-"compress_mbps": 0.73,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 5364132,
-"ratio": 0.5263,
-"compress_mbps": 12.9,
-"decompress_mbps": 81.52
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 5165701,
-"ratio": 0.5068,
-"compress_mbps": 11.35,
-"decompress_mbps": 88.58
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 5046240,
-"ratio": 0.4951,
-"compress_mbps": 9.91,
-"decompress_mbps": 96.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4889382,
-"ratio": 0.4797,
-"compress_mbps": 6.05,
-"decompress_mbps": 96.44
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 4867273,
-"ratio": 0.4775,
-"compress_mbps": 5.57,
-"decompress_mbps": 98.93
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 4832420,
-"ratio": 0.4741,
-"compress_mbps": 4.71,
-"decompress_mbps": 101.78
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3922973,
-"ratio": 0.3849,
-"compress_mbps": 1.51,
-"decompress_mbps": 100.71
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3919702,
-"ratio": 0.3846,
-"compress_mbps": 1.44,
-"decompress_mbps": 100.56
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3919665,
-"ratio": 0.3846,
-"compress_mbps": 1.44,
-"decompress_mbps": 100.1
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20729473,
-"ratio": 0.4047,
-"compress_mbps": 18.65,
-"decompress_mbps": 72.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20500337,
-"ratio": 0.4002,
-"compress_mbps": 17.1,
-"decompress_mbps": 74.71
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 20349978,
-"ratio": 0.3973,
-"compress_mbps": 15.3,
-"decompress_mbps": 77.73
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19952001,
-"ratio": 0.3895,
-"compress_mbps": 9.01,
-"decompress_mbps": 78.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19925043,
-"ratio": 0.389,
-"compress_mbps": 8.08,
-"decompress_mbps": 82.86
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19882104,
-"ratio": 0.3882,
-"compress_mbps": 6.13,
-"decompress_mbps": 85.11
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19004928,
-"ratio": 0.371,
-"compress_mbps": 1.47,
-"decompress_mbps": 83.44
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19002295,
-"ratio": 0.371,
-"compress_mbps": 1.16,
-"decompress_mbps": 85.22
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19000618,
-"ratio": 0.371,
-"compress_mbps": 0.9,
-"decompress_mbps": 85.01
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 4668650,
-"ratio": 0.4682,
-"compress_mbps": 18.08,
-"decompress_mbps": 74.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 4570500,
-"ratio": 0.4584,
-"compress_mbps": 16.25,
-"decompress_mbps": 77.46
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 4510300,
-"ratio": 0.4524,
-"compress_mbps": 14.35,
-"decompress_mbps": 80.38
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 4369955,
-"ratio": 0.4383,
-"compress_mbps": 8.56,
-"decompress_mbps": 74.15
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 4360147,
-"ratio": 0.4373,
-"compress_mbps": 7.71,
-"decompress_mbps": 76.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 4349427,
-"ratio": 0.4362,
-"compress_mbps": 5.72,
-"decompress_mbps": 77.61
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3678637,
-"ratio": 0.3689,
-"compress_mbps": 1.37,
-"decompress_mbps": 78.57
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3680111,
-"ratio": 0.3691,
-"compress_mbps": 1.05,
-"decompress_mbps": 78.32
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3679584,
-"ratio": 0.369,
-"compress_mbps": 0.83,
-"decompress_mbps": 78.03
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4705330,
-"ratio": 0.1402,
-"compress_mbps": 40.71,
-"decompress_mbps": 263.83
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4457802,
-"ratio": 0.1329,
-"compress_mbps": 35.39,
-"decompress_mbps": 306.73
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 4241801,
-"ratio": 0.1264,
-"compress_mbps": 29.91,
-"decompress_mbps": 332.06
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3946147,
-"ratio": 0.1176,
-"compress_mbps": 17.27,
-"decompress_mbps": 337.23
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3917350,
-"ratio": 0.1167,
-"compress_mbps": 15.45,
-"decompress_mbps": 365.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3871740,
-"ratio": 0.1154,
-"compress_mbps": 11.61,
-"decompress_mbps": 387.03
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3256646,
-"ratio": 0.0971,
-"compress_mbps": 2.89,
-"decompress_mbps": 352.8
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3232193,
-"ratio": 0.0963,
-"compress_mbps": 2.13,
-"decompress_mbps": 371.13
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3211270,
-"ratio": 0.0957,
-"compress_mbps": 1.63,
-"decompress_mbps": 367.4
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3632401,
-"ratio": 0.5904,
-"compress_mbps": 13.63,
-"decompress_mbps": 49.99
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3594843,
-"ratio": 0.5843,
-"compress_mbps": 12.78,
-"decompress_mbps": 51.1
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3570380,
-"ratio": 0.5803,
-"compress_mbps": 11.74,
-"decompress_mbps": 54.22
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3475962,
-"ratio": 0.565,
-"compress_mbps": 8.02,
-"decompress_mbps": 53.96
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3470919,
-"ratio": 0.5642,
-"compress_mbps": 7.42,
-"decompress_mbps": 55.6
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3462594,
-"ratio": 0.5628,
-"compress_mbps": 6.26,
-"decompress_mbps": 56.71
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3100878,
-"ratio": 0.504,
-"compress_mbps": 1.68,
-"decompress_mbps": 57.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3099704,
-"ratio": 0.5038,
-"compress_mbps": 1.49,
-"decompress_mbps": 57.87
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3098139,
-"ratio": 0.5036,
-"compress_mbps": 1.38,
-"decompress_mbps": 57.79
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3889230,
-"ratio": 0.3856,
-"compress_mbps": 20.75,
-"decompress_mbps": 69.69
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3811489,
-"ratio": 0.3779,
-"compress_mbps": 19.03,
-"decompress_mbps": 70.75
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3789217,
-"ratio": 0.3757,
-"compress_mbps": 18.39,
-"decompress_mbps": 72.73
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3742155,
-"ratio": 0.371,
-"compress_mbps": 13.9,
-"decompress_mbps": 71.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3734147,
-"ratio": 0.3702,
-"compress_mbps": 13.23,
-"decompress_mbps": 71.04
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3723457,
-"ratio": 0.3692,
-"compress_mbps": 11.72,
-"decompress_mbps": 71.35
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3723087,
-"ratio": 0.3691,
-"compress_mbps": 2.9,
-"decompress_mbps": 71.7
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3723909,
-"ratio": 0.3692,
-"compress_mbps": 2.73,
-"decompress_mbps": 70.43
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3723909,
-"ratio": 0.3692,
-"compress_mbps": 2.74,
-"decompress_mbps": 70.53
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2592263,
-"ratio": 0.3912,
-"compress_mbps": 16.15,
-"decompress_mbps": 98.15
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2479835,
-"ratio": 0.3742,
-"compress_mbps": 13.84,
-"decompress_mbps": 107.71
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2405060,
-"ratio": 0.3629,
-"compress_mbps": 11.6,
-"decompress_mbps": 119.06
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2257758,
-"ratio": 0.3407,
-"compress_mbps": 6.51,
-"decompress_mbps": 118.75
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 2239545,
-"ratio": 0.3379,
-"compress_mbps": 5.57,
-"decompress_mbps": 126.46
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 2207053,
-"ratio": 0.333,
-"compress_mbps": 3.92,
-"decompress_mbps": 128.96
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1865730,
-"ratio": 0.2815,
-"compress_mbps": 1.06,
-"decompress_mbps": 134.67
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1860184,
-"ratio": 0.2807,
-"compress_mbps": 0.86,
-"decompress_mbps": 132.22
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1858631,
-"ratio": 0.2805,
-"compress_mbps": 0.74,
-"decompress_mbps": 131.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6185865,
-"ratio": 0.2863,
-"compress_mbps": 24.72,
-"decompress_mbps": 132.01
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 6066146,
-"ratio": 0.2808,
-"compress_mbps": 21.83,
-"decompress_mbps": 138.84
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5993070,
-"ratio": 0.2774,
-"compress_mbps": 18.74,
-"decompress_mbps": 142.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5847650,
-"ratio": 0.2706,
-"compress_mbps": 11.33,
-"decompress_mbps": 146.4
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5837234,
-"ratio": 0.2702,
-"compress_mbps": 10.42,
-"decompress_mbps": 149.45
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5823141,
-"ratio": 0.2695,
-"compress_mbps": 8.6,
-"decompress_mbps": 153.32
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5455440,
-"ratio": 0.2525,
-"compress_mbps": 2.35,
-"decompress_mbps": 153.6
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5450250,
-"ratio": 0.2523,
-"compress_mbps": 1.94,
-"decompress_mbps": 151.46
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5449052,
-"ratio": 0.2522,
-"compress_mbps": 1.61,
-"decompress_mbps": 154.04
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5514279,
-"ratio": 0.7604,
-"compress_mbps": 12.95,
-"decompress_mbps": 52.18
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5472540,
-"ratio": 0.7546,
-"compress_mbps": 12.07,
-"decompress_mbps": 55.43
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5448811,
-"ratio": 0.7514,
-"compress_mbps": 11.0,
-"decompress_mbps": 54.42
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5375802,
-"ratio": 0.7413,
-"compress_mbps": 7.24,
-"decompress_mbps": 57.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5370794,
-"ratio": 0.7406,
-"compress_mbps": 6.67,
-"decompress_mbps": 55.17
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5362339,
-"ratio": 0.7394,
-"compress_mbps": 5.67,
-"decompress_mbps": 57.57
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5358816,
-"ratio": 0.7389,
-"compress_mbps": 1.54,
-"decompress_mbps": 58.43
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5358607,
-"ratio": 0.7389,
-"compress_mbps": 1.52,
-"decompress_mbps": 54.57
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5358607,
-"ratio": 0.7389,
-"compress_mbps": 1.53,
-"decompress_mbps": 57.21
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 16232235,
-"ratio": 0.3915,
-"compress_mbps": 16.92,
-"decompress_mbps": 104.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 15659043,
-"ratio": 0.3777,
-"compress_mbps": 15.37,
-"decompress_mbps": 112.48
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 15341951,
-"ratio": 0.3701,
-"compress_mbps": 13.58,
-"decompress_mbps": 119.87
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 14794018,
-"ratio": 0.3568,
-"compress_mbps": 8.42,
-"decompress_mbps": 119.37
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 14735437,
-"ratio": 0.3554,
-"compress_mbps": 7.63,
-"decompress_mbps": 123.74
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 14635001,
-"ratio": 0.353,
-"compress_mbps": 6.16,
-"decompress_mbps": 126.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12345372,
-"ratio": 0.2978,
-"compress_mbps": 1.85,
-"decompress_mbps": 125.4
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12327847,
-"ratio": 0.2974,
-"compress_mbps": 1.74,
-"decompress_mbps": 127.7
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12327819,
-"ratio": 0.2974,
-"compress_mbps": 1.73,
-"decompress_mbps": 127.43
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 7300743,
-"ratio": 0.8615,
-"compress_mbps": 11.96,
-"decompress_mbps": 40.7
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 7258514,
-"ratio": 0.8565,
-"compress_mbps": 10.65,
-"decompress_mbps": 43.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 5983501,
-"ratio": 0.7061,
-"compress_mbps": 10.56,
-"decompress_mbps": 46.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 5965382,
-"ratio": 0.7039,
-"compress_mbps": 8.75,
-"decompress_mbps": 42.45
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 5964821,
-"ratio": 0.7039,
-"compress_mbps": 8.75,
-"decompress_mbps": 43.47
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5964654,
-"ratio": 0.7039,
-"compress_mbps": 8.56,
-"decompress_mbps": 44.2
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5964649,
-"ratio": 0.7039,
-"compress_mbps": 2.37,
-"decompress_mbps": 43.35
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5964649,
-"ratio": 0.7039,
-"compress_mbps": 2.39,
-"decompress_mbps": 44.18
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5964649,
-"ratio": 0.7039,
-"compress_mbps": 2.36,
-"decompress_mbps": 43.66
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 968373,
-"ratio": 0.1812,
-"compress_mbps": 33.81,
-"decompress_mbps": 200.17
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 912756,
-"ratio": 0.1708,
-"compress_mbps": 29.82,
-"decompress_mbps": 217.6
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 875269,
-"ratio": 0.1637,
-"compress_mbps": 25.45,
-"decompress_mbps": 240.65
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 826760,
-"ratio": 0.1547,
-"compress_mbps": 14.51,
-"decompress_mbps": 235.48
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 818408,
-"ratio": 0.1531,
-"compress_mbps": 13.13,
-"decompress_mbps": 262.55
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 805917,
-"ratio": 0.1508,
-"compress_mbps": 10.54,
-"decompress_mbps": 273.88
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 685265,
-"ratio": 0.1282,
-"compress_mbps": 3.01,
-"decompress_mbps": 286.06
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 683484,
-"ratio": 0.1279,
-"compress_mbps": 2.67,
-"decompress_mbps": 270.99
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 683122,
-"ratio": 0.1278,
-"compress_mbps": 2.59,
-"decompress_mbps": 274.85
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4585612,
-"ratio": 0.4499,
-"compress_mbps": 113.41,
-"decompress_mbps": 342.19
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4389474,
-"ratio": 0.4307,
-"compress_mbps": 95.63,
-"decompress_mbps": 363.71
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4192079,
-"ratio": 0.4113,
-"compress_mbps": 59.33,
-"decompress_mbps": 389.49
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4095021,
-"ratio": 0.4018,
-"compress_mbps": 65.35,
-"decompress_mbps": 369.61
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3949169,
-"ratio": 0.3875,
-"compress_mbps": 35.84,
-"decompress_mbps": 359.21
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3871628,
-"ratio": 0.3799,
-"compress_mbps": 21.1,
-"decompress_mbps": 366.43
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3858876,
-"ratio": 0.3786,
-"compress_mbps": 17.63,
-"decompress_mbps": 367.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3854729,
-"ratio": 0.3782,
-"compress_mbps": 15.05,
-"decompress_mbps": 368.36
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3854729,
-"ratio": 0.3782,
-"compress_mbps": 15.1,
-"decompress_mbps": 370.27
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20577220,
-"ratio": 0.4017,
-"compress_mbps": 112.93,
-"decompress_mbps": 374.1
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20247697,
-"ratio": 0.3953,
-"compress_mbps": 101.22,
-"decompress_mbps": 381.64
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19987880,
-"ratio": 0.3902,
-"compress_mbps": 76.6,
-"decompress_mbps": 389.78
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19512665,
-"ratio": 0.381,
-"compress_mbps": 75.6,
-"decompress_mbps": 378.5
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19213507,
-"ratio": 0.3751,
-"compress_mbps": 52.78,
-"decompress_mbps": 380.28
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19089118,
-"ratio": 0.3727,
-"compress_mbps": 34.11,
-"decompress_mbps": 385.45
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19061204,
-"ratio": 0.3721,
-"compress_mbps": 27.13,
-"decompress_mbps": 386.32
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19040998,
-"ratio": 0.3717,
-"compress_mbps": 15.38,
-"decompress_mbps": 395.23
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19044390,
-"ratio": 0.3718,
-"compress_mbps": 9.51,
-"decompress_mbps": 383.17
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3828360,
-"ratio": 0.384,
-"compress_mbps": 140.36,
-"decompress_mbps": 449.21
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3798539,
-"ratio": 0.381,
-"compress_mbps": 124.68,
-"decompress_mbps": 459.56
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3674568,
-"ratio": 0.3685,
-"compress_mbps": 77.52,
-"decompress_mbps": 477.52
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3680923,
-"ratio": 0.3692,
-"compress_mbps": 85.77,
-"decompress_mbps": 421.01
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3698707,
-"ratio": 0.371,
-"compress_mbps": 47.74,
-"decompress_mbps": 401.07
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3675935,
-"ratio": 0.3687,
-"compress_mbps": 26.32,
-"decompress_mbps": 415.88
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3670281,
-"ratio": 0.3681,
-"compress_mbps": 20.69,
-"decompress_mbps": 420.52
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3661103,
-"ratio": 0.3672,
-"compress_mbps": 10.87,
-"decompress_mbps": 420.94
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3660788,
-"ratio": 0.3672,
-"compress_mbps": 9.43,
-"decompress_mbps": 424.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4624591,
-"ratio": 0.1378,
-"compress_mbps": 332.2,
-"decompress_mbps": 843.43
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4303176,
-"ratio": 0.1282,
-"compress_mbps": 308.07,
-"decompress_mbps": 872.53
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 4010156,
-"ratio": 0.1195,
-"compress_mbps": 257.27,
-"decompress_mbps": 954.87
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3713866,
-"ratio": 0.1107,
-"compress_mbps": 211.05,
-"decompress_mbps": 941.74
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3378136,
-"ratio": 0.1007,
-"compress_mbps": 165.24,
-"decompress_mbps": 1024.55
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3200182,
-"ratio": 0.0954,
-"compress_mbps": 113.59,
-"decompress_mbps": 1057.12
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3141278,
-"ratio": 0.0936,
-"compress_mbps": 89.98,
-"decompress_mbps": 1066.05
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3031199,
-"ratio": 0.0903,
-"compress_mbps": 39.2,
-"decompress_mbps": 1010.46
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2987995,
-"ratio": 0.0891,
-"compress_mbps": 21.45,
-"decompress_mbps": 1064.31
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3290526,
-"ratio": 0.5349,
-"compress_mbps": 78.95,
-"decompress_mbps": 257.91
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3238282,
-"ratio": 0.5264,
-"compress_mbps": 72.25,
-"decompress_mbps": 262.31
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3193366,
-"ratio": 0.5191,
-"compress_mbps": 56.47,
-"decompress_mbps": 263.36
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3158012,
-"ratio": 0.5133,
-"compress_mbps": 54.73,
-"decompress_mbps": 262.21
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3115309,
-"ratio": 0.5064,
-"compress_mbps": 38.65,
-"decompress_mbps": 266.08
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3097288,
-"ratio": 0.5034,
-"compress_mbps": 26.18,
-"decompress_mbps": 270.71
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3094363,
-"ratio": 0.503,
-"compress_mbps": 21.83,
-"decompress_mbps": 271.16
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3093026,
-"ratio": 0.5028,
-"compress_mbps": 17.05,
-"decompress_mbps": 272.13
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3092920,
-"ratio": 0.5027,
-"compress_mbps": 15.35,
-"decompress_mbps": 270.99
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4076385,
-"ratio": 0.4042,
-"compress_mbps": 126.61,
-"decompress_mbps": 451.9
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3991014,
-"ratio": 0.3957,
-"compress_mbps": 118.41,
-"decompress_mbps": 469.22
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3934055,
-"ratio": 0.3901,
-"compress_mbps": 94.45,
-"decompress_mbps": 486.82
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3825092,
-"ratio": 0.3793,
-"compress_mbps": 85.05,
-"decompress_mbps": 474.79
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3752932,
-"ratio": 0.3721,
-"compress_mbps": 65.15,
-"decompress_mbps": 473.72
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3695164,
-"ratio": 0.3664,
-"compress_mbps": 49.41,
-"decompress_mbps": 466.07
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3676881,
-"ratio": 0.3646,
-"compress_mbps": 38.08,
-"decompress_mbps": 480.03
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3673171,
-"ratio": 0.3642,
-"compress_mbps": 31.89,
-"decompress_mbps": 486.62
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3673171,
-"ratio": 0.3642,
-"compress_mbps": 31.9,
-"decompress_mbps": 484.76
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2376424,
-"ratio": 0.3586,
-"compress_mbps": 129.63,
-"decompress_mbps": 395.09
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2259060,
-"ratio": 0.3409,
-"compress_mbps": 112.09,
-"decompress_mbps": 412.6
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2135664,
-"ratio": 0.3223,
-"compress_mbps": 72.41,
-"decompress_mbps": 429.97
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2052793,
-"ratio": 0.3098,
-"compress_mbps": 81.72,
-"decompress_mbps": 427.88
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1932127,
-"ratio": 0.2915,
-"compress_mbps": 45.23,
-"decompress_mbps": 423.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1860865,
-"ratio": 0.2808,
-"compress_mbps": 22.78,
-"decompress_mbps": 433.0
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1838671,
-"ratio": 0.2774,
-"compress_mbps": 15.9,
-"decompress_mbps": 428.78
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1823235,
-"ratio": 0.2751,
-"compress_mbps": 8.11,
-"decompress_mbps": 435.32
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1823190,
-"ratio": 0.2751,
-"compress_mbps": 8.07,
-"decompress_mbps": 432.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6329449,
-"ratio": 0.2929,
-"compress_mbps": 168.61,
-"decompress_mbps": 459.83
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 6128866,
-"ratio": 0.2837,
-"compress_mbps": 155.37,
-"decompress_mbps": 548.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5982546,
-"ratio": 0.2769,
-"compress_mbps": 124.41,
-"decompress_mbps": 573.03
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5656400,
-"ratio": 0.2618,
-"compress_mbps": 115.83,
-"decompress_mbps": 570.76
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5511352,
-"ratio": 0.2551,
-"compress_mbps": 81.64,
-"decompress_mbps": 577.51
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5451399,
-"ratio": 0.2523,
-"compress_mbps": 56.23,
-"decompress_mbps": 591.12
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5417123,
-"ratio": 0.2507,
-"compress_mbps": 46.39,
-"decompress_mbps": 591.26
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5404364,
-"ratio": 0.2501,
-"compress_mbps": 32.56,
-"decompress_mbps": 600.38
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5402704,
-"ratio": 0.2501,
-"compress_mbps": 29.69,
-"decompress_mbps": 602.34
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5567768,
-"ratio": 0.7678,
-"compress_mbps": 64.12,
-"decompress_mbps": 315.55
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5504009,
-"ratio": 0.759,
-"compress_mbps": 58.18,
-"decompress_mbps": 327.78
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5439339,
-"ratio": 0.7501,
-"compress_mbps": 46.11,
-"decompress_mbps": 332.34
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5394604,
-"ratio": 0.7439,
-"compress_mbps": 47.79,
-"decompress_mbps": 346.26
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5370116,
-"ratio": 0.7405,
-"compress_mbps": 32.98,
-"decompress_mbps": 333.52
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5331793,
-"ratio": 0.7352,
-"compress_mbps": 22.95,
-"decompress_mbps": 334.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5327677,
-"ratio": 0.7347,
-"compress_mbps": 21.0,
-"decompress_mbps": 347.1
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5325914,
-"ratio": 0.7344,
-"compress_mbps": 19.0,
-"decompress_mbps": 347.35
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5325914,
-"ratio": 0.7344,
-"compress_mbps": 18.99,
-"decompress_mbps": 345.95
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 14991236,
-"ratio": 0.3616,
-"compress_mbps": 137.68,
-"decompress_mbps": 374.4
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 14249692,
-"ratio": 0.3437,
-"compress_mbps": 121.15,
-"decompress_mbps": 407.23
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 13627761,
-"ratio": 0.3287,
-"compress_mbps": 87.82,
-"decompress_mbps": 423.08
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 13001990,
-"ratio": 0.3136,
-"compress_mbps": 85.1,
-"decompress_mbps": 400.11
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12445991,
-"ratio": 0.3002,
-"compress_mbps": 54.74,
-"decompress_mbps": 397.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12213941,
-"ratio": 0.2946,
-"compress_mbps": 36.35,
-"decompress_mbps": 403.76
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12130416,
-"ratio": 0.2926,
-"compress_mbps": 29.39,
-"decompress_mbps": 404.99
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12073697,
-"ratio": 0.2912,
-"compress_mbps": 21.33,
-"decompress_mbps": 405.63
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12073469,
-"ratio": 0.2912,
-"compress_mbps": 21.16,
-"decompress_mbps": 406.12
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6033926,
-"ratio": 0.712,
-"compress_mbps": 74.68,
-"decompress_mbps": 278.85
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 5997474,
-"ratio": 0.7077,
-"compress_mbps": 67.62,
-"decompress_mbps": 288.14
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 5966621,
-"ratio": 0.7041,
-"compress_mbps": 54.89,
-"decompress_mbps": 294.82
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6091108,
-"ratio": 0.7188,
-"compress_mbps": 45.82,
-"decompress_mbps": 257.47
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6053566,
-"ratio": 0.7143,
-"compress_mbps": 37.09,
-"decompress_mbps": 265.93
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6045111,
-"ratio": 0.7134,
-"compress_mbps": 34.83,
-"decompress_mbps": 268.83
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6045034,
-"ratio": 0.7133,
-"compress_mbps": 34.74,
-"decompress_mbps": 265.43
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6045032,
-"ratio": 0.7133,
-"compress_mbps": 34.41,
-"decompress_mbps": 265.75
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6045032,
-"ratio": 0.7133,
-"compress_mbps": 34.48,
-"decompress_mbps": 268.71
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 965242,
-"ratio": 0.1806,
-"compress_mbps": 262.34,
-"decompress_mbps": 685.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 887265,
-"ratio": 0.166,
-"compress_mbps": 246.56,
-"decompress_mbps": 744.15
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 822167,
-"ratio": 0.1538,
-"compress_mbps": 191.22,
-"decompress_mbps": 789.44
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 807518,
-"ratio": 0.1511,
-"compress_mbps": 168.7,
-"decompress_mbps": 764.43
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 730574,
-"ratio": 0.1367,
-"compress_mbps": 121.64,
-"decompress_mbps": 814.91
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 687991,
-"ratio": 0.1287,
-"compress_mbps": 79.44,
-"decompress_mbps": 873.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 673933,
-"ratio": 0.1261,
-"compress_mbps": 64.98,
-"decompress_mbps": 884.66
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 659518,
-"ratio": 0.1234,
-"compress_mbps": 42.96,
-"decompress_mbps": 884.85
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 658899,
-"ratio": 0.1233,
-"compress_mbps": 39.74,
-"decompress_mbps": 897.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 5363862,
-"ratio": 0.5263,
-"compress_mbps": 140.67,
-"decompress_mbps": 358.75
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4438205,
-"ratio": 0.4354,
-"compress_mbps": 129.76,
-"decompress_mbps": 430.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4054333,
-"ratio": 0.3978,
-"compress_mbps": 63.93,
-"decompress_mbps": 478.59
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4038550,
-"ratio": 0.3962,
-"compress_mbps": 58.02,
-"decompress_mbps": 472.16
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3954920,
-"ratio": 0.388,
-"compress_mbps": 40.43,
-"decompress_mbps": 463.56
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3872874,
-"ratio": 0.38,
-"compress_mbps": 22.64,
-"decompress_mbps": 472.02
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3859937,
-"ratio": 0.3787,
-"compress_mbps": 18.89,
-"decompress_mbps": 470.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3855935,
-"ratio": 0.3783,
-"compress_mbps": 17.09,
-"decompress_mbps": 469.5
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3855791,
-"ratio": 0.3783,
-"compress_mbps": 17.04,
-"decompress_mbps": 469.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 22334882,
-"ratio": 0.4361,
-"compress_mbps": 232.88,
-"decompress_mbps": 374.84
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20150366,
-"ratio": 0.3934,
-"compress_mbps": 121.92,
-"decompress_mbps": 387.83
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19495014,
-"ratio": 0.3806,
-"compress_mbps": 70.69,
-"decompress_mbps": 398.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19424978,
-"ratio": 0.3792,
-"compress_mbps": 71.94,
-"decompress_mbps": 412.53
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19298736,
-"ratio": 0.3768,
-"compress_mbps": 54.47,
-"decompress_mbps": 428.4
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19179167,
-"ratio": 0.3744,
-"compress_mbps": 29.8,
-"decompress_mbps": 431.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19151324,
-"ratio": 0.3739,
-"compress_mbps": 21.96,
-"decompress_mbps": 432.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19144373,
-"ratio": 0.3738,
-"compress_mbps": 16.6,
-"decompress_mbps": 429.55
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19141383,
-"ratio": 0.3737,
-"compress_mbps": 14.13,
-"decompress_mbps": 409.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 4249731,
-"ratio": 0.4262,
-"compress_mbps": 309.29,
-"decompress_mbps": 473.63
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3775479,
-"ratio": 0.3787,
-"compress_mbps": 159.95,
-"decompress_mbps": 556.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3656966,
-"ratio": 0.3668,
-"compress_mbps": 81.2,
-"decompress_mbps": 578.25
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3740378,
-"ratio": 0.3751,
-"compress_mbps": 68.39,
-"decompress_mbps": 539.54
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3713604,
-"ratio": 0.3725,
-"compress_mbps": 49.2,
-"decompress_mbps": 504.09
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3683556,
-"ratio": 0.3694,
-"compress_mbps": 25.11,
-"decompress_mbps": 522.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3683797,
-"ratio": 0.3695,
-"compress_mbps": 18.99,
-"decompress_mbps": 532.57
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3684477,
-"ratio": 0.3695,
-"compress_mbps": 14.33,
-"decompress_mbps": 538.96
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3679414,
-"ratio": 0.369,
-"compress_mbps": 12.34,
-"decompress_mbps": 541.79
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 5594622,
-"ratio": 0.1667,
-"compress_mbps": 417.27,
-"decompress_mbps": 869.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4179532,
-"ratio": 0.1246,
-"compress_mbps": 326.86,
-"decompress_mbps": 959.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3542329,
-"ratio": 0.1056,
-"compress_mbps": 212.82,
-"decompress_mbps": 906.25
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3323363,
-"ratio": 0.099,
-"compress_mbps": 196.37,
-"decompress_mbps": 850.27
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3230343,
-"ratio": 0.0963,
-"compress_mbps": 163.31,
-"decompress_mbps": 1027.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3123421,
-"ratio": 0.0931,
-"compress_mbps": 95.87,
-"decompress_mbps": 1070.3
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3093778,
-"ratio": 0.0922,
-"compress_mbps": 70.31,
-"decompress_mbps": 1039.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3067318,
-"ratio": 0.0914,
-"compress_mbps": 50.03,
-"decompress_mbps": 1106.65
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3050695,
-"ratio": 0.0909,
-"compress_mbps": 41.97,
-"decompress_mbps": 1029.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3543611,
-"ratio": 0.576,
-"compress_mbps": 168.83,
-"decompress_mbps": 270.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3226818,
-"ratio": 0.5245,
-"compress_mbps": 87.44,
-"decompress_mbps": 289.54
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3144140,
-"ratio": 0.5111,
-"compress_mbps": 53.18,
-"decompress_mbps": 299.76
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3129833,
-"ratio": 0.5087,
-"compress_mbps": 51.9,
-"decompress_mbps": 328.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3114809,
-"ratio": 0.5063,
-"compress_mbps": 40.62,
-"decompress_mbps": 340.96
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3095705,
-"ratio": 0.5032,
-"compress_mbps": 25.22,
-"decompress_mbps": 347.21
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3090055,
-"ratio": 0.5023,
-"compress_mbps": 20.53,
-"decompress_mbps": 348.36
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3087665,
-"ratio": 0.5019,
-"compress_mbps": 17.45,
-"decompress_mbps": 350.0
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3087158,
-"ratio": 0.5018,
-"compress_mbps": 16.36,
-"decompress_mbps": 349.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 5419510,
-"ratio": 0.5373,
-"compress_mbps": 240.15,
-"decompress_mbps": 510.17
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3982547,
-"ratio": 0.3949,
-"compress_mbps": 124.58,
-"decompress_mbps": 555.69
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3806102,
-"ratio": 0.3774,
-"compress_mbps": 82.59,
-"decompress_mbps": 570.77
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3761477,
-"ratio": 0.373,
-"compress_mbps": 79.44,
-"decompress_mbps": 609.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3740298,
-"ratio": 0.3709,
-"compress_mbps": 68.12,
-"decompress_mbps": 609.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3686116,
-"ratio": 0.3655,
-"compress_mbps": 49.72,
-"decompress_mbps": 644.56
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3668442,
-"ratio": 0.3637,
-"compress_mbps": 38.97,
-"decompress_mbps": 656.81
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3665072,
-"ratio": 0.3634,
-"compress_mbps": 33.28,
-"decompress_mbps": 653.63
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3665057,
-"ratio": 0.3634,
-"compress_mbps": 33.18,
-"decompress_mbps": 650.86
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2842321,
-"ratio": 0.4289,
-"compress_mbps": 192.16,
-"decompress_mbps": 474.73
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2232180,
-"ratio": 0.3368,
-"compress_mbps": 153.55,
-"decompress_mbps": 516.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2003056,
-"ratio": 0.3022,
-"compress_mbps": 82.19,
-"decompress_mbps": 554.98
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1985375,
-"ratio": 0.2996,
-"compress_mbps": 74.02,
-"decompress_mbps": 562.56
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1933775,
-"ratio": 0.2918,
-"compress_mbps": 52.01,
-"decompress_mbps": 541.61
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1858103,
-"ratio": 0.2804,
-"compress_mbps": 22.0,
-"decompress_mbps": 545.38
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1840414,
-"ratio": 0.2777,
-"compress_mbps": 15.1,
-"decompress_mbps": 548.02
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1831679,
-"ratio": 0.2764,
-"compress_mbps": 11.71,
-"decompress_mbps": 539.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1827137,
-"ratio": 0.2757,
-"compress_mbps": 10.13,
-"decompress_mbps": 542.48
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 7089759,
-"ratio": 0.3281,
-"compress_mbps": 288.38,
-"decompress_mbps": 559.54
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5966231,
-"ratio": 0.2761,
-"compress_mbps": 173.81,
-"decompress_mbps": 625.71
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5611838,
-"ratio": 0.2597,
-"compress_mbps": 111.48,
-"decompress_mbps": 638.16
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5535436,
-"ratio": 0.2562,
-"compress_mbps": 105.57,
-"decompress_mbps": 677.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5480971,
-"ratio": 0.2537,
-"compress_mbps": 81.79,
-"decompress_mbps": 688.57
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5437556,
-"ratio": 0.2517,
-"compress_mbps": 49.61,
-"decompress_mbps": 694.4
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5432108,
-"ratio": 0.2514,
-"compress_mbps": 40.14,
-"decompress_mbps": 698.93
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5428571,
-"ratio": 0.2512,
-"compress_mbps": 33.6,
-"decompress_mbps": 643.9
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5425526,
-"ratio": 0.2511,
-"compress_mbps": 30.47,
-"decompress_mbps": 654.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5900800,
-"ratio": 0.8137,
-"compress_mbps": 188.31,
-"decompress_mbps": 313.03
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5523611,
-"ratio": 0.7617,
-"compress_mbps": 70.12,
-"decompress_mbps": 340.36
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5393086,
-"ratio": 0.7437,
-"compress_mbps": 40.6,
-"decompress_mbps": 350.73
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5401582,
-"ratio": 0.7448,
-"compress_mbps": 40.79,
-"decompress_mbps": 367.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5371274,
-"ratio": 0.7407,
-"compress_mbps": 31.25,
-"decompress_mbps": 358.87
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5330096,
-"ratio": 0.735,
-"compress_mbps": 20.96,
-"decompress_mbps": 364.81
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5325437,
-"ratio": 0.7343,
-"compress_mbps": 19.1,
-"decompress_mbps": 365.32
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5323934,
-"ratio": 0.7341,
-"compress_mbps": 18.14,
-"decompress_mbps": 366.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323621,
-"ratio": 0.7341,
-"compress_mbps": 17.82,
-"decompress_mbps": 366.31
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 17587173,
-"ratio": 0.4242,
-"compress_mbps": 182.41,
-"decompress_mbps": 371.38
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 14171707,
-"ratio": 0.3418,
-"compress_mbps": 150.18,
-"decompress_mbps": 422.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12774851,
-"ratio": 0.3081,
-"compress_mbps": 85.98,
-"decompress_mbps": 450.71
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12612554,
-"ratio": 0.3042,
-"compress_mbps": 76.8,
-"decompress_mbps": 452.79
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12392339,
-"ratio": 0.2989,
-"compress_mbps": 58.34,
-"decompress_mbps": 467.04
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12158314,
-"ratio": 0.2933,
-"compress_mbps": 34.46,
-"decompress_mbps": 473.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12107840,
-"ratio": 0.292,
-"compress_mbps": 27.59,
-"decompress_mbps": 480.16
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12081311,
-"ratio": 0.2914,
-"compress_mbps": 22.89,
-"decompress_mbps": 476.85
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12081011,
-"ratio": 0.2914,
-"compress_mbps": 22.8,
-"decompress_mbps": 475.03
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6527324,
-"ratio": 0.7703,
-"compress_mbps": 236.9,
-"decompress_mbps": 320.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6051483,
-"ratio": 0.7141,
-"compress_mbps": 76.73,
-"decompress_mbps": 329.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6010123,
-"ratio": 0.7092,
-"compress_mbps": 52.87,
-"decompress_mbps": 330.73
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6024815,
-"ratio": 0.711,
-"compress_mbps": 45.17,
-"decompress_mbps": 282.92
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6005181,
-"ratio": 0.7086,
-"compress_mbps": 40.91,
-"decompress_mbps": 289.63
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5997508,
-"ratio": 0.7077,
-"compress_mbps": 38.25,
-"decompress_mbps": 294.01
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5997403,
-"ratio": 0.7077,
-"compress_mbps": 38.31,
-"decompress_mbps": 292.95
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5997403,
-"ratio": 0.7077,
-"compress_mbps": 38.23,
-"decompress_mbps": 294.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5997403,
-"ratio": 0.7077,
-"compress_mbps": 38.3,
-"decompress_mbps": 294.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 1147652,
-"ratio": 0.2147,
-"compress_mbps": 385.61,
-"decompress_mbps": 842.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 919639,
-"ratio": 0.172,
-"compress_mbps": 263.55,
-"decompress_mbps": 956.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 752341,
-"ratio": 0.1407,
-"compress_mbps": 167.38,
-"decompress_mbps": 1054.37
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 735537,
-"ratio": 0.1376,
-"compress_mbps": 161.64,
-"decompress_mbps": 1041.68
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 706789,
-"ratio": 0.1322,
-"compress_mbps": 123.85,
-"decompress_mbps": 1133.46
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 676279,
-"ratio": 0.1265,
-"compress_mbps": 69.63,
-"decompress_mbps": 1225.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 668772,
-"ratio": 0.1251,
-"compress_mbps": 56.1,
-"decompress_mbps": 1225.27
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 665340,
-"ratio": 0.1245,
-"compress_mbps": 47.58,
-"decompress_mbps": 1193.27
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 664273,
-"ratio": 0.1243,
-"compress_mbps": 45.86,
-"decompress_mbps": 1220.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": 242.6,
-"decompress_mbps": 818.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4053259,
-"ratio": 0.3977,
-"compress_mbps": 169.42,
-"decompress_mbps": 892.23
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": 138.93,
-"decompress_mbps": 957.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3972869,
-"ratio": 0.3898,
-"compress_mbps": 127.06,
-"decompress_mbps": 859.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3894026,
-"ratio": 0.3821,
-"compress_mbps": 99.05,
-"decompress_mbps": 812.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": 75.48,
-"decompress_mbps": 831.21
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3837515,
-"ratio": 0.3765,
-"compress_mbps": 55.65,
-"decompress_mbps": 834.16
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3811467,
-"ratio": 0.374,
-"compress_mbps": 35.89,
-"decompress_mbps": 829.5
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": 32.66,
-"decompress_mbps": 824.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": 240.28,
-"decompress_mbps": 699.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 19374226,
-"ratio": 0.3783,
-"compress_mbps": 183.08,
-"decompress_mbps": 675.72
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": 174.16,
-"decompress_mbps": 748.95
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19145385,
-"ratio": 0.3738,
-"compress_mbps": 163.12,
-"decompress_mbps": 746.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 18878875,
-"ratio": 0.3686,
-"compress_mbps": 143.29,
-"decompress_mbps": 765.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": 120.44,
-"decompress_mbps": 782.21
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 18749947,
-"ratio": 0.3661,
-"compress_mbps": 87.66,
-"decompress_mbps": 785.12
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 18718540,
-"ratio": 0.3655,
-"compress_mbps": 47.37,
-"decompress_mbps": 783.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": 33.57,
-"decompress_mbps": 784.05
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": 291.97,
-"decompress_mbps": 776.47
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3707407,
-"ratio": 0.3718,
-"compress_mbps": 217.32,
-"decompress_mbps": 886.08
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": 184.26,
-"decompress_mbps": 946.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3660011,
-"ratio": 0.3671,
-"compress_mbps": 170.13,
-"decompress_mbps": 850.17
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3664245,
-"ratio": 0.3675,
-"compress_mbps": 140.85,
-"decompress_mbps": 804.63
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": 106.31,
-"decompress_mbps": 852.28
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3635323,
-"ratio": 0.3646,
-"compress_mbps": 68.48,
-"decompress_mbps": 848.26
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3624778,
-"ratio": 0.3635,
-"compress_mbps": 43.01,
-"decompress_mbps": 876.22
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": 38.87,
-"decompress_mbps": 871.55
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": 606.99,
-"decompress_mbps": 1661.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3714632,
-"ratio": 0.1107,
-"compress_mbps": 462.59,
-"decompress_mbps": 1844.81
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": 427.37,
-"decompress_mbps": 1897.12
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3431843,
-"ratio": 0.1023,
-"compress_mbps": 385.66,
-"decompress_mbps": 1807.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3268188,
-"ratio": 0.0974,
-"compress_mbps": 343.98,
-"decompress_mbps": 1794.53
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": 263.6,
-"decompress_mbps": 1869.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3032499,
-"ratio": 0.0904,
-"compress_mbps": 185.24,
-"decompress_mbps": 1853.29
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 2949097,
-"ratio": 0.0879,
-"compress_mbps": 97.07,
-"decompress_mbps": 1836.13
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": 69.03,
-"decompress_mbps": 1867.12
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": 166.23,
-"decompress_mbps": 470.77
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3150806,
-"ratio": 0.5121,
-"compress_mbps": 126.97,
-"decompress_mbps": 504.39
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": 120.1,
-"decompress_mbps": 521.94
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3129676,
-"ratio": 0.5087,
-"compress_mbps": 116.2,
-"decompress_mbps": 542.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3079277,
-"ratio": 0.5005,
-"compress_mbps": 98.62,
-"decompress_mbps": 556.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": 87.95,
-"decompress_mbps": 562.57
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3068123,
-"ratio": 0.4987,
-"compress_mbps": 75.3,
-"decompress_mbps": 568.54
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3067299,
-"ratio": 0.4986,
-"compress_mbps": 55.06,
-"decompress_mbps": 564.55
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": 49.63,
-"decompress_mbps": 568.19
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": 286.3,
-"decompress_mbps": 902.6
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3839158,
-"ratio": 0.3807,
-"compress_mbps": 209.99,
-"decompress_mbps": 924.39
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": 195.21,
-"decompress_mbps": 952.29
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3789325,
-"ratio": 0.3757,
-"compress_mbps": 178.2,
-"decompress_mbps": 981.11
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3666476,
-"ratio": 0.3635,
-"compress_mbps": 154.7,
-"decompress_mbps": 967.38
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": 139.26,
-"decompress_mbps": 1013.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3659491,
-"ratio": 0.3628,
-"compress_mbps": 132.39,
-"decompress_mbps": 1027.6
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3654863,
-"ratio": 0.3624,
-"compress_mbps": 111.69,
-"decompress_mbps": 1012.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": 108.45,
-"decompress_mbps": 1027.94
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": 296.9,
-"decompress_mbps": 1030.56
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2082309,
-"ratio": 0.3142,
-"compress_mbps": 214.98,
-"decompress_mbps": 1124.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": 177.64,
-"decompress_mbps": 1229.27
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1990952,
-"ratio": 0.3004,
-"compress_mbps": 157.84,
-"decompress_mbps": 1118.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1921113,
-"ratio": 0.2899,
-"compress_mbps": 126.58,
-"decompress_mbps": 1070.38
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": 86.57,
-"decompress_mbps": 1061.22
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1832695,
-"ratio": 0.2765,
-"compress_mbps": 46.39,
-"decompress_mbps": 1072.81
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1809967,
-"ratio": 0.2731,
-"compress_mbps": 24.26,
-"decompress_mbps": 1042.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": 19.85,
-"decompress_mbps": 1040.37
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": 340.15,
-"decompress_mbps": 921.76
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5695942,
-"ratio": 0.2636,
-"compress_mbps": 254.58,
-"decompress_mbps": 1071.02
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": 231.86,
-"decompress_mbps": 1101.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5553432,
-"ratio": 0.257,
-"compress_mbps": 215.5,
-"decompress_mbps": 1089.28
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5416713,
-"ratio": 0.2507,
-"compress_mbps": 186.25,
-"decompress_mbps": 1081.28
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": 143.26,
-"decompress_mbps": 1105.44
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5310181,
-"ratio": 0.2458,
-"compress_mbps": 100.1,
-"decompress_mbps": 1084.81
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5272761,
-"ratio": 0.244,
-"compress_mbps": 62.13,
-"decompress_mbps": 976.16
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": 50.05,
-"decompress_mbps": 1087.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": 163.15,
-"decompress_mbps": 471.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5417142,
-"ratio": 0.747,
-"compress_mbps": 116.27,
-"decompress_mbps": 507.65
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": 104.56,
-"decompress_mbps": 519.84
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5391125,
-"ratio": 0.7434,
-"compress_mbps": 99.09,
-"decompress_mbps": 533.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5352212,
-"ratio": 0.738,
-"compress_mbps": 86.61,
-"decompress_mbps": 504.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": 72.93,
-"decompress_mbps": 520.88
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5325697,
-"ratio": 0.7344,
-"compress_mbps": 62.79,
-"decompress_mbps": 516.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5324004,
-"ratio": 0.7341,
-"compress_mbps": 51.84,
-"decompress_mbps": 519.17
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": 50.26,
-"decompress_mbps": 518.34
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": 265.53,
-"decompress_mbps": 834.05
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 13130705,
-"ratio": 0.3167,
-"compress_mbps": 198.98,
-"decompress_mbps": 970.73
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": 178.35,
-"decompress_mbps": 1056.9
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12601933,
-"ratio": 0.304,
-"compress_mbps": 162.87,
-"decompress_mbps": 949.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12310776,
-"ratio": 0.2969,
-"compress_mbps": 132.54,
-"decompress_mbps": 932.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": 105.72,
-"decompress_mbps": 936.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12025296,
-"ratio": 0.2901,
-"compress_mbps": 75.47,
-"decompress_mbps": 942.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 11893824,
-"ratio": 0.2869,
-"compress_mbps": 46.02,
-"decompress_mbps": 931.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": 39.58,
-"decompress_mbps": 927.94
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": 145.19,
-"decompress_mbps": 520.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6058412,
-"ratio": 0.7149,
-"compress_mbps": 120.56,
-"decompress_mbps": 530.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": 120.42,
-"decompress_mbps": 549.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6058363,
-"ratio": 0.7149,
-"compress_mbps": 120.32,
-"decompress_mbps": 437.12
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 5998400,
-"ratio": 0.7078,
-"compress_mbps": 108.06,
-"decompress_mbps": 464.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": 108.12,
-"decompress_mbps": 465.54
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5998439,
-"ratio": 0.7078,
-"compress_mbps": 108.07,
-"decompress_mbps": 467.11
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": 88.91,
-"decompress_mbps": 468.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": 89.07,
-"decompress_mbps": 462.26
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": 490.35,
-"decompress_mbps": 1623.47
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 843475,
-"ratio": 0.1578,
-"compress_mbps": 365.58,
-"decompress_mbps": 1813.05
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": 337.28,
-"decompress_mbps": 1889.12
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 747602,
-"ratio": 0.1399,
-"compress_mbps": 300.06,
-"decompress_mbps": 1807.37
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 718615,
-"ratio": 0.1344,
-"compress_mbps": 261.74,
-"decompress_mbps": 1848.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": 205.37,
-"decompress_mbps": 1930.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 664859,
-"ratio": 0.1244,
-"compress_mbps": 141.74,
-"decompress_mbps": 1908.84
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 650835,
-"ratio": 0.1218,
-"compress_mbps": 84.63,
-"decompress_mbps": 1879.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": 68.28,
-"decompress_mbps": 1857.99
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 65708,
-"ratio": 0.432,
-"compress_mbps": 91.12,
-"decompress_mbps": 168.87
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 60259,
-"ratio": 0.3962,
-"compress_mbps": 68.69,
-"decompress_mbps": 186.71
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 58544,
-"ratio": 0.3849,
-"compress_mbps": 59.01,
-"decompress_mbps": 196.54
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56238,
-"ratio": 0.3698,
-"compress_mbps": 58.4,
-"decompress_mbps": 196.67
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54764,
-"ratio": 0.3601,
-"compress_mbps": 36.47,
-"decompress_mbps": 203.11
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54311,
-"ratio": 0.3571,
-"compress_mbps": 28.72,
-"decompress_mbps": 201.81
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54262,
-"ratio": 0.3568,
-"compress_mbps": 25.77,
-"decompress_mbps": 205.05
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54247,
-"ratio": 0.3567,
-"compress_mbps": 24.71,
-"decompress_mbps": 202.6
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54247,
-"ratio": 0.3567,
-"compress_mbps": 24.25,
-"decompress_mbps": 200.32
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 56882,
-"ratio": 0.4544,
-"compress_mbps": 87.87,
-"decompress_mbps": 159.35
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 52826,
-"ratio": 0.422,
-"compress_mbps": 62.64,
-"decompress_mbps": 174.97
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51625,
-"ratio": 0.4124,
-"compress_mbps": 53.67,
-"decompress_mbps": 180.78
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50034,
-"ratio": 0.3997,
-"compress_mbps": 53.12,
-"decompress_mbps": 183.04
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48912,
-"ratio": 0.3907,
-"compress_mbps": 34.54,
-"decompress_mbps": 187.79
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48738,
-"ratio": 0.3893,
-"compress_mbps": 28.61,
-"decompress_mbps": 186.89
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48719,
-"ratio": 0.3892,
-"compress_mbps": 27.95,
-"decompress_mbps": 189.27
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48716,
-"ratio": 0.3892,
-"compress_mbps": 27.73,
-"decompress_mbps": 190.13
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48716,
-"ratio": 0.3892,
-"compress_mbps": 27.53,
-"decompress_mbps": 188.66
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8988,
-"ratio": 0.3653,
-"compress_mbps": 55.21,
-"decompress_mbps": 184.79
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8564,
-"ratio": 0.3481,
-"compress_mbps": 58.82,
-"decompress_mbps": 199.5
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8390,
-"ratio": 0.341,
-"compress_mbps": 61.66,
-"decompress_mbps": 279.41
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8167,
-"ratio": 0.332,
-"compress_mbps": 54.86,
-"decompress_mbps": 276.56
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7965,
-"ratio": 0.3237,
-"compress_mbps": 48.85,
-"decompress_mbps": 294.35
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7916,
-"ratio": 0.3217,
-"compress_mbps": 41.99,
-"decompress_mbps": 211.56
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7900,
-"ratio": 0.3211,
-"compress_mbps": 39.21,
-"decompress_mbps": 287.36
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7900,
-"ratio": 0.3211,
-"compress_mbps": 38.37,
-"decompress_mbps": 292.73
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7900,
-"ratio": 0.3211,
-"compress_mbps": 38.68,
-"decompress_mbps": 277.06
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3731,
-"ratio": 0.3346,
-"compress_mbps": 36.53,
-"decompress_mbps": 214.37
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3491,
-"ratio": 0.3131,
-"compress_mbps": 45.63,
-"decompress_mbps": 232.49
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3384,
-"ratio": 0.3035,
-"compress_mbps": 44.74,
-"decompress_mbps": 230.1
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3220,
-"ratio": 0.2888,
-"compress_mbps": 42.34,
-"decompress_mbps": 222.63
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3138,
-"ratio": 0.2814,
-"compress_mbps": 36.87,
-"decompress_mbps": 227.93
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3118,
-"ratio": 0.2796,
-"compress_mbps": 35.48,
-"decompress_mbps": 227.34
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 35.29,
-"decompress_mbps": 220.03
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 32.81,
-"decompress_mbps": 226.36
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 32.86,
-"decompress_mbps": 226.31
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1352,
-"ratio": 0.3633,
-"compress_mbps": 15.28,
-"decompress_mbps": 158.19
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1287,
-"ratio": 0.3459,
-"compress_mbps": 20.26,
-"decompress_mbps": 156.58
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1284,
-"ratio": 0.3451,
-"compress_mbps": 19.32,
-"decompress_mbps": 147.04
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1226,
-"ratio": 0.3295,
-"compress_mbps": 20.83,
-"decompress_mbps": 151.22
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 18.43,
-"decompress_mbps": 163.99
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 18.11,
-"decompress_mbps": 159.18
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 17.52,
-"decompress_mbps": 150.52
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 19.77,
-"decompress_mbps": 148.8
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 18.73,
-"decompress_mbps": 147.9
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 245423,
-"ratio": 0.2383,
-"compress_mbps": 235.01,
-"decompress_mbps": 368.42
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 229642,
-"ratio": 0.223,
-"compress_mbps": 200.74,
-"decompress_mbps": 427.98
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 225678,
-"ratio": 0.2192,
-"compress_mbps": 175.33,
-"decompress_mbps": 423.12
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 218218,
-"ratio": 0.2119,
-"compress_mbps": 161.64,
-"decompress_mbps": 460.83
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 210550,
-"ratio": 0.2045,
-"compress_mbps": 95.15,
-"decompress_mbps": 420.28
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 207949,
-"ratio": 0.2019,
-"compress_mbps": 41.26,
-"decompress_mbps": 399.73
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 207413,
-"ratio": 0.2014,
-"compress_mbps": 24.25,
-"decompress_mbps": 392.86
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 207478,
-"ratio": 0.2015,
-"compress_mbps": 7.28,
-"decompress_mbps": 429.08
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 207482,
-"ratio": 0.2015,
-"compress_mbps": 3.5,
-"decompress_mbps": 417.45
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 175980,
-"ratio": 0.4124,
-"compress_mbps": 105.8,
-"decompress_mbps": 178.78
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 160455,
-"ratio": 0.376,
-"compress_mbps": 78.59,
-"decompress_mbps": 207.33
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 156690,
-"ratio": 0.3672,
-"compress_mbps": 67.52,
-"decompress_mbps": 211.87
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 149064,
-"ratio": 0.3493,
-"compress_mbps": 64.12,
-"decompress_mbps": 214.73
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145616,
-"ratio": 0.3412,
-"compress_mbps": 40.2,
-"decompress_mbps": 214.54
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144773,
-"ratio": 0.3392,
-"compress_mbps": 32.41,
-"decompress_mbps": 212.71
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144603,
-"ratio": 0.3388,
-"compress_mbps": 29.21,
-"decompress_mbps": 215.31
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144573,
-"ratio": 0.3388,
-"compress_mbps": 28.34,
-"decompress_mbps": 208.31
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 144570,
-"ratio": 0.3388,
-"compress_mbps": 28.93,
-"decompress_mbps": 218.05
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 228837,
-"ratio": 0.4749,
-"compress_mbps": 94.32,
-"decompress_mbps": 157.6
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 211248,
-"ratio": 0.4384,
-"compress_mbps": 65.19,
-"decompress_mbps": 173.09
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 205619,
-"ratio": 0.4267,
-"compress_mbps": 53.75,
-"decompress_mbps": 185.52
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 200595,
-"ratio": 0.4163,
-"compress_mbps": 54.25,
-"decompress_mbps": 188.4
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 195418,
-"ratio": 0.4055,
-"compress_mbps": 32.63,
-"decompress_mbps": 187.92
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 194148,
-"ratio": 0.4029,
-"compress_mbps": 24.74,
-"decompress_mbps": 185.8
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 193994,
-"ratio": 0.4026,
-"compress_mbps": 22.93,
-"decompress_mbps": 187.63
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 193991,
-"ratio": 0.4026,
-"compress_mbps": 23.2,
-"decompress_mbps": 184.03
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 193991,
-"ratio": 0.4026,
-"compress_mbps": 23.01,
-"decompress_mbps": 184.96
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 60990,
-"ratio": 0.1188,
-"compress_mbps": 276.53,
-"decompress_mbps": 485.64
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 61650,
-"ratio": 0.1201,
-"compress_mbps": 260.46,
-"decompress_mbps": 530.04
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 60035,
-"ratio": 0.117,
-"compress_mbps": 237.8,
-"decompress_mbps": 552.41
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 57005,
-"ratio": 0.1111,
-"compress_mbps": 192.91,
-"decompress_mbps": 526.51
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 55779,
-"ratio": 0.1087,
-"compress_mbps": 157.4,
-"decompress_mbps": 568.7
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 54970,
-"ratio": 0.1071,
-"compress_mbps": 107.4,
-"decompress_mbps": 547.83
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 53922,
-"ratio": 0.1051,
-"compress_mbps": 80.07,
-"decompress_mbps": 577.25
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 51977,
-"ratio": 0.1013,
-"compress_mbps": 28.81,
-"decompress_mbps": 576.83
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 51474,
-"ratio": 0.1003,
-"compress_mbps": 7.4,
-"decompress_mbps": 571.72
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14783,
-"ratio": 0.3866,
-"compress_mbps": 65.48,
-"decompress_mbps": 186.82
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 14101,
-"ratio": 0.3688,
-"compress_mbps": 67.16,
-"decompress_mbps": 203.32
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13975,
-"ratio": 0.3655,
-"compress_mbps": 62.18,
-"decompress_mbps": 212
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13632,
-"ratio": 0.3565,
-"compress_mbps": 63,
-"decompress_mbps": 196.27
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13302,
-"ratio": 0.3479,
-"compress_mbps": 49.99,
-"decompress_mbps": 214.25
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13279,
-"ratio": 0.3473,
-"compress_mbps": 41.62,
-"decompress_mbps": 214.73
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13274,
-"ratio": 0.3471,
-"compress_mbps": 34.17,
-"decompress_mbps": 213.82
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13260,
-"ratio": 0.3468,
-"compress_mbps": 19.97,
-"decompress_mbps": 245.75
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13260,
-"ratio": 0.3468,
-"compress_mbps": 13.04,
-"decompress_mbps": 223.24
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1862,
-"ratio": 0.4405,
-"compress_mbps": 16.08,
-"decompress_mbps": 122.75
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1803,
-"ratio": 0.4265,
-"compress_mbps": 21.05,
-"decompress_mbps": 150.87
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1791,
-"ratio": 0.4237,
-"compress_mbps": 20.68,
-"decompress_mbps": 119.84
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1746,
-"ratio": 0.4131,
-"compress_mbps": 20.37,
-"decompress_mbps": 165.4
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 20.57,
-"decompress_mbps": 133.37
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 18.78,
-"decompress_mbps": 153.49
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 22.55,
-"decompress_mbps": 157.42
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 19.69,
-"decompress_mbps": 146.79
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 20.66,
-"decompress_mbps": 152.12
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4623589,
-"ratio": 0.4536,
-"compress_mbps": 106.46,
-"decompress_mbps": 174.84
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4241525,
-"ratio": 0.4161,
-"compress_mbps": 71.24,
-"decompress_mbps": 194.62
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4123202,
-"ratio": 0.4045,
-"compress_mbps": 59.05,
-"decompress_mbps": 204.17
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3985937,
-"ratio": 0.3911,
-"compress_mbps": 61.33,
-"decompress_mbps": 209.58
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3883839,
-"ratio": 0.3811,
-"compress_mbps": 35.66,
-"decompress_mbps": 202.59
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3860437,
-"ratio": 0.3788,
-"compress_mbps": 28.04,
-"decompress_mbps": 202.01
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3857076,
-"ratio": 0.3784,
-"compress_mbps": 24.78,
-"decompress_mbps": 203.77
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3856651,
-"ratio": 0.3784,
-"compress_mbps": 24.63,
-"decompress_mbps": 203.27
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3856651,
-"ratio": 0.3784,
-"compress_mbps": 24.76,
-"decompress_mbps": 211.72
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 21508211,
-"ratio": 0.4199,
-"compress_mbps": 142.98,
-"decompress_mbps": 246.74
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20538783,
-"ratio": 0.401,
-"compress_mbps": 108.3,
-"decompress_mbps": 228.71
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 20334352,
-"ratio": 0.397,
-"compress_mbps": 93.47,
-"decompress_mbps": 246.34
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19886937,
-"ratio": 0.3883,
-"compress_mbps": 87.89,
-"decompress_mbps": 238.01
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19582363,
-"ratio": 0.3823,
-"compress_mbps": 64.2,
-"decompress_mbps": 242.86
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19512479,
-"ratio": 0.381,
-"compress_mbps": 44.15,
-"decompress_mbps": 255.88
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19489160,
-"ratio": 0.3805,
-"compress_mbps": 32.36,
-"decompress_mbps": 252.49
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19475109,
-"ratio": 0.3802,
-"compress_mbps": 18.59,
-"decompress_mbps": 247.27
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19476276,
-"ratio": 0.3802,
-"compress_mbps": 10.51,
-"decompress_mbps": 243.51
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3967718,
-"ratio": 0.3979,
-"compress_mbps": 146.46,
-"decompress_mbps": 222.75
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3773274,
-"ratio": 0.3784,
-"compress_mbps": 102.39,
-"decompress_mbps": 230.13
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3670460,
-"ratio": 0.3681,
-"compress_mbps": 75.33,
-"decompress_mbps": 242.04
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3655100,
-"ratio": 0.3666,
-"compress_mbps": 87.59,
-"decompress_mbps": 238.12
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3620881,
-"ratio": 0.3632,
-"compress_mbps": 50.88,
-"decompress_mbps": 250.51
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3606626,
-"ratio": 0.3617,
-"compress_mbps": 33.89,
-"decompress_mbps": 247.41
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3605405,
-"ratio": 0.3616,
-"compress_mbps": 30.81,
-"decompress_mbps": 246.74
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3601635,
-"ratio": 0.3612,
-"compress_mbps": 25.68,
-"decompress_mbps": 227.24
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3601151,
-"ratio": 0.3612,
-"compress_mbps": 19.2,
-"decompress_mbps": 245.97
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4501482,
-"ratio": 0.1342,
-"compress_mbps": 333.02,
-"decompress_mbps": 483.43
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3875891,
-"ratio": 0.1155,
-"compress_mbps": 306.97,
-"decompress_mbps": 612.28
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3731525,
-"ratio": 0.1112,
-"compress_mbps": 279.53,
-"decompress_mbps": 632.7
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3542242,
-"ratio": 0.1056,
-"compress_mbps": 236.63,
-"decompress_mbps": 649.49
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3239184,
-"ratio": 0.0965,
-"compress_mbps": 173.99,
-"decompress_mbps": 719.1
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3113927,
-"ratio": 0.0928,
-"compress_mbps": 118.81,
-"decompress_mbps": 719.15
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3063520,
-"ratio": 0.0913,
-"compress_mbps": 82.15,
-"decompress_mbps": 681.16
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 2961320,
-"ratio": 0.0883,
-"compress_mbps": 28.78,
-"decompress_mbps": 725.62
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2940087,
-"ratio": 0.0876,
-"compress_mbps": 20.5,
-"decompress_mbps": 702.47
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3462708,
-"ratio": 0.5628,
-"compress_mbps": 96.7,
-"decompress_mbps": 163.94
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3327399,
-"ratio": 0.5408,
-"compress_mbps": 69.38,
-"decompress_mbps": 172
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3297422,
-"ratio": 0.536,
-"compress_mbps": 66.48,
-"decompress_mbps": 168.63
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3249485,
-"ratio": 0.5282,
-"compress_mbps": 64.43,
-"decompress_mbps": 170.8
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3220046,
-"ratio": 0.5234,
-"compress_mbps": 47.97,
-"decompress_mbps": 180.46
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3213239,
-"ratio": 0.5223,
-"compress_mbps": 41.91,
-"decompress_mbps": 177.23
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3212009,
-"ratio": 0.5221,
-"compress_mbps": 38.45,
-"decompress_mbps": 176.52
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3211575,
-"ratio": 0.522,
-"compress_mbps": 33.68,
-"decompress_mbps": 178.54
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3211561,
-"ratio": 0.522,
-"compress_mbps": 30.24,
-"decompress_mbps": 175.6
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4334497,
-"ratio": 0.4298,
-"compress_mbps": 137.98,
-"decompress_mbps": 232.72
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3900156,
-"ratio": 0.3867,
-"compress_mbps": 132.35,
-"decompress_mbps": 249.83
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3876099,
-"ratio": 0.3843,
-"compress_mbps": 118.4,
-"decompress_mbps": 253.84
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3782364,
-"ratio": 0.375,
-"compress_mbps": 108.19,
-"decompress_mbps": 260.26
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3679310,
-"ratio": 0.3648,
-"compress_mbps": 86.38,
-"decompress_mbps": 271
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3679424,
-"ratio": 0.3648,
-"compress_mbps": 85,
-"decompress_mbps": 272.89
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3679163,
-"ratio": 0.3648,
-"compress_mbps": 82.65,
-"decompress_mbps": 270.6
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3679169,
-"ratio": 0.3648,
-"compress_mbps": 79.52,
-"decompress_mbps": 273.9
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3679169,
-"ratio": 0.3648,
-"compress_mbps": 81.42,
-"decompress_mbps": 271.83
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2496363,
-"ratio": 0.3767,
-"compress_mbps": 129.12,
-"decompress_mbps": 204.48
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2202601,
-"ratio": 0.3324,
-"compress_mbps": 92.91,
-"decompress_mbps": 241.42
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2103089,
-"ratio": 0.3173,
-"compress_mbps": 67.1,
-"decompress_mbps": 251.29
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1999697,
-"ratio": 0.3017,
-"compress_mbps": 73.42,
-"decompress_mbps": 259.63
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1892143,
-"ratio": 0.2855,
-"compress_mbps": 36.54,
-"decompress_mbps": 258.67
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1838372,
-"ratio": 0.2774,
-"compress_mbps": 20.22,
-"decompress_mbps": 254.09
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1828850,
-"ratio": 0.276,
-"compress_mbps": 15.81,
-"decompress_mbps": 261.92
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1823159,
-"ratio": 0.2751,
-"compress_mbps": 12.48,
-"decompress_mbps": 258.66
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1823159,
-"ratio": 0.2751,
-"compress_mbps": 12.35,
-"decompress_mbps": 259.37
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6447290,
-"ratio": 0.2984,
-"compress_mbps": 188.76,
-"decompress_mbps": 308.38
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 6030257,
-"ratio": 0.2791,
-"compress_mbps": 146.76,
-"decompress_mbps": 321.61
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5928121,
-"ratio": 0.2744,
-"compress_mbps": 127.38,
-"decompress_mbps": 314.13
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5615804,
-"ratio": 0.2599,
-"compress_mbps": 116.92,
-"decompress_mbps": 352.74
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5496738,
-"ratio": 0.2544,
-"compress_mbps": 82.63,
-"decompress_mbps": 353.09
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5464184,
-"ratio": 0.2529,
-"compress_mbps": 62.47,
-"decompress_mbps": 338.22
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5429645,
-"ratio": 0.2513,
-"compress_mbps": 48.92,
-"decompress_mbps": 346.05
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5418135,
-"ratio": 0.2508,
-"compress_mbps": 37.6,
-"decompress_mbps": 331.17
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5416628,
-"ratio": 0.2507,
-"compress_mbps": 33.11,
-"decompress_mbps": 340.52
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5759187,
-"ratio": 0.7942,
-"compress_mbps": 98.44,
-"decompress_mbps": 174.26
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5619390,
-"ratio": 0.7749,
-"compress_mbps": 64.68,
-"decompress_mbps": 173.71
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5560914,
-"ratio": 0.7668,
-"compress_mbps": 55.42,
-"decompress_mbps": 176.35
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5544069,
-"ratio": 0.7645,
-"compress_mbps": 56.96,
-"decompress_mbps": 180.58
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5518257,
-"ratio": 0.7609,
-"compress_mbps": 43.87,
-"decompress_mbps": 181.18
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5508662,
-"ratio": 0.7596,
-"compress_mbps": 40.09,
-"decompress_mbps": 184.24
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5507534,
-"ratio": 0.7595,
-"compress_mbps": 38.84,
-"decompress_mbps": 185.4
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5507183,
-"ratio": 0.7594,
-"compress_mbps": 38.12,
-"decompress_mbps": 181.95
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5507183,
-"ratio": 0.7594,
-"compress_mbps": 38.4,
-"decompress_mbps": 180.12
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 15230651,
-"ratio": 0.3674,
-"compress_mbps": 123.34,
-"decompress_mbps": 204.2
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 13822040,
-"ratio": 0.3334,
-"compress_mbps": 92.99,
-"decompress_mbps": 227.62
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 13397592,
-"ratio": 0.3232,
-"compress_mbps": 83.93,
-"decompress_mbps": 237.25
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12759940,
-"ratio": 0.3078,
-"compress_mbps": 82.09,
-"decompress_mbps": 245.12
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12274278,
-"ratio": 0.2961,
-"compress_mbps": 52.94,
-"decompress_mbps": 238.04
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12131738,
-"ratio": 0.2926,
-"compress_mbps": 40.1,
-"decompress_mbps": 245.6
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12060450,
-"ratio": 0.2909,
-"compress_mbps": 32.69,
-"decompress_mbps": 256.06
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12036900,
-"ratio": 0.2903,
-"compress_mbps": 29.36,
-"decompress_mbps": 256.57
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12036900,
-"ratio": 0.2903,
-"compress_mbps": 29.24,
-"decompress_mbps": 255.77
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6653052,
-"ratio": 0.7851,
-"compress_mbps": 174.98,
-"decompress_mbps": 178.76
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6305035,
-"ratio": 0.744,
-"compress_mbps": 67.83,
-"decompress_mbps": 162.76
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6302730,
-"ratio": 0.7438,
-"compress_mbps": 67.37,
-"decompress_mbps": 163.05
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6299134,
-"ratio": 0.7433,
-"compress_mbps": 67.02,
-"decompress_mbps": 163.39
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6289022,
-"ratio": 0.7421,
-"compress_mbps": 63.92,
-"decompress_mbps": 165.24
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6289013,
-"ratio": 0.7421,
-"compress_mbps": 64.58,
-"decompress_mbps": 165.92
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6289013,
-"ratio": 0.7421,
-"compress_mbps": 64.28,
-"decompress_mbps": 163.17
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6289012,
-"ratio": 0.7421,
-"compress_mbps": 63.72,
-"decompress_mbps": 163.75
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6289012,
-"ratio": 0.7421,
-"compress_mbps": 63.85,
-"decompress_mbps": 166.63
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 989456,
-"ratio": 0.1851,
-"compress_mbps": 251.05,
-"decompress_mbps": 381.62
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 839766,
-"ratio": 0.1571,
-"compress_mbps": 229.03,
-"decompress_mbps": 483.44
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 800619,
-"ratio": 0.1498,
-"compress_mbps": 191.04,
-"decompress_mbps": 522.72
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 776397,
-"ratio": 0.1452,
-"compress_mbps": 169.69,
-"decompress_mbps": 486.85
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 712679,
-"ratio": 0.1333,
-"compress_mbps": 122.98,
-"decompress_mbps": 536.51
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 683707,
-"ratio": 0.1279,
-"compress_mbps": 93.21,
-"decompress_mbps": 563.06
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 668601,
-"ratio": 0.1251,
-"compress_mbps": 70.72,
-"decompress_mbps": 550.36
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 659106,
-"ratio": 0.1233,
-"compress_mbps": 48.38,
-"decompress_mbps": 601.92
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 658920,
-"ratio": 0.1233,
-"compress_mbps": 46.58,
-"decompress_mbps": 561.41
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 62797,
-"ratio": 0.4129,
-"compress_mbps": 74.25,
-"decompress_mbps": 167.23
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 59605,
-"ratio": 0.3919,
-"compress_mbps": 51.93,
-"decompress_mbps": 207.48
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 57675,
-"ratio": 0.3792,
-"compress_mbps": 44.8,
-"decompress_mbps": 192.69
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56500,
-"ratio": 0.3715,
-"compress_mbps": 39.14,
-"decompress_mbps": 204.7
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 56440,
-"ratio": 0.3711,
-"compress_mbps": 38.88,
-"decompress_mbps": 206.94
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 55443,
-"ratio": 0.3645,
-"compress_mbps": 31.58,
-"decompress_mbps": 226.48
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 55373,
-"ratio": 0.3641,
-"compress_mbps": 31.78,
-"decompress_mbps": 207.48
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 55352,
-"ratio": 0.3639,
-"compress_mbps": 31.54,
-"decompress_mbps": 202.08
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 55352,
-"ratio": 0.3639,
-"compress_mbps": 31.51,
-"decompress_mbps": 211.38
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 55063,
-"ratio": 0.4399,
-"compress_mbps": 76.04,
-"decompress_mbps": 187.2
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 52932,
-"ratio": 0.4229,
-"compress_mbps": 61.88,
-"decompress_mbps": 175.39
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51597,
-"ratio": 0.4122,
-"compress_mbps": 44.51,
-"decompress_mbps": 171.18
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50780,
-"ratio": 0.4057,
-"compress_mbps": 38.47,
-"decompress_mbps": 173.54
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 50767,
-"ratio": 0.4056,
-"compress_mbps": 38.3,
-"decompress_mbps": 177.12
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 50160,
-"ratio": 0.4007,
-"compress_mbps": 32.93,
-"decompress_mbps": 192.43
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 50138,
-"ratio": 0.4005,
-"compress_mbps": 31.87,
-"decompress_mbps": 182.06
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 50138,
-"ratio": 0.4005,
-"compress_mbps": 32.19,
-"decompress_mbps": 181.45
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 50138,
-"ratio": 0.4005,
-"compress_mbps": 32.34,
-"decompress_mbps": 179.48
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8730,
-"ratio": 0.3548,
-"compress_mbps": 73.88,
-"decompress_mbps": 132.63
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8457,
-"ratio": 0.3437,
-"compress_mbps": 58.43,
-"decompress_mbps": 134.93
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8353,
-"ratio": 0.3395,
-"compress_mbps": 63.02,
-"decompress_mbps": 116.37
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8301,
-"ratio": 0.3374,
-"compress_mbps": 60.52,
-"decompress_mbps": 140.58
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8212,
-"ratio": 0.3338,
-"compress_mbps": 62.76,
-"decompress_mbps": 114.25
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 8172,
-"ratio": 0.3322,
-"compress_mbps": 55.65,
-"decompress_mbps": 115.06
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 8171,
-"ratio": 0.3321,
-"compress_mbps": 55.83,
-"decompress_mbps": 115.26
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 8171,
-"ratio": 0.3321,
-"compress_mbps": 52.89,
-"decompress_mbps": 116.01
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 8171,
-"ratio": 0.3321,
-"compress_mbps": 56.37,
-"decompress_mbps": 113.83
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3475,
-"ratio": 0.3117,
-"compress_mbps": 112.85,
-"decompress_mbps": 115.46
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3305,
-"ratio": 0.2964,
-"compress_mbps": 101.69,
-"decompress_mbps": 105.52
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3225,
-"ratio": 0.2892,
-"compress_mbps": 102.05,
-"decompress_mbps": 109.18
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3192,
-"ratio": 0.2863,
-"compress_mbps": 101.53,
-"decompress_mbps": 127.86
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3180,
-"ratio": 0.2852,
-"compress_mbps": 100.58,
-"decompress_mbps": 129.11
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 97.53,
-"decompress_mbps": 143.25
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 95.44,
-"decompress_mbps": 119.68
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 94.85,
-"decompress_mbps": 122.41
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 96.48,
-"decompress_mbps": 134.8
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1275,
-"ratio": 0.3426,
-"compress_mbps": 61.69,
-"decompress_mbps": 49.2
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1247,
-"ratio": 0.3351,
-"compress_mbps": 60.51,
-"decompress_mbps": 50.56
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 58.82,
-"decompress_mbps": 52.09
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1238,
-"ratio": 0.3327,
-"compress_mbps": 58.29,
-"decompress_mbps": 50.06
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 59.27,
-"decompress_mbps": 53.66
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 63.19,
-"decompress_mbps": 51.87
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 59.33,
-"decompress_mbps": 53.75
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 61.83,
-"decompress_mbps": 52.24
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 58.73,
-"decompress_mbps": 53.98
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 226284,
-"ratio": 0.2197,
-"compress_mbps": 110.56,
-"decompress_mbps": 297.22
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 221369,
-"ratio": 0.215,
-"compress_mbps": 88.86,
-"decompress_mbps": 311.44
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 218607,
-"ratio": 0.2123,
-"compress_mbps": 79.85,
-"decompress_mbps": 314.72
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 217919,
-"ratio": 0.2116,
-"compress_mbps": 70.99,
-"decompress_mbps": 327.79
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 217919,
-"ratio": 0.2116,
-"compress_mbps": 61.76,
-"decompress_mbps": 315.73
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 217312,
-"ratio": 0.211,
-"compress_mbps": 44.12,
-"decompress_mbps": 310.73
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 215966,
-"ratio": 0.2097,
-"compress_mbps": 31.28,
-"decompress_mbps": 305.83
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 215930,
-"ratio": 0.2097,
-"compress_mbps": 14.26,
-"decompress_mbps": 303.4
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 215912,
-"ratio": 0.2097,
-"compress_mbps": 11.29,
-"decompress_mbps": 350.23
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 167622,
-"ratio": 0.3928,
-"compress_mbps": 61.66,
-"decompress_mbps": 168.94
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 158003,
-"ratio": 0.3702,
-"compress_mbps": 54.4,
-"decompress_mbps": 186.71
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 152928,
-"ratio": 0.3584,
-"compress_mbps": 46.97,
-"decompress_mbps": 189.26
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 149886,
-"ratio": 0.3512,
-"compress_mbps": 40.23,
-"decompress_mbps": 158.73
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 149767,
-"ratio": 0.3509,
-"compress_mbps": 40.02,
-"decompress_mbps": 191.87
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 147818,
-"ratio": 0.3464,
-"compress_mbps": 33.31,
-"decompress_mbps": 180.4
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 147733,
-"ratio": 0.3462,
-"compress_mbps": 32.8,
-"decompress_mbps": 191.02
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 147709,
-"ratio": 0.3461,
-"compress_mbps": 31.96,
-"decompress_mbps": 164.61
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 147705,
-"ratio": 0.3461,
-"compress_mbps": 32.64,
-"decompress_mbps": 153.65
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 222866,
-"ratio": 0.4625,
-"compress_mbps": 58.94,
-"decompress_mbps": 158.31
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 212925,
-"ratio": 0.4419,
-"compress_mbps": 48.98,
-"decompress_mbps": 189.98
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 206913,
-"ratio": 0.4294,
-"compress_mbps": 40.43,
-"decompress_mbps": 174.84
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 202875,
-"ratio": 0.421,
-"compress_mbps": 34.16,
-"decompress_mbps": 178.06
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 202867,
-"ratio": 0.421,
-"compress_mbps": 33.29,
-"decompress_mbps": 195.75
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 199818,
-"ratio": 0.4147,
-"compress_mbps": 27.78,
-"decompress_mbps": 195.46
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 199664,
-"ratio": 0.4144,
-"compress_mbps": 27.21,
-"decompress_mbps": 174.87
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 199634,
-"ratio": 0.4143,
-"compress_mbps": 28.08,
-"decompress_mbps": 179.17
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 199634,
-"ratio": 0.4143,
-"compress_mbps": 27.59,
-"decompress_mbps": 176.39
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 60580,
-"ratio": 0.118,
-"compress_mbps": 113.36,
-"decompress_mbps": 280.91
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 59663,
-"ratio": 0.1163,
-"compress_mbps": 107.03,
-"decompress_mbps": 307.86
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 59465,
-"ratio": 0.1159,
-"compress_mbps": 101.79,
-"decompress_mbps": 300.57
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 59353,
-"ratio": 0.1156,
-"compress_mbps": 95.8,
-"decompress_mbps": 293.13
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 58830,
-"ratio": 0.1146,
-"compress_mbps": 86.05,
-"decompress_mbps": 301.25
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 57884,
-"ratio": 0.1128,
-"compress_mbps": 57.39,
-"decompress_mbps": 290.58
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 57206,
-"ratio": 0.1115,
-"compress_mbps": 45.57,
-"decompress_mbps": 300.04
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 56545,
-"ratio": 0.1102,
-"compress_mbps": 23.23,
-"decompress_mbps": 284.03
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 56454,
-"ratio": 0.11,
-"compress_mbps": 9.14,
-"decompress_mbps": 302.34
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14194,
-"ratio": 0.3712,
-"compress_mbps": 81.24,
-"decompress_mbps": 136.64
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13770,
-"ratio": 0.3601,
-"compress_mbps": 70.56,
-"decompress_mbps": 119.31
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13611,
-"ratio": 0.3559,
-"compress_mbps": 66.71,
-"decompress_mbps": 122.65
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13534,
-"ratio": 0.3539,
-"compress_mbps": 63.46,
-"decompress_mbps": 130.44
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13527,
-"ratio": 0.3537,
-"compress_mbps": 63.13,
-"decompress_mbps": 149.08
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13438,
-"ratio": 0.3514,
-"compress_mbps": 50.22,
-"decompress_mbps": 145.86
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13419,
-"ratio": 0.3509,
-"compress_mbps": 45.9,
-"decompress_mbps": 123.05
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13404,
-"ratio": 0.3505,
-"compress_mbps": 42.26,
-"decompress_mbps": 131.89
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13390,
-"ratio": 0.3502,
-"compress_mbps": 36.7,
-"decompress_mbps": 124.93
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1832,
-"ratio": 0.4334,
-"compress_mbps": 61.56,
-"decompress_mbps": 56.84
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1776,
-"ratio": 0.4202,
-"compress_mbps": 60.97,
-"decompress_mbps": 68.52
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1764,
-"ratio": 0.4173,
-"compress_mbps": 59.96,
-"decompress_mbps": 63.64
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1763,
-"ratio": 0.4171,
-"compress_mbps": 60.29,
-"decompress_mbps": 57.95
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 57.26,
-"decompress_mbps": 57.5
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 59.69,
-"decompress_mbps": 64.6
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 59.23,
-"decompress_mbps": 68.61
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 59.56,
-"decompress_mbps": 68.42
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 59.83,
-"decompress_mbps": 58.69
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4462632,
-"ratio": 0.4378,
-"compress_mbps": 62.18,
-"decompress_mbps": 173.87
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4244833,
-"ratio": 0.4165,
-"compress_mbps": 50.89,
-"decompress_mbps": 201.85
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4112285,
-"ratio": 0.4035,
-"compress_mbps": 42.09,
-"decompress_mbps": 183.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4020435,
-"ratio": 0.3945,
-"compress_mbps": 35.57,
-"decompress_mbps": 195.02
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 4019177,
-"ratio": 0.3943,
-"compress_mbps": 35.98,
-"decompress_mbps": 195.68
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3956464,
-"ratio": 0.3882,
-"compress_mbps": 28.83,
-"decompress_mbps": 187.08
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3953310,
-"ratio": 0.3879,
-"compress_mbps": 28.68,
-"decompress_mbps": 201.81
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3952872,
-"ratio": 0.3878,
-"compress_mbps": 29.26,
-"decompress_mbps": 223.56
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3952872,
-"ratio": 0.3878,
-"compress_mbps": 29.19,
-"decompress_mbps": 229.9
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20177423,
-"ratio": 0.3939,
-"compress_mbps": 72.38,
-"decompress_mbps": 217.73
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 19759467,
-"ratio": 0.3858,
-"compress_mbps": 63.54,
-"decompress_mbps": 200.68
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19583171,
-"ratio": 0.3823,
-"compress_mbps": 56.88,
-"decompress_mbps": 213.41
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19479125,
-"ratio": 0.3803,
-"compress_mbps": 51.05,
-"decompress_mbps": 226.18
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19423693,
-"ratio": 0.3792,
-"compress_mbps": 48.99,
-"decompress_mbps": 195.52
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19337683,
-"ratio": 0.3775,
-"compress_mbps": 36.22,
-"decompress_mbps": 206.71
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19323922,
-"ratio": 0.3773,
-"compress_mbps": 30.44,
-"decompress_mbps": 203.82
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19314797,
-"ratio": 0.3771,
-"compress_mbps": 19.34,
-"decompress_mbps": 216.09
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19312663,
-"ratio": 0.377,
-"compress_mbps": 11.02,
-"decompress_mbps": 224.35
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3762978,
-"ratio": 0.3774,
-"compress_mbps": 78.06,
-"decompress_mbps": 158.08
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3711615,
-"ratio": 0.3723,
-"compress_mbps": 67.98,
-"decompress_mbps": 211.43
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3663131,
-"ratio": 0.3674,
-"compress_mbps": 57.96,
-"decompress_mbps": 221.94
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3631512,
-"ratio": 0.3642,
-"compress_mbps": 48.43,
-"decompress_mbps": 204.02
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3630867,
-"ratio": 0.3642,
-"compress_mbps": 48.23,
-"decompress_mbps": 201
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3615953,
-"ratio": 0.3627,
-"compress_mbps": 38.3,
-"decompress_mbps": 229.47
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3615518,
-"ratio": 0.3626,
-"compress_mbps": 35.97,
-"decompress_mbps": 204.3
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3613845,
-"ratio": 0.3625,
-"compress_mbps": 30.3,
-"decompress_mbps": 255.4
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3614283,
-"ratio": 0.3625,
-"compress_mbps": 26.31,
-"decompress_mbps": 228.58
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4418800,
-"ratio": 0.1317,
-"compress_mbps": 130.71,
-"decompress_mbps": 369.72
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4026774,
-"ratio": 0.12,
-"compress_mbps": 122.45,
-"decompress_mbps": 389.14
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3837798,
-"ratio": 0.1144,
-"compress_mbps": 116.09,
-"decompress_mbps": 443.42
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3751023,
-"ratio": 0.1118,
-"compress_mbps": 111.56,
-"decompress_mbps": 413.61
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3643468,
-"ratio": 0.1086,
-"compress_mbps": 102.54,
-"decompress_mbps": 412.02
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3379481,
-"ratio": 0.1007,
-"compress_mbps": 69.02,
-"decompress_mbps": 429.31
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3354082,
-"ratio": 0.1,
-"compress_mbps": 61.13,
-"decompress_mbps": 431.77
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3330028,
-"ratio": 0.0992,
-"compress_mbps": 47.82,
-"decompress_mbps": 442.73
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3327482,
-"ratio": 0.0992,
-"compress_mbps": 37.59,
-"decompress_mbps": 421.2
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3233790,
-"ratio": 0.5256,
-"compress_mbps": 54.05,
-"decompress_mbps": 127.18
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3184644,
-"ratio": 0.5176,
-"compress_mbps": 47.33,
-"decompress_mbps": 128.98
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3160521,
-"ratio": 0.5137,
-"compress_mbps": 44.22,
-"decompress_mbps": 143.07
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3141929,
-"ratio": 0.5107,
-"compress_mbps": 39.8,
-"decompress_mbps": 162.49
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3138514,
-"ratio": 0.5101,
-"compress_mbps": 38.68,
-"decompress_mbps": 145.42
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3126843,
-"ratio": 0.5082,
-"compress_mbps": 32.2,
-"decompress_mbps": 146.98
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3126796,
-"ratio": 0.5082,
-"compress_mbps": 30.36,
-"decompress_mbps": 148.14
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3126322,
-"ratio": 0.5082,
-"compress_mbps": 26.94,
-"decompress_mbps": 146.91
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3126286,
-"ratio": 0.5082,
-"compress_mbps": 22.89,
-"decompress_mbps": 147.39
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4076349,
-"ratio": 0.4042,
-"compress_mbps": 78.93,
-"decompress_mbps": 211.38
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3914739,
-"ratio": 0.3881,
-"compress_mbps": 71.76,
-"decompress_mbps": 231.12
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3845160,
-"ratio": 0.3812,
-"compress_mbps": 68.63,
-"decompress_mbps": 282.67
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3822047,
-"ratio": 0.379,
-"compress_mbps": 64.6,
-"decompress_mbps": 254.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3799472,
-"ratio": 0.3767,
-"compress_mbps": 60.68,
-"decompress_mbps": 278.97
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3783861,
-"ratio": 0.3752,
-"compress_mbps": 58.24,
-"decompress_mbps": 284.08
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3783432,
-"ratio": 0.3751,
-"compress_mbps": 57.98,
-"decompress_mbps": 282.33
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3783342,
-"ratio": 0.3751,
-"compress_mbps": 57.83,
-"decompress_mbps": 287.15
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3783342,
-"ratio": 0.3751,
-"compress_mbps": 57.91,
-"decompress_mbps": 291.22
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2261112,
-"ratio": 0.3412,
-"compress_mbps": 72.06,
-"decompress_mbps": 226.8
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2128691,
-"ratio": 0.3212,
-"compress_mbps": 58.58,
-"decompress_mbps": 213.25
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2049023,
-"ratio": 0.3092,
-"compress_mbps": 49.56,
-"decompress_mbps": 233.33
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1990249,
-"ratio": 0.3003,
-"compress_mbps": 40.91,
-"decompress_mbps": 212.86
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1975224,
-"ratio": 0.298,
-"compress_mbps": 38.75,
-"decompress_mbps": 207.84
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1910262,
-"ratio": 0.2882,
-"compress_mbps": 27.88,
-"decompress_mbps": 195.73
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1902923,
-"ratio": 0.2871,
-"compress_mbps": 25.32,
-"decompress_mbps": 197.79
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1900964,
-"ratio": 0.2868,
-"compress_mbps": 23.18,
-"decompress_mbps": 229.68
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1900958,
-"ratio": 0.2868,
-"compress_mbps": 24.34,
-"decompress_mbps": 233.76
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6016919,
-"ratio": 0.2785,
-"compress_mbps": 92.98,
-"decompress_mbps": 252.21
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5767272,
-"ratio": 0.2669,
-"compress_mbps": 81.98,
-"decompress_mbps": 259.05
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5669548,
-"ratio": 0.2624,
-"compress_mbps": 76.36,
-"decompress_mbps": 272.14
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5619947,
-"ratio": 0.2601,
-"compress_mbps": 68.61,
-"decompress_mbps": 275.8
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5586034,
-"ratio": 0.2585,
-"compress_mbps": 65.35,
-"decompress_mbps": 283.34
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5540130,
-"ratio": 0.2564,
-"compress_mbps": 50.98,
-"decompress_mbps": 281.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5537271,
-"ratio": 0.2563,
-"compress_mbps": 48.19,
-"decompress_mbps": 261.4
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5530686,
-"ratio": 0.256,
-"compress_mbps": 37.62,
-"decompress_mbps": 305.35
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5529823,
-"ratio": 0.2559,
-"compress_mbps": 31.13,
-"decompress_mbps": 285.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5602819,
-"ratio": 0.7726,
-"compress_mbps": 49.13,
-"decompress_mbps": 166.9
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5504019,
-"ratio": 0.759,
-"compress_mbps": 43.06,
-"decompress_mbps": 155.83
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5452816,
-"ratio": 0.7519,
-"compress_mbps": 39.24,
-"decompress_mbps": 157.12
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5425752,
-"ratio": 0.7482,
-"compress_mbps": 34.72,
-"decompress_mbps": 189.99
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5425752,
-"ratio": 0.7482,
-"compress_mbps": 34.92,
-"decompress_mbps": 159.32
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5407602,
-"ratio": 0.7457,
-"compress_mbps": 30.72,
-"decompress_mbps": 160.05
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5406417,
-"ratio": 0.7455,
-"compress_mbps": 30.63,
-"decompress_mbps": 158.56
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5406380,
-"ratio": 0.7455,
-"compress_mbps": 30.03,
-"decompress_mbps": 139.82
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5406380,
-"ratio": 0.7455,
-"compress_mbps": 30.67,
-"decompress_mbps": 156.97
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 14342407,
-"ratio": 0.3459,
-"compress_mbps": 74.36,
-"decompress_mbps": 194.26
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 13424966,
-"ratio": 0.3238,
-"compress_mbps": 62.93,
-"decompress_mbps": 216.25
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 13061399,
-"ratio": 0.315,
-"compress_mbps": 54.76,
-"decompress_mbps": 210.45
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12877207,
-"ratio": 0.3106,
-"compress_mbps": 50,
-"decompress_mbps": 214.23
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12671090,
-"ratio": 0.3056,
-"compress_mbps": 47.01,
-"decompress_mbps": 215.37
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12511088,
-"ratio": 0.3018,
-"compress_mbps": 40.19,
-"decompress_mbps": 236.92
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12503313,
-"ratio": 0.3016,
-"compress_mbps": 38.48,
-"decompress_mbps": 236.41
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12502263,
-"ratio": 0.3016,
-"compress_mbps": 39.01,
-"decompress_mbps": 227.08
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12502263,
-"ratio": 0.3016,
-"compress_mbps": 39.8,
-"decompress_mbps": 236.88
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6022390,
-"ratio": 0.7107,
-"compress_mbps": 54.54,
-"decompress_mbps": 147.7
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 5997124,
-"ratio": 0.7077,
-"compress_mbps": 49,
-"decompress_mbps": 150.97
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 5979254,
-"ratio": 0.7056,
-"compress_mbps": 43.95,
-"decompress_mbps": 150.86
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 5967955,
-"ratio": 0.7042,
-"compress_mbps": 42.03,
-"decompress_mbps": 185.25
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 5967953,
-"ratio": 0.7042,
-"compress_mbps": 41.93,
-"decompress_mbps": 152.87
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5965386,
-"ratio": 0.7039,
-"compress_mbps": 41.38,
-"decompress_mbps": 157.82
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5965383,
-"ratio": 0.7039,
-"compress_mbps": 42.2,
-"decompress_mbps": 155.95
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5965383,
-"ratio": 0.7039,
-"compress_mbps": 41.73,
-"decompress_mbps": 154.98
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5965383,
-"ratio": 0.7039,
-"compress_mbps": 41.71,
-"decompress_mbps": 140.86
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 985606,
-"ratio": 0.1844,
-"compress_mbps": 112.33,
-"decompress_mbps": 311.7
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 852636,
-"ratio": 0.1595,
-"compress_mbps": 101.36,
-"decompress_mbps": 349.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 814293,
-"ratio": 0.1523,
-"compress_mbps": 96.4,
-"decompress_mbps": 340.21
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 788388,
-"ratio": 0.1475,
-"compress_mbps": 90.28,
-"decompress_mbps": 353.5
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 749390,
-"ratio": 0.1402,
-"compress_mbps": 81.91,
-"decompress_mbps": 381.16
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 706892,
-"ratio": 0.1322,
-"compress_mbps": 67.06,
-"decompress_mbps": 383.86
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 705695,
-"ratio": 0.132,
-"compress_mbps": 64.89,
-"decompress_mbps": 409.17
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 703904,
-"ratio": 0.1317,
-"compress_mbps": 60.32,
-"decompress_mbps": 376.72
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 703900,
-"ratio": 0.1317,
-"compress_mbps": 60.38,
-"decompress_mbps": 403.97
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 84.63,
-"decompress_mbps": 312.12
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 86.16,
-"decompress_mbps": 314.27
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 89.15,
-"decompress_mbps": 312.88
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 88.94,
-"decompress_mbps": 315.76
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54531,
-"ratio": 0.3585,
-"compress_mbps": 55.32,
-"decompress_mbps": 305.77
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54068,
-"ratio": 0.3555,
-"compress_mbps": 41.3,
-"decompress_mbps": 307.21
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54003,
-"ratio": 0.3551,
-"compress_mbps": 37.63,
-"decompress_mbps": 308.6
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 53974,
-"ratio": 0.3549,
-"compress_mbps": 33.19,
-"decompress_mbps": 310.69
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 53974,
-"ratio": 0.3549,
-"compress_mbps": 33.38,
-"decompress_mbps": 305.28
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 84.35,
-"decompress_mbps": 277.41
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 84.49,
-"decompress_mbps": 281.17
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 84.68,
-"decompress_mbps": 276.72
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 84.68,
-"decompress_mbps": 272.42
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48753,
-"ratio": 0.3895,
-"compress_mbps": 49.42,
-"decompress_mbps": 273.36
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48557,
-"ratio": 0.3879,
-"compress_mbps": 41.15,
-"decompress_mbps": 278.92
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48523,
-"ratio": 0.3876,
-"compress_mbps": 39.03,
-"decompress_mbps": 277.67
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48522,
-"ratio": 0.3876,
-"compress_mbps": 38.15,
-"decompress_mbps": 271.91
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48522,
-"ratio": 0.3876,
-"compress_mbps": 38.25,
-"decompress_mbps": 272.16
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 176.49,
-"decompress_mbps": 283.21
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 157.0,
-"decompress_mbps": 283.62
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 168.95,
-"decompress_mbps": 283.35
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 164.57,
-"decompress_mbps": 283.89
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7965,
-"ratio": 0.3237,
-"compress_mbps": 107.86,
-"decompress_mbps": 289.08
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7914,
-"ratio": 0.3217,
-"compress_mbps": 88.23,
-"decompress_mbps": 289.56
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7895,
-"ratio": 0.3209,
-"compress_mbps": 76.27,
-"decompress_mbps": 292.21
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7896,
-"ratio": 0.3209,
-"compress_mbps": 74.65,
-"decompress_mbps": 291.45
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7896,
-"ratio": 0.3209,
-"compress_mbps": 71.51,
-"decompress_mbps": 291.41
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 170.11,
-"decompress_mbps": 258.5
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 171.12,
-"decompress_mbps": 256.78
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 177.2,
-"decompress_mbps": 261.19
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 176.99,
-"decompress_mbps": 260.26
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3136,
-"ratio": 0.2813,
-"compress_mbps": 151.39,
-"decompress_mbps": 266.63
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3115,
-"ratio": 0.2794,
-"compress_mbps": 127.43,
-"decompress_mbps": 267.56
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 118.23,
-"decompress_mbps": 269.45
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 107.09,
-"decompress_mbps": 268.59
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 107.78,
-"decompress_mbps": 269.38
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 111.06,
-"decompress_mbps": 120.59
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 114.25,
-"decompress_mbps": 117.15
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 114.48,
-"decompress_mbps": 117.08
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 122.1,
-"decompress_mbps": 119.19
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 112.57,
-"decompress_mbps": 119.9
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 102.93,
-"decompress_mbps": 119.04
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 101.26,
-"decompress_mbps": 118.89
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 102.37,
-"decompress_mbps": 120.33
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 102.25,
-"decompress_mbps": 120.01
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 231.42,
-"decompress_mbps": 460.38
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 228.39,
-"decompress_mbps": 462.25
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 232.41,
-"decompress_mbps": 462.41
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 227.78,
-"decompress_mbps": 463.25
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 218313,
-"ratio": 0.212,
-"compress_mbps": 164.41,
-"decompress_mbps": 446.66
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 215095,
-"ratio": 0.2089,
-"compress_mbps": 105.73,
-"decompress_mbps": 445.2
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 213213,
-"ratio": 0.2071,
-"compress_mbps": 73.14,
-"decompress_mbps": 453.02
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 210955,
-"ratio": 0.2049,
-"compress_mbps": 9.43,
-"decompress_mbps": 453.8
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 210981,
-"ratio": 0.2049,
-"compress_mbps": 4.64,
-"decompress_mbps": 451.7
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 92.4,
-"decompress_mbps": 306.71
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 92.81,
-"decompress_mbps": 306.22
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 89.76,
-"decompress_mbps": 303.23
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 90.15,
-"decompress_mbps": 305.08
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145024,
-"ratio": 0.3398,
-"compress_mbps": 58.08,
-"decompress_mbps": 304.88
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144159,
-"ratio": 0.3378,
-"compress_mbps": 44.57,
-"decompress_mbps": 306.06
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 143991,
-"ratio": 0.3374,
-"compress_mbps": 39.42,
-"decompress_mbps": 299.5
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 143941,
-"ratio": 0.3373,
-"compress_mbps": 37.28,
-"decompress_mbps": 307.95
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 143939,
-"ratio": 0.3373,
-"compress_mbps": 36.26,
-"decompress_mbps": 304.87
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 81.79,
-"decompress_mbps": 257.44
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 81.97,
-"decompress_mbps": 257.92
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 82.18,
-"decompress_mbps": 256.18
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 81.68,
-"decompress_mbps": 255.75
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 194496,
-"ratio": 0.4036,
-"compress_mbps": 46.2,
-"decompress_mbps": 250.51
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 193176,
-"ratio": 0.4009,
-"compress_mbps": 34.69,
-"decompress_mbps": 249.92
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 192991,
-"ratio": 0.4005,
-"compress_mbps": 30.65,
-"decompress_mbps": 250.16
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 192980,
-"ratio": 0.4005,
-"compress_mbps": 29.84,
-"decompress_mbps": 254.16
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 192980,
-"ratio": 0.4005,
-"compress_mbps": 29.85,
-"decompress_mbps": 252.99
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 294.51,
-"decompress_mbps": 736.64
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 297.67,
-"decompress_mbps": 734.2
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 294.46,
-"decompress_mbps": 736.7
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 295.54,
-"decompress_mbps": 739.72
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 56050,
-"ratio": 0.1092,
-"compress_mbps": 232.0,
-"decompress_mbps": 760.55
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55292,
-"ratio": 0.1077,
-"compress_mbps": 149.88,
-"decompress_mbps": 772.53
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 54651,
-"ratio": 0.1065,
-"compress_mbps": 123.87,
-"decompress_mbps": 797.45
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 52583,
-"ratio": 0.1025,
-"compress_mbps": 46.68,
-"decompress_mbps": 821.02
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 51816,
-"ratio": 0.101,
-"compress_mbps": 15.7,
-"decompress_mbps": 839.84
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 118.05,
-"decompress_mbps": 306.01
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 117.56,
-"decompress_mbps": 309.08
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 119.56,
-"decompress_mbps": 305.2
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 113.19,
-"decompress_mbps": 304.41
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13290,
-"ratio": 0.3475,
-"compress_mbps": 84.8,
-"decompress_mbps": 316.74
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13258,
-"ratio": 0.3467,
-"compress_mbps": 65.11,
-"decompress_mbps": 315.1
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13246,
-"ratio": 0.3464,
-"compress_mbps": 56.55,
-"decompress_mbps": 320.71
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13236,
-"ratio": 0.3461,
-"compress_mbps": 24.91,
-"decompress_mbps": 322.05
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13233,
-"ratio": 0.3461,
-"compress_mbps": 16.19,
-"decompress_mbps": 321.85
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 96.4,
-"decompress_mbps": 133.7
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 95.34,
-"decompress_mbps": 133.58
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 96.07,
-"decompress_mbps": 135.51
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 95.82,
-"decompress_mbps": 135.16
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 91.54,
-"decompress_mbps": 135.99
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 91.04,
-"decompress_mbps": 135.74
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 90.12,
-"decompress_mbps": 136.28
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 91.0,
-"decompress_mbps": 136.31
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 91.66,
-"decompress_mbps": 136.03
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 83.98,
-"decompress_mbps": 273.26
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 80.13,
-"decompress_mbps": 270.86
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 83.53,
-"decompress_mbps": 270.42
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 81.44,
-"decompress_mbps": 268.13
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3863846,
-"ratio": 0.3791,
-"compress_mbps": 49.14,
-"decompress_mbps": 268.57
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3838854,
-"ratio": 0.3766,
-"compress_mbps": 36.09,
-"decompress_mbps": 265.48
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3835182,
-"ratio": 0.3763,
-"compress_mbps": 32.84,
-"decompress_mbps": 266.63
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3834518,
-"ratio": 0.3762,
-"compress_mbps": 30.85,
-"decompress_mbps": 265.36
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3834518,
-"ratio": 0.3762,
-"compress_mbps": 31.51,
-"decompress_mbps": 271.03
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 98.52,
-"decompress_mbps": 246.32
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 104.17,
-"decompress_mbps": 253.04
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 104.59,
-"decompress_mbps": 253.23
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 104.72,
-"decompress_mbps": 253.32
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19578840,
-"ratio": 0.3822,
-"compress_mbps": 78.85,
-"decompress_mbps": 260.58
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19492445,
-"ratio": 0.3806,
-"compress_mbps": 55.6,
-"decompress_mbps": 260.04
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19463481,
-"ratio": 0.38,
-"compress_mbps": 46.38,
-"decompress_mbps": 262.76
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19444704,
-"ratio": 0.3796,
-"compress_mbps": 22.63,
-"decompress_mbps": 260.74
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19440748,
-"ratio": 0.3796,
-"compress_mbps": 13.11,
-"decompress_mbps": 265.47
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 113.01,
-"decompress_mbps": 260.13
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 113.77,
-"decompress_mbps": 262.27
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 112.99,
-"decompress_mbps": 260.29
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 113.64,
-"decompress_mbps": 262.21
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3637736,
-"ratio": 0.3648,
-"compress_mbps": 64.5,
-"decompress_mbps": 266.08
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3621530,
-"ratio": 0.3632,
-"compress_mbps": 46.74,
-"decompress_mbps": 269.66
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3623924,
-"ratio": 0.3635,
-"compress_mbps": 42.18,
-"decompress_mbps": 267.79
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3623112,
-"ratio": 0.3634,
-"compress_mbps": 33.06,
-"decompress_mbps": 270.3
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3623382,
-"ratio": 0.3634,
-"compress_mbps": 24.26,
-"decompress_mbps": 264.04
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 310.52,
-"decompress_mbps": 887.67
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 309.19,
-"decompress_mbps": 878.9
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 310.94,
-"decompress_mbps": 889.01
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 310.69,
-"decompress_mbps": 881.41
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3268887,
-"ratio": 0.0974,
-"compress_mbps": 219.28,
-"decompress_mbps": 920.89
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3131445,
-"ratio": 0.0933,
-"compress_mbps": 159.25,
-"decompress_mbps": 961.72
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3080217,
-"ratio": 0.0918,
-"compress_mbps": 130.17,
-"decompress_mbps": 972.76
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 2978354,
-"ratio": 0.0888,
-"compress_mbps": 57.2,
-"decompress_mbps": 973.27
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2947971,
-"ratio": 0.0879,
-"compress_mbps": 33.86,
-"decompress_mbps": 969.27
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 72.55,
-"decompress_mbps": 182.62
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 69.82,
-"decompress_mbps": 180.39
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 72.37,
-"decompress_mbps": 183.48
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 72.75,
-"decompress_mbps": 183.3
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3178914,
-"ratio": 0.5167,
-"compress_mbps": 56.18,
-"decompress_mbps": 190.61
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3174170,
-"ratio": 0.5159,
-"compress_mbps": 47.0,
-"decompress_mbps": 187.25
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3172734,
-"ratio": 0.5157,
-"compress_mbps": 44.06,
-"decompress_mbps": 186.9
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3171353,
-"ratio": 0.5155,
-"compress_mbps": 38.68,
-"decompress_mbps": 192.17
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3171299,
-"ratio": 0.5155,
-"compress_mbps": 34.82,
-"decompress_mbps": 191.22
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 122.98,
-"decompress_mbps": 273.83
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 116.9,
-"decompress_mbps": 265.81
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 122.87,
-"decompress_mbps": 273.85
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 123.15,
-"decompress_mbps": 272.43
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3654027,
-"ratio": 0.3623,
-"compress_mbps": 96.12,
-"decompress_mbps": 275.81
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3652732,
-"ratio": 0.3622,
-"compress_mbps": 93.23,
-"decompress_mbps": 276.92
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3652496,
-"ratio": 0.3621,
-"compress_mbps": 87.58,
-"decompress_mbps": 276.22
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3652505,
-"ratio": 0.3621,
-"compress_mbps": 87.26,
-"decompress_mbps": 275.69
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3652505,
-"ratio": 0.3621,
-"compress_mbps": 83.87,
-"decompress_mbps": 271.98
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 95.25,
-"decompress_mbps": 349.29
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 96.26,
-"decompress_mbps": 352.89
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 100.25,
-"decompress_mbps": 354.4
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 99.91,
-"decompress_mbps": 354.49
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1892183,
-"ratio": 0.2855,
-"compress_mbps": 53.67,
-"decompress_mbps": 353.03
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1837957,
-"ratio": 0.2773,
-"compress_mbps": 29.78,
-"decompress_mbps": 357.23
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1826603,
-"ratio": 0.2756,
-"compress_mbps": 24.43,
-"decompress_mbps": 362.47
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1818702,
-"ratio": 0.2744,
-"compress_mbps": 16.14,
-"decompress_mbps": 362.63
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1818702,
-"ratio": 0.2744,
-"compress_mbps": 15.98,
-"decompress_mbps": 366.35
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 145.97,
-"decompress_mbps": 400.39
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 145.73,
-"decompress_mbps": 402.35
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 145.9,
-"decompress_mbps": 401.81
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 146.24,
-"decompress_mbps": 400.01
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5501344,
-"ratio": 0.2546,
-"compress_mbps": 100.6,
-"decompress_mbps": 398.03
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5464646,
-"ratio": 0.2529,
-"compress_mbps": 79.6,
-"decompress_mbps": 408.78
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5429975,
-"ratio": 0.2513,
-"compress_mbps": 67.13,
-"decompress_mbps": 407.38
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5419566,
-"ratio": 0.2508,
-"compress_mbps": 49.67,
-"decompress_mbps": 412.93
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5417952,
-"ratio": 0.2508,
-"compress_mbps": 44.29,
-"decompress_mbps": 403.48
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.43,
-"decompress_mbps": 161.36
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.35,
-"decompress_mbps": 160.93
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.57,
-"decompress_mbps": 161.7
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.63,
-"decompress_mbps": 160.7
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5450496,
-"ratio": 0.7516,
-"compress_mbps": 45.59,
-"decompress_mbps": 166.62
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5440281,
-"ratio": 0.7502,
-"compress_mbps": 42.27,
-"decompress_mbps": 166.03
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5439077,
-"ratio": 0.75,
-"compress_mbps": 40.8,
-"decompress_mbps": 165.53
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5438787,
-"ratio": 0.75,
-"compress_mbps": 38.69,
-"decompress_mbps": 166.59
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5438787,
-"ratio": 0.75,
-"compress_mbps": 40.07,
-"decompress_mbps": 165.14
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.32,
-"decompress_mbps": 316.81
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 103.66,
-"decompress_mbps": 312.29
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.87,
-"decompress_mbps": 315.6
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.96,
-"decompress_mbps": 314.93
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12238874,
-"ratio": 0.2952,
-"compress_mbps": 68.98,
-"decompress_mbps": 315.04
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12086531,
-"ratio": 0.2915,
-"compress_mbps": 54.11,
-"decompress_mbps": 321.25
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12020742,
-"ratio": 0.2899,
-"compress_mbps": 46.63,
-"decompress_mbps": 321.66
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 11987253,
-"ratio": 0.2891,
-"compress_mbps": 38.19,
-"decompress_mbps": 320.79
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11987245,
-"ratio": 0.2891,
-"compress_mbps": 37.19,
-"decompress_mbps": 317.49
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 60.39,
-"decompress_mbps": 146.84
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 60.89,
-"decompress_mbps": 147.32
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 57.25,
-"decompress_mbps": 144.18
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 60.77,
-"decompress_mbps": 147.19
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6244483,
-"ratio": 0.7369,
-"compress_mbps": 52.46,
-"decompress_mbps": 146.52
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6244482,
-"ratio": 0.7369,
-"compress_mbps": 55.35,
-"decompress_mbps": 149.04
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6244482,
-"ratio": 0.7369,
-"compress_mbps": 55.26,
-"decompress_mbps": 148.96
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6244480,
-"ratio": 0.7369,
-"compress_mbps": 55.76,
-"decompress_mbps": 149.15
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6244480,
-"ratio": 0.7369,
-"compress_mbps": 55.76,
-"decompress_mbps": 149.06
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 230.26,
-"decompress_mbps": 672.2
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 231.2,
-"decompress_mbps": 669.36
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 230.77,
-"decompress_mbps": 670.71
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 230.62,
-"decompress_mbps": 675.03
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 716461,
-"ratio": 0.134,
-"compress_mbps": 166.95,
-"decompress_mbps": 717.65
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 687053,
-"ratio": 0.1285,
-"compress_mbps": 119.59,
-"decompress_mbps": 723.82
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 673597,
-"ratio": 0.126,
-"compress_mbps": 101.21,
-"decompress_mbps": 741.82
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 662156,
-"ratio": 0.1239,
-"compress_mbps": 65.52,
-"decompress_mbps": 755.83
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 661610,
-"ratio": 0.1238,
-"compress_mbps": 61.34,
-"decompress_mbps": 749.89
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 73589,
-"ratio": 0.4839,
-"compress_mbps": 34.0,
-"decompress_mbps": 57.86
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 69878,
-"ratio": 0.4595,
-"compress_mbps": 31.61,
-"decompress_mbps": 57.3
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 66917,
-"ratio": 0.44,
-"compress_mbps": 26.18,
-"decompress_mbps": 64.01
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 59388,
-"ratio": 0.3905,
-"compress_mbps": 31.49,
-"decompress_mbps": 79.65
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 57062,
-"ratio": 0.3752,
-"compress_mbps": 22.75,
-"decompress_mbps": 79.85
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 55472,
-"ratio": 0.3647,
-"compress_mbps": 16.03,
-"decompress_mbps": 78.4
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 55265,
-"ratio": 0.3634,
-"compress_mbps": 14.39,
-"decompress_mbps": 79.58
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 55168,
-"ratio": 0.3627,
-"compress_mbps": 11.79,
-"decompress_mbps": 78.8
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 55168,
-"ratio": 0.3627,
-"compress_mbps": 11.98,
-"decompress_mbps": 79.72
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 64551,
-"ratio": 0.5157,
-"compress_mbps": 32.2,
-"decompress_mbps": 53.55
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 62089,
-"ratio": 0.496,
-"compress_mbps": 30.3,
-"decompress_mbps": 58.28
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 58690,
-"ratio": 0.4688,
-"compress_mbps": 24.56,
-"decompress_mbps": 60.54
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 53521,
-"ratio": 0.4276,
-"compress_mbps": 29.54,
-"decompress_mbps": 77.82
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 51677,
-"ratio": 0.4128,
-"compress_mbps": 20.38,
-"decompress_mbps": 76.66
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 50638,
-"ratio": 0.4045,
-"compress_mbps": 15.06,
-"decompress_mbps": 82.8
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 50501,
-"ratio": 0.4034,
-"compress_mbps": 13.27,
-"decompress_mbps": 77.7
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 50452,
-"ratio": 0.403,
-"compress_mbps": 12.35,
-"decompress_mbps": 80.51
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 50452,
-"ratio": 0.403,
-"compress_mbps": 12.52,
-"decompress_mbps": 82.94
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 9859,
-"ratio": 0.4007,
-"compress_mbps": 42.58,
-"decompress_mbps": 110.57
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 10473,
-"ratio": 0.4257,
-"compress_mbps": 46.43,
-"decompress_mbps": 148.02
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 10172,
-"ratio": 0.4134,
-"compress_mbps": 42.8,
-"decompress_mbps": 152.86
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8692,
-"ratio": 0.3533,
-"compress_mbps": 39.93,
-"decompress_mbps": 153.37
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8440,
-"ratio": 0.343,
-"compress_mbps": 34.87,
-"decompress_mbps": 156.11
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 8385,
-"ratio": 0.3408,
-"compress_mbps": 30.54,
-"decompress_mbps": 157.37
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 8366,
-"ratio": 0.34,
-"compress_mbps": 29.81,
-"decompress_mbps": 158.65
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 8367,
-"ratio": 0.3401,
-"compress_mbps": 28.3,
-"decompress_mbps": 156.11
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 8367,
-"ratio": 0.3401,
-"compress_mbps": 28.21,
-"decompress_mbps": 158.02
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 4822,
-"ratio": 0.4325,
-"compress_mbps": 54.86,
-"decompress_mbps": 187.41
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 4593,
-"ratio": 0.4119,
-"compress_mbps": 54.7,
-"decompress_mbps": 193.9
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 4381,
-"ratio": 0.3929,
-"compress_mbps": 50.46,
-"decompress_mbps": 200.04
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3725,
-"ratio": 0.3341,
-"compress_mbps": 51.11,
-"decompress_mbps": 207.85
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3614,
-"ratio": 0.3241,
-"compress_mbps": 42.95,
-"decompress_mbps": 207.77
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3578,
-"ratio": 0.3209,
-"compress_mbps": 37.66,
-"decompress_mbps": 209.09
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3572,
-"ratio": 0.3204,
-"compress_mbps": 36.73,
-"decompress_mbps": 206.73
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3568,
-"ratio": 0.32,
-"compress_mbps": 34.26,
-"decompress_mbps": 207.27
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3568,
-"ratio": 0.32,
-"compress_mbps": 33.81,
-"decompress_mbps": 206.08
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1738,
-"ratio": 0.4671,
-"compress_mbps": 32.91,
-"decompress_mbps": 175.87
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1709,
-"ratio": 0.4593,
-"compress_mbps": 32.02,
-"decompress_mbps": 179.28
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1694,
-"ratio": 0.4553,
-"compress_mbps": 30.64,
-"decompress_mbps": 172.97
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1458,
-"ratio": 0.3918,
-"compress_mbps": 30.66,
-"decompress_mbps": 187.78
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1441,
-"ratio": 0.3873,
-"compress_mbps": 27.46,
-"decompress_mbps": 188.54
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.47,
-"decompress_mbps": 190.41
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.01,
-"decompress_mbps": 190.2
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.2,
-"decompress_mbps": 189.99
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.88,
-"decompress_mbps": 189.94
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 260073,
-"ratio": 0.2526,
-"compress_mbps": 52.79,
-"decompress_mbps": 57.19
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 296764,
-"ratio": 0.2882,
-"compress_mbps": 48.12,
-"decompress_mbps": 75.97
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 288989,
-"ratio": 0.2806,
-"compress_mbps": 37.74,
-"decompress_mbps": 78.57
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 246442,
-"ratio": 0.2393,
-"compress_mbps": 54.55,
-"decompress_mbps": 83.01
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 218888,
-"ratio": 0.2126,
-"compress_mbps": 40.77,
-"decompress_mbps": 77.4
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 217830,
-"ratio": 0.2115,
-"compress_mbps": 24.23,
-"decompress_mbps": 87.72
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 221437,
-"ratio": 0.215,
-"compress_mbps": 19.48,
-"decompress_mbps": 86.9
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 219666,
-"ratio": 0.2133,
-"compress_mbps": 5.5,
-"decompress_mbps": 85.51
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 219921,
-"ratio": 0.2136,
-"compress_mbps": 2.8,
-"decompress_mbps": 87.33
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 194588,
-"ratio": 0.456,
-"compress_mbps": 34.49,
-"decompress_mbps": 51.6
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 185757,
-"ratio": 0.4353,
-"compress_mbps": 32.22,
-"decompress_mbps": 48.32
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 175850,
-"ratio": 0.4121,
-"compress_mbps": 27.33,
-"decompress_mbps": 60.3
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 155951,
-"ratio": 0.3654,
-"compress_mbps": 32.18,
-"decompress_mbps": 72.7
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 150274,
-"ratio": 0.3521,
-"compress_mbps": 23.21,
-"decompress_mbps": 71.72
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 147958,
-"ratio": 0.3467,
-"compress_mbps": 16.54,
-"decompress_mbps": 71.31
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 147522,
-"ratio": 0.3457,
-"compress_mbps": 15.18,
-"decompress_mbps": 71.53
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 147331,
-"ratio": 0.3452,
-"compress_mbps": 13.48,
-"decompress_mbps": 71.56
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 147328,
-"ratio": 0.3452,
-"compress_mbps": 13.54,
-"decompress_mbps": 72.26
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 256904,
-"ratio": 0.5331,
-"compress_mbps": 29.48,
-"decompress_mbps": 46.38
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 245675,
-"ratio": 0.5098,
-"compress_mbps": 28.42,
-"decompress_mbps": 49.26
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 231519,
-"ratio": 0.4805,
-"compress_mbps": 22.72,
-"decompress_mbps": 56.6
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 210028,
-"ratio": 0.4359,
-"compress_mbps": 26.96,
-"decompress_mbps": 63.53
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 203312,
-"ratio": 0.4219,
-"compress_mbps": 18.71,
-"decompress_mbps": 61.26
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 199287,
-"ratio": 0.4136,
-"compress_mbps": 12.82,
-"decompress_mbps": 66.09
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 198474,
-"ratio": 0.4119,
-"compress_mbps": 11.26,
-"decompress_mbps": 66.09
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 198080,
-"ratio": 0.4111,
-"compress_mbps": 8.84,
-"decompress_mbps": 64.95
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 198080,
-"ratio": 0.4111,
-"compress_mbps": 8.83,
-"decompress_mbps": 65.35
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 71229,
-"ratio": 0.1388,
-"compress_mbps": 83.11,
-"decompress_mbps": 135.9
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 69946,
-"ratio": 0.1363,
-"compress_mbps": 79.64,
-"decompress_mbps": 137.51
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 68538,
-"ratio": 0.1335,
-"compress_mbps": 68.34,
-"decompress_mbps": 151.14
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 61320,
-"ratio": 0.1195,
-"compress_mbps": 65.95,
-"decompress_mbps": 164.46
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 59993,
-"ratio": 0.1169,
-"compress_mbps": 55.91,
-"decompress_mbps": 163.24
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 58637,
-"ratio": 0.1143,
-"compress_mbps": 41.4,
-"decompress_mbps": 168.02
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 58209,
-"ratio": 0.1134,
-"compress_mbps": 35.53,
-"decompress_mbps": 172.34
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 55749,
-"ratio": 0.1086,
-"compress_mbps": 19.07,
-"decompress_mbps": 176.44
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 54927,
-"ratio": 0.107,
-"compress_mbps": 7.46,
-"decompress_mbps": 174.22
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 16399,
-"ratio": 0.4288,
-"compress_mbps": 35.77,
-"decompress_mbps": 89.38
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 15933,
-"ratio": 0.4167,
-"compress_mbps": 33.98,
-"decompress_mbps": 89.54
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 15739,
-"ratio": 0.4116,
-"compress_mbps": 27.4,
-"decompress_mbps": 86.39
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13834,
-"ratio": 0.3618,
-"compress_mbps": 31.54,
-"decompress_mbps": 108.73
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13463,
-"ratio": 0.3521,
-"compress_mbps": 25.5,
-"decompress_mbps": 110.75
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13353,
-"ratio": 0.3492,
-"compress_mbps": 18.6,
-"decompress_mbps": 110.51
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13317,
-"ratio": 0.3482,
-"compress_mbps": 16.01,
-"decompress_mbps": 110.41
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13255,
-"ratio": 0.3466,
-"compress_mbps": 8.37,
-"decompress_mbps": 110.21
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13171,
-"ratio": 0.3444,
-"compress_mbps": 4.12,
-"decompress_mbps": 111.73
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 2512,
-"ratio": 0.5943,
-"compress_mbps": 30.51,
-"decompress_mbps": 156.62
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 2477,
-"ratio": 0.586,
-"compress_mbps": 28.61,
-"decompress_mbps": 159.7
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 2452,
-"ratio": 0.5801,
-"compress_mbps": 30.04,
-"decompress_mbps": 157.59
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 2110,
-"ratio": 0.4992,
-"compress_mbps": 29.9,
-"decompress_mbps": 163.35
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.79,
-"decompress_mbps": 167.52
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.45,
-"decompress_mbps": 167.55
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.07,
-"decompress_mbps": 167.91
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 27.07,
-"decompress_mbps": 166.74
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.84,
-"decompress_mbps": 169.65
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 5183792,
-"ratio": 0.5086,
-"compress_mbps": 30.88,
-"decompress_mbps": 40.4
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4956750,
-"ratio": 0.4863,
-"compress_mbps": 30.07,
-"decompress_mbps": 43.55
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4644095,
-"ratio": 0.4556,
-"compress_mbps": 23.2,
-"decompress_mbps": 47.39
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4178564,
-"ratio": 0.41,
-"compress_mbps": 28.62,
-"decompress_mbps": 61.44
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 4034632,
-"ratio": 0.3958,
-"compress_mbps": 19.71,
-"decompress_mbps": 59.65
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3952244,
-"ratio": 0.3878,
-"compress_mbps": 13.81,
-"decompress_mbps": 60.65
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3938822,
-"ratio": 0.3864,
-"compress_mbps": 12.19,
-"decompress_mbps": 61.86
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3935171,
-"ratio": 0.3861,
-"compress_mbps": 10.83,
-"decompress_mbps": 60.81
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3935171,
-"ratio": 0.3861,
-"compress_mbps": 10.77,
-"decompress_mbps": 60.93
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 25320013,
-"ratio": 0.4943,
-"compress_mbps": 31.38,
-"decompress_mbps": 35.11
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 24804084,
-"ratio": 0.4843,
-"compress_mbps": 30.32,
-"decompress_mbps": 36.38
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 24241121,
-"ratio": 0.4733,
-"compress_mbps": 25.68,
-"decompress_mbps": 38.29
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 20950547,
-"ratio": 0.409,
-"compress_mbps": 29.3,
-"decompress_mbps": 44.31
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 20592289,
-"ratio": 0.402,
-"compress_mbps": 24.8,
-"decompress_mbps": 46.43
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 20445232,
-"ratio": 0.3992,
-"compress_mbps": 18.69,
-"decompress_mbps": 46.27
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 20407676,
-"ratio": 0.3984,
-"compress_mbps": 15.98,
-"decompress_mbps": 46.7
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 20389473,
-"ratio": 0.3981,
-"compress_mbps": 10.15,
-"decompress_mbps": 45.81
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 20386824,
-"ratio": 0.398,
-"compress_mbps": 6.84,
-"decompress_mbps": 46.29
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3964698,
-"ratio": 0.3976,
-"compress_mbps": 37.98,
-"decompress_mbps": 49.6
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3936391,
-"ratio": 0.3948,
-"compress_mbps": 35.04,
-"decompress_mbps": 48.16
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3823540,
-"ratio": 0.3835,
-"compress_mbps": 28.04,
-"decompress_mbps": 51.71
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3799601,
-"ratio": 0.3811,
-"compress_mbps": 33.33,
-"decompress_mbps": 63.69
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3830938,
-"ratio": 0.3842,
-"compress_mbps": 22.17,
-"decompress_mbps": 58.23
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3808303,
-"ratio": 0.382,
-"compress_mbps": 14.78,
-"decompress_mbps": 57.63
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3802814,
-"ratio": 0.3814,
-"compress_mbps": 11.97,
-"decompress_mbps": 57.81
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3800355,
-"ratio": 0.3812,
-"compress_mbps": 6.73,
-"decompress_mbps": 57.92
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3799676,
-"ratio": 0.3811,
-"compress_mbps": 6.05,
-"decompress_mbps": 58.97
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4899547,
-"ratio": 0.146,
-"compress_mbps": 95.96,
-"decompress_mbps": 131.72
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4587004,
-"ratio": 0.1367,
-"compress_mbps": 95.4,
-"decompress_mbps": 144.38
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 4229035,
-"ratio": 0.126,
-"compress_mbps": 90.75,
-"decompress_mbps": 154.08
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3791322,
-"ratio": 0.113,
-"compress_mbps": 81.31,
-"decompress_mbps": 160.64
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3449193,
-"ratio": 0.1028,
-"compress_mbps": 73.45,
-"decompress_mbps": 169.63
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3269452,
-"ratio": 0.0974,
-"compress_mbps": 58.52,
-"decompress_mbps": 173.97
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3211286,
-"ratio": 0.0957,
-"compress_mbps": 50.5,
-"decompress_mbps": 174.44
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3101534,
-"ratio": 0.0924,
-"compress_mbps": 27.56,
-"decompress_mbps": 176.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3058177,
-"ratio": 0.0911,
-"compress_mbps": 16.59,
-"decompress_mbps": 176.36
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 4024327,
-"ratio": 0.6541,
-"compress_mbps": 22.34,
-"decompress_mbps": 29.69
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3953722,
-"ratio": 0.6427,
-"compress_mbps": 21.83,
-"decompress_mbps": 30.54
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3887921,
-"ratio": 0.632,
-"compress_mbps": 18.53,
-"decompress_mbps": 31.51
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3320440,
-"ratio": 0.5397,
-"compress_mbps": 21.35,
-"decompress_mbps": 37.56
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3279338,
-"ratio": 0.533,
-"compress_mbps": 17.93,
-"decompress_mbps": 38.03
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3254309,
-"ratio": 0.529,
-"compress_mbps": 13.71,
-"decompress_mbps": 37.84
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3250139,
-"ratio": 0.5283,
-"compress_mbps": 12.24,
-"decompress_mbps": 37.76
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3247018,
-"ratio": 0.5278,
-"compress_mbps": 10.18,
-"decompress_mbps": 37.87
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3246865,
-"ratio": 0.5278,
-"compress_mbps": 9.45,
-"decompress_mbps": 37.98
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4471091,
-"ratio": 0.4433,
-"compress_mbps": 35.03,
-"decompress_mbps": 69.78
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 4372105,
-"ratio": 0.4335,
-"compress_mbps": 33.16,
-"decompress_mbps": 71.97
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 4305270,
-"ratio": 0.4269,
-"compress_mbps": 30.15,
-"decompress_mbps": 73.19
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3920495,
-"ratio": 0.3887,
-"compress_mbps": 30.43,
-"decompress_mbps": 64.99
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3853177,
-"ratio": 0.382,
-"compress_mbps": 26.27,
-"decompress_mbps": 63.33
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3780878,
-"ratio": 0.3749,
-"compress_mbps": 22.95,
-"decompress_mbps": 63.59
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3763880,
-"ratio": 0.3732,
-"compress_mbps": 19.76,
-"decompress_mbps": 72.71
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3757719,
-"ratio": 0.3726,
-"compress_mbps": 18.09,
-"decompress_mbps": 72.73
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3757719,
-"ratio": 0.3726,
-"compress_mbps": 18.27,
-"decompress_mbps": 73.27
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2722387,
-"ratio": 0.4108,
-"compress_mbps": 38.11,
-"decompress_mbps": 64.91
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2572544,
-"ratio": 0.3882,
-"compress_mbps": 36.89,
-"decompress_mbps": 70.61
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2384328,
-"ratio": 0.3598,
-"compress_mbps": 28.61,
-"decompress_mbps": 77.97
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2112060,
-"ratio": 0.3187,
-"compress_mbps": 36.54,
-"decompress_mbps": 85.76
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1991581,
-"ratio": 0.3005,
-"compress_mbps": 25.58,
-"decompress_mbps": 91.86
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1917866,
-"ratio": 0.2894,
-"compress_mbps": 15.19,
-"decompress_mbps": 91.06
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1895353,
-"ratio": 0.286,
-"compress_mbps": 11.07,
-"decompress_mbps": 90.89
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1880740,
-"ratio": 0.2838,
-"compress_mbps": 5.58,
-"decompress_mbps": 91.62
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1880711,
-"ratio": 0.2838,
-"compress_mbps": 5.57,
-"decompress_mbps": 92.01
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 7441483,
-"ratio": 0.3444,
-"compress_mbps": 44.52,
-"decompress_mbps": 67.14
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 7229248,
-"ratio": 0.3346,
-"compress_mbps": 42.44,
-"decompress_mbps": 68.92
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 7083451,
-"ratio": 0.3278,
-"compress_mbps": 39.23,
-"decompress_mbps": 71.48
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 6189639,
-"ratio": 0.2865,
-"compress_mbps": 42.14,
-"decompress_mbps": 92.48
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 6053058,
-"ratio": 0.2802,
-"compress_mbps": 35.22,
-"decompress_mbps": 96.15
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5988137,
-"ratio": 0.2771,
-"compress_mbps": 28.91,
-"decompress_mbps": 102.51
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5949908,
-"ratio": 0.2754,
-"compress_mbps": 25.24,
-"decompress_mbps": 103.3
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5936656,
-"ratio": 0.2748,
-"compress_mbps": 19.41,
-"decompress_mbps": 106.03
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5934701,
-"ratio": 0.2747,
-"compress_mbps": 18.05,
-"decompress_mbps": 105.62
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 6335542,
-"ratio": 0.8736,
-"compress_mbps": 18.5,
-"decompress_mbps": 31.54
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 6247260,
-"ratio": 0.8615,
-"compress_mbps": 17.56,
-"decompress_mbps": 48.25
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 6064713,
-"ratio": 0.8363,
-"compress_mbps": 14.81,
-"decompress_mbps": 56.29
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5568111,
-"ratio": 0.7678,
-"compress_mbps": 17.57,
-"decompress_mbps": 58.14
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5544524,
-"ratio": 0.7646,
-"compress_mbps": 14.15,
-"decompress_mbps": 65.58
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5513056,
-"ratio": 0.7602,
-"compress_mbps": 11.94,
-"decompress_mbps": 62.93
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5508915,
-"ratio": 0.7596,
-"compress_mbps": 11.17,
-"decompress_mbps": 63.48
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5508365,
-"ratio": 0.7596,
-"compress_mbps": 10.39,
-"decompress_mbps": 64.75
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5508365,
-"ratio": 0.7596,
-"compress_mbps": 10.35,
-"decompress_mbps": 63.58
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 16776095,
-"ratio": 0.4046,
-"compress_mbps": 37.06,
-"decompress_mbps": 50.77
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 16032651,
-"ratio": 0.3867,
-"compress_mbps": 35.71,
-"decompress_mbps": 54.63
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 15180334,
-"ratio": 0.3662,
-"compress_mbps": 31.09,
-"decompress_mbps": 52.01
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 13261924,
-"ratio": 0.3199,
-"compress_mbps": 35.02,
-"decompress_mbps": 68.02
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12706028,
-"ratio": 0.3065,
-"compress_mbps": 27.56,
-"decompress_mbps": 71.11
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12464158,
-"ratio": 0.3006,
-"compress_mbps": 20.73,
-"decompress_mbps": 70.78
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12375954,
-"ratio": 0.2985,
-"compress_mbps": 17.9,
-"decompress_mbps": 71.29
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12321552,
-"ratio": 0.2972,
-"compress_mbps": 14.46,
-"decompress_mbps": 70.23
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12320276,
-"ratio": 0.2972,
-"compress_mbps": 14.29,
-"decompress_mbps": 70.56
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6799201,
-"ratio": 0.8023,
-"compress_mbps": 18.07,
-"decompress_mbps": 18.28
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6800500,
-"ratio": 0.8025,
-"compress_mbps": 16.96,
-"decompress_mbps": 18.38
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6803212,
-"ratio": 0.8028,
-"compress_mbps": 14.66,
-"decompress_mbps": 18.44
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6264611,
-"ratio": 0.7393,
-"compress_mbps": 16.89,
-"decompress_mbps": 24.79
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6217901,
-"ratio": 0.7337,
-"compress_mbps": 15.52,
-"decompress_mbps": 25.08
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6201999,
-"ratio": 0.7319,
-"compress_mbps": 15.26,
-"decompress_mbps": 25.27
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6201883,
-"ratio": 0.7319,
-"compress_mbps": 15.29,
-"decompress_mbps": 24.94
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6201887,
-"ratio": 0.7319,
-"compress_mbps": 14.91,
-"decompress_mbps": 24.78
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6201887,
-"ratio": 0.7319,
-"compress_mbps": 15.21,
-"decompress_mbps": 24.8
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 1081679,
-"ratio": 0.2024,
-"compress_mbps": 74.77,
-"decompress_mbps": 107.65
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 1001890,
-"ratio": 0.1874,
-"compress_mbps": 72.28,
-"decompress_mbps": 116.39
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 921722,
-"ratio": 0.1724,
-"compress_mbps": 66.78,
-"decompress_mbps": 128.43
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 849263,
-"ratio": 0.1589,
-"compress_mbps": 64.02,
-"decompress_mbps": 140.82
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 771964,
-"ratio": 0.1444,
-"compress_mbps": 54.38,
-"decompress_mbps": 142.2
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 728098,
-"ratio": 0.1362,
-"compress_mbps": 42.78,
-"decompress_mbps": 149.85
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 713635,
-"ratio": 0.1335,
-"compress_mbps": 37.25,
-"decompress_mbps": 153.54
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 699093,
-"ratio": 0.1308,
-"compress_mbps": 26.78,
-"decompress_mbps": 143.66
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 698459,
-"ratio": 0.1307,
-"compress_mbps": 25.0,
-"decompress_mbps": 147.53
-}
-]
+  "meta": {
+    "date": "2026-06-10T07:53:15Z",
+    "machine": "Linux chungus x86_64",
+    "git_commit": "e94ac0d2",
+    "toolchain": "leanprover/lean4:v4.30.0-rc2",
+    "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic | native/zlib/miniz/libdeflate regenerated post block-splitting (#2524); go/js/zig/ocaml reused from prior run (external, unchanged); zopfli dropped (too slow)"
+  },
+  "results": [
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 59545,
+      "ratio": 0.3915,
+      "compress_mbps": 14.43,
+      "decompress_mbps": 85.73
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 57936,
+      "ratio": 0.3809,
+      "compress_mbps": 12.66,
+      "decompress_mbps": 93.95
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 56891,
+      "ratio": 0.3741,
+      "compress_mbps": 11.14,
+      "decompress_mbps": 103.32
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 55541,
+      "ratio": 0.3652,
+      "compress_mbps": 6.78,
+      "decompress_mbps": 103.28
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 55282,
+      "ratio": 0.3635,
+      "compress_mbps": 6.21,
+      "decompress_mbps": 106.28
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54902,
+      "ratio": 0.361,
+      "compress_mbps": 5.2,
+      "decompress_mbps": 111.65
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54758,
+      "ratio": 0.36,
+      "compress_mbps": 1.65,
+      "decompress_mbps": 109.58
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 54717,
+      "ratio": 0.3598,
+      "compress_mbps": 1.53,
+      "decompress_mbps": 110.7
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 54716,
+      "ratio": 0.3598,
+      "compress_mbps": 1.51,
+      "decompress_mbps": 110.75
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 52768,
+      "ratio": 0.4215,
+      "compress_mbps": 13.5,
+      "decompress_mbps": 82.09
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 51760,
+      "ratio": 0.4135,
+      "compress_mbps": 12.02,
+      "decompress_mbps": 87.16
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 51056,
+      "ratio": 0.4079,
+      "compress_mbps": 10.53,
+      "decompress_mbps": 92.93
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 49963,
+      "ratio": 0.3991,
+      "compress_mbps": 6.53,
+      "decompress_mbps": 94.03
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 49779,
+      "ratio": 0.3977,
+      "compress_mbps": 6.09,
+      "decompress_mbps": 97.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 49540,
+      "ratio": 0.3958,
+      "compress_mbps": 5.23,
+      "decompress_mbps": 99.89
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 49419,
+      "ratio": 0.3948,
+      "compress_mbps": 1.75,
+      "decompress_mbps": 100.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 49409,
+      "ratio": 0.3947,
+      "compress_mbps": 1.7,
+      "decompress_mbps": 99.82
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 49409,
+      "ratio": 0.3947,
+      "compress_mbps": 1.7,
+      "decompress_mbps": 100.18
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8430,
+      "ratio": 0.3426,
+      "compress_mbps": 16.28,
+      "decompress_mbps": 85.94
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8297,
+      "ratio": 0.3372,
+      "compress_mbps": 15.3,
+      "decompress_mbps": 89.83
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8218,
+      "ratio": 0.334,
+      "compress_mbps": 14.26,
+      "decompress_mbps": 93.03
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8055,
+      "ratio": 0.3274,
+      "compress_mbps": 10.35,
+      "decompress_mbps": 90.58
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 8049,
+      "ratio": 0.3272,
+      "compress_mbps": 9.78,
+      "decompress_mbps": 92.56
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 8043,
+      "ratio": 0.3269,
+      "compress_mbps": 8.82,
+      "decompress_mbps": 92.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 8038,
+      "ratio": 0.3267,
+      "compress_mbps": 2.82,
+      "decompress_mbps": 93.98
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 8038,
+      "ratio": 0.3267,
+      "compress_mbps": 2.82,
+      "decompress_mbps": 92.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 8038,
+      "ratio": 0.3267,
+      "compress_mbps": 2.82,
+      "decompress_mbps": 92.96
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3325,
+      "ratio": 0.2982,
+      "compress_mbps": 13.41,
+      "decompress_mbps": 75.49
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3251,
+      "ratio": 0.2916,
+      "compress_mbps": 12.84,
+      "decompress_mbps": 78.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3202,
+      "ratio": 0.2872,
+      "compress_mbps": 12.28,
+      "decompress_mbps": 79.97
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3150,
+      "ratio": 0.2825,
+      "compress_mbps": 9.47,
+      "decompress_mbps": 82.28
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3141,
+      "ratio": 0.2817,
+      "compress_mbps": 9.16,
+      "decompress_mbps": 82.97
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3136,
+      "ratio": 0.2813,
+      "compress_mbps": 8.54,
+      "decompress_mbps": 83.79
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3134,
+      "ratio": 0.2811,
+      "compress_mbps": 2.77,
+      "decompress_mbps": 83.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3134,
+      "ratio": 0.2811,
+      "compress_mbps": 2.74,
+      "decompress_mbps": 84.67
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3134,
+      "ratio": 0.2811,
+      "compress_mbps": 2.73,
+      "decompress_mbps": 84.49
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1251,
+      "ratio": 0.3362,
+      "compress_mbps": 8.58,
+      "decompress_mbps": 42.71
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1241,
+      "ratio": 0.3335,
+      "compress_mbps": 8.4,
+      "decompress_mbps": 43.02
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1241,
+      "ratio": 0.3335,
+      "compress_mbps": 8.21,
+      "decompress_mbps": 43.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1225,
+      "ratio": 0.3292,
+      "compress_mbps": 7.3,
+      "decompress_mbps": 44.36
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1224,
+      "ratio": 0.3289,
+      "compress_mbps": 7.24,
+      "decompress_mbps": 44.59
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1224,
+      "ratio": 0.3289,
+      "compress_mbps": 7.18,
+      "decompress_mbps": 44.09
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1224,
+      "ratio": 0.3289,
+      "compress_mbps": 2.49,
+      "decompress_mbps": 44.53
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1224,
+      "ratio": 0.3289,
+      "compress_mbps": 2.49,
+      "decompress_mbps": 44.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1224,
+      "ratio": 0.3289,
+      "compress_mbps": 2.5,
+      "decompress_mbps": 44.52
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 248840,
+      "ratio": 0.2417,
+      "compress_mbps": 25.21,
+      "decompress_mbps": 131.64
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 247429,
+      "ratio": 0.2403,
+      "compress_mbps": 22.33,
+      "decompress_mbps": 151.42
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 246442,
+      "ratio": 0.2393,
+      "compress_mbps": 20.45,
+      "decompress_mbps": 158.17
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 213851,
+      "ratio": 0.2077,
+      "compress_mbps": 10.77,
+      "decompress_mbps": 163.89
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 212782,
+      "ratio": 0.2066,
+      "compress_mbps": 9.38,
+      "decompress_mbps": 131.9
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 210061,
+      "ratio": 0.204,
+      "compress_mbps": 6.29,
+      "decompress_mbps": 133.2
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 199322,
+      "ratio": 0.1936,
+      "compress_mbps": 1.3,
+      "decompress_mbps": 124.29
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 199462,
+      "ratio": 0.1937,
+      "compress_mbps": 0.8,
+      "decompress_mbps": 122.04
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 199644,
+      "ratio": 0.1939,
+      "compress_mbps": 0.48,
+      "decompress_mbps": 121.72
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 194388,
+      "ratio": 0.4555,
+      "compress_mbps": 15.36,
+      "decompress_mbps": 90.69
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 153708,
+      "ratio": 0.3602,
+      "compress_mbps": 13.42,
+      "decompress_mbps": 97.14
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 150718,
+      "ratio": 0.3532,
+      "compress_mbps": 11.69,
+      "decompress_mbps": 106.94
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 177586,
+      "ratio": 0.4161,
+      "compress_mbps": 7.32,
+      "decompress_mbps": 107.91
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 146857,
+      "ratio": 0.3441,
+      "compress_mbps": 6.77,
+      "decompress_mbps": 111.92
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 146118,
+      "ratio": 0.3424,
+      "compress_mbps": 5.73,
+      "decompress_mbps": 113.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 145876,
+      "ratio": 0.3418,
+      "compress_mbps": 1.84,
+      "decompress_mbps": 115.89
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 145803,
+      "ratio": 0.3417,
+      "compress_mbps": 1.75,
+      "decompress_mbps": 114.91
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 145799,
+      "ratio": 0.3416,
+      "compress_mbps": 1.73,
+      "decompress_mbps": 114.83
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 212305,
+      "ratio": 0.4406,
+      "compress_mbps": 13.13,
+      "decompress_mbps": 78.92
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 263152,
+      "ratio": 0.5461,
+      "compress_mbps": 11.58,
+      "decompress_mbps": 86.18
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 257812,
+      "ratio": 0.535,
+      "compress_mbps": 9.7,
+      "decompress_mbps": 91.17
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 249343,
+      "ratio": 0.5175,
+      "compress_mbps": 5.92,
+      "decompress_mbps": 92.13
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 199229,
+      "ratio": 0.4135,
+      "compress_mbps": 5.48,
+      "decompress_mbps": 94.91
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 198023,
+      "ratio": 0.411,
+      "compress_mbps": 4.59,
+      "decompress_mbps": 98.04
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 197532,
+      "ratio": 0.4099,
+      "compress_mbps": 1.45,
+      "decompress_mbps": 98.68
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 197364,
+      "ratio": 0.4096,
+      "compress_mbps": 1.32,
+      "decompress_mbps": 98.26
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 197347,
+      "ratio": 0.4096,
+      "compress_mbps": 1.26,
+      "decompress_mbps": 97.83
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 60352,
+      "ratio": 0.1176,
+      "compress_mbps": 41.72,
+      "decompress_mbps": 242.21
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 59696,
+      "ratio": 0.1163,
+      "compress_mbps": 34.97,
+      "decompress_mbps": 255.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 59069,
+      "ratio": 0.1151,
+      "compress_mbps": 27.82,
+      "decompress_mbps": 266.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 56435,
+      "ratio": 0.11,
+      "compress_mbps": 16.02,
+      "decompress_mbps": 242.14
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 56350,
+      "ratio": 0.1098,
+      "compress_mbps": 13.97,
+      "decompress_mbps": 259.73
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 56014,
+      "ratio": 0.1091,
+      "compress_mbps": 9.53,
+      "decompress_mbps": 275.47
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 54781,
+      "ratio": 0.1067,
+      "compress_mbps": 2.17,
+      "decompress_mbps": 286.94
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 54031,
+      "ratio": 0.1053,
+      "compress_mbps": 1.39,
+      "decompress_mbps": 299.54
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 53850,
+      "ratio": 0.1049,
+      "compress_mbps": 0.81,
+      "decompress_mbps": 303.82
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 13725,
+      "ratio": 0.3589,
+      "compress_mbps": 13.59,
+      "decompress_mbps": 66.8
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13615,
+      "ratio": 0.356,
+      "compress_mbps": 12.93,
+      "decompress_mbps": 70.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13548,
+      "ratio": 0.3543,
+      "compress_mbps": 12.18,
+      "decompress_mbps": 73.4
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13080,
+      "ratio": 0.3421,
+      "compress_mbps": 8.91,
+      "decompress_mbps": 71.33
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13060,
+      "ratio": 0.3415,
+      "compress_mbps": 8.28,
+      "decompress_mbps": 74.77
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13015,
+      "ratio": 0.3404,
+      "compress_mbps": 6.78,
+      "decompress_mbps": 75.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 12923,
+      "ratio": 0.3379,
+      "compress_mbps": 1.65,
+      "decompress_mbps": 76.32
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 12905,
+      "ratio": 0.3375,
+      "compress_mbps": 1.22,
+      "decompress_mbps": 78.81
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 12887,
+      "ratio": 0.337,
+      "compress_mbps": 0.83,
+      "decompress_mbps": 78.41
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1781,
+      "ratio": 0.4213,
+      "compress_mbps": 8.4,
+      "decompress_mbps": 42.37
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1764,
+      "ratio": 0.4173,
+      "compress_mbps": 8.32,
+      "decompress_mbps": 43.04
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1765,
+      "ratio": 0.4176,
+      "compress_mbps": 8.3,
+      "decompress_mbps": 43.45
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1747,
+      "ratio": 0.4133,
+      "compress_mbps": 7.63,
+      "decompress_mbps": 44.2
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1747,
+      "ratio": 0.4133,
+      "compress_mbps": 7.64,
+      "decompress_mbps": 44.13
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1747,
+      "ratio": 0.4133,
+      "compress_mbps": 7.71,
+      "decompress_mbps": 44.19
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1747,
+      "ratio": 0.4133,
+      "compress_mbps": 2.69,
+      "decompress_mbps": 44.13
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1747,
+      "ratio": 0.4133,
+      "compress_mbps": 2.67,
+      "decompress_mbps": 43.99
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1747,
+      "ratio": 0.4133,
+      "compress_mbps": 2.68,
+      "decompress_mbps": 44.01
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 65130,
+      "ratio": 0.4282,
+      "compress_mbps": 116.66,
+      "decompress_mbps": 392.68
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 62270,
+      "ratio": 0.4094,
+      "compress_mbps": 101.03,
+      "decompress_mbps": 412.26
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 59488,
+      "ratio": 0.3911,
+      "compress_mbps": 66.56,
+      "decompress_mbps": 427.97
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 57679,
+      "ratio": 0.3792,
+      "compress_mbps": 70.17,
+      "decompress_mbps": 404.96
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 55616,
+      "ratio": 0.3657,
+      "compress_mbps": 41.38,
+      "decompress_mbps": 396.75
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54398,
+      "ratio": 0.3577,
+      "compress_mbps": 25.3,
+      "decompress_mbps": 410.31
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54253,
+      "ratio": 0.3567,
+      "compress_mbps": 21.27,
+      "decompress_mbps": 413.12
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 54164,
+      "ratio": 0.3561,
+      "compress_mbps": 16.87,
+      "decompress_mbps": 412.86
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 54164,
+      "ratio": 0.3561,
+      "compress_mbps": 16.87,
+      "decompress_mbps": 414.31
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 56791,
+      "ratio": 0.4537,
+      "compress_mbps": 114.26,
+      "decompress_mbps": 384.65
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 54652,
+      "ratio": 0.4366,
+      "compress_mbps": 96.79,
+      "decompress_mbps": 399.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 52663,
+      "ratio": 0.4207,
+      "compress_mbps": 61.93,
+      "decompress_mbps": 419.07
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 51266,
+      "ratio": 0.4095,
+      "compress_mbps": 65.87,
+      "decompress_mbps": 391.22
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 49622,
+      "ratio": 0.3964,
+      "compress_mbps": 36.92,
+      "decompress_mbps": 380.92
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48891,
+      "ratio": 0.3906,
+      "compress_mbps": 22.62,
+      "decompress_mbps": 388.75
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48801,
+      "ratio": 0.3898,
+      "compress_mbps": 19.85,
+      "decompress_mbps": 387.25
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 48772,
+      "ratio": 0.3896,
+      "compress_mbps": 17.99,
+      "decompress_mbps": 388.66
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 48772,
+      "ratio": 0.3896,
+      "compress_mbps": 17.99,
+      "decompress_mbps": 388.33
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 9028,
+      "ratio": 0.3669,
+      "compress_mbps": 402.07,
+      "decompress_mbps": 1048.26
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8811,
+      "ratio": 0.3581,
+      "compress_mbps": 220.77,
+      "decompress_mbps": 1071.97
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8616,
+      "ratio": 0.3502,
+      "compress_mbps": 157.74,
+      "decompress_mbps": 1086.66
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8219,
+      "ratio": 0.3341,
+      "compress_mbps": 112.55,
+      "decompress_mbps": 1116.55
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 8001,
+      "ratio": 0.3252,
+      "compress_mbps": 82.97,
+      "decompress_mbps": 1144.21
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7955,
+      "ratio": 0.3233,
+      "compress_mbps": 67.27,
+      "decompress_mbps": 1143.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7933,
+      "ratio": 0.3224,
+      "compress_mbps": 61.72,
+      "decompress_mbps": 1150.38
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7934,
+      "ratio": 0.3225,
+      "compress_mbps": 57.02,
+      "decompress_mbps": 1152.42
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7934,
+      "ratio": 0.3225,
+      "compress_mbps": 56.86,
+      "decompress_mbps": 1148.98
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3647,
+      "ratio": 0.3271,
+      "compress_mbps": 409.83,
+      "decompress_mbps": 1057.53
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3501,
+      "ratio": 0.314,
+      "compress_mbps": 395.03,
+      "decompress_mbps": 1103.74
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3393,
+      "ratio": 0.3043,
+      "compress_mbps": 329.17,
+      "decompress_mbps": 1132.06
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3215,
+      "ratio": 0.2883,
+      "compress_mbps": 265.19,
+      "decompress_mbps": 1162.0
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3140,
+      "ratio": 0.2816,
+      "compress_mbps": 198.22,
+      "decompress_mbps": 1191.83
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3116,
+      "ratio": 0.2795,
+      "compress_mbps": 150.1,
+      "decompress_mbps": 1206.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 129.2,
+      "decompress_mbps": 1209.17
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3109,
+      "ratio": 0.2788,
+      "compress_mbps": 109.15,
+      "decompress_mbps": 1209.86
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3109,
+      "ratio": 0.2788,
+      "compress_mbps": 108.29,
+      "decompress_mbps": 1210.55
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1326,
+      "ratio": 0.3564,
+      "compress_mbps": 306.76,
+      "decompress_mbps": 775.82
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1306,
+      "ratio": 0.351,
+      "compress_mbps": 300.81,
+      "decompress_mbps": 773.29
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1301,
+      "ratio": 0.3496,
+      "compress_mbps": 283.12,
+      "decompress_mbps": 778.72
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1228,
+      "ratio": 0.33,
+      "compress_mbps": 218.61,
+      "decompress_mbps": 816.53
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 186.0,
+      "decompress_mbps": 817.47
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 168.44,
+      "decompress_mbps": 808.34
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 161.62,
+      "decompress_mbps": 818.22
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 159.2,
+      "decompress_mbps": 808.53
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 159.07,
+      "decompress_mbps": 808.89
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 242293,
+      "ratio": 0.2353,
+      "compress_mbps": 255.12,
+      "decompress_mbps": 835.7
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 233553,
+      "ratio": 0.2268,
+      "compress_mbps": 245.29,
+      "decompress_mbps": 987.93
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 228222,
+      "ratio": 0.2216,
+      "compress_mbps": 193.73,
+      "decompress_mbps": 1049.64
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 223668,
+      "ratio": 0.2172,
+      "compress_mbps": 173.17,
+      "decompress_mbps": 1081.64
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 205994,
+      "ratio": 0.2,
+      "compress_mbps": 108.61,
+      "decompress_mbps": 1032.04
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 203986,
+      "ratio": 0.1981,
+      "compress_mbps": 49.69,
+      "decompress_mbps": 1037.12
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 207681,
+      "ratio": 0.2017,
+      "compress_mbps": 36.76,
+      "decompress_mbps": 1032.21
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 206827,
+      "ratio": 0.2009,
+      "compress_mbps": 7.25,
+      "decompress_mbps": 1003.22
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 207023,
+      "ratio": 0.201,
+      "compress_mbps": 3.41,
+      "decompress_mbps": 1009.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 174124,
+      "ratio": 0.408,
+      "compress_mbps": 122.89,
+      "decompress_mbps": 394.78
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 166150,
+      "ratio": 0.3893,
+      "compress_mbps": 104.49,
+      "decompress_mbps": 405.1
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 158784,
+      "ratio": 0.3721,
+      "compress_mbps": 70.0,
+      "decompress_mbps": 424.31
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 152782,
+      "ratio": 0.358,
+      "compress_mbps": 72.68,
+      "decompress_mbps": 410.58
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 147196,
+      "ratio": 0.3449,
+      "compress_mbps": 43.24,
+      "decompress_mbps": 406.39
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144898,
+      "ratio": 0.3395,
+      "compress_mbps": 26.31,
+      "decompress_mbps": 417.01
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 144589,
+      "ratio": 0.3388,
+      "compress_mbps": 22.85,
+      "decompress_mbps": 419.31
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 144436,
+      "ratio": 0.3385,
+      "compress_mbps": 19.63,
+      "decompress_mbps": 419.67
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 144433,
+      "ratio": 0.3384,
+      "compress_mbps": 19.57,
+      "decompress_mbps": 419.94
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 228883,
+      "ratio": 0.475,
+      "compress_mbps": 107.6,
+      "decompress_mbps": 370.32
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 219047,
+      "ratio": 0.4546,
+      "compress_mbps": 90.6,
+      "decompress_mbps": 384.8
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 209408,
+      "ratio": 0.4346,
+      "compress_mbps": 55.25,
+      "decompress_mbps": 403.02
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 205916,
+      "ratio": 0.4273,
+      "compress_mbps": 61.47,
+      "decompress_mbps": 377.18
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 199188,
+      "ratio": 0.4134,
+      "compress_mbps": 32.96,
+      "decompress_mbps": 360.71
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 195255,
+      "ratio": 0.4052,
+      "compress_mbps": 19.36,
+      "decompress_mbps": 369.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 194657,
+      "ratio": 0.404,
+      "compress_mbps": 16.4,
+      "decompress_mbps": 369.25
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 194326,
+      "ratio": 0.4033,
+      "compress_mbps": 12.95,
+      "decompress_mbps": 367.84
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 194326,
+      "ratio": 0.4033,
+      "compress_mbps": 12.94,
+      "decompress_mbps": 368.12
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 65553,
+      "ratio": 0.1277,
+      "compress_mbps": 274.16,
+      "decompress_mbps": 895.61
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 63891,
+      "ratio": 0.1245,
+      "compress_mbps": 247.42,
+      "decompress_mbps": 922.32
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 62515,
+      "ratio": 0.1218,
+      "compress_mbps": 194.16,
+      "decompress_mbps": 982.39
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 58451,
+      "ratio": 0.1139,
+      "compress_mbps": 165.85,
+      "decompress_mbps": 699.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 57410,
+      "ratio": 0.1119,
+      "compress_mbps": 128.59,
+      "decompress_mbps": 727.84
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 56459,
+      "ratio": 0.11,
+      "compress_mbps": 76.88,
+      "decompress_mbps": 777.41
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 55358,
+      "ratio": 0.1079,
+      "compress_mbps": 60.21,
+      "decompress_mbps": 813.71
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 52991,
+      "ratio": 0.1033,
+      "compress_mbps": 27.45,
+      "decompress_mbps": 868.33
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 52215,
+      "ratio": 0.1017,
+      "compress_mbps": 9.81,
+      "decompress_mbps": 884.46
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 14112,
+      "ratio": 0.369,
+      "compress_mbps": 127.64,
+      "decompress_mbps": 932.27
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13815,
+      "ratio": 0.3613,
+      "compress_mbps": 109.08,
+      "decompress_mbps": 967.49
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13795,
+      "ratio": 0.3607,
+      "compress_mbps": 78.91,
+      "decompress_mbps": 995.81
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13375,
+      "ratio": 0.3498,
+      "compress_mbps": 79.14,
+      "decompress_mbps": 991.1
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13062,
+      "ratio": 0.3416,
+      "compress_mbps": 55.01,
+      "decompress_mbps": 1026.44
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 12984,
+      "ratio": 0.3395,
+      "compress_mbps": 32.85,
+      "decompress_mbps": 1049.63
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 12949,
+      "ratio": 0.3386,
+      "compress_mbps": 25.24,
+      "decompress_mbps": 1051.54
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 12894,
+      "ratio": 0.3372,
+      "compress_mbps": 11.01,
+      "decompress_mbps": 1068.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 12832,
+      "ratio": 0.3356,
+      "compress_mbps": 5.06,
+      "decompress_mbps": 1073.93
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1846,
+      "ratio": 0.4367,
+      "compress_mbps": 281.76,
+      "decompress_mbps": 702.91
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1820,
+      "ratio": 0.4306,
+      "compress_mbps": 275.17,
+      "decompress_mbps": 716.65
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1808,
+      "ratio": 0.4277,
+      "compress_mbps": 264.17,
+      "decompress_mbps": 725.95
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1749,
+      "ratio": 0.4138,
+      "compress_mbps": 216.92,
+      "decompress_mbps": 737.37
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 190.14,
+      "decompress_mbps": 748.32
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 188.28,
+      "decompress_mbps": 748.32
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 185.07,
+      "decompress_mbps": 748.32
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 185.25,
+      "decompress_mbps": 745.27
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 185.27,
+      "decompress_mbps": 744.58
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 76470,
+      "ratio": 0.5028,
+      "compress_mbps": 153.81,
+      "decompress_mbps": 455.74
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 62765,
+      "ratio": 0.4127,
+      "compress_mbps": 131.47,
+      "decompress_mbps": 505.37
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 57162,
+      "ratio": 0.3758,
+      "compress_mbps": 71.94,
+      "decompress_mbps": 561.74
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 56826,
+      "ratio": 0.3736,
+      "compress_mbps": 63.87,
+      "decompress_mbps": 545.05
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 55696,
+      "ratio": 0.3662,
+      "compress_mbps": 46.55,
+      "decompress_mbps": 536.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54440,
+      "ratio": 0.3579,
+      "compress_mbps": 26.47,
+      "decompress_mbps": 552.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54283,
+      "ratio": 0.3569,
+      "compress_mbps": 22.33,
+      "decompress_mbps": 551.7
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 54221,
+      "ratio": 0.3565,
+      "compress_mbps": 19.66,
+      "decompress_mbps": 548.72
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 54217,
+      "ratio": 0.3565,
+      "compress_mbps": 19.42,
+      "decompress_mbps": 550.94
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 64926,
+      "ratio": 0.5187,
+      "compress_mbps": 148.34,
+      "decompress_mbps": 435.51
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 54985,
+      "ratio": 0.4393,
+      "compress_mbps": 123.31,
+      "decompress_mbps": 482.04
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 51148,
+      "ratio": 0.4086,
+      "compress_mbps": 66.89,
+      "decompress_mbps": 547.34
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 50599,
+      "ratio": 0.4042,
+      "compress_mbps": 58.67,
+      "decompress_mbps": 532.3
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 49775,
+      "ratio": 0.3976,
+      "compress_mbps": 42.46,
+      "decompress_mbps": 514.06
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48967,
+      "ratio": 0.3912,
+      "compress_mbps": 24.9,
+      "decompress_mbps": 531.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48870,
+      "ratio": 0.3904,
+      "compress_mbps": 22.08,
+      "decompress_mbps": 530.26
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 48845,
+      "ratio": 0.3902,
+      "compress_mbps": 20.84,
+      "decompress_mbps": 531.93
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 48845,
+      "ratio": 0.3902,
+      "compress_mbps": 20.83,
+      "decompress_mbps": 532.55
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 10024,
+      "ratio": 0.4074,
+      "compress_mbps": 565.34,
+      "decompress_mbps": 892.68
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8577,
+      "ratio": 0.3486,
+      "compress_mbps": 254.79,
+      "decompress_mbps": 926.16
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8168,
+      "ratio": 0.332,
+      "compress_mbps": 153.77,
+      "decompress_mbps": 940.94
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8069,
+      "ratio": 0.328,
+      "compress_mbps": 115.12,
+      "decompress_mbps": 966.16
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 7997,
+      "ratio": 0.325,
+      "compress_mbps": 99.69,
+      "decompress_mbps": 996.87
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7952,
+      "ratio": 0.3232,
+      "compress_mbps": 74.93,
+      "decompress_mbps": 1003.56
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7947,
+      "ratio": 0.323,
+      "compress_mbps": 72.24,
+      "decompress_mbps": 1007.66
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7947,
+      "ratio": 0.323,
+      "compress_mbps": 71.04,
+      "decompress_mbps": 1008.04
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7947,
+      "ratio": 0.323,
+      "compress_mbps": 70.54,
+      "decompress_mbps": 1007.61
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 4061,
+      "ratio": 0.3642,
+      "compress_mbps": 503.76,
+      "decompress_mbps": 855.54
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3446,
+      "ratio": 0.3091,
+      "compress_mbps": 305.74,
+      "decompress_mbps": 894.77
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3201,
+      "ratio": 0.2871,
+      "compress_mbps": 234.68,
+      "decompress_mbps": 923.93
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 194.17,
+      "decompress_mbps": 950.78
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3139,
+      "ratio": 0.2815,
+      "compress_mbps": 161.99,
+      "decompress_mbps": 971.27
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3115,
+      "ratio": 0.2794,
+      "compress_mbps": 116.27,
+      "decompress_mbps": 979.95
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 105.86,
+      "decompress_mbps": 981.76
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 102.83,
+      "decompress_mbps": 983.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 102.4,
+      "decompress_mbps": 983.76
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1410,
+      "ratio": 0.3789,
+      "compress_mbps": 364.67,
+      "decompress_mbps": 589.57
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1262,
+      "ratio": 0.3392,
+      "compress_mbps": 236.31,
+      "decompress_mbps": 591.44
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1238,
+      "ratio": 0.3327,
+      "compress_mbps": 207.04,
+      "decompress_mbps": 597.11
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1219,
+      "ratio": 0.3276,
+      "compress_mbps": 176.37,
+      "decompress_mbps": 619.74
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 162.58,
+      "decompress_mbps": 626.19
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 146.86,
+      "decompress_mbps": 623.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 146.58,
+      "decompress_mbps": 627.3
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 147.18,
+      "decompress_mbps": 626.85
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 147.14,
+      "decompress_mbps": 624.76
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 274412,
+      "ratio": 0.2665,
+      "compress_mbps": 443.67,
+      "decompress_mbps": 798.16
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 213239,
+      "ratio": 0.2071,
+      "compress_mbps": 274.09,
+      "decompress_mbps": 899.64
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 232107,
+      "ratio": 0.2254,
+      "compress_mbps": 136.27,
+      "decompress_mbps": 944.48
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 202733,
+      "ratio": 0.1969,
+      "compress_mbps": 129.43,
+      "decompress_mbps": 949.94
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 207803,
+      "ratio": 0.2018,
+      "compress_mbps": 83.96,
+      "decompress_mbps": 961.16
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 205270,
+      "ratio": 0.1993,
+      "compress_mbps": 27.22,
+      "decompress_mbps": 988.66
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 209951,
+      "ratio": 0.2039,
+      "compress_mbps": 19.26,
+      "decompress_mbps": 1001.94
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 209656,
+      "ratio": 0.2036,
+      "compress_mbps": 12.2,
+      "decompress_mbps": 1014.63
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 209189,
+      "ratio": 0.2031,
+      "compress_mbps": 8.93,
+      "decompress_mbps": 1012.1
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 208640,
+      "ratio": 0.4889,
+      "compress_mbps": 153.97,
+      "decompress_mbps": 439.97
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 167329,
+      "ratio": 0.3921,
+      "compress_mbps": 137.21,
+      "decompress_mbps": 478.6
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 151097,
+      "ratio": 0.3541,
+      "compress_mbps": 73.33,
+      "decompress_mbps": 525.73
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 150035,
+      "ratio": 0.3516,
+      "compress_mbps": 65.94,
+      "decompress_mbps": 518.63
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 147375,
+      "ratio": 0.3453,
+      "compress_mbps": 47.83,
+      "decompress_mbps": 516.11
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144908,
+      "ratio": 0.3396,
+      "compress_mbps": 27.92,
+      "decompress_mbps": 526.67
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 144562,
+      "ratio": 0.3387,
+      "compress_mbps": 24.52,
+      "decompress_mbps": 527.74
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 144449,
+      "ratio": 0.3385,
+      "compress_mbps": 22.28,
+      "decompress_mbps": 528.85
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 144438,
+      "ratio": 0.3385,
+      "compress_mbps": 22.19,
+      "decompress_mbps": 528.37
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 264549,
+      "ratio": 0.549,
+      "compress_mbps": 132.29,
+      "decompress_mbps": 390.16
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 223724,
+      "ratio": 0.4643,
+      "compress_mbps": 117.51,
+      "decompress_mbps": 436.67
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 204825,
+      "ratio": 0.4251,
+      "compress_mbps": 60.42,
+      "decompress_mbps": 489.67
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 203945,
+      "ratio": 0.4232,
+      "compress_mbps": 53.54,
+      "decompress_mbps": 479.32
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 199780,
+      "ratio": 0.4146,
+      "compress_mbps": 37.72,
+      "decompress_mbps": 462.36
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 195417,
+      "ratio": 0.4055,
+      "compress_mbps": 21.07,
+      "decompress_mbps": 473.61
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 194796,
+      "ratio": 0.4043,
+      "compress_mbps": 17.79,
+      "decompress_mbps": 472.76
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 194543,
+      "ratio": 0.4037,
+      "compress_mbps": 15.6,
+      "decompress_mbps": 471.77
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 194460,
+      "ratio": 0.4036,
+      "compress_mbps": 14.96,
+      "decompress_mbps": 472.51
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 67436,
+      "ratio": 0.1314,
+      "compress_mbps": 619.83,
+      "decompress_mbps": 1037.94
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 59257,
+      "ratio": 0.1155,
+      "compress_mbps": 275.27,
+      "decompress_mbps": 1082.33
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 58316,
+      "ratio": 0.1136,
+      "compress_mbps": 180.18,
+      "decompress_mbps": 1166.09
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 56291,
+      "ratio": 0.1097,
+      "compress_mbps": 182.71,
+      "decompress_mbps": 1181.24
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 56220,
+      "ratio": 0.1095,
+      "compress_mbps": 144.84,
+      "decompress_mbps": 1237.43
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 55972,
+      "ratio": 0.1091,
+      "compress_mbps": 74.09,
+      "decompress_mbps": 1300.55
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 55121,
+      "ratio": 0.1074,
+      "compress_mbps": 51.87,
+      "decompress_mbps": 1338.54
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 54124,
+      "ratio": 0.1055,
+      "compress_mbps": 36.57,
+      "decompress_mbps": 1405.48
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 53699,
+      "ratio": 0.1046,
+      "compress_mbps": 28.57,
+      "decompress_mbps": 1433.26
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 15612,
+      "ratio": 0.4083,
+      "compress_mbps": 491.58,
+      "decompress_mbps": 850.28
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 14133,
+      "ratio": 0.3696,
+      "compress_mbps": 143.01,
+      "decompress_mbps": 884.71
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13341,
+      "ratio": 0.3489,
+      "compress_mbps": 87.49,
+      "decompress_mbps": 907.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13289,
+      "ratio": 0.3475,
+      "compress_mbps": 82.65,
+      "decompress_mbps": 931.32
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13052,
+      "ratio": 0.3413,
+      "compress_mbps": 66.29,
+      "decompress_mbps": 970.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 12996,
+      "ratio": 0.3399,
+      "compress_mbps": 36.96,
+      "decompress_mbps": 987.9
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 12972,
+      "ratio": 0.3392,
+      "compress_mbps": 27.13,
+      "decompress_mbps": 982.98
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 12951,
+      "ratio": 0.3387,
+      "compress_mbps": 18.99,
+      "decompress_mbps": 995.05
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 12933,
+      "ratio": 0.3382,
+      "compress_mbps": 14.83,
+      "decompress_mbps": 999.79
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1988,
+      "ratio": 0.4703,
+      "compress_mbps": 339.27,
+      "decompress_mbps": 541.61
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1802,
+      "ratio": 0.4263,
+      "compress_mbps": 217.93,
+      "decompress_mbps": 549.43
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 204.68,
+      "decompress_mbps": 554.88
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1732,
+      "ratio": 0.4097,
+      "compress_mbps": 170.84,
+      "decompress_mbps": 563.57
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 165.74,
+      "decompress_mbps": 572.69
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 165.98,
+      "decompress_mbps": 574.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 165.12,
+      "decompress_mbps": 573.51
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 165.77,
+      "decompress_mbps": 575.97
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 164.34,
+      "decompress_mbps": 574.16
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 59790,
+      "ratio": 0.3931,
+      "compress_mbps": 261.78,
+      "decompress_mbps": 999.3
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 57173,
+      "ratio": 0.3759,
+      "compress_mbps": 180.28,
+      "decompress_mbps": 1080.8
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 56189,
+      "ratio": 0.3694,
+      "compress_mbps": 150.31,
+      "decompress_mbps": 1159.1
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 55816,
+      "ratio": 0.367,
+      "compress_mbps": 137.42,
+      "decompress_mbps": 1202.9
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 54758,
+      "ratio": 0.36,
+      "compress_mbps": 108.51,
+      "decompress_mbps": 1256.58
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54220,
+      "ratio": 0.3565,
+      "compress_mbps": 83.98,
+      "decompress_mbps": 1294.19
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 53801,
+      "ratio": 0.3537,
+      "compress_mbps": 61.06,
+      "decompress_mbps": 1300.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 53573,
+      "ratio": 0.3522,
+      "compress_mbps": 38.94,
+      "decompress_mbps": 1302.16
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 53546,
+      "ratio": 0.3521,
+      "compress_mbps": 34.4,
+      "decompress_mbps": 1298.08
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 52276,
+      "ratio": 0.4176,
+      "compress_mbps": 243.46,
+      "decompress_mbps": 952.23
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 50534,
+      "ratio": 0.4037,
+      "compress_mbps": 168.65,
+      "decompress_mbps": 1004.24
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 49919,
+      "ratio": 0.3988,
+      "compress_mbps": 141.76,
+      "decompress_mbps": 1069.64
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 49715,
+      "ratio": 0.3972,
+      "compress_mbps": 131.29,
+      "decompress_mbps": 1106.23
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 48735,
+      "ratio": 0.3893,
+      "compress_mbps": 100.6,
+      "decompress_mbps": 1152.27
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48422,
+      "ratio": 0.3868,
+      "compress_mbps": 79.37,
+      "decompress_mbps": 1178.93
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48249,
+      "ratio": 0.3854,
+      "compress_mbps": 61.14,
+      "decompress_mbps": 1182.05
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 47977,
+      "ratio": 0.3833,
+      "compress_mbps": 42.93,
+      "decompress_mbps": 1185.47
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 47971,
+      "ratio": 0.3832,
+      "compress_mbps": 41.0,
+      "decompress_mbps": 1183.05
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8385,
+      "ratio": 0.3408,
+      "compress_mbps": 690.6,
+      "decompress_mbps": 935.13
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8380,
+      "ratio": 0.3406,
+      "compress_mbps": 439.97,
+      "decompress_mbps": 980.0
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8286,
+      "ratio": 0.3368,
+      "compress_mbps": 397.49,
+      "decompress_mbps": 978.74
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8163,
+      "ratio": 0.3318,
+      "compress_mbps": 371.05,
+      "decompress_mbps": 999.84
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 8053,
+      "ratio": 0.3273,
+      "compress_mbps": 340.2,
+      "decompress_mbps": 985.69
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7986,
+      "ratio": 0.3246,
+      "compress_mbps": 277.77,
+      "decompress_mbps": 1070.79
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7954,
+      "ratio": 0.3233,
+      "compress_mbps": 188.58,
+      "decompress_mbps": 1067.77
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7916,
+      "ratio": 0.3217,
+      "compress_mbps": 128.17,
+      "decompress_mbps": 1060.77
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7916,
+      "ratio": 0.3217,
+      "compress_mbps": 125.64,
+      "decompress_mbps": 1073.78
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3401,
+      "ratio": 0.305,
+      "compress_mbps": 587.81,
+      "decompress_mbps": 798.85
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3307,
+      "ratio": 0.2966,
+      "compress_mbps": 395.11,
+      "decompress_mbps": 778.95
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3242,
+      "ratio": 0.2908,
+      "compress_mbps": 368.8,
+      "decompress_mbps": 854.3
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3205,
+      "ratio": 0.2874,
+      "compress_mbps": 349.64,
+      "decompress_mbps": 857.47
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3150,
+      "ratio": 0.2825,
+      "compress_mbps": 314.5,
+      "decompress_mbps": 887.53
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3126,
+      "ratio": 0.2804,
+      "compress_mbps": 267.0,
+      "decompress_mbps": 887.53
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3106,
+      "ratio": 0.2786,
+      "compress_mbps": 206.93,
+      "decompress_mbps": 897.11
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3102,
+      "ratio": 0.2782,
+      "compress_mbps": 147.87,
+      "decompress_mbps": 896.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3102,
+      "ratio": 0.2782,
+      "compress_mbps": 141.21,
+      "decompress_mbps": 896.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1251,
+      "ratio": 0.3362,
+      "compress_mbps": 379.65,
+      "decompress_mbps": 462.6
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1228,
+      "ratio": 0.33,
+      "compress_mbps": 268.45,
+      "decompress_mbps": 456.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1219,
+      "ratio": 0.3276,
+      "compress_mbps": 260.49,
+      "decompress_mbps": 490.21
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1220,
+      "ratio": 0.3279,
+      "compress_mbps": 255.0,
+      "decompress_mbps": 480.52
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 240.78,
+      "decompress_mbps": 471.95
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 223.04,
+      "decompress_mbps": 444.63
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 203.22,
+      "decompress_mbps": 475.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1204,
+      "ratio": 0.3236,
+      "compress_mbps": 169.07,
+      "decompress_mbps": 497.21
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1204,
+      "ratio": 0.3236,
+      "compress_mbps": 168.8,
+      "decompress_mbps": 485.31
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 221813,
+      "ratio": 0.2154,
+      "compress_mbps": 588.6,
+      "decompress_mbps": 1014.58
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 199825,
+      "ratio": 0.1941,
+      "compress_mbps": 407.43,
+      "decompress_mbps": 1471.37
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 195675,
+      "ratio": 0.19,
+      "compress_mbps": 281.25,
+      "decompress_mbps": 1541.56
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 195664,
+      "ratio": 0.19,
+      "compress_mbps": 278.19,
+      "decompress_mbps": 1551.61
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 198900,
+      "ratio": 0.1932,
+      "compress_mbps": 238.37,
+      "decompress_mbps": 1135.95
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 199347,
+      "ratio": 0.1936,
+      "compress_mbps": 203.81,
+      "decompress_mbps": 1129.81
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 199777,
+      "ratio": 0.194,
+      "compress_mbps": 123.42,
+      "decompress_mbps": 1192.91
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 182094,
+      "ratio": 0.1768,
+      "compress_mbps": 25.59,
+      "decompress_mbps": 1176.73
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 181451,
+      "ratio": 0.1762,
+      "compress_mbps": 13.59,
+      "decompress_mbps": 1179.16
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 159063,
+      "ratio": 0.3727,
+      "compress_mbps": 265.62,
+      "decompress_mbps": 1029.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 152115,
+      "ratio": 0.3564,
+      "compress_mbps": 186.86,
+      "decompress_mbps": 1107.17
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 149162,
+      "ratio": 0.3495,
+      "compress_mbps": 156.48,
+      "decompress_mbps": 1199.21
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 148359,
+      "ratio": 0.3476,
+      "compress_mbps": 142.85,
+      "decompress_mbps": 1051.93
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 145353,
+      "ratio": 0.3406,
+      "compress_mbps": 112.44,
+      "decompress_mbps": 1009.83
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144209,
+      "ratio": 0.3379,
+      "compress_mbps": 87.2,
+      "decompress_mbps": 1056.32
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 143604,
+      "ratio": 0.3365,
+      "compress_mbps": 65.59,
+      "decompress_mbps": 1053.74
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 142086,
+      "ratio": 0.3329,
+      "compress_mbps": 44.12,
+      "decompress_mbps": 1060.01
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 142027,
+      "ratio": 0.3328,
+      "compress_mbps": 40.37,
+      "decompress_mbps": 1059.55
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 210662,
+      "ratio": 0.4372,
+      "compress_mbps": 231.28,
+      "decompress_mbps": 875.16
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 202881,
+      "ratio": 0.421,
+      "compress_mbps": 158.53,
+      "decompress_mbps": 945.81
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 200409,
+      "ratio": 0.4159,
+      "compress_mbps": 133.25,
+      "decompress_mbps": 1026.25
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 199678,
+      "ratio": 0.4144,
+      "compress_mbps": 122.99,
+      "decompress_mbps": 861.01
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 195798,
+      "ratio": 0.4063,
+      "compress_mbps": 93.16,
+      "decompress_mbps": 810.98
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 194029,
+      "ratio": 0.4027,
+      "compress_mbps": 71.96,
+      "decompress_mbps": 838.09
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 192773,
+      "ratio": 0.4001,
+      "compress_mbps": 51.34,
+      "decompress_mbps": 841.59
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 191739,
+      "ratio": 0.3979,
+      "compress_mbps": 33.58,
+      "decompress_mbps": 841.73
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 191676,
+      "ratio": 0.3978,
+      "compress_mbps": 30.97,
+      "decompress_mbps": 840.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 58079,
+      "ratio": 0.1132,
+      "compress_mbps": 372.45,
+      "decompress_mbps": 1713.09
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 57838,
+      "ratio": 0.1127,
+      "compress_mbps": 411.55,
+      "decompress_mbps": 1792.92
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 57554,
+      "ratio": 0.1121,
+      "compress_mbps": 394.06,
+      "decompress_mbps": 1920.02
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 57064,
+      "ratio": 0.1112,
+      "compress_mbps": 372.94,
+      "decompress_mbps": 1744.1
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 55743,
+      "ratio": 0.1086,
+      "compress_mbps": 342.49,
+      "decompress_mbps": 1816.24
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 55102,
+      "ratio": 0.1074,
+      "compress_mbps": 282.73,
+      "decompress_mbps": 1891.92
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 54742,
+      "ratio": 0.1067,
+      "compress_mbps": 186.9,
+      "decompress_mbps": 1955.85
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 53133,
+      "ratio": 0.1035,
+      "compress_mbps": 102.84,
+      "decompress_mbps": 2019.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 52186,
+      "ratio": 0.1017,
+      "compress_mbps": 72.15,
+      "decompress_mbps": 2056.59
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 14122,
+      "ratio": 0.3693,
+      "compress_mbps": 648.04,
+      "decompress_mbps": 828.0
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13374,
+      "ratio": 0.3497,
+      "compress_mbps": 349.65,
+      "decompress_mbps": 881.97
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13293,
+      "ratio": 0.3476,
+      "compress_mbps": 283.4,
+      "decompress_mbps": 970.94
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13259,
+      "ratio": 0.3467,
+      "compress_mbps": 258.71,
+      "decompress_mbps": 977.66
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 12641,
+      "ratio": 0.3306,
+      "compress_mbps": 193.57,
+      "decompress_mbps": 1023.1
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 12432,
+      "ratio": 0.3251,
+      "compress_mbps": 166.22,
+      "decompress_mbps": 1026.76
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 12439,
+      "ratio": 0.3253,
+      "compress_mbps": 124.01,
+      "decompress_mbps": 1044.55
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 12579,
+      "ratio": 0.3289,
+      "compress_mbps": 67.42,
+      "decompress_mbps": 1051.97
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 12574,
+      "ratio": 0.3288,
+      "compress_mbps": 47.28,
+      "decompress_mbps": 1053.73
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1777,
+      "ratio": 0.4204,
+      "compress_mbps": 386.05,
+      "decompress_mbps": 393.13
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1756,
+      "ratio": 0.4154,
+      "compress_mbps": 258.79,
+      "decompress_mbps": 400.28
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1746,
+      "ratio": 0.4131,
+      "compress_mbps": 255.06,
+      "decompress_mbps": 401.59
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1740,
+      "ratio": 0.4116,
+      "compress_mbps": 252.63,
+      "decompress_mbps": 395.56
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1722,
+      "ratio": 0.4074,
+      "compress_mbps": 240.22,
+      "decompress_mbps": 429.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1721,
+      "ratio": 0.4071,
+      "compress_mbps": 236.46,
+      "decompress_mbps": 432.3
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 234.1,
+      "decompress_mbps": 432.76
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1717,
+      "ratio": 0.4062,
+      "compress_mbps": 216.74,
+      "decompress_mbps": 442.02
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1717,
+      "ratio": 0.4062,
+      "compress_mbps": 217.37,
+      "decompress_mbps": 441.53
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 5364132,
+      "ratio": 0.5263,
+      "compress_mbps": 13.08,
+      "decompress_mbps": 83.45
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 5165701,
+      "ratio": 0.5068,
+      "compress_mbps": 11.55,
+      "decompress_mbps": 90.67
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 5046240,
+      "ratio": 0.4951,
+      "compress_mbps": 10.09,
+      "decompress_mbps": 97.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 4889382,
+      "ratio": 0.4797,
+      "compress_mbps": 6.05,
+      "decompress_mbps": 98.61
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 4867273,
+      "ratio": 0.4775,
+      "compress_mbps": 5.54,
+      "decompress_mbps": 100.03
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 4832420,
+      "ratio": 0.4741,
+      "compress_mbps": 4.77,
+      "decompress_mbps": 101.14
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3922973,
+      "ratio": 0.3849,
+      "compress_mbps": 1.5,
+      "decompress_mbps": 103.6
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3919702,
+      "ratio": 0.3846,
+      "compress_mbps": 1.45,
+      "decompress_mbps": 101.81
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3919665,
+      "ratio": 0.3846,
+      "compress_mbps": 1.45,
+      "decompress_mbps": 100.43
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20729473,
+      "ratio": 0.4047,
+      "compress_mbps": 17.91,
+      "decompress_mbps": 74.33
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 20500337,
+      "ratio": 0.4002,
+      "compress_mbps": 17.05,
+      "decompress_mbps": 76.95
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 20349978,
+      "ratio": 0.3973,
+      "compress_mbps": 15.32,
+      "decompress_mbps": 79.33
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19952001,
+      "ratio": 0.3895,
+      "compress_mbps": 9.07,
+      "decompress_mbps": 81.35
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19925043,
+      "ratio": 0.389,
+      "compress_mbps": 8.05,
+      "decompress_mbps": 83.24
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19882104,
+      "ratio": 0.3882,
+      "compress_mbps": 6.12,
+      "decompress_mbps": 85.21
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19004928,
+      "ratio": 0.371,
+      "compress_mbps": 1.49,
+      "decompress_mbps": 81.03
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19002295,
+      "ratio": 0.371,
+      "compress_mbps": 1.15,
+      "decompress_mbps": 86.38
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19000618,
+      "ratio": 0.371,
+      "compress_mbps": 0.87,
+      "decompress_mbps": 83.24
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 4668650,
+      "ratio": 0.4682,
+      "compress_mbps": 18.87,
+      "decompress_mbps": 73.4
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 4570500,
+      "ratio": 0.4584,
+      "compress_mbps": 16.62,
+      "decompress_mbps": 76.72
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 4510300,
+      "ratio": 0.4524,
+      "compress_mbps": 14.84,
+      "decompress_mbps": 77.95
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 4369955,
+      "ratio": 0.4383,
+      "compress_mbps": 8.65,
+      "decompress_mbps": 72.84
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 4360147,
+      "ratio": 0.4373,
+      "compress_mbps": 7.81,
+      "decompress_mbps": 74.49
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 4349427,
+      "ratio": 0.4362,
+      "compress_mbps": 5.74,
+      "decompress_mbps": 76.61
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3678637,
+      "ratio": 0.3689,
+      "compress_mbps": 1.38,
+      "decompress_mbps": 77.57
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3680111,
+      "ratio": 0.3691,
+      "compress_mbps": 1.06,
+      "decompress_mbps": 78.87
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3679584,
+      "ratio": 0.369,
+      "compress_mbps": 0.83,
+      "decompress_mbps": 78.13
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 4705330,
+      "ratio": 0.1402,
+      "compress_mbps": 41.87,
+      "decompress_mbps": 270.0
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 4457802,
+      "ratio": 0.1329,
+      "compress_mbps": 36.4,
+      "decompress_mbps": 299.34
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 4241801,
+      "ratio": 0.1264,
+      "compress_mbps": 30.42,
+      "decompress_mbps": 330.43
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3946147,
+      "ratio": 0.1176,
+      "compress_mbps": 17.33,
+      "decompress_mbps": 333.42
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3917350,
+      "ratio": 0.1167,
+      "compress_mbps": 15.53,
+      "decompress_mbps": 364.13
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3871740,
+      "ratio": 0.1154,
+      "compress_mbps": 11.66,
+      "decompress_mbps": 385.47
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3256646,
+      "ratio": 0.0971,
+      "compress_mbps": 2.91,
+      "decompress_mbps": 364.51
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3232193,
+      "ratio": 0.0963,
+      "compress_mbps": 2.14,
+      "decompress_mbps": 384.87
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 3211270,
+      "ratio": 0.0957,
+      "compress_mbps": 1.64,
+      "decompress_mbps": 360.65
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3632401,
+      "ratio": 0.5904,
+      "compress_mbps": 13.87,
+      "decompress_mbps": 49.82
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3594843,
+      "ratio": 0.5843,
+      "compress_mbps": 13.09,
+      "decompress_mbps": 50.91
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3570380,
+      "ratio": 0.5803,
+      "compress_mbps": 11.99,
+      "decompress_mbps": 53.43
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3475962,
+      "ratio": 0.565,
+      "compress_mbps": 8.15,
+      "decompress_mbps": 55.08
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3470919,
+      "ratio": 0.5642,
+      "compress_mbps": 7.51,
+      "decompress_mbps": 55.7
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3462594,
+      "ratio": 0.5628,
+      "compress_mbps": 6.32,
+      "decompress_mbps": 56.28
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3100878,
+      "ratio": 0.504,
+      "compress_mbps": 1.68,
+      "decompress_mbps": 56.93
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3099704,
+      "ratio": 0.5038,
+      "compress_mbps": 1.43,
+      "decompress_mbps": 44.35
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3098139,
+      "ratio": 0.5036,
+      "compress_mbps": 1.36,
+      "decompress_mbps": 55.86
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3889230,
+      "ratio": 0.3856,
+      "compress_mbps": 20.14,
+      "decompress_mbps": 69.18
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3811489,
+      "ratio": 0.3779,
+      "compress_mbps": 18.81,
+      "decompress_mbps": 71.9
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3789217,
+      "ratio": 0.3757,
+      "compress_mbps": 18.31,
+      "decompress_mbps": 73.68
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3742155,
+      "ratio": 0.371,
+      "compress_mbps": 13.8,
+      "decompress_mbps": 74.13
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3734147,
+      "ratio": 0.3702,
+      "compress_mbps": 13.12,
+      "decompress_mbps": 73.63
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3723457,
+      "ratio": 0.3692,
+      "compress_mbps": 11.68,
+      "decompress_mbps": 73.03
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3723087,
+      "ratio": 0.3691,
+      "compress_mbps": 2.89,
+      "decompress_mbps": 71.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3723909,
+      "ratio": 0.3692,
+      "compress_mbps": 2.78,
+      "decompress_mbps": 73.61
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3723909,
+      "ratio": 0.3692,
+      "compress_mbps": 2.75,
+      "decompress_mbps": 70.9
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2592263,
+      "ratio": 0.3912,
+      "compress_mbps": 15.92,
+      "decompress_mbps": 98.95
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2479835,
+      "ratio": 0.3742,
+      "compress_mbps": 14.06,
+      "decompress_mbps": 106.65
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2405060,
+      "ratio": 0.3629,
+      "compress_mbps": 11.74,
+      "decompress_mbps": 119.27
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 2257758,
+      "ratio": 0.3407,
+      "compress_mbps": 6.5,
+      "decompress_mbps": 117.17
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 2239545,
+      "ratio": 0.3379,
+      "compress_mbps": 5.59,
+      "decompress_mbps": 122.62
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 2207053,
+      "ratio": 0.333,
+      "compress_mbps": 3.96,
+      "decompress_mbps": 127.06
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1865730,
+      "ratio": 0.2815,
+      "compress_mbps": 1.06,
+      "decompress_mbps": 128.26
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1860184,
+      "ratio": 0.2807,
+      "compress_mbps": 0.79,
+      "decompress_mbps": 129.87
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1858631,
+      "ratio": 0.2805,
+      "compress_mbps": 0.74,
+      "decompress_mbps": 131.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 6185865,
+      "ratio": 0.2863,
+      "compress_mbps": 24.21,
+      "decompress_mbps": 131.07
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 6066146,
+      "ratio": 0.2808,
+      "compress_mbps": 22.06,
+      "decompress_mbps": 138.18
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5993070,
+      "ratio": 0.2774,
+      "compress_mbps": 19.03,
+      "decompress_mbps": 142.93
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5847650,
+      "ratio": 0.2706,
+      "compress_mbps": 11.46,
+      "decompress_mbps": 145.69
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5837234,
+      "ratio": 0.2702,
+      "compress_mbps": 10.4,
+      "decompress_mbps": 150.46
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5823141,
+      "ratio": 0.2695,
+      "compress_mbps": 8.61,
+      "decompress_mbps": 152.11
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5455440,
+      "ratio": 0.2525,
+      "compress_mbps": 2.35,
+      "decompress_mbps": 151.25
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5450250,
+      "ratio": 0.2523,
+      "compress_mbps": 1.96,
+      "decompress_mbps": 154.1
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5449052,
+      "ratio": 0.2522,
+      "compress_mbps": 1.62,
+      "decompress_mbps": 149.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5514279,
+      "ratio": 0.7604,
+      "compress_mbps": 13.16,
+      "decompress_mbps": 53.52
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5472540,
+      "ratio": 0.7546,
+      "compress_mbps": 11.94,
+      "decompress_mbps": 54.48
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5448811,
+      "ratio": 0.7514,
+      "compress_mbps": 11.13,
+      "decompress_mbps": 55.64
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5375802,
+      "ratio": 0.7413,
+      "compress_mbps": 7.28,
+      "decompress_mbps": 56.04
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5370794,
+      "ratio": 0.7406,
+      "compress_mbps": 6.75,
+      "decompress_mbps": 57.08
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5362339,
+      "ratio": 0.7394,
+      "compress_mbps": 5.63,
+      "decompress_mbps": 56.64
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5358816,
+      "ratio": 0.7389,
+      "compress_mbps": 1.54,
+      "decompress_mbps": 58.53
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5358607,
+      "ratio": 0.7389,
+      "compress_mbps": 1.54,
+      "decompress_mbps": 56.77
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5358607,
+      "ratio": 0.7389,
+      "compress_mbps": 1.53,
+      "decompress_mbps": 56.99
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 16232235,
+      "ratio": 0.3915,
+      "compress_mbps": 17.41,
+      "decompress_mbps": 104.18
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 15659043,
+      "ratio": 0.3777,
+      "compress_mbps": 15.68,
+      "decompress_mbps": 108.38
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 15341951,
+      "ratio": 0.3701,
+      "compress_mbps": 13.44,
+      "decompress_mbps": 115.73
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 14794018,
+      "ratio": 0.3568,
+      "compress_mbps": 8.39,
+      "decompress_mbps": 118.09
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 14735437,
+      "ratio": 0.3554,
+      "compress_mbps": 7.85,
+      "decompress_mbps": 120.7
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 14635001,
+      "ratio": 0.353,
+      "compress_mbps": 6.3,
+      "decompress_mbps": 124.95
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12345372,
+      "ratio": 0.2978,
+      "compress_mbps": 1.9,
+      "decompress_mbps": 126.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12327847,
+      "ratio": 0.2974,
+      "compress_mbps": 1.76,
+      "decompress_mbps": 126.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12327819,
+      "ratio": 0.2974,
+      "compress_mbps": 1.75,
+      "decompress_mbps": 127.05
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 7300743,
+      "ratio": 0.8615,
+      "compress_mbps": 12.03,
+      "decompress_mbps": 40.27
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 7258514,
+      "ratio": 0.8565,
+      "compress_mbps": 11.3,
+      "decompress_mbps": 43.56
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 5983501,
+      "ratio": 0.7061,
+      "compress_mbps": 10.89,
+      "decompress_mbps": 45.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 5965382,
+      "ratio": 0.7039,
+      "compress_mbps": 9.06,
+      "decompress_mbps": 42.72
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 5964821,
+      "ratio": 0.7039,
+      "compress_mbps": 8.92,
+      "decompress_mbps": 43.83
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5964654,
+      "ratio": 0.7039,
+      "compress_mbps": 8.42,
+      "decompress_mbps": 43.64
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 5964649,
+      "ratio": 0.7039,
+      "compress_mbps": 2.36,
+      "decompress_mbps": 43.93
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 5964649,
+      "ratio": 0.7039,
+      "compress_mbps": 2.37,
+      "decompress_mbps": 44.4
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5964649,
+      "ratio": 0.7039,
+      "compress_mbps": 2.38,
+      "decompress_mbps": 43.14
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 968373,
+      "ratio": 0.1812,
+      "compress_mbps": 33.45,
+      "decompress_mbps": 202.31
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 912756,
+      "ratio": 0.1708,
+      "compress_mbps": 29.32,
+      "decompress_mbps": 221.01
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 875269,
+      "ratio": 0.1637,
+      "compress_mbps": 25.13,
+      "decompress_mbps": 237.45
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 826760,
+      "ratio": 0.1547,
+      "compress_mbps": 14.45,
+      "decompress_mbps": 232.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 818408,
+      "ratio": 0.1531,
+      "compress_mbps": 13.03,
+      "decompress_mbps": 260.58
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 805917,
+      "ratio": 0.1508,
+      "compress_mbps": 10.6,
+      "decompress_mbps": 274.84
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 685265,
+      "ratio": 0.1282,
+      "compress_mbps": 3.02,
+      "decompress_mbps": 276.85
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 683484,
+      "ratio": 0.1279,
+      "compress_mbps": 2.66,
+      "decompress_mbps": 258.16
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 683122,
+      "ratio": 0.1278,
+      "compress_mbps": 2.59,
+      "decompress_mbps": 281.89
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4585612,
+      "ratio": 0.4499,
+      "compress_mbps": 112.62,
+      "decompress_mbps": 326.51
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4389474,
+      "ratio": 0.4307,
+      "compress_mbps": 94.58,
+      "decompress_mbps": 345.63
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4192079,
+      "ratio": 0.4113,
+      "compress_mbps": 58.99,
+      "decompress_mbps": 377.25
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 4095021,
+      "ratio": 0.4018,
+      "compress_mbps": 64.89,
+      "decompress_mbps": 362.75
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3949169,
+      "ratio": 0.3875,
+      "compress_mbps": 35.69,
+      "decompress_mbps": 347.67
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3871628,
+      "ratio": 0.3799,
+      "compress_mbps": 21.16,
+      "decompress_mbps": 350.65
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3858876,
+      "ratio": 0.3786,
+      "compress_mbps": 17.65,
+      "decompress_mbps": 353.82
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3854729,
+      "ratio": 0.3782,
+      "compress_mbps": 15.05,
+      "decompress_mbps": 363.76
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3854729,
+      "ratio": 0.3782,
+      "compress_mbps": 15.01,
+      "decompress_mbps": 361.96
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20577220,
+      "ratio": 0.4017,
+      "compress_mbps": 110.99,
+      "decompress_mbps": 365.77
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 20247697,
+      "ratio": 0.3953,
+      "compress_mbps": 99.66,
+      "decompress_mbps": 374.56
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19987880,
+      "ratio": 0.3902,
+      "compress_mbps": 75.72,
+      "decompress_mbps": 378.61
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19512665,
+      "ratio": 0.381,
+      "compress_mbps": 74.0,
+      "decompress_mbps": 364.35
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19213507,
+      "ratio": 0.3751,
+      "compress_mbps": 52.58,
+      "decompress_mbps": 370.25
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19089118,
+      "ratio": 0.3727,
+      "compress_mbps": 34.13,
+      "decompress_mbps": 380.67
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19061204,
+      "ratio": 0.3721,
+      "compress_mbps": 27.07,
+      "decompress_mbps": 380.06
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19040998,
+      "ratio": 0.3717,
+      "compress_mbps": 15.33,
+      "decompress_mbps": 382.97
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19044390,
+      "ratio": 0.3718,
+      "compress_mbps": 9.35,
+      "decompress_mbps": 354.76
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3828360,
+      "ratio": 0.384,
+      "compress_mbps": 137.17,
+      "decompress_mbps": 438.18
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3798539,
+      "ratio": 0.381,
+      "compress_mbps": 126.24,
+      "decompress_mbps": 413.39
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3674568,
+      "ratio": 0.3685,
+      "compress_mbps": 79.0,
+      "decompress_mbps": 475.84
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3680923,
+      "ratio": 0.3692,
+      "compress_mbps": 87.01,
+      "decompress_mbps": 417.33
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3698707,
+      "ratio": 0.371,
+      "compress_mbps": 47.26,
+      "decompress_mbps": 391.61
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3675935,
+      "ratio": 0.3687,
+      "compress_mbps": 26.19,
+      "decompress_mbps": 407.4
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3670281,
+      "ratio": 0.3681,
+      "compress_mbps": 20.54,
+      "decompress_mbps": 416.49
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3661103,
+      "ratio": 0.3672,
+      "compress_mbps": 10.84,
+      "decompress_mbps": 415.62
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3660788,
+      "ratio": 0.3672,
+      "compress_mbps": 9.28,
+      "decompress_mbps": 422.39
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 4624591,
+      "ratio": 0.1378,
+      "compress_mbps": 329.8,
+      "decompress_mbps": 821.38
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 4303176,
+      "ratio": 0.1282,
+      "compress_mbps": 305.84,
+      "decompress_mbps": 842.86
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 4010156,
+      "ratio": 0.1195,
+      "compress_mbps": 256.42,
+      "decompress_mbps": 919.56
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3713866,
+      "ratio": 0.1107,
+      "compress_mbps": 208.42,
+      "decompress_mbps": 879.91
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3378136,
+      "ratio": 0.1007,
+      "compress_mbps": 163.75,
+      "decompress_mbps": 938.51
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3200182,
+      "ratio": 0.0954,
+      "compress_mbps": 112.93,
+      "decompress_mbps": 983.84
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3141278,
+      "ratio": 0.0936,
+      "compress_mbps": 89.57,
+      "decompress_mbps": 1006.14
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3031199,
+      "ratio": 0.0903,
+      "compress_mbps": 37.22,
+      "decompress_mbps": 1029.02
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2987995,
+      "ratio": 0.0891,
+      "compress_mbps": 21.3,
+      "decompress_mbps": 871.38
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3290526,
+      "ratio": 0.5349,
+      "compress_mbps": 75.98,
+      "decompress_mbps": 244.57
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3238282,
+      "ratio": 0.5264,
+      "compress_mbps": 66.84,
+      "decompress_mbps": 252.61
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3193366,
+      "ratio": 0.5191,
+      "compress_mbps": 55.63,
+      "decompress_mbps": 258.22
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3158012,
+      "ratio": 0.5133,
+      "compress_mbps": 54.19,
+      "decompress_mbps": 262.52
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3115309,
+      "ratio": 0.5064,
+      "compress_mbps": 38.44,
+      "decompress_mbps": 260.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3097288,
+      "ratio": 0.5034,
+      "compress_mbps": 24.37,
+      "decompress_mbps": 228.41
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3094363,
+      "ratio": 0.503,
+      "compress_mbps": 20.91,
+      "decompress_mbps": 260.98
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3093026,
+      "ratio": 0.5028,
+      "compress_mbps": 16.17,
+      "decompress_mbps": 263.86
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3092920,
+      "ratio": 0.5027,
+      "compress_mbps": 15.4,
+      "decompress_mbps": 261.98
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 4076385,
+      "ratio": 0.4042,
+      "compress_mbps": 123.6,
+      "decompress_mbps": 439.26
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3991014,
+      "ratio": 0.3957,
+      "compress_mbps": 115.11,
+      "decompress_mbps": 457.42
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3934055,
+      "ratio": 0.3901,
+      "compress_mbps": 92.19,
+      "decompress_mbps": 467.32
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3825092,
+      "ratio": 0.3793,
+      "compress_mbps": 83.17,
+      "decompress_mbps": 464.28
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3752932,
+      "ratio": 0.3721,
+      "compress_mbps": 63.86,
+      "decompress_mbps": 459.59
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3695164,
+      "ratio": 0.3664,
+      "compress_mbps": 48.87,
+      "decompress_mbps": 465.98
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3676881,
+      "ratio": 0.3646,
+      "compress_mbps": 37.86,
+      "decompress_mbps": 451.9
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3673171,
+      "ratio": 0.3642,
+      "compress_mbps": 30.38,
+      "decompress_mbps": 468.86
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3673171,
+      "ratio": 0.3642,
+      "compress_mbps": 27.98,
+      "decompress_mbps": 469.77
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2376424,
+      "ratio": 0.3586,
+      "compress_mbps": 121.31,
+      "decompress_mbps": 376.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2259060,
+      "ratio": 0.3409,
+      "compress_mbps": 84.63,
+      "decompress_mbps": 390.11
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2135664,
+      "ratio": 0.3223,
+      "compress_mbps": 64.79,
+      "decompress_mbps": 398.49
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 2052793,
+      "ratio": 0.3098,
+      "compress_mbps": 76.89,
+      "decompress_mbps": 375.45
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1932127,
+      "ratio": 0.2915,
+      "compress_mbps": 43.59,
+      "decompress_mbps": 417.83
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1860865,
+      "ratio": 0.2808,
+      "compress_mbps": 22.36,
+      "decompress_mbps": 418.24
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1838671,
+      "ratio": 0.2774,
+      "compress_mbps": 14.72,
+      "decompress_mbps": 331.73
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1823235,
+      "ratio": 0.2751,
+      "compress_mbps": 7.0,
+      "decompress_mbps": 377.34
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1823190,
+      "ratio": 0.2751,
+      "compress_mbps": 7.79,
+      "decompress_mbps": 419.25
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 6329449,
+      "ratio": 0.2929,
+      "compress_mbps": 158.73,
+      "decompress_mbps": 465.39
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 6128866,
+      "ratio": 0.2837,
+      "compress_mbps": 132.8,
+      "decompress_mbps": 501.83
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5982546,
+      "ratio": 0.2769,
+      "compress_mbps": 105.5,
+      "decompress_mbps": 546.09
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5656400,
+      "ratio": 0.2618,
+      "compress_mbps": 111.69,
+      "decompress_mbps": 554.52
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5511352,
+      "ratio": 0.2551,
+      "compress_mbps": 75.4,
+      "decompress_mbps": 570.37
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5451399,
+      "ratio": 0.2523,
+      "compress_mbps": 48.48,
+      "decompress_mbps": 506.08
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5417123,
+      "ratio": 0.2507,
+      "compress_mbps": 39.99,
+      "decompress_mbps": 563.3
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5404364,
+      "ratio": 0.2501,
+      "compress_mbps": 28.4,
+      "decompress_mbps": 556.8
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5402704,
+      "ratio": 0.2501,
+      "compress_mbps": 26.12,
+      "decompress_mbps": 544.55
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5567768,
+      "ratio": 0.7678,
+      "compress_mbps": 56.02,
+      "decompress_mbps": 285.78
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5504009,
+      "ratio": 0.759,
+      "compress_mbps": 45.85,
+      "decompress_mbps": 276.42
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5439339,
+      "ratio": 0.7501,
+      "compress_mbps": 37.94,
+      "decompress_mbps": 263.59
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5394604,
+      "ratio": 0.7439,
+      "compress_mbps": 40.81,
+      "decompress_mbps": 293.75
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5370116,
+      "ratio": 0.7405,
+      "compress_mbps": 27.23,
+      "decompress_mbps": 278.18
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5331793,
+      "ratio": 0.7352,
+      "compress_mbps": 21.13,
+      "decompress_mbps": 323.35
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5327677,
+      "ratio": 0.7347,
+      "compress_mbps": 19.45,
+      "decompress_mbps": 329.72
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5325914,
+      "ratio": 0.7344,
+      "compress_mbps": 16.66,
+      "decompress_mbps": 337.85
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5325914,
+      "ratio": 0.7344,
+      "compress_mbps": 18.3,
+      "decompress_mbps": 337.72
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 14991236,
+      "ratio": 0.3616,
+      "compress_mbps": 123.03,
+      "decompress_mbps": 370.76
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 14249692,
+      "ratio": 0.3437,
+      "compress_mbps": 115.23,
+      "decompress_mbps": 393.87
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 13627761,
+      "ratio": 0.3287,
+      "compress_mbps": 84.99,
+      "decompress_mbps": 407.18
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 13001990,
+      "ratio": 0.3136,
+      "compress_mbps": 81.23,
+      "decompress_mbps": 386.22
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12445991,
+      "ratio": 0.3002,
+      "compress_mbps": 52.25,
+      "decompress_mbps": 378.08
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12213941,
+      "ratio": 0.2946,
+      "compress_mbps": 35.92,
+      "decompress_mbps": 389.79
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12130416,
+      "ratio": 0.2926,
+      "compress_mbps": 27.88,
+      "decompress_mbps": 393.35
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12073697,
+      "ratio": 0.2912,
+      "compress_mbps": 21.0,
+      "decompress_mbps": 386.34
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12073469,
+      "ratio": 0.2912,
+      "compress_mbps": 20.59,
+      "decompress_mbps": 400.02
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6033926,
+      "ratio": 0.712,
+      "compress_mbps": 72.67,
+      "decompress_mbps": 278.51
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 5997474,
+      "ratio": 0.7077,
+      "compress_mbps": 66.99,
+      "decompress_mbps": 284.65
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 5966621,
+      "ratio": 0.7041,
+      "compress_mbps": 54.17,
+      "decompress_mbps": 287.51
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6091108,
+      "ratio": 0.7188,
+      "compress_mbps": 44.66,
+      "decompress_mbps": 248.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6053566,
+      "ratio": 0.7143,
+      "compress_mbps": 36.13,
+      "decompress_mbps": 257.67
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 6045111,
+      "ratio": 0.7134,
+      "compress_mbps": 34.12,
+      "decompress_mbps": 262.19
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 6045034,
+      "ratio": 0.7133,
+      "compress_mbps": 34.03,
+      "decompress_mbps": 261.12
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 6045032,
+      "ratio": 0.7133,
+      "compress_mbps": 34.07,
+      "decompress_mbps": 260.63
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 6045032,
+      "ratio": 0.7133,
+      "compress_mbps": 33.96,
+      "decompress_mbps": 259.4
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 965242,
+      "ratio": 0.1806,
+      "compress_mbps": 255.68,
+      "decompress_mbps": 672.39
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 887265,
+      "ratio": 0.166,
+      "compress_mbps": 239.8,
+      "decompress_mbps": 722.07
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 822167,
+      "ratio": 0.1538,
+      "compress_mbps": 186.8,
+      "decompress_mbps": 766.33
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 807518,
+      "ratio": 0.1511,
+      "compress_mbps": 164.2,
+      "decompress_mbps": 735.56
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 730574,
+      "ratio": 0.1367,
+      "compress_mbps": 119.02,
+      "decompress_mbps": 777.13
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 687991,
+      "ratio": 0.1287,
+      "compress_mbps": 77.84,
+      "decompress_mbps": 831.54
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 673933,
+      "ratio": 0.1261,
+      "compress_mbps": 63.95,
+      "decompress_mbps": 846.38
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 659518,
+      "ratio": 0.1234,
+      "compress_mbps": 40.84,
+      "decompress_mbps": 853.31
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 658899,
+      "ratio": 0.1233,
+      "compress_mbps": 39.29,
+      "decompress_mbps": 862.18
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 5363862,
+      "ratio": 0.5263,
+      "compress_mbps": 139.04,
+      "decompress_mbps": 375.89
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4438205,
+      "ratio": 0.4354,
+      "compress_mbps": 126.11,
+      "decompress_mbps": 433.9
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4054333,
+      "ratio": 0.3978,
+      "compress_mbps": 63.54,
+      "decompress_mbps": 478.51
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 4038550,
+      "ratio": 0.3962,
+      "compress_mbps": 57.13,
+      "decompress_mbps": 474.12
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3954920,
+      "ratio": 0.388,
+      "compress_mbps": 40.06,
+      "decompress_mbps": 464.75
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3872874,
+      "ratio": 0.38,
+      "compress_mbps": 22.43,
+      "decompress_mbps": 472.67
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3859937,
+      "ratio": 0.3787,
+      "compress_mbps": 18.69,
+      "decompress_mbps": 475.29
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3855935,
+      "ratio": 0.3783,
+      "compress_mbps": 16.97,
+      "decompress_mbps": 475.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3855791,
+      "ratio": 0.3783,
+      "compress_mbps": 16.9,
+      "decompress_mbps": 479.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 22334882,
+      "ratio": 0.4361,
+      "compress_mbps": 227.78,
+      "decompress_mbps": 354.07
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 20150366,
+      "ratio": 0.3934,
+      "compress_mbps": 118.53,
+      "decompress_mbps": 336.44
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19495014,
+      "ratio": 0.3806,
+      "compress_mbps": 65.06,
+      "decompress_mbps": 383.43
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19424978,
+      "ratio": 0.3792,
+      "compress_mbps": 66.11,
+      "decompress_mbps": 369.38
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19298736,
+      "ratio": 0.3768,
+      "compress_mbps": 47.07,
+      "decompress_mbps": 398.69
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19179167,
+      "ratio": 0.3744,
+      "compress_mbps": 29.28,
+      "decompress_mbps": 420.54
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19151324,
+      "ratio": 0.3739,
+      "compress_mbps": 20.91,
+      "decompress_mbps": 426.61
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19144373,
+      "ratio": 0.3738,
+      "compress_mbps": 16.5,
+      "decompress_mbps": 436.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19141383,
+      "ratio": 0.3737,
+      "compress_mbps": 14.14,
+      "decompress_mbps": 428.25
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 4249731,
+      "ratio": 0.4262,
+      "compress_mbps": 305.01,
+      "decompress_mbps": 504.63
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3775479,
+      "ratio": 0.3787,
+      "compress_mbps": 156.53,
+      "decompress_mbps": 562.67
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3656966,
+      "ratio": 0.3668,
+      "compress_mbps": 79.35,
+      "decompress_mbps": 585.17
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3740378,
+      "ratio": 0.3751,
+      "compress_mbps": 67.08,
+      "decompress_mbps": 544.17
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3713604,
+      "ratio": 0.3725,
+      "compress_mbps": 48.05,
+      "decompress_mbps": 511.73
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3683556,
+      "ratio": 0.3694,
+      "compress_mbps": 24.79,
+      "decompress_mbps": 526.3
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3683797,
+      "ratio": 0.3695,
+      "compress_mbps": 18.85,
+      "decompress_mbps": 533.91
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3684477,
+      "ratio": 0.3695,
+      "compress_mbps": 14.27,
+      "decompress_mbps": 538.36
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3679414,
+      "ratio": 0.369,
+      "compress_mbps": 12.27,
+      "decompress_mbps": 543.61
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 5594622,
+      "ratio": 0.1667,
+      "compress_mbps": 423.35,
+      "decompress_mbps": 844.53
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 4179532,
+      "ratio": 0.1246,
+      "compress_mbps": 322.13,
+      "decompress_mbps": 947.74
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3542329,
+      "ratio": 0.1056,
+      "compress_mbps": 205.73,
+      "decompress_mbps": 855.88
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3323363,
+      "ratio": 0.099,
+      "compress_mbps": 191.3,
+      "decompress_mbps": 874.69
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3230343,
+      "ratio": 0.0963,
+      "compress_mbps": 157.45,
+      "decompress_mbps": 981.2
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3123421,
+      "ratio": 0.0931,
+      "compress_mbps": 95.04,
+      "decompress_mbps": 1065.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3093778,
+      "ratio": 0.0922,
+      "compress_mbps": 70.52,
+      "decompress_mbps": 1050.76
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3067318,
+      "ratio": 0.0914,
+      "compress_mbps": 49.97,
+      "decompress_mbps": 1118.33
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 3050695,
+      "ratio": 0.0909,
+      "compress_mbps": 41.95,
+      "decompress_mbps": 1091.36
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3543611,
+      "ratio": 0.576,
+      "compress_mbps": 164.77,
+      "decompress_mbps": 288.52
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3226818,
+      "ratio": 0.5245,
+      "compress_mbps": 86.18,
+      "decompress_mbps": 295.12
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3144140,
+      "ratio": 0.5111,
+      "compress_mbps": 52.91,
+      "decompress_mbps": 308.07
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3129833,
+      "ratio": 0.5087,
+      "compress_mbps": 51.83,
+      "decompress_mbps": 334.69
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3114809,
+      "ratio": 0.5063,
+      "compress_mbps": 40.48,
+      "decompress_mbps": 343.23
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3095705,
+      "ratio": 0.5032,
+      "compress_mbps": 25.17,
+      "decompress_mbps": 352.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3090055,
+      "ratio": 0.5023,
+      "compress_mbps": 20.45,
+      "decompress_mbps": 348.8
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3087665,
+      "ratio": 0.5019,
+      "compress_mbps": 17.39,
+      "decompress_mbps": 356.27
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3087158,
+      "ratio": 0.5018,
+      "compress_mbps": 16.3,
+      "decompress_mbps": 354.71
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 5419510,
+      "ratio": 0.5373,
+      "compress_mbps": 239.86,
+      "decompress_mbps": 544.67
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3982547,
+      "ratio": 0.3949,
+      "compress_mbps": 122.82,
+      "decompress_mbps": 559.61
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3806102,
+      "ratio": 0.3774,
+      "compress_mbps": 81.81,
+      "decompress_mbps": 580.67
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3761477,
+      "ratio": 0.373,
+      "compress_mbps": 77.87,
+      "decompress_mbps": 611.44
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3740298,
+      "ratio": 0.3709,
+      "compress_mbps": 67.18,
+      "decompress_mbps": 616.54
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3686116,
+      "ratio": 0.3655,
+      "compress_mbps": 49.15,
+      "decompress_mbps": 650.16
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3668442,
+      "ratio": 0.3637,
+      "compress_mbps": 38.68,
+      "decompress_mbps": 659.91
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3665072,
+      "ratio": 0.3634,
+      "compress_mbps": 33.04,
+      "decompress_mbps": 662.37
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3665057,
+      "ratio": 0.3634,
+      "compress_mbps": 32.94,
+      "decompress_mbps": 663.53
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2842321,
+      "ratio": 0.4289,
+      "compress_mbps": 187.4,
+      "decompress_mbps": 489.65
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2232180,
+      "ratio": 0.3368,
+      "compress_mbps": 152.13,
+      "decompress_mbps": 528.55
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2003056,
+      "ratio": 0.3022,
+      "compress_mbps": 81.88,
+      "decompress_mbps": 560.53
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 1985375,
+      "ratio": 0.2996,
+      "compress_mbps": 73.83,
+      "decompress_mbps": 571.01
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1933775,
+      "ratio": 0.2918,
+      "compress_mbps": 51.69,
+      "decompress_mbps": 546.33
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1858103,
+      "ratio": 0.2804,
+      "compress_mbps": 21.92,
+      "decompress_mbps": 544.65
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1840414,
+      "ratio": 0.2777,
+      "compress_mbps": 15.05,
+      "decompress_mbps": 551.6
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1831679,
+      "ratio": 0.2764,
+      "compress_mbps": 11.68,
+      "decompress_mbps": 551.19
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1827137,
+      "ratio": 0.2757,
+      "compress_mbps": 10.11,
+      "decompress_mbps": 542.95
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 7089759,
+      "ratio": 0.3281,
+      "compress_mbps": 285.04,
+      "decompress_mbps": 573.95
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 5966231,
+      "ratio": 0.2761,
+      "compress_mbps": 174.05,
+      "decompress_mbps": 640.07
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5611838,
+      "ratio": 0.2597,
+      "compress_mbps": 111.36,
+      "decompress_mbps": 665.34
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5535436,
+      "ratio": 0.2562,
+      "compress_mbps": 104.76,
+      "decompress_mbps": 683.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5480971,
+      "ratio": 0.2537,
+      "compress_mbps": 81.05,
+      "decompress_mbps": 700.12
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5437556,
+      "ratio": 0.2517,
+      "compress_mbps": 49.34,
+      "decompress_mbps": 711.27
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5432108,
+      "ratio": 0.2514,
+      "compress_mbps": 40.22,
+      "decompress_mbps": 708.24
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5428571,
+      "ratio": 0.2512,
+      "compress_mbps": 33.47,
+      "decompress_mbps": 713.49
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5425526,
+      "ratio": 0.2511,
+      "compress_mbps": 30.35,
+      "decompress_mbps": 712.25
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5900800,
+      "ratio": 0.8137,
+      "compress_mbps": 187.56,
+      "decompress_mbps": 333.03
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5523611,
+      "ratio": 0.7617,
+      "compress_mbps": 68.0,
+      "decompress_mbps": 345.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5393086,
+      "ratio": 0.7437,
+      "compress_mbps": 40.15,
+      "decompress_mbps": 356.22
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5401582,
+      "ratio": 0.7448,
+      "compress_mbps": 40.16,
+      "decompress_mbps": 371.06
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5371274,
+      "ratio": 0.7407,
+      "compress_mbps": 31.1,
+      "decompress_mbps": 363.04
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5330096,
+      "ratio": 0.735,
+      "compress_mbps": 20.7,
+      "decompress_mbps": 368.17
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5325437,
+      "ratio": 0.7343,
+      "compress_mbps": 18.91,
+      "decompress_mbps": 367.52
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5323934,
+      "ratio": 0.7341,
+      "compress_mbps": 17.95,
+      "decompress_mbps": 367.63
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323621,
+      "ratio": 0.7341,
+      "compress_mbps": 17.64,
+      "decompress_mbps": 368.64
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 17587173,
+      "ratio": 0.4242,
+      "compress_mbps": 180.18,
+      "decompress_mbps": 389.26
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 14171707,
+      "ratio": 0.3418,
+      "compress_mbps": 148.31,
+      "decompress_mbps": 425.81
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12774851,
+      "ratio": 0.3081,
+      "compress_mbps": 85.44,
+      "decompress_mbps": 456.86
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12612554,
+      "ratio": 0.3042,
+      "compress_mbps": 75.98,
+      "decompress_mbps": 449.1
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12392339,
+      "ratio": 0.2989,
+      "compress_mbps": 57.8,
+      "decompress_mbps": 456.12
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12158314,
+      "ratio": 0.2933,
+      "compress_mbps": 34.2,
+      "decompress_mbps": 465.75
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12107840,
+      "ratio": 0.292,
+      "compress_mbps": 27.45,
+      "decompress_mbps": 473.6
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12081311,
+      "ratio": 0.2914,
+      "compress_mbps": 22.76,
+      "decompress_mbps": 470.85
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12081011,
+      "ratio": 0.2914,
+      "compress_mbps": 22.61,
+      "decompress_mbps": 467.6
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6527324,
+      "ratio": 0.7703,
+      "compress_mbps": 236.95,
+      "decompress_mbps": 328.89
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6051483,
+      "ratio": 0.7141,
+      "compress_mbps": 74.7,
+      "decompress_mbps": 331.93
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6010123,
+      "ratio": 0.7092,
+      "compress_mbps": 51.91,
+      "decompress_mbps": 334.06
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6024815,
+      "ratio": 0.711,
+      "compress_mbps": 44.46,
+      "decompress_mbps": 287.06
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6005181,
+      "ratio": 0.7086,
+      "compress_mbps": 40.22,
+      "decompress_mbps": 295.72
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5997508,
+      "ratio": 0.7077,
+      "compress_mbps": 37.79,
+      "decompress_mbps": 298.45
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 5997403,
+      "ratio": 0.7077,
+      "compress_mbps": 37.57,
+      "decompress_mbps": 298.37
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 5997403,
+      "ratio": 0.7077,
+      "compress_mbps": 37.65,
+      "decompress_mbps": 298.26
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5997403,
+      "ratio": 0.7077,
+      "compress_mbps": 37.65,
+      "decompress_mbps": 299.12
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 1147652,
+      "ratio": 0.2147,
+      "compress_mbps": 384.12,
+      "decompress_mbps": 856.94
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 919639,
+      "ratio": 0.172,
+      "compress_mbps": 261.16,
+      "decompress_mbps": 978.65
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 752341,
+      "ratio": 0.1407,
+      "compress_mbps": 166.88,
+      "decompress_mbps": 1070.46
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 735537,
+      "ratio": 0.1376,
+      "compress_mbps": 156.35,
+      "decompress_mbps": 1044.87
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 706789,
+      "ratio": 0.1322,
+      "compress_mbps": 122.74,
+      "decompress_mbps": 1142.63
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 676279,
+      "ratio": 0.1265,
+      "compress_mbps": 69.3,
+      "decompress_mbps": 1220.66
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 668772,
+      "ratio": 0.1251,
+      "compress_mbps": 55.79,
+      "decompress_mbps": 1233.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 665340,
+      "ratio": 0.1245,
+      "compress_mbps": 47.4,
+      "decompress_mbps": 1209.49
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 664273,
+      "ratio": 0.1243,
+      "compress_mbps": 45.65,
+      "decompress_mbps": 1219.0
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": 243.29,
+      "decompress_mbps": 797.03
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4053259,
+      "ratio": 0.3977,
+      "compress_mbps": 169.73,
+      "decompress_mbps": 851.55
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": 139.96,
+      "decompress_mbps": 930.1
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 3972869,
+      "ratio": 0.3898,
+      "compress_mbps": 127.86,
+      "decompress_mbps": 818.19
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3894026,
+      "ratio": 0.3821,
+      "compress_mbps": 99.23,
+      "decompress_mbps": 789.01
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": 75.07,
+      "decompress_mbps": 790.07
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3837515,
+      "ratio": 0.3765,
+      "compress_mbps": 55.26,
+      "decompress_mbps": 802.24
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3811467,
+      "ratio": 0.374,
+      "compress_mbps": 35.89,
+      "decompress_mbps": 813.38
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": 32.59,
+      "decompress_mbps": 803.0
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": 240.39,
+      "decompress_mbps": 694.43
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 19374226,
+      "ratio": 0.3783,
+      "compress_mbps": 183.88,
+      "decompress_mbps": 670.42
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": 172.74,
+      "decompress_mbps": 723.81
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19145385,
+      "ratio": 0.3738,
+      "compress_mbps": 162.19,
+      "decompress_mbps": 722.39
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 18878875,
+      "ratio": 0.3686,
+      "compress_mbps": 143.5,
+      "decompress_mbps": 763.05
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": 120.35,
+      "decompress_mbps": 773.88
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 18749947,
+      "ratio": 0.3661,
+      "compress_mbps": 86.77,
+      "decompress_mbps": 774.41
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 18718540,
+      "ratio": 0.3655,
+      "compress_mbps": 46.91,
+      "decompress_mbps": 748.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": 33.47,
+      "decompress_mbps": 771.79
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": 293.26,
+      "decompress_mbps": 855.15
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3707407,
+      "ratio": 0.3718,
+      "compress_mbps": 214.61,
+      "decompress_mbps": 880.78
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": 183.36,
+      "decompress_mbps": 928.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3660011,
+      "ratio": 0.3671,
+      "compress_mbps": 170.6,
+      "decompress_mbps": 850.97
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3664245,
+      "ratio": 0.3675,
+      "compress_mbps": 141.29,
+      "decompress_mbps": 787.01
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": 105.55,
+      "decompress_mbps": 826.34
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3635323,
+      "ratio": 0.3646,
+      "compress_mbps": 68.62,
+      "decompress_mbps": 838.25
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3624778,
+      "ratio": 0.3635,
+      "compress_mbps": 43.15,
+      "decompress_mbps": 870.35
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": 38.98,
+      "decompress_mbps": 857.37
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": 603.69,
+      "decompress_mbps": 1533.02
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 3714632,
+      "ratio": 0.1107,
+      "compress_mbps": 459.47,
+      "decompress_mbps": 1774.49
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": 425.98,
+      "decompress_mbps": 1883.68
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3431843,
+      "ratio": 0.1023,
+      "compress_mbps": 387.89,
+      "decompress_mbps": 1790.83
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3268188,
+      "ratio": 0.0974,
+      "compress_mbps": 348.16,
+      "decompress_mbps": 1767.64
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": 262.56,
+      "decompress_mbps": 1819.82
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3032499,
+      "ratio": 0.0904,
+      "compress_mbps": 185.73,
+      "decompress_mbps": 1791.95
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 2949097,
+      "ratio": 0.0879,
+      "compress_mbps": 96.62,
+      "decompress_mbps": 1663.55
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": 68.7,
+      "decompress_mbps": 1774.14
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": 164.97,
+      "decompress_mbps": 497.31
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3150806,
+      "ratio": 0.5121,
+      "compress_mbps": 128.03,
+      "decompress_mbps": 518.07
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": 120.29,
+      "decompress_mbps": 529.46
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3129676,
+      "ratio": 0.5087,
+      "compress_mbps": 116.52,
+      "decompress_mbps": 547.49
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3079277,
+      "ratio": 0.5005,
+      "compress_mbps": 99.85,
+      "decompress_mbps": 568.97
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": 89.34,
+      "decompress_mbps": 576.18
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3068123,
+      "ratio": 0.4987,
+      "compress_mbps": 76.24,
+      "decompress_mbps": 574.94
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3067299,
+      "ratio": 0.4986,
+      "compress_mbps": 55.29,
+      "decompress_mbps": 581.37
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": 49.96,
+      "decompress_mbps": 569.48
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": 284.63,
+      "decompress_mbps": 888.01
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3839158,
+      "ratio": 0.3807,
+      "compress_mbps": 211.44,
+      "decompress_mbps": 922.17
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": 195.54,
+      "decompress_mbps": 932.84
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3789325,
+      "ratio": 0.3757,
+      "compress_mbps": 178.26,
+      "decompress_mbps": 921.23
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3666476,
+      "ratio": 0.3635,
+      "compress_mbps": 156.34,
+      "decompress_mbps": 953.76
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": 140.72,
+      "decompress_mbps": 974.67
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3659491,
+      "ratio": 0.3628,
+      "compress_mbps": 133.16,
+      "decompress_mbps": 988.19
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3654863,
+      "ratio": 0.3624,
+      "compress_mbps": 114.82,
+      "decompress_mbps": 978.25
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": 114.65,
+      "decompress_mbps": 988.42
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": 301.15,
+      "decompress_mbps": 984.04
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2082309,
+      "ratio": 0.3142,
+      "compress_mbps": 215.11,
+      "decompress_mbps": 1127.34
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": 179.15,
+      "decompress_mbps": 1251.51
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 1990952,
+      "ratio": 0.3004,
+      "compress_mbps": 158.82,
+      "decompress_mbps": 1163.95
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1921113,
+      "ratio": 0.2899,
+      "compress_mbps": 127.74,
+      "decompress_mbps": 1071.58
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": 87.08,
+      "decompress_mbps": 1084.78
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1832695,
+      "ratio": 0.2765,
+      "compress_mbps": 46.59,
+      "decompress_mbps": 1095.57
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1809967,
+      "ratio": 0.2731,
+      "compress_mbps": 24.24,
+      "decompress_mbps": 974.17
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": 19.81,
+      "decompress_mbps": 997.88
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": 340.3,
+      "decompress_mbps": 977.81
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 5695942,
+      "ratio": 0.2636,
+      "compress_mbps": 255.95,
+      "decompress_mbps": 1047.54
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": 233.55,
+      "decompress_mbps": 1068.86
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5553432,
+      "ratio": 0.257,
+      "compress_mbps": 216.23,
+      "decompress_mbps": 1060.53
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5416713,
+      "ratio": 0.2507,
+      "compress_mbps": 186.98,
+      "decompress_mbps": 1059.64
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": 142.95,
+      "decompress_mbps": 1068.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5310181,
+      "ratio": 0.2458,
+      "compress_mbps": 100.2,
+      "decompress_mbps": 1087.86
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5272761,
+      "ratio": 0.244,
+      "compress_mbps": 62.1,
+      "decompress_mbps": 1081.73
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": 49.97,
+      "decompress_mbps": 1089.58
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": 162.78,
+      "decompress_mbps": 488.87
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5417142,
+      "ratio": 0.747,
+      "compress_mbps": 117.0,
+      "decompress_mbps": 524.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": 105.12,
+      "decompress_mbps": 529.28
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5391125,
+      "ratio": 0.7434,
+      "compress_mbps": 99.07,
+      "decompress_mbps": 537.31
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5352212,
+      "ratio": 0.738,
+      "compress_mbps": 87.92,
+      "decompress_mbps": 511.43
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": 73.79,
+      "decompress_mbps": 519.95
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5325697,
+      "ratio": 0.7344,
+      "compress_mbps": 61.48,
+      "decompress_mbps": 501.6
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5324004,
+      "ratio": 0.7341,
+      "compress_mbps": 52.41,
+      "decompress_mbps": 522.54
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": 50.88,
+      "decompress_mbps": 518.99
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": 265.61,
+      "decompress_mbps": 825.34
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 13130705,
+      "ratio": 0.3167,
+      "compress_mbps": 200.16,
+      "decompress_mbps": 992.24
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": 178.18,
+      "decompress_mbps": 1029.93
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12601933,
+      "ratio": 0.304,
+      "compress_mbps": 163.16,
+      "decompress_mbps": 900.81
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12310776,
+      "ratio": 0.2969,
+      "compress_mbps": 131.5,
+      "decompress_mbps": 900.98
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": 105.33,
+      "decompress_mbps": 920.24
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12025296,
+      "ratio": 0.2901,
+      "compress_mbps": 74.8,
+      "decompress_mbps": 917.47
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 11893824,
+      "ratio": 0.2869,
+      "compress_mbps": 45.95,
+      "decompress_mbps": 885.58
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": 39.48,
+      "decompress_mbps": 925.38
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": 144.82,
+      "decompress_mbps": 518.13
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6058412,
+      "ratio": 0.7149,
+      "compress_mbps": 120.42,
+      "decompress_mbps": 540.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": 120.28,
+      "decompress_mbps": 553.08
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6058363,
+      "ratio": 0.7149,
+      "compress_mbps": 120.29,
+      "decompress_mbps": 439.55
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 5998400,
+      "ratio": 0.7078,
+      "compress_mbps": 108.19,
+      "decompress_mbps": 460.08
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": 108.08,
+      "decompress_mbps": 468.25
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 5998439,
+      "ratio": 0.7078,
+      "compress_mbps": 108.02,
+      "decompress_mbps": 470.24
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": 90.02,
+      "decompress_mbps": 465.29
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": 90.17,
+      "decompress_mbps": 469.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": 490.57,
+      "decompress_mbps": 1311.4
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 843475,
+      "ratio": 0.1578,
+      "compress_mbps": 364.45,
+      "decompress_mbps": 1482.65
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": 337.01,
+      "decompress_mbps": 1599.5
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 747602,
+      "ratio": 0.1399,
+      "compress_mbps": 302.92,
+      "decompress_mbps": 1539.85
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 718615,
+      "ratio": 0.1344,
+      "compress_mbps": 262.19,
+      "decompress_mbps": 1548.89
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": 206.13,
+      "decompress_mbps": 1542.88
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 664859,
+      "ratio": 0.1244,
+      "compress_mbps": 142.3,
+      "decompress_mbps": 1559.83
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 650835,
+      "ratio": 0.1218,
+      "compress_mbps": 84.4,
+      "decompress_mbps": 1568.02
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": 68.12,
+      "decompress_mbps": 1548.79
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 65708,
+      "ratio": 0.432,
+      "compress_mbps": 93.97,
+      "decompress_mbps": 168.58
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 60259,
+      "ratio": 0.3962,
+      "compress_mbps": 69.13,
+      "decompress_mbps": 189.8
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 58544,
+      "ratio": 0.3849,
+      "compress_mbps": 58.71,
+      "decompress_mbps": 196.44
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 56238,
+      "ratio": 0.3698,
+      "compress_mbps": 58.8,
+      "decompress_mbps": 201.92
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 54764,
+      "ratio": 0.3601,
+      "compress_mbps": 36.27,
+      "decompress_mbps": 198.52
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54311,
+      "ratio": 0.3571,
+      "compress_mbps": 28.95,
+      "decompress_mbps": 203.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54262,
+      "ratio": 0.3568,
+      "compress_mbps": 25.69,
+      "decompress_mbps": 201.42
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 54247,
+      "ratio": 0.3567,
+      "compress_mbps": 24.62,
+      "decompress_mbps": 201.68
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 54247,
+      "ratio": 0.3567,
+      "compress_mbps": 24.83,
+      "decompress_mbps": 204.29
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 56882,
+      "ratio": 0.4544,
+      "compress_mbps": 86.09,
+      "decompress_mbps": 164.96
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 52826,
+      "ratio": 0.422,
+      "compress_mbps": 61.37,
+      "decompress_mbps": 174.8
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 51625,
+      "ratio": 0.4124,
+      "compress_mbps": 56.41,
+      "decompress_mbps": 182.62
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 50034,
+      "ratio": 0.3997,
+      "compress_mbps": 53.68,
+      "decompress_mbps": 194.83
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 48912,
+      "ratio": 0.3907,
+      "compress_mbps": 34.72,
+      "decompress_mbps": 186.81
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48738,
+      "ratio": 0.3893,
+      "compress_mbps": 28.92,
+      "decompress_mbps": 184.76
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48719,
+      "ratio": 0.3892,
+      "compress_mbps": 27.76,
+      "decompress_mbps": 180.64
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 48716,
+      "ratio": 0.3892,
+      "compress_mbps": 27.37,
+      "decompress_mbps": 181.63
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 48716,
+      "ratio": 0.3892,
+      "compress_mbps": 27.47,
+      "decompress_mbps": 184.73
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8988,
+      "ratio": 0.3653,
+      "compress_mbps": 56.99,
+      "decompress_mbps": 172.99
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8564,
+      "ratio": 0.3481,
+      "compress_mbps": 63.84,
+      "decompress_mbps": 257.83
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8390,
+      "ratio": 0.341,
+      "compress_mbps": 58.81,
+      "decompress_mbps": 262.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8167,
+      "ratio": 0.332,
+      "compress_mbps": 55.67,
+      "decompress_mbps": 215.44
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 7965,
+      "ratio": 0.3237,
+      "compress_mbps": 46.53,
+      "decompress_mbps": 190.83
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7916,
+      "ratio": 0.3217,
+      "compress_mbps": 42.42,
+      "decompress_mbps": 296.25
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7900,
+      "ratio": 0.3211,
+      "compress_mbps": 38.7,
+      "decompress_mbps": 276.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7900,
+      "ratio": 0.3211,
+      "compress_mbps": 42.57,
+      "decompress_mbps": 204.24
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7900,
+      "ratio": 0.3211,
+      "compress_mbps": 35.62,
+      "decompress_mbps": 276
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3731,
+      "ratio": 0.3346,
+      "compress_mbps": 38.33,
+      "decompress_mbps": 192.01
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3491,
+      "ratio": 0.3131,
+      "compress_mbps": 47.67,
+      "decompress_mbps": 219.54
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3384,
+      "ratio": 0.3035,
+      "compress_mbps": 48.06,
+      "decompress_mbps": 221.19
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3220,
+      "ratio": 0.2888,
+      "compress_mbps": 44.97,
+      "decompress_mbps": 225.06
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3138,
+      "ratio": 0.2814,
+      "compress_mbps": 37.04,
+      "decompress_mbps": 232.57
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3118,
+      "ratio": 0.2796,
+      "compress_mbps": 33.9,
+      "decompress_mbps": 231.85
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3116,
+      "ratio": 0.2795,
+      "compress_mbps": 32.44,
+      "decompress_mbps": 224.78
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3116,
+      "ratio": 0.2795,
+      "compress_mbps": 32.18,
+      "decompress_mbps": 225.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3116,
+      "ratio": 0.2795,
+      "compress_mbps": 32.73,
+      "decompress_mbps": 228.53
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1352,
+      "ratio": 0.3633,
+      "compress_mbps": 14.66,
+      "decompress_mbps": 157.46
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1287,
+      "ratio": 0.3459,
+      "compress_mbps": 21.15,
+      "decompress_mbps": 161.8
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1284,
+      "ratio": 0.3451,
+      "compress_mbps": 21.34,
+      "decompress_mbps": 167.05
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1226,
+      "ratio": 0.3295,
+      "compress_mbps": 18.11,
+      "decompress_mbps": 148.99
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 19.08,
+      "decompress_mbps": 147.93
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 18.77,
+      "decompress_mbps": 150.99
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 18.17,
+      "decompress_mbps": 144.52
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 18.88,
+      "decompress_mbps": 161.89
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 18.36,
+      "decompress_mbps": 162.23
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 245423,
+      "ratio": 0.2383,
+      "compress_mbps": 235.4,
+      "decompress_mbps": 372.54
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 229642,
+      "ratio": 0.223,
+      "compress_mbps": 209.32,
+      "decompress_mbps": 425.39
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 225678,
+      "ratio": 0.2192,
+      "compress_mbps": 173.13,
+      "decompress_mbps": 434.55
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 218218,
+      "ratio": 0.2119,
+      "compress_mbps": 161.96,
+      "decompress_mbps": 462.23
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 210550,
+      "ratio": 0.2045,
+      "compress_mbps": 95.4,
+      "decompress_mbps": 420.28
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 207949,
+      "ratio": 0.2019,
+      "compress_mbps": 41.76,
+      "decompress_mbps": 430.42
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 207413,
+      "ratio": 0.2014,
+      "compress_mbps": 24.25,
+      "decompress_mbps": 389.81
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 207478,
+      "ratio": 0.2015,
+      "compress_mbps": 7.41,
+      "decompress_mbps": 427.67
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 207482,
+      "ratio": 0.2015,
+      "compress_mbps": 3.72,
+      "decompress_mbps": 426.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 175980,
+      "ratio": 0.4124,
+      "compress_mbps": 104.44,
+      "decompress_mbps": 182.23
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 160455,
+      "ratio": 0.376,
+      "compress_mbps": 78.66,
+      "decompress_mbps": 202.11
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 156690,
+      "ratio": 0.3672,
+      "compress_mbps": 68.11,
+      "decompress_mbps": 209.35
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 149064,
+      "ratio": 0.3493,
+      "compress_mbps": 65.7,
+      "decompress_mbps": 217.57
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 145616,
+      "ratio": 0.3412,
+      "compress_mbps": 39.99,
+      "decompress_mbps": 215.14
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144773,
+      "ratio": 0.3392,
+      "compress_mbps": 32.96,
+      "decompress_mbps": 219.96
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 144603,
+      "ratio": 0.3388,
+      "compress_mbps": 29.78,
+      "decompress_mbps": 219.01
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 144573,
+      "ratio": 0.3388,
+      "compress_mbps": 28.72,
+      "decompress_mbps": 217.1
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 144570,
+      "ratio": 0.3388,
+      "compress_mbps": 28.43,
+      "decompress_mbps": 215.15
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 228837,
+      "ratio": 0.4749,
+      "compress_mbps": 94.82,
+      "decompress_mbps": 160.47
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 211248,
+      "ratio": 0.4384,
+      "compress_mbps": 64.98,
+      "decompress_mbps": 176.58
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 205619,
+      "ratio": 0.4267,
+      "compress_mbps": 53.94,
+      "decompress_mbps": 182.92
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 200595,
+      "ratio": 0.4163,
+      "compress_mbps": 55.38,
+      "decompress_mbps": 190.22
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 195418,
+      "ratio": 0.4055,
+      "compress_mbps": 31.86,
+      "decompress_mbps": 183.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 194148,
+      "ratio": 0.4029,
+      "compress_mbps": 25.26,
+      "decompress_mbps": 183.91
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 193994,
+      "ratio": 0.4026,
+      "compress_mbps": 23.36,
+      "decompress_mbps": 184.67
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 193991,
+      "ratio": 0.4026,
+      "compress_mbps": 23.33,
+      "decompress_mbps": 183.29
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 193991,
+      "ratio": 0.4026,
+      "compress_mbps": 23.18,
+      "decompress_mbps": 182.03
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 60990,
+      "ratio": 0.1188,
+      "compress_mbps": 279.08,
+      "decompress_mbps": 486.6
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 61650,
+      "ratio": 0.1201,
+      "compress_mbps": 255.34,
+      "decompress_mbps": 527.01
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 60035,
+      "ratio": 0.117,
+      "compress_mbps": 227.47,
+      "decompress_mbps": 507.73
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 57005,
+      "ratio": 0.1111,
+      "compress_mbps": 192.08,
+      "decompress_mbps": 523.08
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 55779,
+      "ratio": 0.1087,
+      "compress_mbps": 163.01,
+      "decompress_mbps": 564.34
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 54970,
+      "ratio": 0.1071,
+      "compress_mbps": 109.02,
+      "decompress_mbps": 566.98
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 53922,
+      "ratio": 0.1051,
+      "compress_mbps": 81.32,
+      "decompress_mbps": 534.98
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 51977,
+      "ratio": 0.1013,
+      "compress_mbps": 28.9,
+      "decompress_mbps": 559.44
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 51474,
+      "ratio": 0.1003,
+      "compress_mbps": 7.48,
+      "decompress_mbps": 572.73
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 14783,
+      "ratio": 0.3866,
+      "compress_mbps": 68.02,
+      "decompress_mbps": 184.29
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 14101,
+      "ratio": 0.3688,
+      "compress_mbps": 75.23,
+      "decompress_mbps": 197.03
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13975,
+      "ratio": 0.3655,
+      "compress_mbps": 68.45,
+      "decompress_mbps": 207.15
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13632,
+      "ratio": 0.3565,
+      "compress_mbps": 60.58,
+      "decompress_mbps": 200.98
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13302,
+      "ratio": 0.3479,
+      "compress_mbps": 51.74,
+      "decompress_mbps": 212.11
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13279,
+      "ratio": 0.3473,
+      "compress_mbps": 42.06,
+      "decompress_mbps": 210.88
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 13274,
+      "ratio": 0.3471,
+      "compress_mbps": 34.25,
+      "decompress_mbps": 223.25
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 13260,
+      "ratio": 0.3468,
+      "compress_mbps": 19.79,
+      "decompress_mbps": 223.22
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 13260,
+      "ratio": 0.3468,
+      "compress_mbps": 13.24,
+      "decompress_mbps": 207.56
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1862,
+      "ratio": 0.4405,
+      "compress_mbps": 16.18,
+      "decompress_mbps": 133.98
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1803,
+      "ratio": 0.4265,
+      "compress_mbps": 22.61,
+      "decompress_mbps": 130.35
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1791,
+      "ratio": 0.4237,
+      "compress_mbps": 20.89,
+      "decompress_mbps": 139.54
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1746,
+      "ratio": 0.4131,
+      "compress_mbps": 21.34,
+      "decompress_mbps": 145.46
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 20.3,
+      "decompress_mbps": 154.69
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 21.13,
+      "decompress_mbps": 151.85
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 19.71,
+      "decompress_mbps": 149.19
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 22.59,
+      "decompress_mbps": 162.23
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 20.81,
+      "decompress_mbps": 151.2
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4623589,
+      "ratio": 0.4536,
+      "compress_mbps": 107.09,
+      "decompress_mbps": 174.19
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4241525,
+      "ratio": 0.4161,
+      "compress_mbps": 71.73,
+      "decompress_mbps": 197.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4123202,
+      "ratio": 0.4045,
+      "compress_mbps": 59.24,
+      "decompress_mbps": 204.76
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 3985937,
+      "ratio": 0.3911,
+      "compress_mbps": 61.34,
+      "decompress_mbps": 209.14
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3883839,
+      "ratio": 0.3811,
+      "compress_mbps": 35.62,
+      "decompress_mbps": 201.59
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3860437,
+      "ratio": 0.3788,
+      "compress_mbps": 27.77,
+      "decompress_mbps": 209.52
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3857076,
+      "ratio": 0.3784,
+      "compress_mbps": 25.44,
+      "decompress_mbps": 206.32
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3856651,
+      "ratio": 0.3784,
+      "compress_mbps": 24.83,
+      "decompress_mbps": 210.43
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3856651,
+      "ratio": 0.3784,
+      "compress_mbps": 24.8,
+      "decompress_mbps": 209.2
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 21508211,
+      "ratio": 0.4199,
+      "compress_mbps": 142.2,
+      "decompress_mbps": 243.36
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 20538783,
+      "ratio": 0.401,
+      "compress_mbps": 104.33,
+      "decompress_mbps": 240.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 20334352,
+      "ratio": 0.397,
+      "compress_mbps": 90.9,
+      "decompress_mbps": 239.8
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19886937,
+      "ratio": 0.3883,
+      "compress_mbps": 90.36,
+      "decompress_mbps": 247.44
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19582363,
+      "ratio": 0.3823,
+      "compress_mbps": 64.34,
+      "decompress_mbps": 253.04
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19512479,
+      "ratio": 0.381,
+      "compress_mbps": 44.35,
+      "decompress_mbps": 249.7
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19489160,
+      "ratio": 0.3805,
+      "compress_mbps": 32.39,
+      "decompress_mbps": 254.06
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19475109,
+      "ratio": 0.3802,
+      "compress_mbps": 18.49,
+      "decompress_mbps": 248.3
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19476276,
+      "ratio": 0.3802,
+      "compress_mbps": 10.49,
+      "decompress_mbps": 257.21
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3967718,
+      "ratio": 0.3979,
+      "compress_mbps": 147.83,
+      "decompress_mbps": 231.92
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3773274,
+      "ratio": 0.3784,
+      "compress_mbps": 103.65,
+      "decompress_mbps": 228.92
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3670460,
+      "ratio": 0.3681,
+      "compress_mbps": 77.92,
+      "decompress_mbps": 245.25
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3655100,
+      "ratio": 0.3666,
+      "compress_mbps": 86.98,
+      "decompress_mbps": 241.98
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3620881,
+      "ratio": 0.3632,
+      "compress_mbps": 49.84,
+      "decompress_mbps": 255.79
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3606626,
+      "ratio": 0.3617,
+      "compress_mbps": 33.66,
+      "decompress_mbps": 250.71
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3605405,
+      "ratio": 0.3616,
+      "compress_mbps": 30.75,
+      "decompress_mbps": 260.48
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3601635,
+      "ratio": 0.3612,
+      "compress_mbps": 26.17,
+      "decompress_mbps": 249.75
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3601151,
+      "ratio": 0.3612,
+      "compress_mbps": 19.09,
+      "decompress_mbps": 249.72
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 4501482,
+      "ratio": 0.1342,
+      "compress_mbps": 334.24,
+      "decompress_mbps": 508.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 3875891,
+      "ratio": 0.1155,
+      "compress_mbps": 317.8,
+      "decompress_mbps": 614.15
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3731525,
+      "ratio": 0.1112,
+      "compress_mbps": 286.08,
+      "decompress_mbps": 651.73
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3542242,
+      "ratio": 0.1056,
+      "compress_mbps": 237.37,
+      "decompress_mbps": 643.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3239184,
+      "ratio": 0.0965,
+      "compress_mbps": 175.04,
+      "decompress_mbps": 677.11
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3113927,
+      "ratio": 0.0928,
+      "compress_mbps": 123.16,
+      "decompress_mbps": 698.68
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3063520,
+      "ratio": 0.0913,
+      "compress_mbps": 84.21,
+      "decompress_mbps": 656.38
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 2961320,
+      "ratio": 0.0883,
+      "compress_mbps": 29.45,
+      "decompress_mbps": 676.27
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2940087,
+      "ratio": 0.0876,
+      "compress_mbps": 20.46,
+      "decompress_mbps": 725.24
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3462708,
+      "ratio": 0.5628,
+      "compress_mbps": 99.8,
+      "decompress_mbps": 164.39
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3327399,
+      "ratio": 0.5408,
+      "compress_mbps": 73.4,
+      "decompress_mbps": 172.44
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3297422,
+      "ratio": 0.536,
+      "compress_mbps": 64.55,
+      "decompress_mbps": 169.04
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3249485,
+      "ratio": 0.5282,
+      "compress_mbps": 62.2,
+      "decompress_mbps": 173.32
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3220046,
+      "ratio": 0.5234,
+      "compress_mbps": 48.42,
+      "decompress_mbps": 178.35
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3213239,
+      "ratio": 0.5223,
+      "compress_mbps": 42.53,
+      "decompress_mbps": 178.68
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3212009,
+      "ratio": 0.5221,
+      "compress_mbps": 39.56,
+      "decompress_mbps": 177.69
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3211575,
+      "ratio": 0.522,
+      "compress_mbps": 32.83,
+      "decompress_mbps": 177.42
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3211561,
+      "ratio": 0.522,
+      "compress_mbps": 30.36,
+      "decompress_mbps": 174.62
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 4334497,
+      "ratio": 0.4298,
+      "compress_mbps": 139.69,
+      "decompress_mbps": 229.1
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3900156,
+      "ratio": 0.3867,
+      "compress_mbps": 131.1,
+      "decompress_mbps": 257.92
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3876099,
+      "ratio": 0.3843,
+      "compress_mbps": 121.58,
+      "decompress_mbps": 255.66
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3782364,
+      "ratio": 0.375,
+      "compress_mbps": 107.02,
+      "decompress_mbps": 263.28
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3679310,
+      "ratio": 0.3648,
+      "compress_mbps": 88.88,
+      "decompress_mbps": 272.83
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3679424,
+      "ratio": 0.3648,
+      "compress_mbps": 87.42,
+      "decompress_mbps": 271.32
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3679163,
+      "ratio": 0.3648,
+      "compress_mbps": 80.87,
+      "decompress_mbps": 270.59
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3679169,
+      "ratio": 0.3648,
+      "compress_mbps": 79.39,
+      "decompress_mbps": 270.96
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3679169,
+      "ratio": 0.3648,
+      "compress_mbps": 79.39,
+      "decompress_mbps": 271.62
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2496363,
+      "ratio": 0.3767,
+      "compress_mbps": 126.83,
+      "decompress_mbps": 206.84
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2202601,
+      "ratio": 0.3324,
+      "compress_mbps": 94.3,
+      "decompress_mbps": 235.58
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2103089,
+      "ratio": 0.3173,
+      "compress_mbps": 66.96,
+      "decompress_mbps": 251.05
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 1999697,
+      "ratio": 0.3017,
+      "compress_mbps": 72.98,
+      "decompress_mbps": 257.6
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1892143,
+      "ratio": 0.2855,
+      "compress_mbps": 35.71,
+      "decompress_mbps": 256.83
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1838372,
+      "ratio": 0.2774,
+      "compress_mbps": 20.4,
+      "decompress_mbps": 261.4
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1828850,
+      "ratio": 0.276,
+      "compress_mbps": 15.61,
+      "decompress_mbps": 254.38
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1823159,
+      "ratio": 0.2751,
+      "compress_mbps": 12.34,
+      "decompress_mbps": 253.75
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1823159,
+      "ratio": 0.2751,
+      "compress_mbps": 12.38,
+      "decompress_mbps": 263.27
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 6447290,
+      "ratio": 0.2984,
+      "compress_mbps": 190.64,
+      "decompress_mbps": 295.26
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 6030257,
+      "ratio": 0.2791,
+      "compress_mbps": 148.16,
+      "decompress_mbps": 328.02
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5928121,
+      "ratio": 0.2744,
+      "compress_mbps": 127.49,
+      "decompress_mbps": 332.2
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5615804,
+      "ratio": 0.2599,
+      "compress_mbps": 122.18,
+      "decompress_mbps": 347.57
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5496738,
+      "ratio": 0.2544,
+      "compress_mbps": 81.35,
+      "decompress_mbps": 339.22
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5464184,
+      "ratio": 0.2529,
+      "compress_mbps": 62.88,
+      "decompress_mbps": 357.13
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5429645,
+      "ratio": 0.2513,
+      "compress_mbps": 47.62,
+      "decompress_mbps": 338.72
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5418135,
+      "ratio": 0.2508,
+      "compress_mbps": 37.79,
+      "decompress_mbps": 347.72
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5416628,
+      "ratio": 0.2507,
+      "compress_mbps": 33.8,
+      "decompress_mbps": 336.42
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5759187,
+      "ratio": 0.7942,
+      "compress_mbps": 100.77,
+      "decompress_mbps": 178.32
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5619390,
+      "ratio": 0.7749,
+      "compress_mbps": 65.88,
+      "decompress_mbps": 172.31
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5560914,
+      "ratio": 0.7668,
+      "compress_mbps": 55.19,
+      "decompress_mbps": 182.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5544069,
+      "ratio": 0.7645,
+      "compress_mbps": 57.65,
+      "decompress_mbps": 181.24
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5518257,
+      "ratio": 0.7609,
+      "compress_mbps": 44.34,
+      "decompress_mbps": 183.52
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5508662,
+      "ratio": 0.7596,
+      "compress_mbps": 39.75,
+      "decompress_mbps": 178.79
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5507534,
+      "ratio": 0.7595,
+      "compress_mbps": 39.09,
+      "decompress_mbps": 182.14
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5507183,
+      "ratio": 0.7594,
+      "compress_mbps": 38.84,
+      "decompress_mbps": 180.55
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5507183,
+      "ratio": 0.7594,
+      "compress_mbps": 38.49,
+      "decompress_mbps": 184.13
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 15230651,
+      "ratio": 0.3674,
+      "compress_mbps": 122.81,
+      "decompress_mbps": 203.89
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 13822040,
+      "ratio": 0.3334,
+      "compress_mbps": 92.26,
+      "decompress_mbps": 217.55
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 13397592,
+      "ratio": 0.3232,
+      "compress_mbps": 82.63,
+      "decompress_mbps": 226.38
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12759940,
+      "ratio": 0.3078,
+      "compress_mbps": 81.96,
+      "decompress_mbps": 249.23
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12274278,
+      "ratio": 0.2961,
+      "compress_mbps": 52.63,
+      "decompress_mbps": 246.37
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12131738,
+      "ratio": 0.2926,
+      "compress_mbps": 40.6,
+      "decompress_mbps": 255.74
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12060450,
+      "ratio": 0.2909,
+      "compress_mbps": 33.47,
+      "decompress_mbps": 244.44
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12036900,
+      "ratio": 0.2903,
+      "compress_mbps": 30.23,
+      "decompress_mbps": 260.16
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12036900,
+      "ratio": 0.2903,
+      "compress_mbps": 29.57,
+      "decompress_mbps": 241.67
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6653052,
+      "ratio": 0.7851,
+      "compress_mbps": 175.48,
+      "decompress_mbps": 182.91
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6305035,
+      "ratio": 0.744,
+      "compress_mbps": 67.51,
+      "decompress_mbps": 163.49
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6302730,
+      "ratio": 0.7438,
+      "compress_mbps": 68.63,
+      "decompress_mbps": 165.35
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6299134,
+      "ratio": 0.7433,
+      "compress_mbps": 67.45,
+      "decompress_mbps": 163.65
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6289022,
+      "ratio": 0.7421,
+      "compress_mbps": 65.09,
+      "decompress_mbps": 165.1
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 6289013,
+      "ratio": 0.7421,
+      "compress_mbps": 65.03,
+      "decompress_mbps": 165.15
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 6289013,
+      "ratio": 0.7421,
+      "compress_mbps": 64.27,
+      "decompress_mbps": 165.14
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 6289012,
+      "ratio": 0.7421,
+      "compress_mbps": 64.2,
+      "decompress_mbps": 164.9
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 6289012,
+      "ratio": 0.7421,
+      "compress_mbps": 64.85,
+      "decompress_mbps": 166.62
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 989456,
+      "ratio": 0.1851,
+      "compress_mbps": 249.4,
+      "decompress_mbps": 374.12
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 839766,
+      "ratio": 0.1571,
+      "compress_mbps": 222.45,
+      "decompress_mbps": 453.31
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 800619,
+      "ratio": 0.1498,
+      "compress_mbps": 199.17,
+      "decompress_mbps": 497.06
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 776397,
+      "ratio": 0.1452,
+      "compress_mbps": 173.34,
+      "decompress_mbps": 451.21
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 712679,
+      "ratio": 0.1333,
+      "compress_mbps": 119.36,
+      "decompress_mbps": 510.5
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 683707,
+      "ratio": 0.1279,
+      "compress_mbps": 93.44,
+      "decompress_mbps": 542.98
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 668601,
+      "ratio": 0.1251,
+      "compress_mbps": 70.12,
+      "decompress_mbps": 569.67
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 659106,
+      "ratio": 0.1233,
+      "compress_mbps": 47.35,
+      "decompress_mbps": 571.09
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 658920,
+      "ratio": 0.1233,
+      "compress_mbps": 47.26,
+      "decompress_mbps": 573.62
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 62797,
+      "ratio": 0.4129,
+      "compress_mbps": 76.55,
+      "decompress_mbps": 168.04
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 59605,
+      "ratio": 0.3919,
+      "compress_mbps": 52.48,
+      "decompress_mbps": 200.71
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 57675,
+      "ratio": 0.3792,
+      "compress_mbps": 45.22,
+      "decompress_mbps": 187.82
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 56500,
+      "ratio": 0.3715,
+      "compress_mbps": 38.27,
+      "decompress_mbps": 193.48
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 56440,
+      "ratio": 0.3711,
+      "compress_mbps": 38.71,
+      "decompress_mbps": 192.73
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 55443,
+      "ratio": 0.3645,
+      "compress_mbps": 32.29,
+      "decompress_mbps": 222.43
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 55373,
+      "ratio": 0.3641,
+      "compress_mbps": 32.28,
+      "decompress_mbps": 202.12
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 55352,
+      "ratio": 0.3639,
+      "compress_mbps": 31.43,
+      "decompress_mbps": 197.54
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 55352,
+      "ratio": 0.3639,
+      "compress_mbps": 30.84,
+      "decompress_mbps": 199.72
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 55063,
+      "ratio": 0.4399,
+      "compress_mbps": 74.71,
+      "decompress_mbps": 166.16
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 52932,
+      "ratio": 0.4229,
+      "compress_mbps": 61.16,
+      "decompress_mbps": 170.72
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 51597,
+      "ratio": 0.4122,
+      "compress_mbps": 43.19,
+      "decompress_mbps": 163.28
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 50780,
+      "ratio": 0.4057,
+      "compress_mbps": 38.73,
+      "decompress_mbps": 189.43
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 50767,
+      "ratio": 0.4056,
+      "compress_mbps": 38.25,
+      "decompress_mbps": 185.68
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 50160,
+      "ratio": 0.4007,
+      "compress_mbps": 33.21,
+      "decompress_mbps": 184.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 50138,
+      "ratio": 0.4005,
+      "compress_mbps": 32.52,
+      "decompress_mbps": 185.34
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 50138,
+      "ratio": 0.4005,
+      "compress_mbps": 32.54,
+      "decompress_mbps": 185.9
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 50138,
+      "ratio": 0.4005,
+      "compress_mbps": 32.25,
+      "decompress_mbps": 202.45
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8730,
+      "ratio": 0.3548,
+      "compress_mbps": 61.29,
+      "decompress_mbps": 131.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8457,
+      "ratio": 0.3437,
+      "compress_mbps": 59,
+      "decompress_mbps": 133.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8353,
+      "ratio": 0.3395,
+      "compress_mbps": 65.53,
+      "decompress_mbps": 113.73
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8301,
+      "ratio": 0.3374,
+      "compress_mbps": 62.58,
+      "decompress_mbps": 137.46
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 8212,
+      "ratio": 0.3338,
+      "compress_mbps": 58.58,
+      "decompress_mbps": 115.08
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 8172,
+      "ratio": 0.3322,
+      "compress_mbps": 52.85,
+      "decompress_mbps": 115.09
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 8171,
+      "ratio": 0.3321,
+      "compress_mbps": 55.59,
+      "decompress_mbps": 113.76
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 8171,
+      "ratio": 0.3321,
+      "compress_mbps": 58.27,
+      "decompress_mbps": 114.23
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 8171,
+      "ratio": 0.3321,
+      "compress_mbps": 55.26,
+      "decompress_mbps": 116.91
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3475,
+      "ratio": 0.3117,
+      "compress_mbps": 110.57,
+      "decompress_mbps": 104.55
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3305,
+      "ratio": 0.2964,
+      "compress_mbps": 106.41,
+      "decompress_mbps": 106.58
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3225,
+      "ratio": 0.2892,
+      "compress_mbps": 103.63,
+      "decompress_mbps": 113.79
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3192,
+      "ratio": 0.2863,
+      "compress_mbps": 101.41,
+      "decompress_mbps": 125.77
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3180,
+      "ratio": 0.2852,
+      "compress_mbps": 99.8,
+      "decompress_mbps": 127.37
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 97.01,
+      "decompress_mbps": 123.1
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 95.04,
+      "decompress_mbps": 100.6
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 93.47,
+      "decompress_mbps": 128.21
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 95.31,
+      "decompress_mbps": 128.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1275,
+      "ratio": 0.3426,
+      "compress_mbps": 57.58,
+      "decompress_mbps": 52.84
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1247,
+      "ratio": 0.3351,
+      "compress_mbps": 61.07,
+      "decompress_mbps": 51.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1239,
+      "ratio": 0.333,
+      "compress_mbps": 59.84,
+      "decompress_mbps": 54.29
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1238,
+      "ratio": 0.3327,
+      "compress_mbps": 58.96,
+      "decompress_mbps": 55.41
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1239,
+      "ratio": 0.333,
+      "compress_mbps": 60.04,
+      "decompress_mbps": 51.67
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1237,
+      "ratio": 0.3324,
+      "compress_mbps": 58.51,
+      "decompress_mbps": 54.4
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1237,
+      "ratio": 0.3324,
+      "compress_mbps": 56.32,
+      "decompress_mbps": 49.1
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1237,
+      "ratio": 0.3324,
+      "compress_mbps": 57.18,
+      "decompress_mbps": 55.95
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1237,
+      "ratio": 0.3324,
+      "compress_mbps": 58.75,
+      "decompress_mbps": 50.75
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 226284,
+      "ratio": 0.2197,
+      "compress_mbps": 113.52,
+      "decompress_mbps": 302.96
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 221369,
+      "ratio": 0.215,
+      "compress_mbps": 90.46,
+      "decompress_mbps": 304.27
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 218607,
+      "ratio": 0.2123,
+      "compress_mbps": 79.67,
+      "decompress_mbps": 318.92
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 217919,
+      "ratio": 0.2116,
+      "compress_mbps": 69.19,
+      "decompress_mbps": 317.49
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 217919,
+      "ratio": 0.2116,
+      "compress_mbps": 67.85,
+      "decompress_mbps": 323.77
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 217312,
+      "ratio": 0.211,
+      "compress_mbps": 44.49,
+      "decompress_mbps": 310.09
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 215966,
+      "ratio": 0.2097,
+      "compress_mbps": 31.36,
+      "decompress_mbps": 309.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 215930,
+      "ratio": 0.2097,
+      "compress_mbps": 14.36,
+      "decompress_mbps": 321.59
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 215912,
+      "ratio": 0.2097,
+      "compress_mbps": 11.32,
+      "decompress_mbps": 342.58
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 167622,
+      "ratio": 0.3928,
+      "compress_mbps": 64.41,
+      "decompress_mbps": 152.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 158003,
+      "ratio": 0.3702,
+      "compress_mbps": 54.1,
+      "decompress_mbps": 183
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 152928,
+      "ratio": 0.3584,
+      "compress_mbps": 44.89,
+      "decompress_mbps": 186.05
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 149886,
+      "ratio": 0.3512,
+      "compress_mbps": 40.31,
+      "decompress_mbps": 171.72
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 149767,
+      "ratio": 0.3509,
+      "compress_mbps": 38.35,
+      "decompress_mbps": 173.32
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 147818,
+      "ratio": 0.3464,
+      "compress_mbps": 33.17,
+      "decompress_mbps": 187.21
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 147733,
+      "ratio": 0.3462,
+      "compress_mbps": 31.52,
+      "decompress_mbps": 178.75
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 147709,
+      "ratio": 0.3461,
+      "compress_mbps": 32.49,
+      "decompress_mbps": 177.09
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 147705,
+      "ratio": 0.3461,
+      "compress_mbps": 32.62,
+      "decompress_mbps": 154.41
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 222866,
+      "ratio": 0.4625,
+      "compress_mbps": 59.99,
+      "decompress_mbps": 166.04
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 212925,
+      "ratio": 0.4419,
+      "compress_mbps": 49.6,
+      "decompress_mbps": 190.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 206913,
+      "ratio": 0.4294,
+      "compress_mbps": 40.87,
+      "decompress_mbps": 181.32
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 202875,
+      "ratio": 0.421,
+      "compress_mbps": 34.13,
+      "decompress_mbps": 181.14
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 202867,
+      "ratio": 0.421,
+      "compress_mbps": 34.26,
+      "decompress_mbps": 206.67
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 199818,
+      "ratio": 0.4147,
+      "compress_mbps": 28.69,
+      "decompress_mbps": 209.29
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 199664,
+      "ratio": 0.4144,
+      "compress_mbps": 27.71,
+      "decompress_mbps": 189.99
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 199634,
+      "ratio": 0.4143,
+      "compress_mbps": 28.38,
+      "decompress_mbps": 185.16
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 199634,
+      "ratio": 0.4143,
+      "compress_mbps": 28.56,
+      "decompress_mbps": 183.42
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 60580,
+      "ratio": 0.118,
+      "compress_mbps": 118.9,
+      "decompress_mbps": 270.44
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 59663,
+      "ratio": 0.1163,
+      "compress_mbps": 109.34,
+      "decompress_mbps": 315.26
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 59465,
+      "ratio": 0.1159,
+      "compress_mbps": 102.77,
+      "decompress_mbps": 320.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 59353,
+      "ratio": 0.1156,
+      "compress_mbps": 95.56,
+      "decompress_mbps": 288.79
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 58830,
+      "ratio": 0.1146,
+      "compress_mbps": 92.07,
+      "decompress_mbps": 271.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 57884,
+      "ratio": 0.1128,
+      "compress_mbps": 58.11,
+      "decompress_mbps": 303.24
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 57206,
+      "ratio": 0.1115,
+      "compress_mbps": 45.73,
+      "decompress_mbps": 303.36
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 56545,
+      "ratio": 0.1102,
+      "compress_mbps": 23.15,
+      "decompress_mbps": 306.65
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 56454,
+      "ratio": 0.11,
+      "compress_mbps": 9.19,
+      "decompress_mbps": 312.05
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 14194,
+      "ratio": 0.3712,
+      "compress_mbps": 82.37,
+      "decompress_mbps": 135.25
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13770,
+      "ratio": 0.3601,
+      "compress_mbps": 71.75,
+      "decompress_mbps": 128.59
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13611,
+      "ratio": 0.3559,
+      "compress_mbps": 67.83,
+      "decompress_mbps": 119.79
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13534,
+      "ratio": 0.3539,
+      "compress_mbps": 61.28,
+      "decompress_mbps": 130.77
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13527,
+      "ratio": 0.3537,
+      "compress_mbps": 62.71,
+      "decompress_mbps": 147.89
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13438,
+      "ratio": 0.3514,
+      "compress_mbps": 50.14,
+      "decompress_mbps": 146.69
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 13419,
+      "ratio": 0.3509,
+      "compress_mbps": 47.51,
+      "decompress_mbps": 121.53
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 13404,
+      "ratio": 0.3505,
+      "compress_mbps": 42.01,
+      "decompress_mbps": 128.34
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 13390,
+      "ratio": 0.3502,
+      "compress_mbps": 36.78,
+      "decompress_mbps": 123.68
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1832,
+      "ratio": 0.4334,
+      "compress_mbps": 59.99,
+      "decompress_mbps": 60.99
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1776,
+      "ratio": 0.4202,
+      "compress_mbps": 60.68,
+      "decompress_mbps": 58.25
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1764,
+      "ratio": 0.4173,
+      "compress_mbps": 59.85,
+      "decompress_mbps": 50.07
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1763,
+      "ratio": 0.4171,
+      "compress_mbps": 62.98,
+      "decompress_mbps": 57.82
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 59.5,
+      "decompress_mbps": 60.72
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 58.56,
+      "decompress_mbps": 55.96
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 59.79,
+      "decompress_mbps": 62.77
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 59.06,
+      "decompress_mbps": 57.09
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 59.56,
+      "decompress_mbps": 59.7
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4462632,
+      "ratio": 0.4378,
+      "compress_mbps": 62.91,
+      "decompress_mbps": 168.3
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4244833,
+      "ratio": 0.4165,
+      "compress_mbps": 50.87,
+      "decompress_mbps": 206.2
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4112285,
+      "ratio": 0.4035,
+      "compress_mbps": 42,
+      "decompress_mbps": 188.74
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 4020435,
+      "ratio": 0.3945,
+      "compress_mbps": 36.09,
+      "decompress_mbps": 198.6
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 4019177,
+      "ratio": 0.3943,
+      "compress_mbps": 35.16,
+      "decompress_mbps": 188.08
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3956464,
+      "ratio": 0.3882,
+      "compress_mbps": 29.71,
+      "decompress_mbps": 219.83
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3953310,
+      "ratio": 0.3879,
+      "compress_mbps": 28.49,
+      "decompress_mbps": 199.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3952872,
+      "ratio": 0.3878,
+      "compress_mbps": 29.32,
+      "decompress_mbps": 190.33
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3952872,
+      "ratio": 0.3878,
+      "compress_mbps": 29.38,
+      "decompress_mbps": 220.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20177423,
+      "ratio": 0.3939,
+      "compress_mbps": 72.31,
+      "decompress_mbps": 217.31
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 19759467,
+      "ratio": 0.3858,
+      "compress_mbps": 63.6,
+      "decompress_mbps": 200.6
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19583171,
+      "ratio": 0.3823,
+      "compress_mbps": 57.05,
+      "decompress_mbps": 220.36
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19479125,
+      "ratio": 0.3803,
+      "compress_mbps": 51.2,
+      "decompress_mbps": 223.17
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19423693,
+      "ratio": 0.3792,
+      "compress_mbps": 48.39,
+      "decompress_mbps": 206.02
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19337683,
+      "ratio": 0.3775,
+      "compress_mbps": 36.32,
+      "decompress_mbps": 202.55
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19323922,
+      "ratio": 0.3773,
+      "compress_mbps": 29.89,
+      "decompress_mbps": 200.64
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19314797,
+      "ratio": 0.3771,
+      "compress_mbps": 19.54,
+      "decompress_mbps": 220.25
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19312663,
+      "ratio": 0.377,
+      "compress_mbps": 10.98,
+      "decompress_mbps": 214.4
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3762978,
+      "ratio": 0.3774,
+      "compress_mbps": 77.69,
+      "decompress_mbps": 187
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3711615,
+      "ratio": 0.3723,
+      "compress_mbps": 68.42,
+      "decompress_mbps": 186.26
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3663131,
+      "ratio": 0.3674,
+      "compress_mbps": 58.75,
+      "decompress_mbps": 224
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3631512,
+      "ratio": 0.3642,
+      "compress_mbps": 49.89,
+      "decompress_mbps": 191.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3630867,
+      "ratio": 0.3642,
+      "compress_mbps": 49.09,
+      "decompress_mbps": 200.81
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3615953,
+      "ratio": 0.3627,
+      "compress_mbps": 37.7,
+      "decompress_mbps": 251.17
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3615518,
+      "ratio": 0.3626,
+      "compress_mbps": 35.93,
+      "decompress_mbps": 204.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3613845,
+      "ratio": 0.3625,
+      "compress_mbps": 30.46,
+      "decompress_mbps": 233.7
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3614283,
+      "ratio": 0.3625,
+      "compress_mbps": 26.31,
+      "decompress_mbps": 225.29
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 4418800,
+      "ratio": 0.1317,
+      "compress_mbps": 132.54,
+      "decompress_mbps": 377.26
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 4026774,
+      "ratio": 0.12,
+      "compress_mbps": 121.68,
+      "decompress_mbps": 389.73
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3837798,
+      "ratio": 0.1144,
+      "compress_mbps": 117.56,
+      "decompress_mbps": 427.95
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3751023,
+      "ratio": 0.1118,
+      "compress_mbps": 111.11,
+      "decompress_mbps": 411.61
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3643468,
+      "ratio": 0.1086,
+      "compress_mbps": 101.59,
+      "decompress_mbps": 414.25
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3379481,
+      "ratio": 0.1007,
+      "compress_mbps": 69.14,
+      "decompress_mbps": 422.94
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3354082,
+      "ratio": 0.1,
+      "compress_mbps": 61.41,
+      "decompress_mbps": 414.8
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3330028,
+      "ratio": 0.0992,
+      "compress_mbps": 48.07,
+      "decompress_mbps": 444.44
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 3327482,
+      "ratio": 0.0992,
+      "compress_mbps": 38.1,
+      "decompress_mbps": 406.56
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3233790,
+      "ratio": 0.5256,
+      "compress_mbps": 53.86,
+      "decompress_mbps": 127.41
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3184644,
+      "ratio": 0.5176,
+      "compress_mbps": 48.34,
+      "decompress_mbps": 131.35
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3160521,
+      "ratio": 0.5137,
+      "compress_mbps": 43.85,
+      "decompress_mbps": 138.8
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3141929,
+      "ratio": 0.5107,
+      "compress_mbps": 39.77,
+      "decompress_mbps": 141.37
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3138514,
+      "ratio": 0.5101,
+      "compress_mbps": 39.15,
+      "decompress_mbps": 142.53
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3126843,
+      "ratio": 0.5082,
+      "compress_mbps": 32.95,
+      "decompress_mbps": 140.76
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3126796,
+      "ratio": 0.5082,
+      "compress_mbps": 30.37,
+      "decompress_mbps": 149.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3126322,
+      "ratio": 0.5082,
+      "compress_mbps": 27.12,
+      "decompress_mbps": 147.78
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3126286,
+      "ratio": 0.5082,
+      "compress_mbps": 23.21,
+      "decompress_mbps": 151.23
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 4076349,
+      "ratio": 0.4042,
+      "compress_mbps": 78.82,
+      "decompress_mbps": 201.37
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3914739,
+      "ratio": 0.3881,
+      "compress_mbps": 71.77,
+      "decompress_mbps": 229.72
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3845160,
+      "ratio": 0.3812,
+      "compress_mbps": 66.88,
+      "decompress_mbps": 274.71
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3822047,
+      "ratio": 0.379,
+      "compress_mbps": 64.42,
+      "decompress_mbps": 249.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3799472,
+      "ratio": 0.3767,
+      "compress_mbps": 59.75,
+      "decompress_mbps": 276.4
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3783861,
+      "ratio": 0.3752,
+      "compress_mbps": 57.88,
+      "decompress_mbps": 237.31
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3783432,
+      "ratio": 0.3751,
+      "compress_mbps": 57.47,
+      "decompress_mbps": 289
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3783342,
+      "ratio": 0.3751,
+      "compress_mbps": 57.51,
+      "decompress_mbps": 286.2
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3783342,
+      "ratio": 0.3751,
+      "compress_mbps": 57.72,
+      "decompress_mbps": 285.9
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2261112,
+      "ratio": 0.3412,
+      "compress_mbps": 71.65,
+      "decompress_mbps": 224.42
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2128691,
+      "ratio": 0.3212,
+      "compress_mbps": 58.87,
+      "decompress_mbps": 208.5
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2049023,
+      "ratio": 0.3092,
+      "compress_mbps": 49.13,
+      "decompress_mbps": 232.59
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 1990249,
+      "ratio": 0.3003,
+      "compress_mbps": 40.79,
+      "decompress_mbps": 216.53
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1975224,
+      "ratio": 0.298,
+      "compress_mbps": 39.82,
+      "decompress_mbps": 227.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1910262,
+      "ratio": 0.2882,
+      "compress_mbps": 27.6,
+      "decompress_mbps": 210.6
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1902923,
+      "ratio": 0.2871,
+      "compress_mbps": 25.31,
+      "decompress_mbps": 196.98
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1900964,
+      "ratio": 0.2868,
+      "compress_mbps": 23.16,
+      "decompress_mbps": 231.53
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1900958,
+      "ratio": 0.2868,
+      "compress_mbps": 24.7,
+      "decompress_mbps": 233.07
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 6016919,
+      "ratio": 0.2785,
+      "compress_mbps": 92.6,
+      "decompress_mbps": 231.42
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 5767272,
+      "ratio": 0.2669,
+      "compress_mbps": 82.48,
+      "decompress_mbps": 288.49
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5669548,
+      "ratio": 0.2624,
+      "compress_mbps": 74.74,
+      "decompress_mbps": 267.85
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5619947,
+      "ratio": 0.2601,
+      "compress_mbps": 69.63,
+      "decompress_mbps": 276.36
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5586034,
+      "ratio": 0.2585,
+      "compress_mbps": 64.88,
+      "decompress_mbps": 280.44
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5540130,
+      "ratio": 0.2564,
+      "compress_mbps": 53,
+      "decompress_mbps": 280.74
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5537271,
+      "ratio": 0.2563,
+      "compress_mbps": 47.13,
+      "decompress_mbps": 273.85
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5530686,
+      "ratio": 0.256,
+      "compress_mbps": 37.42,
+      "decompress_mbps": 307.11
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5529823,
+      "ratio": 0.2559,
+      "compress_mbps": 31.76,
+      "decompress_mbps": 279.02
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5602819,
+      "ratio": 0.7726,
+      "compress_mbps": 49.12,
+      "decompress_mbps": 168.27
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5504019,
+      "ratio": 0.759,
+      "compress_mbps": 42.05,
+      "decompress_mbps": 153.75
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5452816,
+      "ratio": 0.7519,
+      "compress_mbps": 39.4,
+      "decompress_mbps": 157.28
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5425752,
+      "ratio": 0.7482,
+      "compress_mbps": 35.87,
+      "decompress_mbps": 183.48
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5425752,
+      "ratio": 0.7482,
+      "compress_mbps": 35.53,
+      "decompress_mbps": 183.13
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5407602,
+      "ratio": 0.7457,
+      "compress_mbps": 30.8,
+      "decompress_mbps": 158.34
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5406417,
+      "ratio": 0.7455,
+      "compress_mbps": 30.13,
+      "decompress_mbps": 157.87
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5406380,
+      "ratio": 0.7455,
+      "compress_mbps": 30.8,
+      "decompress_mbps": 159.91
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5406380,
+      "ratio": 0.7455,
+      "compress_mbps": 31.24,
+      "decompress_mbps": 160.34
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 14342407,
+      "ratio": 0.3459,
+      "compress_mbps": 74.3,
+      "decompress_mbps": 191.94
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 13424966,
+      "ratio": 0.3238,
+      "compress_mbps": 62.82,
+      "decompress_mbps": 210.8
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 13061399,
+      "ratio": 0.315,
+      "compress_mbps": 55.42,
+      "decompress_mbps": 231.1
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12877207,
+      "ratio": 0.3106,
+      "compress_mbps": 49.74,
+      "decompress_mbps": 202.59
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12671090,
+      "ratio": 0.3056,
+      "compress_mbps": 47.56,
+      "decompress_mbps": 211.79
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12511088,
+      "ratio": 0.3018,
+      "compress_mbps": 39.74,
+      "decompress_mbps": 224.47
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12503313,
+      "ratio": 0.3016,
+      "compress_mbps": 38.39,
+      "decompress_mbps": 236.24
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12502263,
+      "ratio": 0.3016,
+      "compress_mbps": 39.72,
+      "decompress_mbps": 232.92
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12502263,
+      "ratio": 0.3016,
+      "compress_mbps": 39.39,
+      "decompress_mbps": 231.27
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6022390,
+      "ratio": 0.7107,
+      "compress_mbps": 54.57,
+      "decompress_mbps": 147.43
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 5997124,
+      "ratio": 0.7077,
+      "compress_mbps": 47.73,
+      "decompress_mbps": 140.57
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 5979254,
+      "ratio": 0.7056,
+      "compress_mbps": 43.37,
+      "decompress_mbps": 154.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 5967955,
+      "ratio": 0.7042,
+      "compress_mbps": 42.05,
+      "decompress_mbps": 185.18
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 5967953,
+      "ratio": 0.7042,
+      "compress_mbps": 42.29,
+      "decompress_mbps": 153.47
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5965386,
+      "ratio": 0.7039,
+      "compress_mbps": 41.92,
+      "decompress_mbps": 142.4
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 5965383,
+      "ratio": 0.7039,
+      "compress_mbps": 41.56,
+      "decompress_mbps": 130.96
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 5965383,
+      "ratio": 0.7039,
+      "compress_mbps": 41.96,
+      "decompress_mbps": 149.36
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5965383,
+      "ratio": 0.7039,
+      "compress_mbps": 42.02,
+      "decompress_mbps": 156.34
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 985606,
+      "ratio": 0.1844,
+      "compress_mbps": 109.85,
+      "decompress_mbps": 310.58
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 852636,
+      "ratio": 0.1595,
+      "compress_mbps": 101.45,
+      "decompress_mbps": 349.85
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 814293,
+      "ratio": 0.1523,
+      "compress_mbps": 95.35,
+      "decompress_mbps": 331.29
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 788388,
+      "ratio": 0.1475,
+      "compress_mbps": 89.82,
+      "decompress_mbps": 352.77
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 749390,
+      "ratio": 0.1402,
+      "compress_mbps": 83.35,
+      "decompress_mbps": 380.11
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 706892,
+      "ratio": 0.1322,
+      "compress_mbps": 67.15,
+      "decompress_mbps": 376.91
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 705695,
+      "ratio": 0.132,
+      "compress_mbps": 64.52,
+      "decompress_mbps": 406.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 703904,
+      "ratio": 0.1317,
+      "compress_mbps": 60.78,
+      "decompress_mbps": 376.24
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 703900,
+      "ratio": 0.1317,
+      "compress_mbps": 61.14,
+      "decompress_mbps": 397.03
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 56099,
+      "ratio": 0.3689,
+      "compress_mbps": 88.91,
+      "decompress_mbps": 315.05
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 56099,
+      "ratio": 0.3689,
+      "compress_mbps": 88.82,
+      "decompress_mbps": 314.07
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 56099,
+      "ratio": 0.3689,
+      "compress_mbps": 88.9,
+      "decompress_mbps": 310.21
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 56099,
+      "ratio": 0.3689,
+      "compress_mbps": 85.95,
+      "decompress_mbps": 313.18
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 54531,
+      "ratio": 0.3585,
+      "compress_mbps": 53.67,
+      "decompress_mbps": 306.9
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54068,
+      "ratio": 0.3555,
+      "compress_mbps": 42.01,
+      "decompress_mbps": 309.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54003,
+      "ratio": 0.3551,
+      "compress_mbps": 37.64,
+      "decompress_mbps": 306.7
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 53974,
+      "ratio": 0.3549,
+      "compress_mbps": 31.88,
+      "decompress_mbps": 306.27
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 53974,
+      "ratio": 0.3549,
+      "compress_mbps": 33.02,
+      "decompress_mbps": 307.08
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 50031,
+      "ratio": 0.3997,
+      "compress_mbps": 79.59,
+      "decompress_mbps": 275.38
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 50031,
+      "ratio": 0.3997,
+      "compress_mbps": 82.0,
+      "decompress_mbps": 278.95
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 50031,
+      "ratio": 0.3997,
+      "compress_mbps": 81.45,
+      "decompress_mbps": 276.39
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 50031,
+      "ratio": 0.3997,
+      "compress_mbps": 84.1,
+      "decompress_mbps": 275.58
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 48753,
+      "ratio": 0.3895,
+      "compress_mbps": 49.28,
+      "decompress_mbps": 276.64
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48557,
+      "ratio": 0.3879,
+      "compress_mbps": 41.08,
+      "decompress_mbps": 272.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48523,
+      "ratio": 0.3876,
+      "compress_mbps": 38.92,
+      "decompress_mbps": 277.27
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 48522,
+      "ratio": 0.3876,
+      "compress_mbps": 37.97,
+      "decompress_mbps": 276.72
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 48522,
+      "ratio": 0.3876,
+      "compress_mbps": 38.15,
+      "decompress_mbps": 275.9
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8182,
+      "ratio": 0.3326,
+      "compress_mbps": 170.0,
+      "decompress_mbps": 283.43
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8182,
+      "ratio": 0.3326,
+      "compress_mbps": 171.42,
+      "decompress_mbps": 282.89
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8182,
+      "ratio": 0.3326,
+      "compress_mbps": 159.73,
+      "decompress_mbps": 281.91
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8182,
+      "ratio": 0.3326,
+      "compress_mbps": 167.97,
+      "decompress_mbps": 284.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 7965,
+      "ratio": 0.3237,
+      "compress_mbps": 109.99,
+      "decompress_mbps": 288.93
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7914,
+      "ratio": 0.3217,
+      "compress_mbps": 89.17,
+      "decompress_mbps": 291.02
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7895,
+      "ratio": 0.3209,
+      "compress_mbps": 78.05,
+      "decompress_mbps": 290.89
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7896,
+      "ratio": 0.3209,
+      "compress_mbps": 72.83,
+      "decompress_mbps": 288.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7896,
+      "ratio": 0.3209,
+      "compress_mbps": 74.07,
+      "decompress_mbps": 291.72
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3218,
+      "ratio": 0.2886,
+      "compress_mbps": 169.05,
+      "decompress_mbps": 258.64
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3218,
+      "ratio": 0.2886,
+      "compress_mbps": 165.99,
+      "decompress_mbps": 254.49
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3218,
+      "ratio": 0.2886,
+      "compress_mbps": 166.66,
+      "decompress_mbps": 258.08
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3218,
+      "ratio": 0.2886,
+      "compress_mbps": 166.05,
+      "decompress_mbps": 256.08
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3136,
+      "ratio": 0.2813,
+      "compress_mbps": 141.69,
+      "decompress_mbps": 261.62
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3115,
+      "ratio": 0.2794,
+      "compress_mbps": 124.39,
+      "decompress_mbps": 265.19
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 113.46,
+      "decompress_mbps": 263.59
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 105.51,
+      "decompress_mbps": 263.92
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 105.45,
+      "decompress_mbps": 264.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1221,
+      "ratio": 0.3281,
+      "compress_mbps": 119.2,
+      "decompress_mbps": 117.71
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1221,
+      "ratio": 0.3281,
+      "compress_mbps": 119.0,
+      "decompress_mbps": 119.68
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1221,
+      "ratio": 0.3281,
+      "compress_mbps": 120.92,
+      "decompress_mbps": 119.78
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1221,
+      "ratio": 0.3281,
+      "compress_mbps": 115.62,
+      "decompress_mbps": 120.26
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 108.83,
+      "decompress_mbps": 121.08
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 104.91,
+      "decompress_mbps": 120.1
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 101.15,
+      "decompress_mbps": 121.62
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 104.15,
+      "decompress_mbps": 119.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 101.89,
+      "decompress_mbps": 120.34
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 227063,
+      "ratio": 0.2205,
+      "compress_mbps": 226.61,
+      "decompress_mbps": 461.39
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 227063,
+      "ratio": 0.2205,
+      "compress_mbps": 225.16,
+      "decompress_mbps": 461.69
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 227063,
+      "ratio": 0.2205,
+      "compress_mbps": 225.72,
+      "decompress_mbps": 461.06
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 227063,
+      "ratio": 0.2205,
+      "compress_mbps": 231.2,
+      "decompress_mbps": 458.35
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 218313,
+      "ratio": 0.212,
+      "compress_mbps": 162.17,
+      "decompress_mbps": 444.84
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 215095,
+      "ratio": 0.2089,
+      "compress_mbps": 106.73,
+      "decompress_mbps": 447.63
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 213213,
+      "ratio": 0.2071,
+      "compress_mbps": 72.85,
+      "decompress_mbps": 448.46
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 210955,
+      "ratio": 0.2049,
+      "compress_mbps": 9.38,
+      "decompress_mbps": 451.33
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 210981,
+      "ratio": 0.2049,
+      "compress_mbps": 4.63,
+      "decompress_mbps": 451.02
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 148927,
+      "ratio": 0.349,
+      "compress_mbps": 92.88,
+      "decompress_mbps": 305.78
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 148927,
+      "ratio": 0.349,
+      "compress_mbps": 91.73,
+      "decompress_mbps": 306.69
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 148927,
+      "ratio": 0.349,
+      "compress_mbps": 88.28,
+      "decompress_mbps": 302.93
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 148927,
+      "ratio": 0.349,
+      "compress_mbps": 91.63,
+      "decompress_mbps": 304.27
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 145024,
+      "ratio": 0.3398,
+      "compress_mbps": 58.33,
+      "decompress_mbps": 303.54
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144159,
+      "ratio": 0.3378,
+      "compress_mbps": 44.7,
+      "decompress_mbps": 306.43
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 143991,
+      "ratio": 0.3374,
+      "compress_mbps": 40.05,
+      "decompress_mbps": 303.48
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 143941,
+      "ratio": 0.3373,
+      "compress_mbps": 37.1,
+      "decompress_mbps": 307.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 143939,
+      "ratio": 0.3373,
+      "compress_mbps": 36.2,
+      "decompress_mbps": 299.45
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 200074,
+      "ratio": 0.4152,
+      "compress_mbps": 82.1,
+      "decompress_mbps": 259.69
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 200074,
+      "ratio": 0.4152,
+      "compress_mbps": 81.95,
+      "decompress_mbps": 255.9
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 200074,
+      "ratio": 0.4152,
+      "compress_mbps": 81.79,
+      "decompress_mbps": 257.49
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 200074,
+      "ratio": 0.4152,
+      "compress_mbps": 81.34,
+      "decompress_mbps": 258.31
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 194496,
+      "ratio": 0.4036,
+      "compress_mbps": 46.33,
+      "decompress_mbps": 250.66
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 193176,
+      "ratio": 0.4009,
+      "compress_mbps": 34.68,
+      "decompress_mbps": 252.15
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 192991,
+      "ratio": 0.4005,
+      "compress_mbps": 31.28,
+      "decompress_mbps": 254.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 192980,
+      "ratio": 0.4005,
+      "compress_mbps": 29.85,
+      "decompress_mbps": 251.54
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 192980,
+      "ratio": 0.4005,
+      "compress_mbps": 29.78,
+      "decompress_mbps": 252.63
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 57484,
+      "ratio": 0.112,
+      "compress_mbps": 297.61,
+      "decompress_mbps": 735.64
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 57484,
+      "ratio": 0.112,
+      "compress_mbps": 296.91,
+      "decompress_mbps": 734.27
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 57484,
+      "ratio": 0.112,
+      "compress_mbps": 297.9,
+      "decompress_mbps": 737.74
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 57484,
+      "ratio": 0.112,
+      "compress_mbps": 297.0,
+      "decompress_mbps": 732.69
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 56050,
+      "ratio": 0.1092,
+      "compress_mbps": 233.63,
+      "decompress_mbps": 760.32
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 55292,
+      "ratio": 0.1077,
+      "compress_mbps": 148.58,
+      "decompress_mbps": 770.33
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 54651,
+      "ratio": 0.1065,
+      "compress_mbps": 124.98,
+      "decompress_mbps": 799.34
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 52583,
+      "ratio": 0.1025,
+      "compress_mbps": 47.43,
+      "decompress_mbps": 821.51
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 51816,
+      "ratio": 0.101,
+      "compress_mbps": 15.77,
+      "decompress_mbps": 839.64
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 13765,
+      "ratio": 0.36,
+      "compress_mbps": 113.78,
+      "decompress_mbps": 305.77
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13765,
+      "ratio": 0.36,
+      "compress_mbps": 119.13,
+      "decompress_mbps": 305.24
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13765,
+      "ratio": 0.36,
+      "compress_mbps": 119.79,
+      "decompress_mbps": 307.5
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13765,
+      "ratio": 0.36,
+      "compress_mbps": 117.74,
+      "decompress_mbps": 306.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13290,
+      "ratio": 0.3475,
+      "compress_mbps": 89.93,
+      "decompress_mbps": 318.38
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13258,
+      "ratio": 0.3467,
+      "compress_mbps": 69.72,
+      "decompress_mbps": 318.62
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 13246,
+      "ratio": 0.3464,
+      "compress_mbps": 55.24,
+      "decompress_mbps": 321.48
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 13236,
+      "ratio": 0.3461,
+      "compress_mbps": 25.48,
+      "decompress_mbps": 323.37
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 13233,
+      "ratio": 0.3461,
+      "compress_mbps": 16.19,
+      "decompress_mbps": 322.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1742,
+      "ratio": 0.4121,
+      "compress_mbps": 97.27,
+      "decompress_mbps": 133.05
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1742,
+      "ratio": 0.4121,
+      "compress_mbps": 97.48,
+      "decompress_mbps": 132.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1742,
+      "ratio": 0.4121,
+      "compress_mbps": 100.1,
+      "decompress_mbps": 131.83
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1742,
+      "ratio": 0.4121,
+      "compress_mbps": 96.34,
+      "decompress_mbps": 133.53
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 97.65,
+      "decompress_mbps": 134.47
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 91.4,
+      "decompress_mbps": 133.83
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 96.3,
+      "decompress_mbps": 134.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 92.53,
+      "decompress_mbps": 132.87
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 90.13,
+      "decompress_mbps": 134.26
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 3974126,
+      "ratio": 0.3899,
+      "compress_mbps": 80.44,
+      "decompress_mbps": 272.57
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 3974126,
+      "ratio": 0.3899,
+      "compress_mbps": 84.4,
+      "decompress_mbps": 272.73
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3974126,
+      "ratio": 0.3899,
+      "compress_mbps": 84.05,
+      "decompress_mbps": 272.79
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 3974126,
+      "ratio": 0.3899,
+      "compress_mbps": 84.1,
+      "decompress_mbps": 271.71
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3863846,
+      "ratio": 0.3791,
+      "compress_mbps": 47.9,
+      "decompress_mbps": 263.79
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3838854,
+      "ratio": 0.3766,
+      "compress_mbps": 37.56,
+      "decompress_mbps": 271.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3835182,
+      "ratio": 0.3763,
+      "compress_mbps": 33.78,
+      "decompress_mbps": 269.73
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3834518,
+      "ratio": 0.3762,
+      "compress_mbps": 31.35,
+      "decompress_mbps": 271.39
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3834518,
+      "ratio": 0.3762,
+      "compress_mbps": 31.38,
+      "decompress_mbps": 269.66
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 19877952,
+      "ratio": 0.3881,
+      "compress_mbps": 103.87,
+      "decompress_mbps": 251.19
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 19877952,
+      "ratio": 0.3881,
+      "compress_mbps": 103.78,
+      "decompress_mbps": 252.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19877952,
+      "ratio": 0.3881,
+      "compress_mbps": 103.78,
+      "decompress_mbps": 251.47
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19877952,
+      "ratio": 0.3881,
+      "compress_mbps": 98.22,
+      "decompress_mbps": 245.68
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19578840,
+      "ratio": 0.3822,
+      "compress_mbps": 78.47,
+      "decompress_mbps": 260.4
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19492445,
+      "ratio": 0.3806,
+      "compress_mbps": 56.06,
+      "decompress_mbps": 256.86
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19463481,
+      "ratio": 0.38,
+      "compress_mbps": 46.51,
+      "decompress_mbps": 263.98
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19444704,
+      "ratio": 0.3796,
+      "compress_mbps": 22.85,
+      "decompress_mbps": 264.17
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19440748,
+      "ratio": 0.3796,
+      "compress_mbps": 13.08,
+      "decompress_mbps": 264.03
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3662279,
+      "ratio": 0.3673,
+      "compress_mbps": 112.66,
+      "decompress_mbps": 260.14
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3662279,
+      "ratio": 0.3673,
+      "compress_mbps": 112.18,
+      "decompress_mbps": 261.17
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3662279,
+      "ratio": 0.3673,
+      "compress_mbps": 112.22,
+      "decompress_mbps": 260.82
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3662279,
+      "ratio": 0.3673,
+      "compress_mbps": 108.26,
+      "decompress_mbps": 255.87
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3637736,
+      "ratio": 0.3648,
+      "compress_mbps": 66.19,
+      "decompress_mbps": 268.56
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3621530,
+      "ratio": 0.3632,
+      "compress_mbps": 46.79,
+      "decompress_mbps": 269.56
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3623924,
+      "ratio": 0.3635,
+      "compress_mbps": 41.33,
+      "decompress_mbps": 266.67
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3623112,
+      "ratio": 0.3634,
+      "compress_mbps": 32.95,
+      "decompress_mbps": 270.13
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3623382,
+      "ratio": 0.3634,
+      "compress_mbps": 24.97,
+      "decompress_mbps": 270.5
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3580057,
+      "ratio": 0.1067,
+      "compress_mbps": 307.87,
+      "decompress_mbps": 875.53
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 3580057,
+      "ratio": 0.1067,
+      "compress_mbps": 307.41,
+      "decompress_mbps": 873.28
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3580057,
+      "ratio": 0.1067,
+      "compress_mbps": 307.21,
+      "decompress_mbps": 871.22
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3580057,
+      "ratio": 0.1067,
+      "compress_mbps": 309.49,
+      "decompress_mbps": 882.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3268887,
+      "ratio": 0.0974,
+      "compress_mbps": 230.18,
+      "decompress_mbps": 923.75
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3131445,
+      "ratio": 0.0933,
+      "compress_mbps": 163.6,
+      "decompress_mbps": 948.69
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3080217,
+      "ratio": 0.0918,
+      "compress_mbps": 123.79,
+      "decompress_mbps": 940.95
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 2978354,
+      "ratio": 0.0888,
+      "compress_mbps": 57.23,
+      "decompress_mbps": 969.18
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2947971,
+      "ratio": 0.0879,
+      "compress_mbps": 34.89,
+      "decompress_mbps": 981.3
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3221973,
+      "ratio": 0.5237,
+      "compress_mbps": 72.27,
+      "decompress_mbps": 183.13
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3221973,
+      "ratio": 0.5237,
+      "compress_mbps": 72.58,
+      "decompress_mbps": 183.37
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3221973,
+      "ratio": 0.5237,
+      "compress_mbps": 72.59,
+      "decompress_mbps": 182.72
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3221973,
+      "ratio": 0.5237,
+      "compress_mbps": 72.7,
+      "decompress_mbps": 183.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3178914,
+      "ratio": 0.5167,
+      "compress_mbps": 55.79,
+      "decompress_mbps": 190.66
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3174170,
+      "ratio": 0.5159,
+      "compress_mbps": 48.82,
+      "decompress_mbps": 191.8
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3172734,
+      "ratio": 0.5157,
+      "compress_mbps": 46.21,
+      "decompress_mbps": 191.98
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3171353,
+      "ratio": 0.5155,
+      "compress_mbps": 38.76,
+      "decompress_mbps": 192.02
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3171299,
+      "ratio": 0.5155,
+      "compress_mbps": 34.88,
+      "decompress_mbps": 191.58
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3791952,
+      "ratio": 0.376,
+      "compress_mbps": 122.75,
+      "decompress_mbps": 273.24
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3791952,
+      "ratio": 0.376,
+      "compress_mbps": 118.55,
+      "decompress_mbps": 270.62
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3791952,
+      "ratio": 0.376,
+      "compress_mbps": 123.24,
+      "decompress_mbps": 274.18
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3791952,
+      "ratio": 0.376,
+      "compress_mbps": 122.69,
+      "decompress_mbps": 272.5
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3654027,
+      "ratio": 0.3623,
+      "compress_mbps": 95.46,
+      "decompress_mbps": 275.77
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3652732,
+      "ratio": 0.3622,
+      "compress_mbps": 90.44,
+      "decompress_mbps": 273.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3652496,
+      "ratio": 0.3621,
+      "compress_mbps": 86.87,
+      "decompress_mbps": 275.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3652505,
+      "ratio": 0.3621,
+      "compress_mbps": 86.72,
+      "decompress_mbps": 276.09
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3652505,
+      "ratio": 0.3621,
+      "compress_mbps": 87.18,
+      "decompress_mbps": 275.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2009824,
+      "ratio": 0.3033,
+      "compress_mbps": 99.27,
+      "decompress_mbps": 353.86
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2009824,
+      "ratio": 0.3033,
+      "compress_mbps": 99.39,
+      "decompress_mbps": 353.58
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2009824,
+      "ratio": 0.3033,
+      "compress_mbps": 99.78,
+      "decompress_mbps": 353.12
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 2009824,
+      "ratio": 0.3033,
+      "compress_mbps": 96.05,
+      "decompress_mbps": 350.42
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1892183,
+      "ratio": 0.2855,
+      "compress_mbps": 53.81,
+      "decompress_mbps": 353.36
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1837957,
+      "ratio": 0.2773,
+      "compress_mbps": 30.64,
+      "decompress_mbps": 362.81
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1826603,
+      "ratio": 0.2756,
+      "compress_mbps": 24.39,
+      "decompress_mbps": 360.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1818702,
+      "ratio": 0.2744,
+      "compress_mbps": 16.11,
+      "decompress_mbps": 358.98
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1818702,
+      "ratio": 0.2744,
+      "compress_mbps": 16.03,
+      "decompress_mbps": 359.67
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5633558,
+      "ratio": 0.2607,
+      "compress_mbps": 145.57,
+      "decompress_mbps": 396.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 5633558,
+      "ratio": 0.2607,
+      "compress_mbps": 146.19,
+      "decompress_mbps": 397.36
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5633558,
+      "ratio": 0.2607,
+      "compress_mbps": 145.72,
+      "decompress_mbps": 400.38
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5633558,
+      "ratio": 0.2607,
+      "compress_mbps": 145.25,
+      "decompress_mbps": 398.35
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5501344,
+      "ratio": 0.2546,
+      "compress_mbps": 103.67,
+      "decompress_mbps": 403.67
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5464646,
+      "ratio": 0.2529,
+      "compress_mbps": 79.62,
+      "decompress_mbps": 407.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5429975,
+      "ratio": 0.2513,
+      "compress_mbps": 67.01,
+      "decompress_mbps": 407.82
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5419566,
+      "ratio": 0.2508,
+      "compress_mbps": 49.42,
+      "decompress_mbps": 407.14
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5417952,
+      "ratio": 0.2508,
+      "compress_mbps": 45.4,
+      "decompress_mbps": 409.08
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5481930,
+      "ratio": 0.7559,
+      "compress_mbps": 60.6,
+      "decompress_mbps": 161.13
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5481930,
+      "ratio": 0.7559,
+      "compress_mbps": 60.15,
+      "decompress_mbps": 160.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5481930,
+      "ratio": 0.7559,
+      "compress_mbps": 60.33,
+      "decompress_mbps": 161.26
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5481930,
+      "ratio": 0.7559,
+      "compress_mbps": 60.17,
+      "decompress_mbps": 160.91
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5450496,
+      "ratio": 0.7516,
+      "compress_mbps": 46.85,
+      "decompress_mbps": 163.07
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5440281,
+      "ratio": 0.7502,
+      "compress_mbps": 41.87,
+      "decompress_mbps": 164.65
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5439077,
+      "ratio": 0.75,
+      "compress_mbps": 40.74,
+      "decompress_mbps": 163.58
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5438787,
+      "ratio": 0.75,
+      "compress_mbps": 39.83,
+      "decompress_mbps": 163.61
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5438787,
+      "ratio": 0.75,
+      "compress_mbps": 39.93,
+      "decompress_mbps": 164.19
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 12756531,
+      "ratio": 0.3077,
+      "compress_mbps": 108.21,
+      "decompress_mbps": 315.95
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 12756531,
+      "ratio": 0.3077,
+      "compress_mbps": 108.39,
+      "decompress_mbps": 317.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12756531,
+      "ratio": 0.3077,
+      "compress_mbps": 108.99,
+      "decompress_mbps": 315.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12756531,
+      "ratio": 0.3077,
+      "compress_mbps": 109.03,
+      "decompress_mbps": 315.63
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12238874,
+      "ratio": 0.2952,
+      "compress_mbps": 72.84,
+      "decompress_mbps": 317.51
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12086531,
+      "ratio": 0.2915,
+      "compress_mbps": 53.88,
+      "decompress_mbps": 323.9
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12020742,
+      "ratio": 0.2899,
+      "compress_mbps": 46.51,
+      "decompress_mbps": 321.01
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 11987253,
+      "ratio": 0.2891,
+      "compress_mbps": 38.29,
+      "decompress_mbps": 322.03
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11987245,
+      "ratio": 0.2891,
+      "compress_mbps": 38.07,
+      "decompress_mbps": 321.02
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6273039,
+      "ratio": 0.7402,
+      "compress_mbps": 60.86,
+      "decompress_mbps": 147.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6273039,
+      "ratio": 0.7402,
+      "compress_mbps": 60.81,
+      "decompress_mbps": 147.18
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6273039,
+      "ratio": 0.7402,
+      "compress_mbps": 58.35,
+      "decompress_mbps": 145.65
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6273039,
+      "ratio": 0.7402,
+      "compress_mbps": 60.49,
+      "decompress_mbps": 147.76
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6244483,
+      "ratio": 0.7369,
+      "compress_mbps": 55.6,
+      "decompress_mbps": 149.26
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 6244482,
+      "ratio": 0.7369,
+      "compress_mbps": 56.1,
+      "decompress_mbps": 149.43
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 6244482,
+      "ratio": 0.7369,
+      "compress_mbps": 55.99,
+      "decompress_mbps": 149.32
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 6244480,
+      "ratio": 0.7369,
+      "compress_mbps": 52.87,
+      "decompress_mbps": 147.01
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 6244480,
+      "ratio": 0.7369,
+      "compress_mbps": 55.89,
+      "decompress_mbps": 149.48
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 785041,
+      "ratio": 0.1469,
+      "compress_mbps": 230.97,
+      "decompress_mbps": 672.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 785041,
+      "ratio": 0.1469,
+      "compress_mbps": 230.3,
+      "decompress_mbps": 670.4
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 785041,
+      "ratio": 0.1469,
+      "compress_mbps": 231.18,
+      "decompress_mbps": 671.19
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 785041,
+      "ratio": 0.1469,
+      "compress_mbps": 230.93,
+      "decompress_mbps": 670.1
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 716461,
+      "ratio": 0.134,
+      "compress_mbps": 166.23,
+      "decompress_mbps": 701.81
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 687053,
+      "ratio": 0.1285,
+      "compress_mbps": 124.83,
+      "decompress_mbps": 737.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 673597,
+      "ratio": 0.126,
+      "compress_mbps": 101.1,
+      "decompress_mbps": 747.62
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 662156,
+      "ratio": 0.1239,
+      "compress_mbps": 65.54,
+      "decompress_mbps": 756.01
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 661610,
+      "ratio": 0.1238,
+      "compress_mbps": 60.95,
+      "decompress_mbps": 752.04
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 73589,
+      "ratio": 0.4839,
+      "compress_mbps": 33.95,
+      "decompress_mbps": 57.54
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 69878,
+      "ratio": 0.4595,
+      "compress_mbps": 32.18,
+      "decompress_mbps": 58.01
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 66917,
+      "ratio": 0.44,
+      "compress_mbps": 26.86,
+      "decompress_mbps": 66.53
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 59388,
+      "ratio": 0.3905,
+      "compress_mbps": 31.56,
+      "decompress_mbps": 79.33
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 57062,
+      "ratio": 0.3752,
+      "compress_mbps": 22.81,
+      "decompress_mbps": 80.43
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 55472,
+      "ratio": 0.3647,
+      "compress_mbps": 16.3,
+      "decompress_mbps": 80.07
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 55265,
+      "ratio": 0.3634,
+      "compress_mbps": 14.39,
+      "decompress_mbps": 79.65
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 55168,
+      "ratio": 0.3627,
+      "compress_mbps": 11.93,
+      "decompress_mbps": 78.43
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 55168,
+      "ratio": 0.3627,
+      "compress_mbps": 12.01,
+      "decompress_mbps": 79.65
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 64551,
+      "ratio": 0.5157,
+      "compress_mbps": 32.07,
+      "decompress_mbps": 54.14
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 62089,
+      "ratio": 0.496,
+      "compress_mbps": 30.35,
+      "decompress_mbps": 58.39
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 58690,
+      "ratio": 0.4688,
+      "compress_mbps": 24.75,
+      "decompress_mbps": 60.45
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 53521,
+      "ratio": 0.4276,
+      "compress_mbps": 30.27,
+      "decompress_mbps": 79.97
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 51677,
+      "ratio": 0.4128,
+      "compress_mbps": 20.88,
+      "decompress_mbps": 78.06
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 50638,
+      "ratio": 0.4045,
+      "compress_mbps": 14.95,
+      "decompress_mbps": 82.4
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 50501,
+      "ratio": 0.4034,
+      "compress_mbps": 13.59,
+      "decompress_mbps": 78.56
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 50452,
+      "ratio": 0.403,
+      "compress_mbps": 12.68,
+      "decompress_mbps": 83.34
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 50452,
+      "ratio": 0.403,
+      "compress_mbps": 12.58,
+      "decompress_mbps": 83.27
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 9859,
+      "ratio": 0.4007,
+      "compress_mbps": 43.83,
+      "decompress_mbps": 112.64
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 10473,
+      "ratio": 0.4257,
+      "compress_mbps": 46.7,
+      "decompress_mbps": 147.4
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 10172,
+      "ratio": 0.4134,
+      "compress_mbps": 43.33,
+      "decompress_mbps": 153.27
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8692,
+      "ratio": 0.3533,
+      "compress_mbps": 41.01,
+      "decompress_mbps": 152.45
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 8440,
+      "ratio": 0.343,
+      "compress_mbps": 35.19,
+      "decompress_mbps": 157.05
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 8385,
+      "ratio": 0.3408,
+      "compress_mbps": 31.9,
+      "decompress_mbps": 159.26
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 8366,
+      "ratio": 0.34,
+      "compress_mbps": 29.18,
+      "decompress_mbps": 156.73
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 8367,
+      "ratio": 0.3401,
+      "compress_mbps": 28.32,
+      "decompress_mbps": 157.67
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 8367,
+      "ratio": 0.3401,
+      "compress_mbps": 28.31,
+      "decompress_mbps": 158.54
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 4822,
+      "ratio": 0.4325,
+      "compress_mbps": 54.64,
+      "decompress_mbps": 186.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 4593,
+      "ratio": 0.4119,
+      "compress_mbps": 53.78,
+      "decompress_mbps": 193.27
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 4381,
+      "ratio": 0.3929,
+      "compress_mbps": 51.46,
+      "decompress_mbps": 200.08
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3725,
+      "ratio": 0.3341,
+      "compress_mbps": 52.12,
+      "decompress_mbps": 203.31
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3614,
+      "ratio": 0.3241,
+      "compress_mbps": 44.22,
+      "decompress_mbps": 207.35
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3578,
+      "ratio": 0.3209,
+      "compress_mbps": 39.39,
+      "decompress_mbps": 212.34
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3572,
+      "ratio": 0.3204,
+      "compress_mbps": 36.75,
+      "decompress_mbps": 206.86
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3568,
+      "ratio": 0.32,
+      "compress_mbps": 33.76,
+      "decompress_mbps": 207.77
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3568,
+      "ratio": 0.32,
+      "compress_mbps": 34.86,
+      "decompress_mbps": 208.58
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1738,
+      "ratio": 0.4671,
+      "compress_mbps": 32.8,
+      "decompress_mbps": 174.49
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1709,
+      "ratio": 0.4593,
+      "compress_mbps": 32.17,
+      "decompress_mbps": 179.93
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1694,
+      "ratio": 0.4553,
+      "compress_mbps": 31.1,
+      "decompress_mbps": 178.36
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1458,
+      "ratio": 0.3918,
+      "compress_mbps": 30.75,
+      "decompress_mbps": 188.34
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1441,
+      "ratio": 0.3873,
+      "compress_mbps": 28.57,
+      "decompress_mbps": 188.96
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1440,
+      "ratio": 0.387,
+      "compress_mbps": 28.24,
+      "decompress_mbps": 190.62
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1440,
+      "ratio": 0.387,
+      "compress_mbps": 28.01,
+      "decompress_mbps": 190.57
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1440,
+      "ratio": 0.387,
+      "compress_mbps": 27.51,
+      "decompress_mbps": 191.2
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1440,
+      "ratio": 0.387,
+      "compress_mbps": 27.86,
+      "decompress_mbps": 190.62
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 260073,
+      "ratio": 0.2526,
+      "compress_mbps": 52.48,
+      "decompress_mbps": 57.64
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 296764,
+      "ratio": 0.2882,
+      "compress_mbps": 48.91,
+      "decompress_mbps": 76.95
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 288989,
+      "ratio": 0.2806,
+      "compress_mbps": 37.34,
+      "decompress_mbps": 77.44
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 246442,
+      "ratio": 0.2393,
+      "compress_mbps": 55.17,
+      "decompress_mbps": 83.19
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 218888,
+      "ratio": 0.2126,
+      "compress_mbps": 40.83,
+      "decompress_mbps": 77.12
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 217830,
+      "ratio": 0.2115,
+      "compress_mbps": 24.19,
+      "decompress_mbps": 87.86
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 221437,
+      "ratio": 0.215,
+      "compress_mbps": 19.44,
+      "decompress_mbps": 86.43
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 219666,
+      "ratio": 0.2133,
+      "compress_mbps": 5.52,
+      "decompress_mbps": 86.38
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 219921,
+      "ratio": 0.2136,
+      "compress_mbps": 2.76,
+      "decompress_mbps": 86.98
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 194588,
+      "ratio": 0.456,
+      "compress_mbps": 34.17,
+      "decompress_mbps": 51.7
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 185757,
+      "ratio": 0.4353,
+      "compress_mbps": 33.03,
+      "decompress_mbps": 49.98
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 175850,
+      "ratio": 0.4121,
+      "compress_mbps": 27.43,
+      "decompress_mbps": 59.2
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 155951,
+      "ratio": 0.3654,
+      "compress_mbps": 31.58,
+      "decompress_mbps": 71.79
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 150274,
+      "ratio": 0.3521,
+      "compress_mbps": 23.26,
+      "decompress_mbps": 71.1
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 147958,
+      "ratio": 0.3467,
+      "compress_mbps": 16.55,
+      "decompress_mbps": 72.89
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 147522,
+      "ratio": 0.3457,
+      "compress_mbps": 15.22,
+      "decompress_mbps": 71.8
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 147331,
+      "ratio": 0.3452,
+      "compress_mbps": 13.56,
+      "decompress_mbps": 72.12
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 147328,
+      "ratio": 0.3452,
+      "compress_mbps": 13.62,
+      "decompress_mbps": 72.49
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 256904,
+      "ratio": 0.5331,
+      "compress_mbps": 29.13,
+      "decompress_mbps": 46.09
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 245675,
+      "ratio": 0.5098,
+      "compress_mbps": 28.5,
+      "decompress_mbps": 49.67
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 231519,
+      "ratio": 0.4805,
+      "compress_mbps": 22.32,
+      "decompress_mbps": 55.88
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 210028,
+      "ratio": 0.4359,
+      "compress_mbps": 27.98,
+      "decompress_mbps": 65.31
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 203312,
+      "ratio": 0.4219,
+      "compress_mbps": 18.71,
+      "decompress_mbps": 61.15
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 199287,
+      "ratio": 0.4136,
+      "compress_mbps": 12.92,
+      "decompress_mbps": 66.2
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 198474,
+      "ratio": 0.4119,
+      "compress_mbps": 10.99,
+      "decompress_mbps": 64.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 198080,
+      "ratio": 0.4111,
+      "compress_mbps": 8.91,
+      "decompress_mbps": 64.32
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 198080,
+      "ratio": 0.4111,
+      "compress_mbps": 8.76,
+      "decompress_mbps": 64.76
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 71229,
+      "ratio": 0.1388,
+      "compress_mbps": 82.1,
+      "decompress_mbps": 135.63
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 69946,
+      "ratio": 0.1363,
+      "compress_mbps": 79.15,
+      "decompress_mbps": 137.78
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 68538,
+      "ratio": 0.1335,
+      "compress_mbps": 70.5,
+      "decompress_mbps": 151.36
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 61320,
+      "ratio": 0.1195,
+      "compress_mbps": 65.74,
+      "decompress_mbps": 163.45
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 59993,
+      "ratio": 0.1169,
+      "compress_mbps": 57.64,
+      "decompress_mbps": 168.25
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 58637,
+      "ratio": 0.1143,
+      "compress_mbps": 40.66,
+      "decompress_mbps": 166.59
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 58209,
+      "ratio": 0.1134,
+      "compress_mbps": 35.61,
+      "decompress_mbps": 171.82
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 55749,
+      "ratio": 0.1086,
+      "compress_mbps": 19.38,
+      "decompress_mbps": 177.18
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 54927,
+      "ratio": 0.107,
+      "compress_mbps": 7.54,
+      "decompress_mbps": 178.15
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 16399,
+      "ratio": 0.4288,
+      "compress_mbps": 36.03,
+      "decompress_mbps": 88.4
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 15933,
+      "ratio": 0.4167,
+      "compress_mbps": 34.0,
+      "decompress_mbps": 89.39
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 15739,
+      "ratio": 0.4116,
+      "compress_mbps": 28.08,
+      "decompress_mbps": 89.15
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13834,
+      "ratio": 0.3618,
+      "compress_mbps": 31.72,
+      "decompress_mbps": 106.64
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13463,
+      "ratio": 0.3521,
+      "compress_mbps": 26.05,
+      "decompress_mbps": 109.22
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13353,
+      "ratio": 0.3492,
+      "compress_mbps": 19.01,
+      "decompress_mbps": 110.28
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 13317,
+      "ratio": 0.3482,
+      "compress_mbps": 15.82,
+      "decompress_mbps": 110.58
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 13255,
+      "ratio": 0.3466,
+      "compress_mbps": 8.39,
+      "decompress_mbps": 113.33
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 13171,
+      "ratio": 0.3444,
+      "compress_mbps": 4.15,
+      "decompress_mbps": 111.97
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 2512,
+      "ratio": 0.5943,
+      "compress_mbps": 30.36,
+      "decompress_mbps": 156.72
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 2477,
+      "ratio": 0.586,
+      "compress_mbps": 30.13,
+      "decompress_mbps": 157.85
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 2452,
+      "ratio": 0.5801,
+      "compress_mbps": 31.2,
+      "decompress_mbps": 158.48
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 2110,
+      "ratio": 0.4992,
+      "compress_mbps": 29.52,
+      "decompress_mbps": 165.23
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 27.63,
+      "decompress_mbps": 168.41
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 29.43,
+      "decompress_mbps": 166.32
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 28.61,
+      "decompress_mbps": 169.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 28.74,
+      "decompress_mbps": 166.6
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 28.91,
+      "decompress_mbps": 168.52
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 5183792,
+      "ratio": 0.5086,
+      "compress_mbps": 31.24,
+      "decompress_mbps": 40.54
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4956750,
+      "ratio": 0.4863,
+      "compress_mbps": 29.95,
+      "decompress_mbps": 43.53
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4644095,
+      "ratio": 0.4556,
+      "compress_mbps": 23.94,
+      "decompress_mbps": 47.86
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 4178564,
+      "ratio": 0.41,
+      "compress_mbps": 29.47,
+      "decompress_mbps": 62.49
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 4034632,
+      "ratio": 0.3958,
+      "compress_mbps": 20.07,
+      "decompress_mbps": 60.97
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3952244,
+      "ratio": 0.3878,
+      "compress_mbps": 14.07,
+      "decompress_mbps": 61.49
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3938822,
+      "ratio": 0.3864,
+      "compress_mbps": 12.19,
+      "decompress_mbps": 62.32
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3935171,
+      "ratio": 0.3861,
+      "compress_mbps": 10.72,
+      "decompress_mbps": 61.55
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3935171,
+      "ratio": 0.3861,
+      "compress_mbps": 10.88,
+      "decompress_mbps": 61.52
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 25320013,
+      "ratio": 0.4943,
+      "compress_mbps": 32.03,
+      "decompress_mbps": 35.27
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 24804084,
+      "ratio": 0.4843,
+      "compress_mbps": 30.39,
+      "decompress_mbps": 36.48
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 24241121,
+      "ratio": 0.4733,
+      "compress_mbps": 25.75,
+      "decompress_mbps": 38.22
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 20950547,
+      "ratio": 0.409,
+      "compress_mbps": 29.31,
+      "decompress_mbps": 44.59
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 20592289,
+      "ratio": 0.402,
+      "compress_mbps": 24.53,
+      "decompress_mbps": 46.38
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 20445232,
+      "ratio": 0.3992,
+      "compress_mbps": 18.78,
+      "decompress_mbps": 46.29
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 20407676,
+      "ratio": 0.3984,
+      "compress_mbps": 16.06,
+      "decompress_mbps": 46.55
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 20389473,
+      "ratio": 0.3981,
+      "compress_mbps": 10.12,
+      "decompress_mbps": 46.3
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 20386824,
+      "ratio": 0.398,
+      "compress_mbps": 6.76,
+      "decompress_mbps": 45.93
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3964698,
+      "ratio": 0.3976,
+      "compress_mbps": 38.18,
+      "decompress_mbps": 47.93
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3936391,
+      "ratio": 0.3948,
+      "compress_mbps": 34.93,
+      "decompress_mbps": 47.89
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3823540,
+      "ratio": 0.3835,
+      "compress_mbps": 27.69,
+      "decompress_mbps": 51.33
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3799601,
+      "ratio": 0.3811,
+      "compress_mbps": 33.2,
+      "decompress_mbps": 63.61
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3830938,
+      "ratio": 0.3842,
+      "compress_mbps": 22.56,
+      "decompress_mbps": 57.85
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3808303,
+      "ratio": 0.382,
+      "compress_mbps": 14.84,
+      "decompress_mbps": 57.5
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3802814,
+      "ratio": 0.3814,
+      "compress_mbps": 12.13,
+      "decompress_mbps": 57.26
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3800355,
+      "ratio": 0.3812,
+      "compress_mbps": 6.73,
+      "decompress_mbps": 59.09
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3799676,
+      "ratio": 0.3811,
+      "compress_mbps": 6.05,
+      "decompress_mbps": 58.35
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 4899547,
+      "ratio": 0.146,
+      "compress_mbps": 95.03,
+      "decompress_mbps": 131.4
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 4587004,
+      "ratio": 0.1367,
+      "compress_mbps": 95.46,
+      "decompress_mbps": 142.79
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 4229035,
+      "ratio": 0.126,
+      "compress_mbps": 90.24,
+      "decompress_mbps": 152.36
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3791322,
+      "ratio": 0.113,
+      "compress_mbps": 82.4,
+      "decompress_mbps": 161.7
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3449193,
+      "ratio": 0.1028,
+      "compress_mbps": 73.46,
+      "decompress_mbps": 168.48
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3269452,
+      "ratio": 0.0974,
+      "compress_mbps": 58.78,
+      "decompress_mbps": 174.05
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3211286,
+      "ratio": 0.0957,
+      "compress_mbps": 50.44,
+      "decompress_mbps": 173.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3101534,
+      "ratio": 0.0924,
+      "compress_mbps": 27.63,
+      "decompress_mbps": 176.69
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 3058177,
+      "ratio": 0.0911,
+      "compress_mbps": 16.5,
+      "decompress_mbps": 176.2
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 4024327,
+      "ratio": 0.6541,
+      "compress_mbps": 22.97,
+      "decompress_mbps": 30.0
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3953722,
+      "ratio": 0.6427,
+      "compress_mbps": 21.8,
+      "decompress_mbps": 30.49
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3887921,
+      "ratio": 0.632,
+      "compress_mbps": 18.49,
+      "decompress_mbps": 31.17
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3320440,
+      "ratio": 0.5397,
+      "compress_mbps": 21.32,
+      "decompress_mbps": 37.23
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3279338,
+      "ratio": 0.533,
+      "compress_mbps": 17.94,
+      "decompress_mbps": 38.42
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3254309,
+      "ratio": 0.529,
+      "compress_mbps": 14.01,
+      "decompress_mbps": 37.8
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3250139,
+      "ratio": 0.5283,
+      "compress_mbps": 12.33,
+      "decompress_mbps": 37.98
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3247018,
+      "ratio": 0.5278,
+      "compress_mbps": 10.17,
+      "decompress_mbps": 38.04
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3246865,
+      "ratio": 0.5278,
+      "compress_mbps": 9.47,
+      "decompress_mbps": 38.07
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 4471091,
+      "ratio": 0.4433,
+      "compress_mbps": 35.0,
+      "decompress_mbps": 69.69
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 4372105,
+      "ratio": 0.4335,
+      "compress_mbps": 34.08,
+      "decompress_mbps": 72.67
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 4305270,
+      "ratio": 0.4269,
+      "compress_mbps": 30.33,
+      "decompress_mbps": 73.57
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3920495,
+      "ratio": 0.3887,
+      "compress_mbps": 30.34,
+      "decompress_mbps": 64.42
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3853177,
+      "ratio": 0.382,
+      "compress_mbps": 26.78,
+      "decompress_mbps": 63.84
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3780878,
+      "ratio": 0.3749,
+      "compress_mbps": 23.24,
+      "decompress_mbps": 64.07
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3763880,
+      "ratio": 0.3732,
+      "compress_mbps": 20.22,
+      "decompress_mbps": 73.9
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3757719,
+      "ratio": 0.3726,
+      "compress_mbps": 18.23,
+      "decompress_mbps": 73.35
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3757719,
+      "ratio": 0.3726,
+      "compress_mbps": 18.44,
+      "decompress_mbps": 72.92
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2722387,
+      "ratio": 0.4108,
+      "compress_mbps": 38.31,
+      "decompress_mbps": 65.35
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2572544,
+      "ratio": 0.3882,
+      "compress_mbps": 37.37,
+      "decompress_mbps": 71.26
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2384328,
+      "ratio": 0.3598,
+      "compress_mbps": 28.57,
+      "decompress_mbps": 77.96
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 2112060,
+      "ratio": 0.3187,
+      "compress_mbps": 36.49,
+      "decompress_mbps": 84.65
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1991581,
+      "ratio": 0.3005,
+      "compress_mbps": 25.62,
+      "decompress_mbps": 89.47
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1917866,
+      "ratio": 0.2894,
+      "compress_mbps": 15.15,
+      "decompress_mbps": 90.66
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1895353,
+      "ratio": 0.286,
+      "compress_mbps": 10.92,
+      "decompress_mbps": 89.46
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1880740,
+      "ratio": 0.2838,
+      "compress_mbps": 5.58,
+      "decompress_mbps": 91.07
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1880711,
+      "ratio": 0.2838,
+      "compress_mbps": 5.57,
+      "decompress_mbps": 91.13
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 7441483,
+      "ratio": 0.3444,
+      "compress_mbps": 44.06,
+      "decompress_mbps": 66.48
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 7229248,
+      "ratio": 0.3346,
+      "compress_mbps": 43.12,
+      "decompress_mbps": 68.76
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 7083451,
+      "ratio": 0.3278,
+      "compress_mbps": 38.99,
+      "decompress_mbps": 71.31
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 6189639,
+      "ratio": 0.2865,
+      "compress_mbps": 42.47,
+      "decompress_mbps": 92.5
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 6053058,
+      "ratio": 0.2802,
+      "compress_mbps": 34.44,
+      "decompress_mbps": 95.5
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5988137,
+      "ratio": 0.2771,
+      "compress_mbps": 28.64,
+      "decompress_mbps": 102.56
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5949908,
+      "ratio": 0.2754,
+      "compress_mbps": 25.18,
+      "decompress_mbps": 104.39
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5936656,
+      "ratio": 0.2748,
+      "compress_mbps": 19.29,
+      "decompress_mbps": 106.41
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5934701,
+      "ratio": 0.2747,
+      "compress_mbps": 17.96,
+      "decompress_mbps": 105.65
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 6335542,
+      "ratio": 0.8736,
+      "compress_mbps": 18.55,
+      "decompress_mbps": 31.43
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 6247260,
+      "ratio": 0.8615,
+      "compress_mbps": 17.56,
+      "decompress_mbps": 48.44
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 6064713,
+      "ratio": 0.8363,
+      "compress_mbps": 15.2,
+      "decompress_mbps": 56.63
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5568111,
+      "ratio": 0.7678,
+      "compress_mbps": 17.6,
+      "decompress_mbps": 59.45
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5544524,
+      "ratio": 0.7646,
+      "compress_mbps": 14.51,
+      "decompress_mbps": 66.18
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5513056,
+      "ratio": 0.7602,
+      "compress_mbps": 11.98,
+      "decompress_mbps": 62.95
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5508915,
+      "ratio": 0.7596,
+      "compress_mbps": 11.34,
+      "decompress_mbps": 64.97
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5508365,
+      "ratio": 0.7596,
+      "compress_mbps": 10.61,
+      "decompress_mbps": 63.85
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5508365,
+      "ratio": 0.7596,
+      "compress_mbps": 10.59,
+      "decompress_mbps": 64.19
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 16776095,
+      "ratio": 0.4046,
+      "compress_mbps": 37.78,
+      "decompress_mbps": 51.38
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 16032651,
+      "ratio": 0.3867,
+      "compress_mbps": 36.19,
+      "decompress_mbps": 54.78
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 15180334,
+      "ratio": 0.3662,
+      "compress_mbps": 31.2,
+      "decompress_mbps": 52.36
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 13261924,
+      "ratio": 0.3199,
+      "compress_mbps": 36.1,
+      "decompress_mbps": 68.69
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12706028,
+      "ratio": 0.3065,
+      "compress_mbps": 27.82,
+      "decompress_mbps": 71.53
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12464158,
+      "ratio": 0.3006,
+      "compress_mbps": 21.35,
+      "decompress_mbps": 70.7
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12375954,
+      "ratio": 0.2985,
+      "compress_mbps": 18.29,
+      "decompress_mbps": 72.74
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12321552,
+      "ratio": 0.2972,
+      "compress_mbps": 14.48,
+      "decompress_mbps": 70.48
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12320276,
+      "ratio": 0.2972,
+      "compress_mbps": 14.47,
+      "decompress_mbps": 70.51
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6799201,
+      "ratio": 0.8023,
+      "compress_mbps": 18.48,
+      "decompress_mbps": 18.32
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6800500,
+      "ratio": 0.8025,
+      "compress_mbps": 16.97,
+      "decompress_mbps": 18.57
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6803212,
+      "ratio": 0.8028,
+      "compress_mbps": 14.91,
+      "decompress_mbps": 18.41
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6264611,
+      "ratio": 0.7393,
+      "compress_mbps": 17.16,
+      "decompress_mbps": 24.72
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6217901,
+      "ratio": 0.7337,
+      "compress_mbps": 15.85,
+      "decompress_mbps": 25.44
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 6201999,
+      "ratio": 0.7319,
+      "compress_mbps": 15.41,
+      "decompress_mbps": 25.4
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 6201883,
+      "ratio": 0.7319,
+      "compress_mbps": 15.38,
+      "decompress_mbps": 25.02
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 6201887,
+      "ratio": 0.7319,
+      "compress_mbps": 15.41,
+      "decompress_mbps": 24.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 6201887,
+      "ratio": 0.7319,
+      "compress_mbps": 15.37,
+      "decompress_mbps": 24.92
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 1081679,
+      "ratio": 0.2024,
+      "compress_mbps": 73.03,
+      "decompress_mbps": 108.07
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 1001890,
+      "ratio": 0.1874,
+      "compress_mbps": 73.86,
+      "decompress_mbps": 117.58
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 921722,
+      "ratio": 0.1724,
+      "compress_mbps": 67.29,
+      "decompress_mbps": 128.43
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 849263,
+      "ratio": 0.1589,
+      "compress_mbps": 65.72,
+      "decompress_mbps": 142.74
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 771964,
+      "ratio": 0.1444,
+      "compress_mbps": 55.23,
+      "decompress_mbps": 143.96
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 728098,
+      "ratio": 0.1362,
+      "compress_mbps": 42.9,
+      "decompress_mbps": 151.53
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 713635,
+      "ratio": 0.1335,
+      "compress_mbps": 37.37,
+      "decompress_mbps": 155.41
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 699093,
+      "ratio": 0.1308,
+      "compress_mbps": 27.38,
+      "decompress_mbps": 146.92
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 698459,
+      "ratio": 0.1307,
+      "compress_mbps": 25.12,
+      "decompress_mbps": 148.81
+    }
+  ]
 }

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "date": "2026-06-10T07:53:15Z",
+    "date": "2026-06-10T08:22:01Z",
     "machine": "Linux chungus x86_64",
-    "git_commit": "e94ac0d2",
+    "git_commit": "3050fc62",
     "toolchain": "leanprover/lean4:v4.30.0-rc2",
-    "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic | native/zlib/miniz/libdeflate regenerated post block-splitting (#2524); go/js/zig/ocaml reused from prior run (external, unchanged); zopfli dropped (too slow)"
+    "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic | native/zlib/miniz/libdeflate regenerated with entropy-divergence shared-window splitting (#2528) and the bl_count length-limiter repair fix; go/js/zig/ocaml reused from prior run (external, unchanged); zopfli dropped (too slow)"
   },
   "results": [
     {
@@ -14,8 +14,8 @@
       "level": 1,
       "out_size": 59545,
       "ratio": 0.3915,
-      "compress_mbps": 14.43,
-      "decompress_mbps": 85.73
+      "compress_mbps": 14.46,
+      "decompress_mbps": 85.41
     },
     {
       "compressor": "native",
@@ -24,8 +24,8 @@
       "level": 2,
       "out_size": 57936,
       "ratio": 0.3809,
-      "compress_mbps": 12.66,
-      "decompress_mbps": 93.95
+      "compress_mbps": 12.6,
+      "decompress_mbps": 93.08
     },
     {
       "compressor": "native",
@@ -34,8 +34,8 @@
       "level": 3,
       "out_size": 56891,
       "ratio": 0.3741,
-      "compress_mbps": 11.14,
-      "decompress_mbps": 103.32
+      "compress_mbps": 10.97,
+      "decompress_mbps": 101.91
     },
     {
       "compressor": "native",
@@ -44,8 +44,8 @@
       "level": 4,
       "out_size": 55541,
       "ratio": 0.3652,
-      "compress_mbps": 6.78,
-      "decompress_mbps": 103.28
+      "compress_mbps": 6.71,
+      "decompress_mbps": 102.99
     },
     {
       "compressor": "native",
@@ -54,8 +54,8 @@
       "level": 5,
       "out_size": 55282,
       "ratio": 0.3635,
-      "compress_mbps": 6.21,
-      "decompress_mbps": 106.28
+      "compress_mbps": 6.19,
+      "decompress_mbps": 105.98
     },
     {
       "compressor": "native",
@@ -64,38 +64,38 @@
       "level": 6,
       "out_size": 54902,
       "ratio": 0.361,
-      "compress_mbps": 5.2,
-      "decompress_mbps": 111.65
+      "compress_mbps": 5.18,
+      "decompress_mbps": 110.52
     },
     {
       "compressor": "native",
       "pattern": "canterbury/alice29.txt",
       "size": 152089,
       "level": 7,
-      "out_size": 54758,
-      "ratio": 0.36,
-      "compress_mbps": 1.65,
-      "decompress_mbps": 109.58
+      "out_size": 54533,
+      "ratio": 0.3586,
+      "compress_mbps": 1.56,
+      "decompress_mbps": 110.53
     },
     {
       "compressor": "native",
       "pattern": "canterbury/alice29.txt",
       "size": 152089,
       "level": 8,
-      "out_size": 54717,
-      "ratio": 0.3598,
-      "compress_mbps": 1.53,
-      "decompress_mbps": 110.7
+      "out_size": 54492,
+      "ratio": 0.3583,
+      "compress_mbps": 1.45,
+      "decompress_mbps": 110.41
     },
     {
       "compressor": "native",
       "pattern": "canterbury/alice29.txt",
       "size": 152089,
       "level": 9,
-      "out_size": 54716,
-      "ratio": 0.3598,
-      "compress_mbps": 1.51,
-      "decompress_mbps": 110.75
+      "out_size": 54490,
+      "ratio": 0.3583,
+      "compress_mbps": 1.43,
+      "decompress_mbps": 110.73
     },
     {
       "compressor": "native",
@@ -104,8 +104,8 @@
       "level": 1,
       "out_size": 52768,
       "ratio": 0.4215,
-      "compress_mbps": 13.5,
-      "decompress_mbps": 82.09
+      "compress_mbps": 13.49,
+      "decompress_mbps": 81.66
     },
     {
       "compressor": "native",
@@ -114,8 +114,8 @@
       "level": 2,
       "out_size": 51760,
       "ratio": 0.4135,
-      "compress_mbps": 12.02,
-      "decompress_mbps": 87.16
+      "compress_mbps": 11.98,
+      "decompress_mbps": 85.98
     },
     {
       "compressor": "native",
@@ -124,8 +124,8 @@
       "level": 3,
       "out_size": 51056,
       "ratio": 0.4079,
-      "compress_mbps": 10.53,
-      "decompress_mbps": 92.93
+      "compress_mbps": 10.52,
+      "decompress_mbps": 93.52
     },
     {
       "compressor": "native",
@@ -135,7 +135,7 @@
       "out_size": 49963,
       "ratio": 0.3991,
       "compress_mbps": 6.53,
-      "decompress_mbps": 94.03
+      "decompress_mbps": 94.59
     },
     {
       "compressor": "native",
@@ -144,8 +144,8 @@
       "level": 5,
       "out_size": 49779,
       "ratio": 0.3977,
-      "compress_mbps": 6.09,
-      "decompress_mbps": 97.3
+      "compress_mbps": 6.08,
+      "decompress_mbps": 97.57
     },
     {
       "compressor": "native",
@@ -155,37 +155,37 @@
       "out_size": 49540,
       "ratio": 0.3958,
       "compress_mbps": 5.23,
-      "decompress_mbps": 99.89
+      "decompress_mbps": 99.51
     },
     {
       "compressor": "native",
       "pattern": "canterbury/asyoulik.txt",
       "size": 125179,
       "level": 7,
-      "out_size": 49419,
-      "ratio": 0.3948,
-      "compress_mbps": 1.75,
-      "decompress_mbps": 100.23
+      "out_size": 49161,
+      "ratio": 0.3927,
+      "compress_mbps": 1.62,
+      "decompress_mbps": 99.18
     },
     {
       "compressor": "native",
       "pattern": "canterbury/asyoulik.txt",
       "size": 125179,
       "level": 8,
-      "out_size": 49409,
-      "ratio": 0.3947,
-      "compress_mbps": 1.7,
-      "decompress_mbps": 99.82
+      "out_size": 49153,
+      "ratio": 0.3927,
+      "compress_mbps": 1.57,
+      "decompress_mbps": 99.68
     },
     {
       "compressor": "native",
       "pattern": "canterbury/asyoulik.txt",
       "size": 125179,
       "level": 9,
-      "out_size": 49409,
-      "ratio": 0.3947,
-      "compress_mbps": 1.7,
-      "decompress_mbps": 100.18
+      "out_size": 49153,
+      "ratio": 0.3927,
+      "compress_mbps": 1.57,
+      "decompress_mbps": 99.37
     },
     {
       "compressor": "native",
@@ -194,8 +194,8 @@
       "level": 1,
       "out_size": 8430,
       "ratio": 0.3426,
-      "compress_mbps": 16.28,
-      "decompress_mbps": 85.94
+      "compress_mbps": 16.03,
+      "decompress_mbps": 85.61
     },
     {
       "compressor": "native",
@@ -204,8 +204,8 @@
       "level": 2,
       "out_size": 8297,
       "ratio": 0.3372,
-      "compress_mbps": 15.3,
-      "decompress_mbps": 89.83
+      "compress_mbps": 15.34,
+      "decompress_mbps": 90.43
     },
     {
       "compressor": "native",
@@ -214,8 +214,8 @@
       "level": 3,
       "out_size": 8218,
       "ratio": 0.334,
-      "compress_mbps": 14.26,
-      "decompress_mbps": 93.03
+      "compress_mbps": 14.31,
+      "decompress_mbps": 92.16
     },
     {
       "compressor": "native",
@@ -224,8 +224,8 @@
       "level": 4,
       "out_size": 8055,
       "ratio": 0.3274,
-      "compress_mbps": 10.35,
-      "decompress_mbps": 90.58
+      "compress_mbps": 10.37,
+      "decompress_mbps": 91.36
     },
     {
       "compressor": "native",
@@ -234,8 +234,8 @@
       "level": 5,
       "out_size": 8049,
       "ratio": 0.3272,
-      "compress_mbps": 9.78,
-      "decompress_mbps": 92.56
+      "compress_mbps": 9.79,
+      "decompress_mbps": 93.02
     },
     {
       "compressor": "native",
@@ -244,8 +244,8 @@
       "level": 6,
       "out_size": 8043,
       "ratio": 0.3269,
-      "compress_mbps": 8.82,
-      "decompress_mbps": 92.23
+      "compress_mbps": 8.83,
+      "decompress_mbps": 92.99
     },
     {
       "compressor": "native",
@@ -254,8 +254,8 @@
       "level": 7,
       "out_size": 8038,
       "ratio": 0.3267,
-      "compress_mbps": 2.82,
-      "decompress_mbps": 93.98
+      "compress_mbps": 2.49,
+      "decompress_mbps": 93.61
     },
     {
       "compressor": "native",
@@ -264,8 +264,8 @@
       "level": 8,
       "out_size": 8038,
       "ratio": 0.3267,
-      "compress_mbps": 2.82,
-      "decompress_mbps": 92.78
+      "compress_mbps": 2.49,
+      "decompress_mbps": 94.02
     },
     {
       "compressor": "native",
@@ -274,8 +274,8 @@
       "level": 9,
       "out_size": 8038,
       "ratio": 0.3267,
-      "compress_mbps": 2.82,
-      "decompress_mbps": 92.96
+      "compress_mbps": 2.49,
+      "decompress_mbps": 93.56
     },
     {
       "compressor": "native",
@@ -284,8 +284,8 @@
       "level": 1,
       "out_size": 3325,
       "ratio": 0.2982,
-      "compress_mbps": 13.41,
-      "decompress_mbps": 75.49
+      "compress_mbps": 13.62,
+      "decompress_mbps": 75.52
     },
     {
       "compressor": "native",
@@ -294,8 +294,8 @@
       "level": 2,
       "out_size": 3251,
       "ratio": 0.2916,
-      "compress_mbps": 12.84,
-      "decompress_mbps": 78.23
+      "compress_mbps": 12.98,
+      "decompress_mbps": 77.71
     },
     {
       "compressor": "native",
@@ -304,8 +304,8 @@
       "level": 3,
       "out_size": 3202,
       "ratio": 0.2872,
-      "compress_mbps": 12.28,
-      "decompress_mbps": 79.97
+      "compress_mbps": 12.39,
+      "decompress_mbps": 80.2
     },
     {
       "compressor": "native",
@@ -314,8 +314,8 @@
       "level": 4,
       "out_size": 3150,
       "ratio": 0.2825,
-      "compress_mbps": 9.47,
-      "decompress_mbps": 82.28
+      "compress_mbps": 9.53,
+      "decompress_mbps": 82.04
     },
     {
       "compressor": "native",
@@ -324,8 +324,8 @@
       "level": 5,
       "out_size": 3141,
       "ratio": 0.2817,
-      "compress_mbps": 9.16,
-      "decompress_mbps": 82.97
+      "compress_mbps": 9.26,
+      "decompress_mbps": 83.12
     },
     {
       "compressor": "native",
@@ -334,8 +334,8 @@
       "level": 6,
       "out_size": 3136,
       "ratio": 0.2813,
-      "compress_mbps": 8.54,
-      "decompress_mbps": 83.79
+      "compress_mbps": 8.62,
+      "decompress_mbps": 83.42
     },
     {
       "compressor": "native",
@@ -344,8 +344,8 @@
       "level": 7,
       "out_size": 3134,
       "ratio": 0.2811,
-      "compress_mbps": 2.77,
-      "decompress_mbps": 83.78
+      "compress_mbps": 2.32,
+      "decompress_mbps": 83.8
     },
     {
       "compressor": "native",
@@ -354,8 +354,8 @@
       "level": 8,
       "out_size": 3134,
       "ratio": 0.2811,
-      "compress_mbps": 2.74,
-      "decompress_mbps": 84.67
+      "compress_mbps": 2.29,
+      "decompress_mbps": 83.44
     },
     {
       "compressor": "native",
@@ -364,8 +364,8 @@
       "level": 9,
       "out_size": 3134,
       "ratio": 0.2811,
-      "compress_mbps": 2.73,
-      "decompress_mbps": 84.49
+      "compress_mbps": 2.32,
+      "decompress_mbps": 83.71
     },
     {
       "compressor": "native",
@@ -374,8 +374,8 @@
       "level": 1,
       "out_size": 1251,
       "ratio": 0.3362,
-      "compress_mbps": 8.58,
-      "decompress_mbps": 42.71
+      "compress_mbps": 8.54,
+      "decompress_mbps": 42.51
     },
     {
       "compressor": "native",
@@ -384,7 +384,7 @@
       "level": 2,
       "out_size": 1241,
       "ratio": 0.3335,
-      "compress_mbps": 8.4,
+      "compress_mbps": 8.35,
       "decompress_mbps": 43.02
     },
     {
@@ -394,8 +394,8 @@
       "level": 3,
       "out_size": 1241,
       "ratio": 0.3335,
-      "compress_mbps": 8.21,
-      "decompress_mbps": 43.3
+      "compress_mbps": 8.14,
+      "decompress_mbps": 43.11
     },
     {
       "compressor": "native",
@@ -404,8 +404,8 @@
       "level": 4,
       "out_size": 1225,
       "ratio": 0.3292,
-      "compress_mbps": 7.3,
-      "decompress_mbps": 44.36
+      "compress_mbps": 7.28,
+      "decompress_mbps": 43.98
     },
     {
       "compressor": "native",
@@ -414,8 +414,8 @@
       "level": 5,
       "out_size": 1224,
       "ratio": 0.3289,
-      "compress_mbps": 7.24,
-      "decompress_mbps": 44.59
+      "compress_mbps": 7.2,
+      "decompress_mbps": 44.13
     },
     {
       "compressor": "native",
@@ -424,8 +424,8 @@
       "level": 6,
       "out_size": 1224,
       "ratio": 0.3289,
-      "compress_mbps": 7.18,
-      "decompress_mbps": 44.09
+      "compress_mbps": 7.14,
+      "decompress_mbps": 44.1
     },
     {
       "compressor": "native",
@@ -434,8 +434,8 @@
       "level": 7,
       "out_size": 1224,
       "ratio": 0.3289,
-      "compress_mbps": 2.49,
-      "decompress_mbps": 44.53
+      "compress_mbps": 1.83,
+      "decompress_mbps": 44.23
     },
     {
       "compressor": "native",
@@ -444,8 +444,8 @@
       "level": 8,
       "out_size": 1224,
       "ratio": 0.3289,
-      "compress_mbps": 2.49,
-      "decompress_mbps": 44.15
+      "compress_mbps": 1.83,
+      "decompress_mbps": 44.04
     },
     {
       "compressor": "native",
@@ -454,8 +454,8 @@
       "level": 9,
       "out_size": 1224,
       "ratio": 0.3289,
-      "compress_mbps": 2.5,
-      "decompress_mbps": 44.52
+      "compress_mbps": 1.83,
+      "decompress_mbps": 44.2
     },
     {
       "compressor": "native",
@@ -464,8 +464,8 @@
       "level": 1,
       "out_size": 248840,
       "ratio": 0.2417,
-      "compress_mbps": 25.21,
-      "decompress_mbps": 131.64
+      "compress_mbps": 25.09,
+      "decompress_mbps": 130.99
     },
     {
       "compressor": "native",
@@ -474,8 +474,8 @@
       "level": 2,
       "out_size": 247429,
       "ratio": 0.2403,
-      "compress_mbps": 22.33,
-      "decompress_mbps": 151.42
+      "compress_mbps": 22.31,
+      "decompress_mbps": 151.28
     },
     {
       "compressor": "native",
@@ -484,8 +484,8 @@
       "level": 3,
       "out_size": 246442,
       "ratio": 0.2393,
-      "compress_mbps": 20.45,
-      "decompress_mbps": 158.17
+      "compress_mbps": 21.13,
+      "decompress_mbps": 158.92
     },
     {
       "compressor": "native",
@@ -494,8 +494,8 @@
       "level": 4,
       "out_size": 213851,
       "ratio": 0.2077,
-      "compress_mbps": 10.77,
-      "decompress_mbps": 163.89
+      "compress_mbps": 10.84,
+      "decompress_mbps": 165.11
     },
     {
       "compressor": "native",
@@ -504,8 +504,8 @@
       "level": 5,
       "out_size": 212782,
       "ratio": 0.2066,
-      "compress_mbps": 9.38,
-      "decompress_mbps": 131.9
+      "compress_mbps": 9.47,
+      "decompress_mbps": 132.08
     },
     {
       "compressor": "native",
@@ -514,8 +514,8 @@
       "level": 6,
       "out_size": 210061,
       "ratio": 0.204,
-      "compress_mbps": 6.29,
-      "decompress_mbps": 133.2
+      "compress_mbps": 6.28,
+      "decompress_mbps": 131.48
     },
     {
       "compressor": "native",
@@ -524,8 +524,8 @@
       "level": 7,
       "out_size": 199322,
       "ratio": 0.1936,
-      "compress_mbps": 1.3,
-      "decompress_mbps": 124.29
+      "compress_mbps": 1.22,
+      "decompress_mbps": 123.72
     },
     {
       "compressor": "native",
@@ -534,8 +534,8 @@
       "level": 8,
       "out_size": 199462,
       "ratio": 0.1937,
-      "compress_mbps": 0.8,
-      "decompress_mbps": 122.04
+      "compress_mbps": 0.76,
+      "decompress_mbps": 120.56
     },
     {
       "compressor": "native",
@@ -544,18 +544,18 @@
       "level": 9,
       "out_size": 199644,
       "ratio": 0.1939,
-      "compress_mbps": 0.48,
-      "decompress_mbps": 121.72
+      "compress_mbps": 0.46,
+      "decompress_mbps": 119.92
     },
     {
       "compressor": "native",
       "pattern": "canterbury/lcet10.txt",
       "size": 426754,
       "level": 1,
-      "out_size": 194388,
-      "ratio": 0.4555,
-      "compress_mbps": 15.36,
-      "decompress_mbps": 90.69
+      "out_size": 158127,
+      "ratio": 0.3705,
+      "compress_mbps": 15.42,
+      "decompress_mbps": 91.13
     },
     {
       "compressor": "native",
@@ -564,8 +564,8 @@
       "level": 2,
       "out_size": 153708,
       "ratio": 0.3602,
-      "compress_mbps": 13.42,
-      "decompress_mbps": 97.14
+      "compress_mbps": 13.56,
+      "decompress_mbps": 97.72
     },
     {
       "compressor": "native",
@@ -574,18 +574,18 @@
       "level": 3,
       "out_size": 150718,
       "ratio": 0.3532,
-      "compress_mbps": 11.69,
-      "decompress_mbps": 106.94
+      "compress_mbps": 11.54,
+      "decompress_mbps": 108.59
     },
     {
       "compressor": "native",
       "pattern": "canterbury/lcet10.txt",
       "size": 426754,
       "level": 4,
-      "out_size": 177586,
-      "ratio": 0.4161,
-      "compress_mbps": 7.32,
-      "decompress_mbps": 107.91
+      "out_size": 147481,
+      "ratio": 0.3456,
+      "compress_mbps": 7.25,
+      "decompress_mbps": 107.38
     },
     {
       "compressor": "native",
@@ -594,8 +594,8 @@
       "level": 5,
       "out_size": 146857,
       "ratio": 0.3441,
-      "compress_mbps": 6.77,
-      "decompress_mbps": 111.92
+      "compress_mbps": 6.75,
+      "decompress_mbps": 111.19
     },
     {
       "compressor": "native",
@@ -604,38 +604,38 @@
       "level": 6,
       "out_size": 146118,
       "ratio": 0.3424,
-      "compress_mbps": 5.73,
-      "decompress_mbps": 113.78
+      "compress_mbps": 5.7,
+      "decompress_mbps": 114.25
     },
     {
       "compressor": "native",
       "pattern": "canterbury/lcet10.txt",
       "size": 426754,
       "level": 7,
-      "out_size": 145876,
-      "ratio": 0.3418,
-      "compress_mbps": 1.84,
-      "decompress_mbps": 115.89
+      "out_size": 145400,
+      "ratio": 0.3407,
+      "compress_mbps": 1.73,
+      "decompress_mbps": 114.41
     },
     {
       "compressor": "native",
       "pattern": "canterbury/lcet10.txt",
       "size": 426754,
       "level": 8,
-      "out_size": 145803,
-      "ratio": 0.3417,
-      "compress_mbps": 1.75,
-      "decompress_mbps": 114.91
+      "out_size": 145324,
+      "ratio": 0.3405,
+      "compress_mbps": 1.65,
+      "decompress_mbps": 114.7
     },
     {
       "compressor": "native",
       "pattern": "canterbury/lcet10.txt",
       "size": 426754,
       "level": 9,
-      "out_size": 145799,
-      "ratio": 0.3416,
-      "compress_mbps": 1.73,
-      "decompress_mbps": 114.83
+      "out_size": 145320,
+      "ratio": 0.3405,
+      "compress_mbps": 1.63,
+      "decompress_mbps": 115.05
     },
     {
       "compressor": "native",
@@ -644,38 +644,38 @@
       "level": 1,
       "out_size": 212305,
       "ratio": 0.4406,
-      "compress_mbps": 13.13,
-      "decompress_mbps": 78.92
+      "compress_mbps": 13.3,
+      "decompress_mbps": 79.04
     },
     {
       "compressor": "native",
       "pattern": "canterbury/plrabn12.txt",
       "size": 481861,
       "level": 2,
-      "out_size": 263152,
-      "ratio": 0.5461,
-      "compress_mbps": 11.58,
-      "decompress_mbps": 86.18
+      "out_size": 207350,
+      "ratio": 0.4303,
+      "compress_mbps": 11.48,
+      "decompress_mbps": 85.3
     },
     {
       "compressor": "native",
       "pattern": "canterbury/plrabn12.txt",
       "size": 481861,
       "level": 3,
-      "out_size": 257812,
-      "ratio": 0.535,
-      "compress_mbps": 9.7,
-      "decompress_mbps": 91.17
+      "out_size": 203699,
+      "ratio": 0.4227,
+      "compress_mbps": 10.01,
+      "decompress_mbps": 90.3
     },
     {
       "compressor": "native",
       "pattern": "canterbury/plrabn12.txt",
       "size": 481861,
       "level": 4,
-      "out_size": 249343,
-      "ratio": 0.5175,
-      "compress_mbps": 5.92,
-      "decompress_mbps": 92.13
+      "out_size": 200054,
+      "ratio": 0.4152,
+      "compress_mbps": 6.06,
+      "decompress_mbps": 91.5
     },
     {
       "compressor": "native",
@@ -684,8 +684,8 @@
       "level": 5,
       "out_size": 199229,
       "ratio": 0.4135,
-      "compress_mbps": 5.48,
-      "decompress_mbps": 94.91
+      "compress_mbps": 5.57,
+      "decompress_mbps": 94.67
     },
     {
       "compressor": "native",
@@ -694,38 +694,38 @@
       "level": 6,
       "out_size": 198023,
       "ratio": 0.411,
-      "compress_mbps": 4.59,
-      "decompress_mbps": 98.04
+      "compress_mbps": 4.65,
+      "decompress_mbps": 96.92
     },
     {
       "compressor": "native",
       "pattern": "canterbury/plrabn12.txt",
       "size": 481861,
       "level": 7,
-      "out_size": 197532,
-      "ratio": 0.4099,
-      "compress_mbps": 1.45,
-      "decompress_mbps": 98.68
+      "out_size": 197186,
+      "ratio": 0.4092,
+      "compress_mbps": 1.4,
+      "decompress_mbps": 97.6
     },
     {
       "compressor": "native",
       "pattern": "canterbury/plrabn12.txt",
       "size": 481861,
       "level": 8,
-      "out_size": 197364,
-      "ratio": 0.4096,
-      "compress_mbps": 1.32,
-      "decompress_mbps": 98.26
+      "out_size": 197001,
+      "ratio": 0.4088,
+      "compress_mbps": 1.27,
+      "decompress_mbps": 97.42
     },
     {
       "compressor": "native",
       "pattern": "canterbury/plrabn12.txt",
       "size": 481861,
       "level": 9,
-      "out_size": 197347,
-      "ratio": 0.4096,
-      "compress_mbps": 1.26,
-      "decompress_mbps": 97.83
+      "out_size": 196971,
+      "ratio": 0.4088,
+      "compress_mbps": 1.22,
+      "decompress_mbps": 97.75
     },
     {
       "compressor": "native",
@@ -734,8 +734,8 @@
       "level": 1,
       "out_size": 60352,
       "ratio": 0.1176,
-      "compress_mbps": 41.72,
-      "decompress_mbps": 242.21
+      "compress_mbps": 43.16,
+      "decompress_mbps": 236.53
     },
     {
       "compressor": "native",
@@ -744,8 +744,8 @@
       "level": 2,
       "out_size": 59696,
       "ratio": 0.1163,
-      "compress_mbps": 34.97,
-      "decompress_mbps": 255.15
+      "compress_mbps": 35.94,
+      "decompress_mbps": 252.5
     },
     {
       "compressor": "native",
@@ -754,8 +754,8 @@
       "level": 3,
       "out_size": 59069,
       "ratio": 0.1151,
-      "compress_mbps": 27.82,
-      "decompress_mbps": 266.78
+      "compress_mbps": 28.28,
+      "decompress_mbps": 268.72
     },
     {
       "compressor": "native",
@@ -764,8 +764,8 @@
       "level": 4,
       "out_size": 56435,
       "ratio": 0.11,
-      "compress_mbps": 16.02,
-      "decompress_mbps": 242.14
+      "compress_mbps": 16.27,
+      "decompress_mbps": 240.18
     },
     {
       "compressor": "native",
@@ -774,8 +774,8 @@
       "level": 5,
       "out_size": 56350,
       "ratio": 0.1098,
-      "compress_mbps": 13.97,
-      "decompress_mbps": 259.73
+      "compress_mbps": 14.02,
+      "decompress_mbps": 259.37
     },
     {
       "compressor": "native",
@@ -784,8 +784,8 @@
       "level": 6,
       "out_size": 56014,
       "ratio": 0.1091,
-      "compress_mbps": 9.53,
-      "decompress_mbps": 275.47
+      "compress_mbps": 9.54,
+      "decompress_mbps": 274.85
     },
     {
       "compressor": "native",
@@ -794,8 +794,8 @@
       "level": 7,
       "out_size": 54781,
       "ratio": 0.1067,
-      "compress_mbps": 2.17,
-      "decompress_mbps": 286.94
+      "compress_mbps": 2.08,
+      "decompress_mbps": 283.9
     },
     {
       "compressor": "native",
@@ -804,8 +804,8 @@
       "level": 8,
       "out_size": 54031,
       "ratio": 0.1053,
-      "compress_mbps": 1.39,
-      "decompress_mbps": 299.54
+      "compress_mbps": 1.36,
+      "decompress_mbps": 299.37
     },
     {
       "compressor": "native",
@@ -814,8 +814,8 @@
       "level": 9,
       "out_size": 53850,
       "ratio": 0.1049,
-      "compress_mbps": 0.81,
-      "decompress_mbps": 303.82
+      "compress_mbps": 0.8,
+      "decompress_mbps": 301.81
     },
     {
       "compressor": "native",
@@ -824,8 +824,8 @@
       "level": 1,
       "out_size": 13725,
       "ratio": 0.3589,
-      "compress_mbps": 13.59,
-      "decompress_mbps": 66.8
+      "compress_mbps": 13.93,
+      "decompress_mbps": 66.02
     },
     {
       "compressor": "native",
@@ -834,8 +834,8 @@
       "level": 2,
       "out_size": 13615,
       "ratio": 0.356,
-      "compress_mbps": 12.93,
-      "decompress_mbps": 70.3
+      "compress_mbps": 13.24,
+      "decompress_mbps": 69.54
     },
     {
       "compressor": "native",
@@ -844,8 +844,8 @@
       "level": 3,
       "out_size": 13548,
       "ratio": 0.3543,
-      "compress_mbps": 12.18,
-      "decompress_mbps": 73.4
+      "compress_mbps": 12.42,
+      "decompress_mbps": 72.4
     },
     {
       "compressor": "native",
@@ -854,8 +854,8 @@
       "level": 4,
       "out_size": 13080,
       "ratio": 0.3421,
-      "compress_mbps": 8.91,
-      "decompress_mbps": 71.33
+      "compress_mbps": 9.07,
+      "decompress_mbps": 70.49
     },
     {
       "compressor": "native",
@@ -864,8 +864,8 @@
       "level": 5,
       "out_size": 13060,
       "ratio": 0.3415,
-      "compress_mbps": 8.28,
-      "decompress_mbps": 74.77
+      "compress_mbps": 8.41,
+      "decompress_mbps": 74.09
     },
     {
       "compressor": "native",
@@ -874,38 +874,38 @@
       "level": 6,
       "out_size": 13015,
       "ratio": 0.3404,
-      "compress_mbps": 6.78,
-      "decompress_mbps": 75.78
+      "compress_mbps": 6.86,
+      "decompress_mbps": 75.12
     },
     {
       "compressor": "native",
       "pattern": "canterbury/sum",
       "size": 38240,
       "level": 7,
-      "out_size": 12923,
-      "ratio": 0.3379,
-      "compress_mbps": 1.65,
-      "decompress_mbps": 76.32
+      "out_size": 12823,
+      "ratio": 0.3353,
+      "compress_mbps": 1.4,
+      "decompress_mbps": 75.78
     },
     {
       "compressor": "native",
       "pattern": "canterbury/sum",
       "size": 38240,
       "level": 8,
-      "out_size": 12905,
-      "ratio": 0.3375,
-      "compress_mbps": 1.22,
-      "decompress_mbps": 78.81
+      "out_size": 12811,
+      "ratio": 0.335,
+      "compress_mbps": 1.07,
+      "decompress_mbps": 78.07
     },
     {
       "compressor": "native",
       "pattern": "canterbury/sum",
       "size": 38240,
       "level": 9,
-      "out_size": 12887,
-      "ratio": 0.337,
-      "compress_mbps": 0.83,
-      "decompress_mbps": 78.41
+      "out_size": 12791,
+      "ratio": 0.3345,
+      "compress_mbps": 0.76,
+      "decompress_mbps": 78.11
     },
     {
       "compressor": "native",
@@ -914,8 +914,8 @@
       "level": 1,
       "out_size": 1781,
       "ratio": 0.4213,
-      "compress_mbps": 8.4,
-      "decompress_mbps": 42.37
+      "compress_mbps": 8.55,
+      "decompress_mbps": 41.68
     },
     {
       "compressor": "native",
@@ -924,8 +924,8 @@
       "level": 2,
       "out_size": 1764,
       "ratio": 0.4173,
-      "compress_mbps": 8.32,
-      "decompress_mbps": 43.04
+      "compress_mbps": 8.46,
+      "decompress_mbps": 42.94
     },
     {
       "compressor": "native",
@@ -934,8 +934,8 @@
       "level": 3,
       "out_size": 1765,
       "ratio": 0.4176,
-      "compress_mbps": 8.3,
-      "decompress_mbps": 43.45
+      "compress_mbps": 8.46,
+      "decompress_mbps": 42.97
     },
     {
       "compressor": "native",
@@ -944,8 +944,8 @@
       "level": 4,
       "out_size": 1747,
       "ratio": 0.4133,
-      "compress_mbps": 7.63,
-      "decompress_mbps": 44.2
+      "compress_mbps": 7.83,
+      "decompress_mbps": 43.65
     },
     {
       "compressor": "native",
@@ -954,8 +954,8 @@
       "level": 5,
       "out_size": 1747,
       "ratio": 0.4133,
-      "compress_mbps": 7.64,
-      "decompress_mbps": 44.13
+      "compress_mbps": 7.83,
+      "decompress_mbps": 43.63
     },
     {
       "compressor": "native",
@@ -964,8 +964,8 @@
       "level": 6,
       "out_size": 1747,
       "ratio": 0.4133,
-      "compress_mbps": 7.71,
-      "decompress_mbps": 44.19
+      "compress_mbps": 7.84,
+      "decompress_mbps": 43.87
     },
     {
       "compressor": "native",
@@ -974,8 +974,8 @@
       "level": 7,
       "out_size": 1747,
       "ratio": 0.4133,
-      "compress_mbps": 2.69,
-      "decompress_mbps": 44.13
+      "compress_mbps": 1.99,
+      "decompress_mbps": 43.83
     },
     {
       "compressor": "native",
@@ -984,8 +984,8 @@
       "level": 8,
       "out_size": 1747,
       "ratio": 0.4133,
-      "compress_mbps": 2.67,
-      "decompress_mbps": 43.99
+      "compress_mbps": 1.99,
+      "decompress_mbps": 43.61
     },
     {
       "compressor": "native",
@@ -994,8 +994,8 @@
       "level": 9,
       "out_size": 1747,
       "ratio": 0.4133,
-      "compress_mbps": 2.68,
-      "decompress_mbps": 44.01
+      "compress_mbps": 1.99,
+      "decompress_mbps": 43.58
     },
     {
       "compressor": "zlib",
@@ -1004,8 +1004,8 @@
       "level": 1,
       "out_size": 65130,
       "ratio": 0.4282,
-      "compress_mbps": 116.66,
-      "decompress_mbps": 392.68
+      "compress_mbps": 108.83,
+      "decompress_mbps": 398.25
     },
     {
       "compressor": "zlib",
@@ -1014,8 +1014,8 @@
       "level": 2,
       "out_size": 62270,
       "ratio": 0.4094,
-      "compress_mbps": 101.03,
-      "decompress_mbps": 412.26
+      "compress_mbps": 95.4,
+      "decompress_mbps": 416.94
     },
     {
       "compressor": "zlib",
@@ -1024,8 +1024,8 @@
       "level": 3,
       "out_size": 59488,
       "ratio": 0.3911,
-      "compress_mbps": 66.56,
-      "decompress_mbps": 427.97
+      "compress_mbps": 64.64,
+      "decompress_mbps": 431.24
     },
     {
       "compressor": "zlib",
@@ -1034,8 +1034,8 @@
       "level": 4,
       "out_size": 57679,
       "ratio": 0.3792,
-      "compress_mbps": 70.17,
-      "decompress_mbps": 404.96
+      "compress_mbps": 68.41,
+      "decompress_mbps": 410.86
     },
     {
       "compressor": "zlib",
@@ -1044,8 +1044,8 @@
       "level": 5,
       "out_size": 55616,
       "ratio": 0.3657,
-      "compress_mbps": 41.38,
-      "decompress_mbps": 396.75
+      "compress_mbps": 39.97,
+      "decompress_mbps": 397.65
     },
     {
       "compressor": "zlib",
@@ -1054,8 +1054,8 @@
       "level": 6,
       "out_size": 54398,
       "ratio": 0.3577,
-      "compress_mbps": 25.3,
-      "decompress_mbps": 410.31
+      "compress_mbps": 24.79,
+      "decompress_mbps": 410.88
     },
     {
       "compressor": "zlib",
@@ -1064,8 +1064,8 @@
       "level": 7,
       "out_size": 54253,
       "ratio": 0.3567,
-      "compress_mbps": 21.27,
-      "decompress_mbps": 413.12
+      "compress_mbps": 20.9,
+      "decompress_mbps": 415.0
     },
     {
       "compressor": "zlib",
@@ -1074,8 +1074,8 @@
       "level": 8,
       "out_size": 54164,
       "ratio": 0.3561,
-      "compress_mbps": 16.87,
-      "decompress_mbps": 412.86
+      "compress_mbps": 16.66,
+      "decompress_mbps": 413.76
     },
     {
       "compressor": "zlib",
@@ -1084,8 +1084,8 @@
       "level": 9,
       "out_size": 54164,
       "ratio": 0.3561,
-      "compress_mbps": 16.87,
-      "decompress_mbps": 414.31
+      "compress_mbps": 16.66,
+      "decompress_mbps": 412.13
     },
     {
       "compressor": "zlib",
@@ -1094,8 +1094,8 @@
       "level": 1,
       "out_size": 56791,
       "ratio": 0.4537,
-      "compress_mbps": 114.26,
-      "decompress_mbps": 384.65
+      "compress_mbps": 106.72,
+      "decompress_mbps": 391.42
     },
     {
       "compressor": "zlib",
@@ -1104,8 +1104,8 @@
       "level": 2,
       "out_size": 54652,
       "ratio": 0.4366,
-      "compress_mbps": 96.79,
-      "decompress_mbps": 399.2
+      "compress_mbps": 91.89,
+      "decompress_mbps": 401.22
     },
     {
       "compressor": "zlib",
@@ -1114,8 +1114,8 @@
       "level": 3,
       "out_size": 52663,
       "ratio": 0.4207,
-      "compress_mbps": 61.93,
-      "decompress_mbps": 419.07
+      "compress_mbps": 60.31,
+      "decompress_mbps": 419.77
     },
     {
       "compressor": "zlib",
@@ -1124,8 +1124,8 @@
       "level": 4,
       "out_size": 51266,
       "ratio": 0.4095,
-      "compress_mbps": 65.87,
-      "decompress_mbps": 391.22
+      "compress_mbps": 64.13,
+      "decompress_mbps": 396.04
     },
     {
       "compressor": "zlib",
@@ -1134,8 +1134,8 @@
       "level": 5,
       "out_size": 49622,
       "ratio": 0.3964,
-      "compress_mbps": 36.92,
-      "decompress_mbps": 380.92
+      "compress_mbps": 35.73,
+      "decompress_mbps": 364.46
     },
     {
       "compressor": "zlib",
@@ -1144,8 +1144,8 @@
       "level": 6,
       "out_size": 48891,
       "ratio": 0.3906,
-      "compress_mbps": 22.62,
-      "decompress_mbps": 388.75
+      "compress_mbps": 22.19,
+      "decompress_mbps": 389.64
     },
     {
       "compressor": "zlib",
@@ -1154,8 +1154,8 @@
       "level": 7,
       "out_size": 48801,
       "ratio": 0.3898,
-      "compress_mbps": 19.85,
-      "decompress_mbps": 387.25
+      "compress_mbps": 19.53,
+      "decompress_mbps": 388.5
     },
     {
       "compressor": "zlib",
@@ -1164,8 +1164,8 @@
       "level": 8,
       "out_size": 48772,
       "ratio": 0.3896,
-      "compress_mbps": 17.99,
-      "decompress_mbps": 388.66
+      "compress_mbps": 17.72,
+      "decompress_mbps": 386.5
     },
     {
       "compressor": "zlib",
@@ -1174,8 +1174,8 @@
       "level": 9,
       "out_size": 48772,
       "ratio": 0.3896,
-      "compress_mbps": 17.99,
-      "decompress_mbps": 388.33
+      "compress_mbps": 17.73,
+      "decompress_mbps": 387.62
     },
     {
       "compressor": "zlib",
@@ -1184,8 +1184,8 @@
       "level": 1,
       "out_size": 9028,
       "ratio": 0.3669,
-      "compress_mbps": 402.07,
-      "decompress_mbps": 1048.26
+      "compress_mbps": 369.01,
+      "decompress_mbps": 1037.32
     },
     {
       "compressor": "zlib",
@@ -1194,8 +1194,8 @@
       "level": 2,
       "out_size": 8811,
       "ratio": 0.3581,
-      "compress_mbps": 220.77,
-      "decompress_mbps": 1071.97
+      "compress_mbps": 209.43,
+      "decompress_mbps": 1061.59
     },
     {
       "compressor": "zlib",
@@ -1204,8 +1204,8 @@
       "level": 3,
       "out_size": 8616,
       "ratio": 0.3502,
-      "compress_mbps": 157.74,
-      "decompress_mbps": 1086.66
+      "compress_mbps": 150.45,
+      "decompress_mbps": 1079.91
     },
     {
       "compressor": "zlib",
@@ -1214,8 +1214,8 @@
       "level": 4,
       "out_size": 8219,
       "ratio": 0.3341,
-      "compress_mbps": 112.55,
-      "decompress_mbps": 1116.55
+      "compress_mbps": 109.43,
+      "decompress_mbps": 1116.5
     },
     {
       "compressor": "zlib",
@@ -1224,8 +1224,8 @@
       "level": 5,
       "out_size": 8001,
       "ratio": 0.3252,
-      "compress_mbps": 82.97,
-      "decompress_mbps": 1144.21
+      "compress_mbps": 79.68,
+      "decompress_mbps": 1139.55
     },
     {
       "compressor": "zlib",
@@ -1234,8 +1234,8 @@
       "level": 6,
       "out_size": 7955,
       "ratio": 0.3233,
-      "compress_mbps": 67.27,
-      "decompress_mbps": 1143.43
+      "compress_mbps": 64.4,
+      "decompress_mbps": 1140.93
     },
     {
       "compressor": "zlib",
@@ -1244,8 +1244,8 @@
       "level": 7,
       "out_size": 7933,
       "ratio": 0.3224,
-      "compress_mbps": 61.72,
-      "decompress_mbps": 1150.38
+      "compress_mbps": 59.47,
+      "decompress_mbps": 1143.82
     },
     {
       "compressor": "zlib",
@@ -1254,8 +1254,8 @@
       "level": 8,
       "out_size": 7934,
       "ratio": 0.3225,
-      "compress_mbps": 57.02,
-      "decompress_mbps": 1152.42
+      "compress_mbps": 54.93,
+      "decompress_mbps": 1146.45
     },
     {
       "compressor": "zlib",
@@ -1264,8 +1264,8 @@
       "level": 9,
       "out_size": 7934,
       "ratio": 0.3225,
-      "compress_mbps": 56.86,
-      "decompress_mbps": 1148.98
+      "compress_mbps": 54.72,
+      "decompress_mbps": 1143.82
     },
     {
       "compressor": "zlib",
@@ -1274,8 +1274,8 @@
       "level": 1,
       "out_size": 3647,
       "ratio": 0.3271,
-      "compress_mbps": 409.83,
-      "decompress_mbps": 1057.53
+      "compress_mbps": 394.17,
+      "decompress_mbps": 1051.88
     },
     {
       "compressor": "zlib",
@@ -1284,8 +1284,8 @@
       "level": 2,
       "out_size": 3501,
       "ratio": 0.314,
-      "compress_mbps": 395.03,
-      "decompress_mbps": 1103.74
+      "compress_mbps": 379.25,
+      "decompress_mbps": 1102.49
     },
     {
       "compressor": "zlib",
@@ -1294,8 +1294,8 @@
       "level": 3,
       "out_size": 3393,
       "ratio": 0.3043,
-      "compress_mbps": 329.17,
-      "decompress_mbps": 1132.06
+      "compress_mbps": 317.58,
+      "decompress_mbps": 1129.9
     },
     {
       "compressor": "zlib",
@@ -1304,8 +1304,8 @@
       "level": 4,
       "out_size": 3215,
       "ratio": 0.2883,
-      "compress_mbps": 265.19,
-      "decompress_mbps": 1162.0
+      "compress_mbps": 259.35,
+      "decompress_mbps": 1161.87
     },
     {
       "compressor": "zlib",
@@ -1314,8 +1314,8 @@
       "level": 5,
       "out_size": 3140,
       "ratio": 0.2816,
-      "compress_mbps": 198.22,
-      "decompress_mbps": 1191.83
+      "compress_mbps": 193.97,
+      "decompress_mbps": 1192.09
     },
     {
       "compressor": "zlib",
@@ -1324,8 +1324,8 @@
       "level": 6,
       "out_size": 3116,
       "ratio": 0.2795,
-      "compress_mbps": 150.1,
-      "decompress_mbps": 1206.43
+      "compress_mbps": 148.06,
+      "decompress_mbps": 1202.61
     },
     {
       "compressor": "zlib",
@@ -1334,8 +1334,8 @@
       "level": 7,
       "out_size": 3112,
       "ratio": 0.2791,
-      "compress_mbps": 129.2,
-      "decompress_mbps": 1209.17
+      "compress_mbps": 127.23,
+      "decompress_mbps": 1210.14
     },
     {
       "compressor": "zlib",
@@ -1344,8 +1344,8 @@
       "level": 8,
       "out_size": 3109,
       "ratio": 0.2788,
-      "compress_mbps": 109.15,
-      "decompress_mbps": 1209.86
+      "compress_mbps": 107.31,
+      "decompress_mbps": 1209.72
     },
     {
       "compressor": "zlib",
@@ -1354,8 +1354,8 @@
       "level": 9,
       "out_size": 3109,
       "ratio": 0.2788,
-      "compress_mbps": 108.29,
-      "decompress_mbps": 1210.55
+      "compress_mbps": 107.16,
+      "decompress_mbps": 1212.21
     },
     {
       "compressor": "zlib",
@@ -1364,8 +1364,8 @@
       "level": 1,
       "out_size": 1326,
       "ratio": 0.3564,
-      "compress_mbps": 306.76,
-      "decompress_mbps": 775.82
+      "compress_mbps": 296.83,
+      "decompress_mbps": 767.93
     },
     {
       "compressor": "zlib",
@@ -1374,8 +1374,8 @@
       "level": 2,
       "out_size": 1306,
       "ratio": 0.351,
-      "compress_mbps": 300.81,
-      "decompress_mbps": 773.29
+      "compress_mbps": 290.51,
+      "decompress_mbps": 772.45
     },
     {
       "compressor": "zlib",
@@ -1384,8 +1384,8 @@
       "level": 3,
       "out_size": 1301,
       "ratio": 0.3496,
-      "compress_mbps": 283.12,
-      "decompress_mbps": 778.72
+      "compress_mbps": 274.53,
+      "decompress_mbps": 776.33
     },
     {
       "compressor": "zlib",
@@ -1394,8 +1394,8 @@
       "level": 4,
       "out_size": 1228,
       "ratio": 0.33,
-      "compress_mbps": 218.61,
-      "decompress_mbps": 816.53
+      "compress_mbps": 219.85,
+      "decompress_mbps": 805.22
     },
     {
       "compressor": "zlib",
@@ -1404,8 +1404,8 @@
       "level": 5,
       "out_size": 1216,
       "ratio": 0.3268,
-      "compress_mbps": 186.0,
-      "decompress_mbps": 817.47
+      "compress_mbps": 185.68,
+      "decompress_mbps": 806.14
     },
     {
       "compressor": "zlib",
@@ -1414,8 +1414,8 @@
       "level": 6,
       "out_size": 1216,
       "ratio": 0.3268,
-      "compress_mbps": 168.44,
-      "decompress_mbps": 808.34
+      "compress_mbps": 167.67,
+      "decompress_mbps": 804.49
     },
     {
       "compressor": "zlib",
@@ -1424,8 +1424,8 @@
       "level": 7,
       "out_size": 1216,
       "ratio": 0.3268,
-      "compress_mbps": 161.62,
-      "decompress_mbps": 818.22
+      "compress_mbps": 160.34,
+      "decompress_mbps": 804.86
     },
     {
       "compressor": "zlib",
@@ -1434,8 +1434,8 @@
       "level": 8,
       "out_size": 1216,
       "ratio": 0.3268,
-      "compress_mbps": 159.2,
-      "decompress_mbps": 808.53
+      "compress_mbps": 157.98,
+      "decompress_mbps": 803.22
     },
     {
       "compressor": "zlib",
@@ -1444,8 +1444,8 @@
       "level": 9,
       "out_size": 1216,
       "ratio": 0.3268,
-      "compress_mbps": 159.07,
-      "decompress_mbps": 808.89
+      "compress_mbps": 158.0,
+      "decompress_mbps": 803.58
     },
     {
       "compressor": "zlib",
@@ -1454,8 +1454,8 @@
       "level": 1,
       "out_size": 242293,
       "ratio": 0.2353,
-      "compress_mbps": 255.12,
-      "decompress_mbps": 835.7
+      "compress_mbps": 241.25,
+      "decompress_mbps": 833.07
     },
     {
       "compressor": "zlib",
@@ -1464,8 +1464,8 @@
       "level": 2,
       "out_size": 233553,
       "ratio": 0.2268,
-      "compress_mbps": 245.29,
-      "decompress_mbps": 987.93
+      "compress_mbps": 233.79,
+      "decompress_mbps": 986.99
     },
     {
       "compressor": "zlib",
@@ -1474,8 +1474,8 @@
       "level": 3,
       "out_size": 228222,
       "ratio": 0.2216,
-      "compress_mbps": 193.73,
-      "decompress_mbps": 1049.64
+      "compress_mbps": 185.97,
+      "decompress_mbps": 1043.94
     },
     {
       "compressor": "zlib",
@@ -1484,8 +1484,8 @@
       "level": 4,
       "out_size": 223668,
       "ratio": 0.2172,
-      "compress_mbps": 173.17,
-      "decompress_mbps": 1081.64
+      "compress_mbps": 170.4,
+      "decompress_mbps": 1073.87
     },
     {
       "compressor": "zlib",
@@ -1494,8 +1494,8 @@
       "level": 5,
       "out_size": 205994,
       "ratio": 0.2,
-      "compress_mbps": 108.61,
-      "decompress_mbps": 1032.04
+      "compress_mbps": 105.2,
+      "decompress_mbps": 1033.3
     },
     {
       "compressor": "zlib",
@@ -1504,8 +1504,8 @@
       "level": 6,
       "out_size": 203986,
       "ratio": 0.1981,
-      "compress_mbps": 49.69,
-      "decompress_mbps": 1037.12
+      "compress_mbps": 48.72,
+      "decompress_mbps": 1033.88
     },
     {
       "compressor": "zlib",
@@ -1514,8 +1514,8 @@
       "level": 7,
       "out_size": 207681,
       "ratio": 0.2017,
-      "compress_mbps": 36.76,
-      "decompress_mbps": 1032.21
+      "compress_mbps": 36.32,
+      "decompress_mbps": 1003.23
     },
     {
       "compressor": "zlib",
@@ -1524,8 +1524,8 @@
       "level": 8,
       "out_size": 206827,
       "ratio": 0.2009,
-      "compress_mbps": 7.25,
-      "decompress_mbps": 1003.22
+      "compress_mbps": 7.22,
+      "decompress_mbps": 999.92
     },
     {
       "compressor": "zlib",
@@ -1534,8 +1534,8 @@
       "level": 9,
       "out_size": 207023,
       "ratio": 0.201,
-      "compress_mbps": 3.41,
-      "decompress_mbps": 1009.2
+      "compress_mbps": 3.4,
+      "decompress_mbps": 997.22
     },
     {
       "compressor": "zlib",
@@ -1544,8 +1544,8 @@
       "level": 1,
       "out_size": 174124,
       "ratio": 0.408,
-      "compress_mbps": 122.89,
-      "decompress_mbps": 394.78
+      "compress_mbps": 113.97,
+      "decompress_mbps": 389.99
     },
     {
       "compressor": "zlib",
@@ -1554,8 +1554,8 @@
       "level": 2,
       "out_size": 166150,
       "ratio": 0.3893,
-      "compress_mbps": 104.49,
-      "decompress_mbps": 405.1
+      "compress_mbps": 98.51,
+      "decompress_mbps": 401.7
     },
     {
       "compressor": "zlib",
@@ -1564,8 +1564,8 @@
       "level": 3,
       "out_size": 158784,
       "ratio": 0.3721,
-      "compress_mbps": 70.0,
-      "decompress_mbps": 424.31
+      "compress_mbps": 67.56,
+      "decompress_mbps": 415.47
     },
     {
       "compressor": "zlib",
@@ -1574,8 +1574,8 @@
       "level": 4,
       "out_size": 152782,
       "ratio": 0.358,
-      "compress_mbps": 72.68,
-      "decompress_mbps": 410.58
+      "compress_mbps": 70.33,
+      "decompress_mbps": 404.62
     },
     {
       "compressor": "zlib",
@@ -1584,8 +1584,8 @@
       "level": 5,
       "out_size": 147196,
       "ratio": 0.3449,
-      "compress_mbps": 43.24,
-      "decompress_mbps": 406.39
+      "compress_mbps": 41.42,
+      "decompress_mbps": 399.45
     },
     {
       "compressor": "zlib",
@@ -1594,8 +1594,8 @@
       "level": 6,
       "out_size": 144898,
       "ratio": 0.3395,
-      "compress_mbps": 26.31,
-      "decompress_mbps": 417.01
+      "compress_mbps": 25.59,
+      "decompress_mbps": 412.66
     },
     {
       "compressor": "zlib",
@@ -1604,8 +1604,8 @@
       "level": 7,
       "out_size": 144589,
       "ratio": 0.3388,
-      "compress_mbps": 22.85,
-      "decompress_mbps": 419.31
+      "compress_mbps": 22.24,
+      "decompress_mbps": 416.18
     },
     {
       "compressor": "zlib",
@@ -1614,8 +1614,8 @@
       "level": 8,
       "out_size": 144436,
       "ratio": 0.3385,
-      "compress_mbps": 19.63,
-      "decompress_mbps": 419.67
+      "compress_mbps": 19.19,
+      "decompress_mbps": 415.75
     },
     {
       "compressor": "zlib",
@@ -1624,8 +1624,8 @@
       "level": 9,
       "out_size": 144433,
       "ratio": 0.3384,
-      "compress_mbps": 19.57,
-      "decompress_mbps": 419.94
+      "compress_mbps": 19.09,
+      "decompress_mbps": 399.56
     },
     {
       "compressor": "zlib",
@@ -1634,8 +1634,8 @@
       "level": 1,
       "out_size": 228883,
       "ratio": 0.475,
-      "compress_mbps": 107.6,
-      "decompress_mbps": 370.32
+      "compress_mbps": 97.97,
+      "decompress_mbps": 369.75
     },
     {
       "compressor": "zlib",
@@ -1644,8 +1644,8 @@
       "level": 2,
       "out_size": 219047,
       "ratio": 0.4546,
-      "compress_mbps": 90.6,
-      "decompress_mbps": 384.8
+      "compress_mbps": 85.46,
+      "decompress_mbps": 386.45
     },
     {
       "compressor": "zlib",
@@ -1654,8 +1654,8 @@
       "level": 3,
       "out_size": 209408,
       "ratio": 0.4346,
-      "compress_mbps": 55.25,
-      "decompress_mbps": 403.02
+      "compress_mbps": 53.61,
+      "decompress_mbps": 398.69
     },
     {
       "compressor": "zlib",
@@ -1664,8 +1664,8 @@
       "level": 4,
       "out_size": 205916,
       "ratio": 0.4273,
-      "compress_mbps": 61.47,
-      "decompress_mbps": 377.18
+      "compress_mbps": 58.95,
+      "decompress_mbps": 363.83
     },
     {
       "compressor": "zlib",
@@ -1674,8 +1674,8 @@
       "level": 5,
       "out_size": 199188,
       "ratio": 0.4134,
-      "compress_mbps": 32.96,
-      "decompress_mbps": 360.71
+      "compress_mbps": 30.77,
+      "decompress_mbps": 342.17
     },
     {
       "compressor": "zlib",
@@ -1684,8 +1684,8 @@
       "level": 6,
       "out_size": 195255,
       "ratio": 0.4052,
-      "compress_mbps": 19.36,
-      "decompress_mbps": 369.43
+      "compress_mbps": 18.47,
+      "decompress_mbps": 352.81
     },
     {
       "compressor": "zlib",
@@ -1694,8 +1694,8 @@
       "level": 7,
       "out_size": 194657,
       "ratio": 0.404,
-      "compress_mbps": 16.4,
-      "decompress_mbps": 369.25
+      "compress_mbps": 15.7,
+      "decompress_mbps": 354.02
     },
     {
       "compressor": "zlib",
@@ -1704,8 +1704,8 @@
       "level": 8,
       "out_size": 194326,
       "ratio": 0.4033,
-      "compress_mbps": 12.95,
-      "decompress_mbps": 367.84
+      "compress_mbps": 12.45,
+      "decompress_mbps": 355.13
     },
     {
       "compressor": "zlib",
@@ -1714,8 +1714,8 @@
       "level": 9,
       "out_size": 194326,
       "ratio": 0.4033,
-      "compress_mbps": 12.94,
-      "decompress_mbps": 368.12
+      "compress_mbps": 12.46,
+      "decompress_mbps": 356.35
     },
     {
       "compressor": "zlib",
@@ -1724,8 +1724,8 @@
       "level": 1,
       "out_size": 65553,
       "ratio": 0.1277,
-      "compress_mbps": 274.16,
-      "decompress_mbps": 895.61
+      "compress_mbps": 248.19,
+      "decompress_mbps": 842.58
     },
     {
       "compressor": "zlib",
@@ -1734,8 +1734,8 @@
       "level": 2,
       "out_size": 63891,
       "ratio": 0.1245,
-      "compress_mbps": 247.42,
-      "decompress_mbps": 922.32
+      "compress_mbps": 225.7,
+      "decompress_mbps": 875.67
     },
     {
       "compressor": "zlib",
@@ -1744,8 +1744,8 @@
       "level": 3,
       "out_size": 62515,
       "ratio": 0.1218,
-      "compress_mbps": 194.16,
-      "decompress_mbps": 982.39
+      "compress_mbps": 179.55,
+      "decompress_mbps": 937.94
     },
     {
       "compressor": "zlib",
@@ -1754,8 +1754,8 @@
       "level": 4,
       "out_size": 58451,
       "ratio": 0.1139,
-      "compress_mbps": 165.85,
-      "decompress_mbps": 699.2
+      "compress_mbps": 156.37,
+      "decompress_mbps": 673.71
     },
     {
       "compressor": "zlib",
@@ -1764,8 +1764,8 @@
       "level": 5,
       "out_size": 57410,
       "ratio": 0.1119,
-      "compress_mbps": 128.59,
-      "decompress_mbps": 727.84
+      "compress_mbps": 120.22,
+      "decompress_mbps": 702.17
     },
     {
       "compressor": "zlib",
@@ -1774,8 +1774,8 @@
       "level": 6,
       "out_size": 56459,
       "ratio": 0.11,
-      "compress_mbps": 76.88,
-      "decompress_mbps": 777.41
+      "compress_mbps": 73.11,
+      "decompress_mbps": 749.46
     },
     {
       "compressor": "zlib",
@@ -1784,8 +1784,8 @@
       "level": 7,
       "out_size": 55358,
       "ratio": 0.1079,
-      "compress_mbps": 60.21,
-      "decompress_mbps": 813.71
+      "compress_mbps": 57.68,
+      "decompress_mbps": 784.91
     },
     {
       "compressor": "zlib",
@@ -1794,8 +1794,8 @@
       "level": 8,
       "out_size": 52991,
       "ratio": 0.1033,
-      "compress_mbps": 27.45,
-      "decompress_mbps": 868.33
+      "compress_mbps": 26.69,
+      "decompress_mbps": 832.31
     },
     {
       "compressor": "zlib",
@@ -1804,8 +1804,8 @@
       "level": 9,
       "out_size": 52215,
       "ratio": 0.1017,
-      "compress_mbps": 9.81,
-      "decompress_mbps": 884.46
+      "compress_mbps": 9.63,
+      "decompress_mbps": 845.93
     },
     {
       "compressor": "zlib",
@@ -1814,8 +1814,8 @@
       "level": 1,
       "out_size": 14112,
       "ratio": 0.369,
-      "compress_mbps": 127.64,
-      "decompress_mbps": 932.27
+      "compress_mbps": 115.04,
+      "decompress_mbps": 927.9
     },
     {
       "compressor": "zlib",
@@ -1824,8 +1824,8 @@
       "level": 2,
       "out_size": 13815,
       "ratio": 0.3613,
-      "compress_mbps": 109.08,
-      "decompress_mbps": 967.49
+      "compress_mbps": 99.04,
+      "decompress_mbps": 962.84
     },
     {
       "compressor": "zlib",
@@ -1834,8 +1834,8 @@
       "level": 3,
       "out_size": 13795,
       "ratio": 0.3607,
-      "compress_mbps": 78.91,
-      "decompress_mbps": 995.81
+      "compress_mbps": 72.76,
+      "decompress_mbps": 996.3
     },
     {
       "compressor": "zlib",
@@ -1844,8 +1844,8 @@
       "level": 4,
       "out_size": 13375,
       "ratio": 0.3498,
-      "compress_mbps": 79.14,
-      "decompress_mbps": 991.1
+      "compress_mbps": 73.51,
+      "decompress_mbps": 995.7
     },
     {
       "compressor": "zlib",
@@ -1854,8 +1854,8 @@
       "level": 5,
       "out_size": 13062,
       "ratio": 0.3416,
-      "compress_mbps": 55.01,
-      "decompress_mbps": 1026.44
+      "compress_mbps": 51.04,
+      "decompress_mbps": 1023.71
     },
     {
       "compressor": "zlib",
@@ -1864,8 +1864,8 @@
       "level": 6,
       "out_size": 12984,
       "ratio": 0.3395,
-      "compress_mbps": 32.85,
-      "decompress_mbps": 1049.63
+      "compress_mbps": 30.99,
+      "decompress_mbps": 1044.64
     },
     {
       "compressor": "zlib",
@@ -1874,8 +1874,8 @@
       "level": 7,
       "out_size": 12949,
       "ratio": 0.3386,
-      "compress_mbps": 25.24,
-      "decompress_mbps": 1051.54
+      "compress_mbps": 24.13,
+      "decompress_mbps": 1040.59
     },
     {
       "compressor": "zlib",
@@ -1884,8 +1884,8 @@
       "level": 8,
       "out_size": 12894,
       "ratio": 0.3372,
-      "compress_mbps": 11.01,
-      "decompress_mbps": 1068.2
+      "compress_mbps": 10.76,
+      "decompress_mbps": 1059.42
     },
     {
       "compressor": "zlib",
@@ -1894,8 +1894,8 @@
       "level": 9,
       "out_size": 12832,
       "ratio": 0.3356,
-      "compress_mbps": 5.06,
-      "decompress_mbps": 1073.93
+      "compress_mbps": 5.0,
+      "decompress_mbps": 1070.93
     },
     {
       "compressor": "zlib",
@@ -1904,8 +1904,8 @@
       "level": 1,
       "out_size": 1846,
       "ratio": 0.4367,
-      "compress_mbps": 281.76,
-      "decompress_mbps": 702.91
+      "compress_mbps": 271.2,
+      "decompress_mbps": 693.95
     },
     {
       "compressor": "zlib",
@@ -1914,8 +1914,8 @@
       "level": 2,
       "out_size": 1820,
       "ratio": 0.4306,
-      "compress_mbps": 275.17,
-      "decompress_mbps": 716.65
+      "compress_mbps": 266.49,
+      "decompress_mbps": 707.85
     },
     {
       "compressor": "zlib",
@@ -1924,8 +1924,8 @@
       "level": 3,
       "out_size": 1808,
       "ratio": 0.4277,
-      "compress_mbps": 264.17,
-      "decompress_mbps": 725.95
+      "compress_mbps": 254.57,
+      "decompress_mbps": 715.51
     },
     {
       "compressor": "zlib",
@@ -1934,8 +1934,8 @@
       "level": 4,
       "out_size": 1749,
       "ratio": 0.4138,
-      "compress_mbps": 216.92,
-      "decompress_mbps": 737.37
+      "compress_mbps": 211.82,
+      "decompress_mbps": 732.01
     },
     {
       "compressor": "zlib",
@@ -1944,8 +1944,8 @@
       "level": 5,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 190.14,
-      "decompress_mbps": 748.32
+      "compress_mbps": 185.87,
+      "decompress_mbps": 737.23
     },
     {
       "compressor": "zlib",
@@ -1954,8 +1954,8 @@
       "level": 6,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 188.28,
-      "decompress_mbps": 748.32
+      "compress_mbps": 183.53,
+      "decompress_mbps": 737.77
     },
     {
       "compressor": "zlib",
@@ -1964,8 +1964,8 @@
       "level": 7,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 185.07,
-      "decompress_mbps": 748.32
+      "compress_mbps": 181.41,
+      "decompress_mbps": 736.42
     },
     {
       "compressor": "zlib",
@@ -1974,8 +1974,8 @@
       "level": 8,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 185.25,
-      "decompress_mbps": 745.27
+      "compress_mbps": 181.05,
+      "decompress_mbps": 738.72
     },
     {
       "compressor": "zlib",
@@ -1984,8 +1984,8 @@
       "level": 9,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 185.27,
-      "decompress_mbps": 744.58
+      "compress_mbps": 181.32,
+      "decompress_mbps": 737.77
     },
     {
       "compressor": "miniz_oxide",
@@ -1994,8 +1994,8 @@
       "level": 1,
       "out_size": 76470,
       "ratio": 0.5028,
-      "compress_mbps": 153.81,
-      "decompress_mbps": 455.74
+      "compress_mbps": 150.27,
+      "decompress_mbps": 432.95
     },
     {
       "compressor": "miniz_oxide",
@@ -2004,8 +2004,8 @@
       "level": 2,
       "out_size": 62765,
       "ratio": 0.4127,
-      "compress_mbps": 131.47,
-      "decompress_mbps": 505.37
+      "compress_mbps": 127.77,
+      "decompress_mbps": 483.9
     },
     {
       "compressor": "miniz_oxide",
@@ -2014,8 +2014,8 @@
       "level": 3,
       "out_size": 57162,
       "ratio": 0.3758,
-      "compress_mbps": 71.94,
-      "decompress_mbps": 561.74
+      "compress_mbps": 70.44,
+      "decompress_mbps": 539.53
     },
     {
       "compressor": "miniz_oxide",
@@ -2024,8 +2024,8 @@
       "level": 4,
       "out_size": 56826,
       "ratio": 0.3736,
-      "compress_mbps": 63.87,
-      "decompress_mbps": 545.05
+      "compress_mbps": 62.34,
+      "decompress_mbps": 522.64
     },
     {
       "compressor": "miniz_oxide",
@@ -2034,8 +2034,8 @@
       "level": 5,
       "out_size": 55696,
       "ratio": 0.3662,
-      "compress_mbps": 46.55,
-      "decompress_mbps": 536.21
+      "compress_mbps": 45.66,
+      "decompress_mbps": 513.12
     },
     {
       "compressor": "miniz_oxide",
@@ -2044,8 +2044,8 @@
       "level": 6,
       "out_size": 54440,
       "ratio": 0.3579,
-      "compress_mbps": 26.47,
-      "decompress_mbps": 552.4
+      "compress_mbps": 26.11,
+      "decompress_mbps": 529.06
     },
     {
       "compressor": "miniz_oxide",
@@ -2054,8 +2054,8 @@
       "level": 7,
       "out_size": 54283,
       "ratio": 0.3569,
-      "compress_mbps": 22.33,
-      "decompress_mbps": 551.7
+      "compress_mbps": 22.09,
+      "decompress_mbps": 529.64
     },
     {
       "compressor": "miniz_oxide",
@@ -2064,8 +2064,8 @@
       "level": 8,
       "out_size": 54221,
       "ratio": 0.3565,
-      "compress_mbps": 19.66,
-      "decompress_mbps": 548.72
+      "compress_mbps": 19.48,
+      "decompress_mbps": 526.99
     },
     {
       "compressor": "miniz_oxide",
@@ -2074,8 +2074,8 @@
       "level": 9,
       "out_size": 54217,
       "ratio": 0.3565,
-      "compress_mbps": 19.42,
-      "decompress_mbps": 550.94
+      "compress_mbps": 19.24,
+      "decompress_mbps": 525.64
     },
     {
       "compressor": "miniz_oxide",
@@ -2084,8 +2084,8 @@
       "level": 1,
       "out_size": 64926,
       "ratio": 0.5187,
-      "compress_mbps": 148.34,
-      "decompress_mbps": 435.51
+      "compress_mbps": 143.06,
+      "decompress_mbps": 417.71
     },
     {
       "compressor": "miniz_oxide",
@@ -2094,8 +2094,8 @@
       "level": 2,
       "out_size": 54985,
       "ratio": 0.4393,
-      "compress_mbps": 123.31,
-      "decompress_mbps": 482.04
+      "compress_mbps": 119.32,
+      "decompress_mbps": 462.97
     },
     {
       "compressor": "miniz_oxide",
@@ -2104,8 +2104,8 @@
       "level": 3,
       "out_size": 51148,
       "ratio": 0.4086,
-      "compress_mbps": 66.89,
-      "decompress_mbps": 547.34
+      "compress_mbps": 65.32,
+      "decompress_mbps": 529.35
     },
     {
       "compressor": "miniz_oxide",
@@ -2114,8 +2114,8 @@
       "level": 4,
       "out_size": 50599,
       "ratio": 0.4042,
-      "compress_mbps": 58.67,
-      "decompress_mbps": 532.3
+      "compress_mbps": 57.53,
+      "decompress_mbps": 518.03
     },
     {
       "compressor": "miniz_oxide",
@@ -2124,8 +2124,8 @@
       "level": 5,
       "out_size": 49775,
       "ratio": 0.3976,
-      "compress_mbps": 42.46,
-      "decompress_mbps": 514.06
+      "compress_mbps": 41.73,
+      "decompress_mbps": 499.52
     },
     {
       "compressor": "miniz_oxide",
@@ -2134,8 +2134,8 @@
       "level": 6,
       "out_size": 48967,
       "ratio": 0.3912,
-      "compress_mbps": 24.9,
-      "decompress_mbps": 531.4
+      "compress_mbps": 24.62,
+      "decompress_mbps": 512.54
     },
     {
       "compressor": "miniz_oxide",
@@ -2144,8 +2144,8 @@
       "level": 7,
       "out_size": 48870,
       "ratio": 0.3904,
-      "compress_mbps": 22.08,
-      "decompress_mbps": 530.26
+      "compress_mbps": 21.9,
+      "decompress_mbps": 514.83
     },
     {
       "compressor": "miniz_oxide",
@@ -2154,8 +2154,8 @@
       "level": 8,
       "out_size": 48845,
       "ratio": 0.3902,
-      "compress_mbps": 20.84,
-      "decompress_mbps": 531.93
+      "compress_mbps": 20.63,
+      "decompress_mbps": 512.74
     },
     {
       "compressor": "miniz_oxide",
@@ -2164,8 +2164,8 @@
       "level": 9,
       "out_size": 48845,
       "ratio": 0.3902,
-      "compress_mbps": 20.83,
-      "decompress_mbps": 532.55
+      "compress_mbps": 20.64,
+      "decompress_mbps": 515.62
     },
     {
       "compressor": "miniz_oxide",
@@ -2174,8 +2174,8 @@
       "level": 1,
       "out_size": 10024,
       "ratio": 0.4074,
-      "compress_mbps": 565.34,
-      "decompress_mbps": 892.68
+      "compress_mbps": 566.83,
+      "decompress_mbps": 892.55
     },
     {
       "compressor": "miniz_oxide",
@@ -2184,8 +2184,8 @@
       "level": 2,
       "out_size": 8577,
       "ratio": 0.3486,
-      "compress_mbps": 254.79,
-      "decompress_mbps": 926.16
+      "compress_mbps": 257.0,
+      "decompress_mbps": 917.07
     },
     {
       "compressor": "miniz_oxide",
@@ -2194,8 +2194,8 @@
       "level": 3,
       "out_size": 8168,
       "ratio": 0.332,
-      "compress_mbps": 153.77,
-      "decompress_mbps": 940.94
+      "compress_mbps": 154.22,
+      "decompress_mbps": 936.84
     },
     {
       "compressor": "miniz_oxide",
@@ -2204,8 +2204,8 @@
       "level": 4,
       "out_size": 8069,
       "ratio": 0.328,
-      "compress_mbps": 115.12,
-      "decompress_mbps": 966.16
+      "compress_mbps": 111.63,
+      "decompress_mbps": 957.41
     },
     {
       "compressor": "miniz_oxide",
@@ -2214,8 +2214,8 @@
       "level": 5,
       "out_size": 7997,
       "ratio": 0.325,
-      "compress_mbps": 99.69,
-      "decompress_mbps": 996.87
+      "compress_mbps": 96.07,
+      "decompress_mbps": 917.79
     },
     {
       "compressor": "miniz_oxide",
@@ -2224,8 +2224,8 @@
       "level": 6,
       "out_size": 7952,
       "ratio": 0.3232,
-      "compress_mbps": 74.93,
-      "decompress_mbps": 1003.56
+      "compress_mbps": 73.05,
+      "decompress_mbps": 994.88
     },
     {
       "compressor": "miniz_oxide",
@@ -2234,8 +2234,8 @@
       "level": 7,
       "out_size": 7947,
       "ratio": 0.323,
-      "compress_mbps": 72.24,
-      "decompress_mbps": 1007.66
+      "compress_mbps": 70.59,
+      "decompress_mbps": 1000.61
     },
     {
       "compressor": "miniz_oxide",
@@ -2244,8 +2244,8 @@
       "level": 8,
       "out_size": 7947,
       "ratio": 0.323,
-      "compress_mbps": 71.04,
-      "decompress_mbps": 1008.04
+      "compress_mbps": 69.48,
+      "decompress_mbps": 1001.5
     },
     {
       "compressor": "miniz_oxide",
@@ -2254,8 +2254,8 @@
       "level": 9,
       "out_size": 7947,
       "ratio": 0.323,
-      "compress_mbps": 70.54,
-      "decompress_mbps": 1007.61
+      "compress_mbps": 69.29,
+      "decompress_mbps": 1001.5
     },
     {
       "compressor": "miniz_oxide",
@@ -2264,8 +2264,8 @@
       "level": 1,
       "out_size": 4061,
       "ratio": 0.3642,
-      "compress_mbps": 503.76,
-      "decompress_mbps": 855.54
+      "compress_mbps": 505.2,
+      "decompress_mbps": 850.54
     },
     {
       "compressor": "miniz_oxide",
@@ -2274,8 +2274,8 @@
       "level": 2,
       "out_size": 3446,
       "ratio": 0.3091,
-      "compress_mbps": 305.74,
-      "decompress_mbps": 894.77
+      "compress_mbps": 302.5,
+      "decompress_mbps": 889.61
     },
     {
       "compressor": "miniz_oxide",
@@ -2284,8 +2284,8 @@
       "level": 3,
       "out_size": 3201,
       "ratio": 0.2871,
-      "compress_mbps": 234.68,
-      "decompress_mbps": 923.93
+      "compress_mbps": 234.21,
+      "decompress_mbps": 918.66
     },
     {
       "compressor": "miniz_oxide",
@@ -2294,8 +2294,8 @@
       "level": 4,
       "out_size": 3168,
       "ratio": 0.2841,
-      "compress_mbps": 194.17,
-      "decompress_mbps": 950.78
+      "compress_mbps": 194.41,
+      "decompress_mbps": 942.35
     },
     {
       "compressor": "miniz_oxide",
@@ -2304,8 +2304,8 @@
       "level": 5,
       "out_size": 3139,
       "ratio": 0.2815,
-      "compress_mbps": 161.99,
-      "decompress_mbps": 971.27
+      "compress_mbps": 161.87,
+      "decompress_mbps": 959.44
     },
     {
       "compressor": "miniz_oxide",
@@ -2314,8 +2314,8 @@
       "level": 6,
       "out_size": 3115,
       "ratio": 0.2794,
-      "compress_mbps": 116.27,
-      "decompress_mbps": 979.95
+      "compress_mbps": 116.33,
+      "decompress_mbps": 972.6
     },
     {
       "compressor": "miniz_oxide",
@@ -2324,8 +2324,8 @@
       "level": 7,
       "out_size": 3112,
       "ratio": 0.2791,
-      "compress_mbps": 105.86,
-      "decompress_mbps": 981.76
+      "compress_mbps": 105.3,
+      "decompress_mbps": 975.28
     },
     {
       "compressor": "miniz_oxide",
@@ -2334,8 +2334,8 @@
       "level": 8,
       "out_size": 3112,
       "ratio": 0.2791,
-      "compress_mbps": 102.83,
-      "decompress_mbps": 983.21
+      "compress_mbps": 102.96,
+      "decompress_mbps": 978.87
     },
     {
       "compressor": "miniz_oxide",
@@ -2344,8 +2344,8 @@
       "level": 9,
       "out_size": 3112,
       "ratio": 0.2791,
-      "compress_mbps": 102.4,
-      "decompress_mbps": 983.76
+      "compress_mbps": 102.26,
+      "decompress_mbps": 974.3
     },
     {
       "compressor": "miniz_oxide",
@@ -2354,8 +2354,8 @@
       "level": 1,
       "out_size": 1410,
       "ratio": 0.3789,
-      "compress_mbps": 364.67,
-      "decompress_mbps": 589.57
+      "compress_mbps": 363.7,
+      "decompress_mbps": 582.41
     },
     {
       "compressor": "miniz_oxide",
@@ -2364,8 +2364,8 @@
       "level": 2,
       "out_size": 1262,
       "ratio": 0.3392,
-      "compress_mbps": 236.31,
-      "decompress_mbps": 591.44
+      "compress_mbps": 236.81,
+      "decompress_mbps": 593.22
     },
     {
       "compressor": "miniz_oxide",
@@ -2374,8 +2374,8 @@
       "level": 3,
       "out_size": 1238,
       "ratio": 0.3327,
-      "compress_mbps": 207.04,
-      "decompress_mbps": 597.11
+      "compress_mbps": 206.38,
+      "decompress_mbps": 593.81
     },
     {
       "compressor": "miniz_oxide",
@@ -2384,8 +2384,8 @@
       "level": 4,
       "out_size": 1219,
       "ratio": 0.3276,
-      "compress_mbps": 176.37,
-      "decompress_mbps": 619.74
+      "compress_mbps": 176.18,
+      "decompress_mbps": 611.62
     },
     {
       "compressor": "miniz_oxide",
@@ -2394,8 +2394,8 @@
       "level": 5,
       "out_size": 1216,
       "ratio": 0.3268,
-      "compress_mbps": 162.58,
-      "decompress_mbps": 626.19
+      "compress_mbps": 162.06,
+      "decompress_mbps": 617.15
     },
     {
       "compressor": "miniz_oxide",
@@ -2405,7 +2405,7 @@
       "out_size": 1216,
       "ratio": 0.3268,
       "compress_mbps": 146.86,
-      "decompress_mbps": 623.0
+      "decompress_mbps": 614.8
     },
     {
       "compressor": "miniz_oxide",
@@ -2414,8 +2414,8 @@
       "level": 7,
       "out_size": 1216,
       "ratio": 0.3268,
-      "compress_mbps": 146.58,
-      "decompress_mbps": 627.3
+      "compress_mbps": 146.07,
+      "decompress_mbps": 619.63
     },
     {
       "compressor": "miniz_oxide",
@@ -2424,8 +2424,8 @@
       "level": 8,
       "out_size": 1216,
       "ratio": 0.3268,
-      "compress_mbps": 147.18,
-      "decompress_mbps": 626.85
+      "compress_mbps": 145.73,
+      "decompress_mbps": 618.87
     },
     {
       "compressor": "miniz_oxide",
@@ -2434,8 +2434,8 @@
       "level": 9,
       "out_size": 1216,
       "ratio": 0.3268,
-      "compress_mbps": 147.14,
-      "decompress_mbps": 624.76
+      "compress_mbps": 145.72,
+      "decompress_mbps": 618.33
     },
     {
       "compressor": "miniz_oxide",
@@ -2444,8 +2444,8 @@
       "level": 1,
       "out_size": 274412,
       "ratio": 0.2665,
-      "compress_mbps": 443.67,
-      "decompress_mbps": 798.16
+      "compress_mbps": 436.12,
+      "decompress_mbps": 784.24
     },
     {
       "compressor": "miniz_oxide",
@@ -2454,8 +2454,8 @@
       "level": 2,
       "out_size": 213239,
       "ratio": 0.2071,
-      "compress_mbps": 274.09,
-      "decompress_mbps": 899.64
+      "compress_mbps": 266.58,
+      "decompress_mbps": 886.54
     },
     {
       "compressor": "miniz_oxide",
@@ -2464,8 +2464,8 @@
       "level": 3,
       "out_size": 232107,
       "ratio": 0.2254,
-      "compress_mbps": 136.27,
-      "decompress_mbps": 944.48
+      "compress_mbps": 134.18,
+      "decompress_mbps": 933.68
     },
     {
       "compressor": "miniz_oxide",
@@ -2474,8 +2474,8 @@
       "level": 4,
       "out_size": 202733,
       "ratio": 0.1969,
-      "compress_mbps": 129.43,
-      "decompress_mbps": 949.94
+      "compress_mbps": 127.88,
+      "decompress_mbps": 942.08
     },
     {
       "compressor": "miniz_oxide",
@@ -2484,8 +2484,8 @@
       "level": 5,
       "out_size": 207803,
       "ratio": 0.2018,
-      "compress_mbps": 83.96,
-      "decompress_mbps": 961.16
+      "compress_mbps": 83.02,
+      "decompress_mbps": 947.54
     },
     {
       "compressor": "miniz_oxide",
@@ -2494,8 +2494,8 @@
       "level": 6,
       "out_size": 205270,
       "ratio": 0.1993,
-      "compress_mbps": 27.22,
-      "decompress_mbps": 988.66
+      "compress_mbps": 27.05,
+      "decompress_mbps": 974.78
     },
     {
       "compressor": "miniz_oxide",
@@ -2504,8 +2504,8 @@
       "level": 7,
       "out_size": 209951,
       "ratio": 0.2039,
-      "compress_mbps": 19.26,
-      "decompress_mbps": 1001.94
+      "compress_mbps": 19.14,
+      "decompress_mbps": 988.51
     },
     {
       "compressor": "miniz_oxide",
@@ -2514,8 +2514,8 @@
       "level": 8,
       "out_size": 209656,
       "ratio": 0.2036,
-      "compress_mbps": 12.2,
-      "decompress_mbps": 1014.63
+      "compress_mbps": 12.15,
+      "decompress_mbps": 998.53
     },
     {
       "compressor": "miniz_oxide",
@@ -2524,8 +2524,8 @@
       "level": 9,
       "out_size": 209189,
       "ratio": 0.2031,
-      "compress_mbps": 8.93,
-      "decompress_mbps": 1012.1
+      "compress_mbps": 8.89,
+      "decompress_mbps": 1001.34
     },
     {
       "compressor": "miniz_oxide",
@@ -2534,8 +2534,8 @@
       "level": 1,
       "out_size": 208640,
       "ratio": 0.4889,
-      "compress_mbps": 153.97,
-      "decompress_mbps": 439.97
+      "compress_mbps": 149.97,
+      "decompress_mbps": 422.62
     },
     {
       "compressor": "miniz_oxide",
@@ -2544,8 +2544,8 @@
       "level": 2,
       "out_size": 167329,
       "ratio": 0.3921,
-      "compress_mbps": 137.21,
-      "decompress_mbps": 478.6
+      "compress_mbps": 132.67,
+      "decompress_mbps": 458.34
     },
     {
       "compressor": "miniz_oxide",
@@ -2554,8 +2554,8 @@
       "level": 3,
       "out_size": 151097,
       "ratio": 0.3541,
-      "compress_mbps": 73.33,
-      "decompress_mbps": 525.73
+      "compress_mbps": 71.54,
+      "decompress_mbps": 507.97
     },
     {
       "compressor": "miniz_oxide",
@@ -2564,8 +2564,8 @@
       "level": 4,
       "out_size": 150035,
       "ratio": 0.3516,
-      "compress_mbps": 65.94,
-      "decompress_mbps": 518.63
+      "compress_mbps": 64.46,
+      "decompress_mbps": 502.49
     },
     {
       "compressor": "miniz_oxide",
@@ -2574,8 +2574,8 @@
       "level": 5,
       "out_size": 147375,
       "ratio": 0.3453,
-      "compress_mbps": 47.83,
-      "decompress_mbps": 516.11
+      "compress_mbps": 46.92,
+      "decompress_mbps": 499.6
     },
     {
       "compressor": "miniz_oxide",
@@ -2584,8 +2584,8 @@
       "level": 6,
       "out_size": 144908,
       "ratio": 0.3396,
-      "compress_mbps": 27.92,
-      "decompress_mbps": 526.67
+      "compress_mbps": 27.59,
+      "decompress_mbps": 510.62
     },
     {
       "compressor": "miniz_oxide",
@@ -2594,8 +2594,8 @@
       "level": 7,
       "out_size": 144562,
       "ratio": 0.3387,
-      "compress_mbps": 24.52,
-      "decompress_mbps": 527.74
+      "compress_mbps": 24.26,
+      "decompress_mbps": 509.55
     },
     {
       "compressor": "miniz_oxide",
@@ -2604,8 +2604,8 @@
       "level": 8,
       "out_size": 144449,
       "ratio": 0.3385,
-      "compress_mbps": 22.28,
-      "decompress_mbps": 528.85
+      "compress_mbps": 22.09,
+      "decompress_mbps": 510.28
     },
     {
       "compressor": "miniz_oxide",
@@ -2614,8 +2614,8 @@
       "level": 9,
       "out_size": 144438,
       "ratio": 0.3385,
-      "compress_mbps": 22.19,
-      "decompress_mbps": 528.37
+      "compress_mbps": 22.02,
+      "decompress_mbps": 509.25
     },
     {
       "compressor": "miniz_oxide",
@@ -2624,8 +2624,8 @@
       "level": 1,
       "out_size": 264549,
       "ratio": 0.549,
-      "compress_mbps": 132.29,
-      "decompress_mbps": 390.16
+      "compress_mbps": 129.61,
+      "decompress_mbps": 374.98
     },
     {
       "compressor": "miniz_oxide",
@@ -2634,8 +2634,8 @@
       "level": 2,
       "out_size": 223724,
       "ratio": 0.4643,
-      "compress_mbps": 117.51,
-      "decompress_mbps": 436.67
+      "compress_mbps": 114.31,
+      "decompress_mbps": 420.26
     },
     {
       "compressor": "miniz_oxide",
@@ -2644,8 +2644,8 @@
       "level": 3,
       "out_size": 204825,
       "ratio": 0.4251,
-      "compress_mbps": 60.42,
-      "decompress_mbps": 489.67
+      "compress_mbps": 59.04,
+      "decompress_mbps": 474.92
     },
     {
       "compressor": "miniz_oxide",
@@ -2654,8 +2654,8 @@
       "level": 4,
       "out_size": 203945,
       "ratio": 0.4232,
-      "compress_mbps": 53.54,
-      "decompress_mbps": 479.32
+      "compress_mbps": 52.44,
+      "decompress_mbps": 466.09
     },
     {
       "compressor": "miniz_oxide",
@@ -2664,8 +2664,8 @@
       "level": 5,
       "out_size": 199780,
       "ratio": 0.4146,
-      "compress_mbps": 37.72,
-      "decompress_mbps": 462.36
+      "compress_mbps": 37.02,
+      "decompress_mbps": 448.7
     },
     {
       "compressor": "miniz_oxide",
@@ -2674,8 +2674,8 @@
       "level": 6,
       "out_size": 195417,
       "ratio": 0.4055,
-      "compress_mbps": 21.07,
-      "decompress_mbps": 473.61
+      "compress_mbps": 20.85,
+      "decompress_mbps": 459.41
     },
     {
       "compressor": "miniz_oxide",
@@ -2684,8 +2684,8 @@
       "level": 7,
       "out_size": 194796,
       "ratio": 0.4043,
-      "compress_mbps": 17.79,
-      "decompress_mbps": 472.76
+      "compress_mbps": 17.65,
+      "decompress_mbps": 459.37
     },
     {
       "compressor": "miniz_oxide",
@@ -2694,8 +2694,8 @@
       "level": 8,
       "out_size": 194543,
       "ratio": 0.4037,
-      "compress_mbps": 15.6,
-      "decompress_mbps": 471.77
+      "compress_mbps": 15.49,
+      "decompress_mbps": 457.97
     },
     {
       "compressor": "miniz_oxide",
@@ -2704,8 +2704,8 @@
       "level": 9,
       "out_size": 194460,
       "ratio": 0.4036,
-      "compress_mbps": 14.96,
-      "decompress_mbps": 472.51
+      "compress_mbps": 14.84,
+      "decompress_mbps": 458.53
     },
     {
       "compressor": "miniz_oxide",
@@ -2714,8 +2714,8 @@
       "level": 1,
       "out_size": 67436,
       "ratio": 0.1314,
-      "compress_mbps": 619.83,
-      "decompress_mbps": 1037.94
+      "compress_mbps": 609.16,
+      "decompress_mbps": 987.96
     },
     {
       "compressor": "miniz_oxide",
@@ -2724,8 +2724,8 @@
       "level": 2,
       "out_size": 59257,
       "ratio": 0.1155,
-      "compress_mbps": 275.27,
-      "decompress_mbps": 1082.33
+      "compress_mbps": 211.38,
+      "decompress_mbps": 1040.05
     },
     {
       "compressor": "miniz_oxide",
@@ -2734,8 +2734,8 @@
       "level": 3,
       "out_size": 58316,
       "ratio": 0.1136,
-      "compress_mbps": 180.18,
-      "decompress_mbps": 1166.09
+      "compress_mbps": 148.63,
+      "decompress_mbps": 1123.61
     },
     {
       "compressor": "miniz_oxide",
@@ -2744,8 +2744,8 @@
       "level": 4,
       "out_size": 56291,
       "ratio": 0.1097,
-      "compress_mbps": 182.71,
-      "decompress_mbps": 1181.24
+      "compress_mbps": 162.36,
+      "decompress_mbps": 1136.94
     },
     {
       "compressor": "miniz_oxide",
@@ -2754,8 +2754,8 @@
       "level": 5,
       "out_size": 56220,
       "ratio": 0.1095,
-      "compress_mbps": 144.84,
-      "decompress_mbps": 1237.43
+      "compress_mbps": 124.0,
+      "decompress_mbps": 1192.87
     },
     {
       "compressor": "miniz_oxide",
@@ -2764,8 +2764,8 @@
       "level": 6,
       "out_size": 55972,
       "ratio": 0.1091,
-      "compress_mbps": 74.09,
-      "decompress_mbps": 1300.55
+      "compress_mbps": 67.98,
+      "decompress_mbps": 1249.47
     },
     {
       "compressor": "miniz_oxide",
@@ -2774,8 +2774,8 @@
       "level": 7,
       "out_size": 55121,
       "ratio": 0.1074,
-      "compress_mbps": 51.87,
-      "decompress_mbps": 1338.54
+      "compress_mbps": 48.73,
+      "decompress_mbps": 1291.72
     },
     {
       "compressor": "miniz_oxide",
@@ -2784,8 +2784,8 @@
       "level": 8,
       "out_size": 54124,
       "ratio": 0.1055,
-      "compress_mbps": 36.57,
-      "decompress_mbps": 1405.48
+      "compress_mbps": 34.89,
+      "decompress_mbps": 1350.44
     },
     {
       "compressor": "miniz_oxide",
@@ -2794,8 +2794,8 @@
       "level": 9,
       "out_size": 53699,
       "ratio": 0.1046,
-      "compress_mbps": 28.57,
-      "decompress_mbps": 1433.26
+      "compress_mbps": 28.24,
+      "decompress_mbps": 1385.53
     },
     {
       "compressor": "miniz_oxide",
@@ -2804,8 +2804,8 @@
       "level": 1,
       "out_size": 15612,
       "ratio": 0.4083,
-      "compress_mbps": 491.58,
-      "decompress_mbps": 850.28
+      "compress_mbps": 486.51,
+      "decompress_mbps": 843.2
     },
     {
       "compressor": "miniz_oxide",
@@ -2814,8 +2814,8 @@
       "level": 2,
       "out_size": 14133,
       "ratio": 0.3696,
-      "compress_mbps": 143.01,
-      "decompress_mbps": 884.71
+      "compress_mbps": 137.16,
+      "decompress_mbps": 884.51
     },
     {
       "compressor": "miniz_oxide",
@@ -2824,8 +2824,8 @@
       "level": 3,
       "out_size": 13341,
       "ratio": 0.3489,
-      "compress_mbps": 87.49,
-      "decompress_mbps": 907.0
+      "compress_mbps": 85.07,
+      "decompress_mbps": 910.92
     },
     {
       "compressor": "miniz_oxide",
@@ -2834,8 +2834,8 @@
       "level": 4,
       "out_size": 13289,
       "ratio": 0.3475,
-      "compress_mbps": 82.65,
-      "decompress_mbps": 931.32
+      "compress_mbps": 80.09,
+      "decompress_mbps": 937.25
     },
     {
       "compressor": "miniz_oxide",
@@ -2844,8 +2844,8 @@
       "level": 5,
       "out_size": 13052,
       "ratio": 0.3413,
-      "compress_mbps": 66.29,
-      "decompress_mbps": 970.4
+      "compress_mbps": 63.91,
+      "decompress_mbps": 975.93
     },
     {
       "compressor": "miniz_oxide",
@@ -2854,8 +2854,8 @@
       "level": 6,
       "out_size": 12996,
       "ratio": 0.3399,
-      "compress_mbps": 36.96,
-      "decompress_mbps": 987.9
+      "compress_mbps": 35.99,
+      "decompress_mbps": 986.52
     },
     {
       "compressor": "miniz_oxide",
@@ -2864,8 +2864,8 @@
       "level": 7,
       "out_size": 12972,
       "ratio": 0.3392,
-      "compress_mbps": 27.13,
-      "decompress_mbps": 982.98
+      "compress_mbps": 26.45,
+      "decompress_mbps": 984.94
     },
     {
       "compressor": "miniz_oxide",
@@ -2874,8 +2874,8 @@
       "level": 8,
       "out_size": 12951,
       "ratio": 0.3387,
-      "compress_mbps": 18.99,
-      "decompress_mbps": 995.05
+      "compress_mbps": 18.76,
+      "decompress_mbps": 990.91
     },
     {
       "compressor": "miniz_oxide",
@@ -2884,8 +2884,8 @@
       "level": 9,
       "out_size": 12933,
       "ratio": 0.3382,
-      "compress_mbps": 14.83,
-      "decompress_mbps": 999.79
+      "compress_mbps": 14.67,
+      "decompress_mbps": 995.62
     },
     {
       "compressor": "miniz_oxide",
@@ -2894,8 +2894,8 @@
       "level": 1,
       "out_size": 1988,
       "ratio": 0.4703,
-      "compress_mbps": 339.27,
-      "decompress_mbps": 541.61
+      "compress_mbps": 339.81,
+      "decompress_mbps": 535.71
     },
     {
       "compressor": "miniz_oxide",
@@ -2904,8 +2904,8 @@
       "level": 2,
       "out_size": 1802,
       "ratio": 0.4263,
-      "compress_mbps": 217.93,
-      "decompress_mbps": 549.43
+      "compress_mbps": 216.4,
+      "decompress_mbps": 543.14
     },
     {
       "compressor": "miniz_oxide",
@@ -2914,8 +2914,8 @@
       "level": 3,
       "out_size": 1760,
       "ratio": 0.4164,
-      "compress_mbps": 204.68,
-      "decompress_mbps": 554.88
+      "compress_mbps": 203.35,
+      "decompress_mbps": 545.86
     },
     {
       "compressor": "miniz_oxide",
@@ -2924,8 +2924,8 @@
       "level": 4,
       "out_size": 1732,
       "ratio": 0.4097,
-      "compress_mbps": 170.84,
-      "decompress_mbps": 563.57
+      "compress_mbps": 169.63,
+      "decompress_mbps": 561.6
     },
     {
       "compressor": "miniz_oxide",
@@ -2934,8 +2934,8 @@
       "level": 5,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 165.74,
-      "decompress_mbps": 572.69
+      "compress_mbps": 164.89,
+      "decompress_mbps": 570.5
     },
     {
       "compressor": "miniz_oxide",
@@ -2944,8 +2944,8 @@
       "level": 6,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 165.98,
-      "decompress_mbps": 574.0
+      "compress_mbps": 164.43,
+      "decompress_mbps": 570.75
     },
     {
       "compressor": "miniz_oxide",
@@ -2954,8 +2954,8 @@
       "level": 7,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 165.12,
-      "decompress_mbps": 573.51
+      "compress_mbps": 164.42,
+      "decompress_mbps": 568.73
     },
     {
       "compressor": "miniz_oxide",
@@ -2964,8 +2964,8 @@
       "level": 8,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 165.77,
-      "decompress_mbps": 575.97
+      "compress_mbps": 163.19,
+      "decompress_mbps": 570.99
     },
     {
       "compressor": "miniz_oxide",
@@ -2974,8 +2974,8 @@
       "level": 9,
       "out_size": 1730,
       "ratio": 0.4093,
-      "compress_mbps": 164.34,
-      "decompress_mbps": 574.16
+      "compress_mbps": 162.44,
+      "decompress_mbps": 570.42
     },
     {
       "compressor": "libdeflate",
@@ -2984,8 +2984,8 @@
       "level": 1,
       "out_size": 59790,
       "ratio": 0.3931,
-      "compress_mbps": 261.78,
-      "decompress_mbps": 999.3
+      "compress_mbps": 251.6,
+      "decompress_mbps": 992.86
     },
     {
       "compressor": "libdeflate",
@@ -2994,8 +2994,8 @@
       "level": 2,
       "out_size": 57173,
       "ratio": 0.3759,
-      "compress_mbps": 180.28,
-      "decompress_mbps": 1080.8
+      "compress_mbps": 178.1,
+      "decompress_mbps": 1074.75
     },
     {
       "compressor": "libdeflate",
@@ -3004,8 +3004,8 @@
       "level": 3,
       "out_size": 56189,
       "ratio": 0.3694,
-      "compress_mbps": 150.31,
-      "decompress_mbps": 1159.1
+      "compress_mbps": 147.9,
+      "decompress_mbps": 1150.9
     },
     {
       "compressor": "libdeflate",
@@ -3014,8 +3014,8 @@
       "level": 4,
       "out_size": 55816,
       "ratio": 0.367,
-      "compress_mbps": 137.42,
-      "decompress_mbps": 1202.9
+      "compress_mbps": 135.78,
+      "decompress_mbps": 1194.39
     },
     {
       "compressor": "libdeflate",
@@ -3024,8 +3024,8 @@
       "level": 5,
       "out_size": 54758,
       "ratio": 0.36,
-      "compress_mbps": 108.51,
-      "decompress_mbps": 1256.58
+      "compress_mbps": 107.28,
+      "decompress_mbps": 1249.33
     },
     {
       "compressor": "libdeflate",
@@ -3034,8 +3034,8 @@
       "level": 6,
       "out_size": 54220,
       "ratio": 0.3565,
-      "compress_mbps": 83.98,
-      "decompress_mbps": 1294.19
+      "compress_mbps": 83.45,
+      "decompress_mbps": 1283.47
     },
     {
       "compressor": "libdeflate",
@@ -3044,8 +3044,8 @@
       "level": 7,
       "out_size": 53801,
       "ratio": 0.3537,
-      "compress_mbps": 61.06,
-      "decompress_mbps": 1300.62
+      "compress_mbps": 60.85,
+      "decompress_mbps": 1281.01
     },
     {
       "compressor": "libdeflate",
@@ -3054,8 +3054,8 @@
       "level": 8,
       "out_size": 53573,
       "ratio": 0.3522,
-      "compress_mbps": 38.94,
-      "decompress_mbps": 1302.16
+      "compress_mbps": 38.75,
+      "decompress_mbps": 1289.4
     },
     {
       "compressor": "libdeflate",
@@ -3064,8 +3064,8 @@
       "level": 9,
       "out_size": 53546,
       "ratio": 0.3521,
-      "compress_mbps": 34.4,
-      "decompress_mbps": 1298.08
+      "compress_mbps": 34.23,
+      "decompress_mbps": 1295.0
     },
     {
       "compressor": "libdeflate",
@@ -3074,8 +3074,8 @@
       "level": 1,
       "out_size": 52276,
       "ratio": 0.4176,
-      "compress_mbps": 243.46,
-      "decompress_mbps": 952.23
+      "compress_mbps": 233.06,
+      "decompress_mbps": 949.8
     },
     {
       "compressor": "libdeflate",
@@ -3084,8 +3084,8 @@
       "level": 2,
       "out_size": 50534,
       "ratio": 0.4037,
-      "compress_mbps": 168.65,
-      "decompress_mbps": 1004.24
+      "compress_mbps": 165.36,
+      "decompress_mbps": 995.59
     },
     {
       "compressor": "libdeflate",
@@ -3094,8 +3094,8 @@
       "level": 3,
       "out_size": 49919,
       "ratio": 0.3988,
-      "compress_mbps": 141.76,
-      "decompress_mbps": 1069.64
+      "compress_mbps": 139.43,
+      "decompress_mbps": 1062.33
     },
     {
       "compressor": "libdeflate",
@@ -3104,8 +3104,8 @@
       "level": 4,
       "out_size": 49715,
       "ratio": 0.3972,
-      "compress_mbps": 131.29,
-      "decompress_mbps": 1106.23
+      "compress_mbps": 129.13,
+      "decompress_mbps": 1099.43
     },
     {
       "compressor": "libdeflate",
@@ -3114,8 +3114,8 @@
       "level": 5,
       "out_size": 48735,
       "ratio": 0.3893,
-      "compress_mbps": 100.6,
-      "decompress_mbps": 1152.27
+      "compress_mbps": 99.43,
+      "decompress_mbps": 1146.06
     },
     {
       "compressor": "libdeflate",
@@ -3124,8 +3124,8 @@
       "level": 6,
       "out_size": 48422,
       "ratio": 0.3868,
-      "compress_mbps": 79.37,
-      "decompress_mbps": 1178.93
+      "compress_mbps": 78.79,
+      "decompress_mbps": 1171.46
     },
     {
       "compressor": "libdeflate",
@@ -3134,8 +3134,8 @@
       "level": 7,
       "out_size": 48249,
       "ratio": 0.3854,
-      "compress_mbps": 61.14,
-      "decompress_mbps": 1182.05
+      "compress_mbps": 60.68,
+      "decompress_mbps": 1172.18
     },
     {
       "compressor": "libdeflate",
@@ -3144,8 +3144,8 @@
       "level": 8,
       "out_size": 47977,
       "ratio": 0.3833,
-      "compress_mbps": 42.93,
-      "decompress_mbps": 1185.47
+      "compress_mbps": 42.61,
+      "decompress_mbps": 1176.11
     },
     {
       "compressor": "libdeflate",
@@ -3154,8 +3154,8 @@
       "level": 9,
       "out_size": 47971,
       "ratio": 0.3832,
-      "compress_mbps": 41.0,
-      "decompress_mbps": 1183.05
+      "compress_mbps": 40.74,
+      "decompress_mbps": 1169.54
     },
     {
       "compressor": "libdeflate",
@@ -3164,8 +3164,8 @@
       "level": 1,
       "out_size": 8385,
       "ratio": 0.3408,
-      "compress_mbps": 690.6,
-      "decompress_mbps": 935.13
+      "compress_mbps": 689.91,
+      "decompress_mbps": 922.88
     },
     {
       "compressor": "libdeflate",
@@ -3174,8 +3174,8 @@
       "level": 2,
       "out_size": 8380,
       "ratio": 0.3406,
-      "compress_mbps": 439.97,
-      "decompress_mbps": 980.0
+      "compress_mbps": 438.57,
+      "decompress_mbps": 943.44
     },
     {
       "compressor": "libdeflate",
@@ -3184,8 +3184,8 @@
       "level": 3,
       "out_size": 8286,
       "ratio": 0.3368,
-      "compress_mbps": 397.49,
-      "decompress_mbps": 978.74
+      "compress_mbps": 403.7,
+      "decompress_mbps": 960.9
     },
     {
       "compressor": "libdeflate",
@@ -3194,8 +3194,8 @@
       "level": 4,
       "out_size": 8163,
       "ratio": 0.3318,
-      "compress_mbps": 371.05,
-      "decompress_mbps": 999.84
+      "compress_mbps": 376.13,
+      "decompress_mbps": 965.01
     },
     {
       "compressor": "libdeflate",
@@ -3204,8 +3204,8 @@
       "level": 5,
       "out_size": 8053,
       "ratio": 0.3273,
-      "compress_mbps": 340.2,
-      "decompress_mbps": 985.69
+      "compress_mbps": 316.43,
+      "decompress_mbps": 1029.04
     },
     {
       "compressor": "libdeflate",
@@ -3214,8 +3214,8 @@
       "level": 6,
       "out_size": 7986,
       "ratio": 0.3246,
-      "compress_mbps": 277.77,
-      "decompress_mbps": 1070.79
+      "compress_mbps": 276.22,
+      "decompress_mbps": 1034.53
     },
     {
       "compressor": "libdeflate",
@@ -3224,8 +3224,8 @@
       "level": 7,
       "out_size": 7954,
       "ratio": 0.3233,
-      "compress_mbps": 188.58,
-      "decompress_mbps": 1067.77
+      "compress_mbps": 190.12,
+      "decompress_mbps": 1044.53
     },
     {
       "compressor": "libdeflate",
@@ -3234,8 +3234,8 @@
       "level": 8,
       "out_size": 7916,
       "ratio": 0.3217,
-      "compress_mbps": 128.17,
-      "decompress_mbps": 1060.77
+      "compress_mbps": 128.7,
+      "decompress_mbps": 1044.44
     },
     {
       "compressor": "libdeflate",
@@ -3244,8 +3244,8 @@
       "level": 9,
       "out_size": 7916,
       "ratio": 0.3217,
-      "compress_mbps": 125.64,
-      "decompress_mbps": 1073.78
+      "compress_mbps": 123.15,
+      "decompress_mbps": 1048.4
     },
     {
       "compressor": "libdeflate",
@@ -3254,8 +3254,8 @@
       "level": 1,
       "out_size": 3401,
       "ratio": 0.305,
-      "compress_mbps": 587.81,
-      "decompress_mbps": 798.85
+      "compress_mbps": 582.05,
+      "decompress_mbps": 783.08
     },
     {
       "compressor": "libdeflate",
@@ -3264,8 +3264,8 @@
       "level": 2,
       "out_size": 3307,
       "ratio": 0.2966,
-      "compress_mbps": 395.11,
-      "decompress_mbps": 778.95
+      "compress_mbps": 391.14,
+      "decompress_mbps": 785.98
     },
     {
       "compressor": "libdeflate",
@@ -3274,8 +3274,8 @@
       "level": 3,
       "out_size": 3242,
       "ratio": 0.2908,
-      "compress_mbps": 368.8,
-      "decompress_mbps": 854.3
+      "compress_mbps": 369.82,
+      "decompress_mbps": 833.08
     },
     {
       "compressor": "libdeflate",
@@ -3284,8 +3284,8 @@
       "level": 4,
       "out_size": 3205,
       "ratio": 0.2874,
-      "compress_mbps": 349.64,
-      "decompress_mbps": 857.47
+      "compress_mbps": 349.6,
+      "decompress_mbps": 843.79
     },
     {
       "compressor": "libdeflate",
@@ -3294,8 +3294,8 @@
       "level": 5,
       "out_size": 3150,
       "ratio": 0.2825,
-      "compress_mbps": 314.5,
-      "decompress_mbps": 887.53
+      "compress_mbps": 312.79,
+      "decompress_mbps": 863.25
     },
     {
       "compressor": "libdeflate",
@@ -3304,8 +3304,8 @@
       "level": 6,
       "out_size": 3126,
       "ratio": 0.2804,
-      "compress_mbps": 267.0,
-      "decompress_mbps": 887.53
+      "compress_mbps": 266.34,
+      "decompress_mbps": 860.31
     },
     {
       "compressor": "libdeflate",
@@ -3314,8 +3314,8 @@
       "level": 7,
       "out_size": 3106,
       "ratio": 0.2786,
-      "compress_mbps": 206.93,
-      "decompress_mbps": 897.11
+      "compress_mbps": 206.1,
+      "decompress_mbps": 863.25
     },
     {
       "compressor": "libdeflate",
@@ -3324,8 +3324,8 @@
       "level": 8,
       "out_size": 3102,
       "ratio": 0.2782,
-      "compress_mbps": 147.87,
-      "decompress_mbps": 896.2
+      "compress_mbps": 147.55,
+      "decompress_mbps": 884.35
     },
     {
       "compressor": "libdeflate",
@@ -3334,8 +3334,8 @@
       "level": 9,
       "out_size": 3102,
       "ratio": 0.2782,
-      "compress_mbps": 141.21,
-      "decompress_mbps": 896.2
+      "compress_mbps": 140.09,
+      "decompress_mbps": 870.53
     },
     {
       "compressor": "libdeflate",
@@ -3344,8 +3344,8 @@
       "level": 1,
       "out_size": 1251,
       "ratio": 0.3362,
-      "compress_mbps": 379.65,
-      "decompress_mbps": 462.6
+      "compress_mbps": 377.43,
+      "decompress_mbps": 453.27
     },
     {
       "compressor": "libdeflate",
@@ -3354,8 +3354,8 @@
       "level": 2,
       "out_size": 1228,
       "ratio": 0.33,
-      "compress_mbps": 268.45,
-      "decompress_mbps": 456.12
+      "compress_mbps": 266.99,
+      "decompress_mbps": 438.53
     },
     {
       "compressor": "libdeflate",
@@ -3364,8 +3364,8 @@
       "level": 3,
       "out_size": 1219,
       "ratio": 0.3276,
-      "compress_mbps": 260.49,
-      "decompress_mbps": 490.21
+      "compress_mbps": 261.02,
+      "decompress_mbps": 425.19
     },
     {
       "compressor": "libdeflate",
@@ -3374,8 +3374,8 @@
       "level": 4,
       "out_size": 1220,
       "ratio": 0.3279,
-      "compress_mbps": 255.0,
-      "decompress_mbps": 480.52
+      "compress_mbps": 254.62,
+      "decompress_mbps": 472.14
     },
     {
       "compressor": "libdeflate",
@@ -3384,8 +3384,8 @@
       "level": 5,
       "out_size": 1207,
       "ratio": 0.3244,
-      "compress_mbps": 240.78,
-      "decompress_mbps": 471.95
+      "compress_mbps": 239.29,
+      "decompress_mbps": 478.12
     },
     {
       "compressor": "libdeflate",
@@ -3394,8 +3394,8 @@
       "level": 6,
       "out_size": 1207,
       "ratio": 0.3244,
-      "compress_mbps": 223.04,
-      "decompress_mbps": 444.63
+      "compress_mbps": 222.36,
+      "decompress_mbps": 473.91
     },
     {
       "compressor": "libdeflate",
@@ -3404,8 +3404,8 @@
       "level": 7,
       "out_size": 1207,
       "ratio": 0.3244,
-      "compress_mbps": 203.22,
-      "decompress_mbps": 475.62
+      "compress_mbps": 202.57,
+      "decompress_mbps": 460.14
     },
     {
       "compressor": "libdeflate",
@@ -3414,8 +3414,8 @@
       "level": 8,
       "out_size": 1204,
       "ratio": 0.3236,
-      "compress_mbps": 169.07,
-      "decompress_mbps": 497.21
+      "compress_mbps": 168.86,
+      "decompress_mbps": 483.07
     },
     {
       "compressor": "libdeflate",
@@ -3424,8 +3424,8 @@
       "level": 9,
       "out_size": 1204,
       "ratio": 0.3236,
-      "compress_mbps": 168.8,
-      "decompress_mbps": 485.31
+      "compress_mbps": 168.38,
+      "decompress_mbps": 481.76
     },
     {
       "compressor": "libdeflate",
@@ -3434,8 +3434,8 @@
       "level": 1,
       "out_size": 221813,
       "ratio": 0.2154,
-      "compress_mbps": 588.6,
-      "decompress_mbps": 1014.58
+      "compress_mbps": 577.04,
+      "decompress_mbps": 1004.16
     },
     {
       "compressor": "libdeflate",
@@ -3444,8 +3444,8 @@
       "level": 2,
       "out_size": 199825,
       "ratio": 0.1941,
-      "compress_mbps": 407.43,
-      "decompress_mbps": 1471.37
+      "compress_mbps": 404.88,
+      "decompress_mbps": 1465.09
     },
     {
       "compressor": "libdeflate",
@@ -3454,8 +3454,8 @@
       "level": 3,
       "out_size": 195675,
       "ratio": 0.19,
-      "compress_mbps": 281.25,
-      "decompress_mbps": 1541.56
+      "compress_mbps": 279.44,
+      "decompress_mbps": 1524.99
     },
     {
       "compressor": "libdeflate",
@@ -3464,8 +3464,8 @@
       "level": 4,
       "out_size": 195664,
       "ratio": 0.19,
-      "compress_mbps": 278.19,
-      "decompress_mbps": 1551.61
+      "compress_mbps": 276.19,
+      "decompress_mbps": 1540.29
     },
     {
       "compressor": "libdeflate",
@@ -3474,8 +3474,8 @@
       "level": 5,
       "out_size": 198900,
       "ratio": 0.1932,
-      "compress_mbps": 238.37,
-      "decompress_mbps": 1135.95
+      "compress_mbps": 237.56,
+      "decompress_mbps": 1132.66
     },
     {
       "compressor": "libdeflate",
@@ -3484,8 +3484,8 @@
       "level": 6,
       "out_size": 199347,
       "ratio": 0.1936,
-      "compress_mbps": 203.81,
-      "decompress_mbps": 1129.81
+      "compress_mbps": 203.06,
+      "decompress_mbps": 1133.11
     },
     {
       "compressor": "libdeflate",
@@ -3494,8 +3494,8 @@
       "level": 7,
       "out_size": 199777,
       "ratio": 0.194,
-      "compress_mbps": 123.42,
-      "decompress_mbps": 1192.91
+      "compress_mbps": 122.7,
+      "decompress_mbps": 1192.44
     },
     {
       "compressor": "libdeflate",
@@ -3505,7 +3505,7 @@
       "out_size": 182094,
       "ratio": 0.1768,
       "compress_mbps": 25.59,
-      "decompress_mbps": 1176.73
+      "decompress_mbps": 1168.78
     },
     {
       "compressor": "libdeflate",
@@ -3514,8 +3514,8 @@
       "level": 9,
       "out_size": 181451,
       "ratio": 0.1762,
-      "compress_mbps": 13.59,
-      "decompress_mbps": 1179.16
+      "compress_mbps": 13.57,
+      "decompress_mbps": 1183.24
     },
     {
       "compressor": "libdeflate",
@@ -3524,8 +3524,8 @@
       "level": 1,
       "out_size": 159063,
       "ratio": 0.3727,
-      "compress_mbps": 265.62,
-      "decompress_mbps": 1029.12
+      "compress_mbps": 254.36,
+      "decompress_mbps": 1026.2
     },
     {
       "compressor": "libdeflate",
@@ -3534,8 +3534,8 @@
       "level": 2,
       "out_size": 152115,
       "ratio": 0.3564,
-      "compress_mbps": 186.86,
-      "decompress_mbps": 1107.17
+      "compress_mbps": 183.41,
+      "decompress_mbps": 1109.49
     },
     {
       "compressor": "libdeflate",
@@ -3544,8 +3544,8 @@
       "level": 3,
       "out_size": 149162,
       "ratio": 0.3495,
-      "compress_mbps": 156.48,
-      "decompress_mbps": 1199.21
+      "compress_mbps": 154.26,
+      "decompress_mbps": 1190.63
     },
     {
       "compressor": "libdeflate",
@@ -3554,8 +3554,8 @@
       "level": 4,
       "out_size": 148359,
       "ratio": 0.3476,
-      "compress_mbps": 142.85,
-      "decompress_mbps": 1051.93
+      "compress_mbps": 141.2,
+      "decompress_mbps": 1045.51
     },
     {
       "compressor": "libdeflate",
@@ -3564,8 +3564,8 @@
       "level": 5,
       "out_size": 145353,
       "ratio": 0.3406,
-      "compress_mbps": 112.44,
-      "decompress_mbps": 1009.83
+      "compress_mbps": 111.6,
+      "decompress_mbps": 1003.02
     },
     {
       "compressor": "libdeflate",
@@ -3574,8 +3574,8 @@
       "level": 6,
       "out_size": 144209,
       "ratio": 0.3379,
-      "compress_mbps": 87.2,
-      "decompress_mbps": 1056.32
+      "compress_mbps": 86.7,
+      "decompress_mbps": 1047.23
     },
     {
       "compressor": "libdeflate",
@@ -3584,8 +3584,8 @@
       "level": 7,
       "out_size": 143604,
       "ratio": 0.3365,
-      "compress_mbps": 65.59,
-      "decompress_mbps": 1053.74
+      "compress_mbps": 66.06,
+      "decompress_mbps": 1043.49
     },
     {
       "compressor": "libdeflate",
@@ -3594,8 +3594,8 @@
       "level": 8,
       "out_size": 142086,
       "ratio": 0.3329,
-      "compress_mbps": 44.12,
-      "decompress_mbps": 1060.01
+      "compress_mbps": 43.92,
+      "decompress_mbps": 1041.19
     },
     {
       "compressor": "libdeflate",
@@ -3604,8 +3604,8 @@
       "level": 9,
       "out_size": 142027,
       "ratio": 0.3328,
-      "compress_mbps": 40.37,
-      "decompress_mbps": 1059.55
+      "compress_mbps": 40.12,
+      "decompress_mbps": 1045.01
     },
     {
       "compressor": "libdeflate",
@@ -3614,8 +3614,8 @@
       "level": 1,
       "out_size": 210662,
       "ratio": 0.4372,
-      "compress_mbps": 231.28,
-      "decompress_mbps": 875.16
+      "compress_mbps": 222.88,
+      "decompress_mbps": 872.46
     },
     {
       "compressor": "libdeflate",
@@ -3624,8 +3624,8 @@
       "level": 2,
       "out_size": 202881,
       "ratio": 0.421,
-      "compress_mbps": 158.53,
-      "decompress_mbps": 945.81
+      "compress_mbps": 155.84,
+      "decompress_mbps": 940.61
     },
     {
       "compressor": "libdeflate",
@@ -3634,8 +3634,8 @@
       "level": 3,
       "out_size": 200409,
       "ratio": 0.4159,
-      "compress_mbps": 133.25,
-      "decompress_mbps": 1026.25
+      "compress_mbps": 131.01,
+      "decompress_mbps": 1021.51
     },
     {
       "compressor": "libdeflate",
@@ -3644,8 +3644,8 @@
       "level": 4,
       "out_size": 199678,
       "ratio": 0.4144,
-      "compress_mbps": 122.99,
-      "decompress_mbps": 861.01
+      "compress_mbps": 121.52,
+      "decompress_mbps": 853.64
     },
     {
       "compressor": "libdeflate",
@@ -3654,8 +3654,8 @@
       "level": 5,
       "out_size": 195798,
       "ratio": 0.4063,
-      "compress_mbps": 93.16,
-      "decompress_mbps": 810.98
+      "compress_mbps": 92.23,
+      "decompress_mbps": 804.32
     },
     {
       "compressor": "libdeflate",
@@ -3664,8 +3664,8 @@
       "level": 6,
       "out_size": 194029,
       "ratio": 0.4027,
-      "compress_mbps": 71.96,
-      "decompress_mbps": 838.09
+      "compress_mbps": 71.35,
+      "decompress_mbps": 830.05
     },
     {
       "compressor": "libdeflate",
@@ -3674,8 +3674,8 @@
       "level": 7,
       "out_size": 192773,
       "ratio": 0.4001,
-      "compress_mbps": 51.34,
-      "decompress_mbps": 841.59
+      "compress_mbps": 50.31,
+      "decompress_mbps": 831.17
     },
     {
       "compressor": "libdeflate",
@@ -3684,8 +3684,8 @@
       "level": 8,
       "out_size": 191739,
       "ratio": 0.3979,
-      "compress_mbps": 33.58,
-      "decompress_mbps": 841.73
+      "compress_mbps": 33.43,
+      "decompress_mbps": 835.31
     },
     {
       "compressor": "libdeflate",
@@ -3694,8 +3694,8 @@
       "level": 9,
       "out_size": 191676,
       "ratio": 0.3978,
-      "compress_mbps": 30.97,
-      "decompress_mbps": 840.2
+      "compress_mbps": 30.81,
+      "decompress_mbps": 829.93
     },
     {
       "compressor": "libdeflate",
@@ -3704,8 +3704,8 @@
       "level": 1,
       "out_size": 58079,
       "ratio": 0.1132,
-      "compress_mbps": 372.45,
-      "decompress_mbps": 1713.09
+      "compress_mbps": 366.23,
+      "decompress_mbps": 1682.92
     },
     {
       "compressor": "libdeflate",
@@ -3714,8 +3714,8 @@
       "level": 2,
       "out_size": 57838,
       "ratio": 0.1127,
-      "compress_mbps": 411.55,
-      "decompress_mbps": 1792.92
+      "compress_mbps": 407.1,
+      "decompress_mbps": 1789.88
     },
     {
       "compressor": "libdeflate",
@@ -3724,8 +3724,8 @@
       "level": 3,
       "out_size": 57554,
       "ratio": 0.1121,
-      "compress_mbps": 394.06,
-      "decompress_mbps": 1920.02
+      "compress_mbps": 387.42,
+      "decompress_mbps": 1904.77
     },
     {
       "compressor": "libdeflate",
@@ -3734,8 +3734,8 @@
       "level": 4,
       "out_size": 57064,
       "ratio": 0.1112,
-      "compress_mbps": 372.94,
-      "decompress_mbps": 1744.1
+      "compress_mbps": 367.17,
+      "decompress_mbps": 1735.74
     },
     {
       "compressor": "libdeflate",
@@ -3744,8 +3744,8 @@
       "level": 5,
       "out_size": 55743,
       "ratio": 0.1086,
-      "compress_mbps": 342.49,
-      "decompress_mbps": 1816.24
+      "compress_mbps": 340.3,
+      "decompress_mbps": 1792.2
     },
     {
       "compressor": "libdeflate",
@@ -3754,8 +3754,8 @@
       "level": 6,
       "out_size": 55102,
       "ratio": 0.1074,
-      "compress_mbps": 282.73,
-      "decompress_mbps": 1891.92
+      "compress_mbps": 281.58,
+      "decompress_mbps": 1880.42
     },
     {
       "compressor": "libdeflate",
@@ -3764,8 +3764,8 @@
       "level": 7,
       "out_size": 54742,
       "ratio": 0.1067,
-      "compress_mbps": 186.9,
-      "decompress_mbps": 1955.85
+      "compress_mbps": 192.05,
+      "decompress_mbps": 1942.33
     },
     {
       "compressor": "libdeflate",
@@ -3774,8 +3774,8 @@
       "level": 8,
       "out_size": 53133,
       "ratio": 0.1035,
-      "compress_mbps": 102.84,
-      "decompress_mbps": 2019.62
+      "compress_mbps": 101.87,
+      "decompress_mbps": 1990.4
     },
     {
       "compressor": "libdeflate",
@@ -3784,8 +3784,8 @@
       "level": 9,
       "out_size": 52186,
       "ratio": 0.1017,
-      "compress_mbps": 72.15,
-      "decompress_mbps": 2056.59
+      "compress_mbps": 71.81,
+      "decompress_mbps": 2036.03
     },
     {
       "compressor": "libdeflate",
@@ -3794,8 +3794,8 @@
       "level": 1,
       "out_size": 14122,
       "ratio": 0.3693,
-      "compress_mbps": 648.04,
-      "decompress_mbps": 828.0
+      "compress_mbps": 639.01,
+      "decompress_mbps": 824.93
     },
     {
       "compressor": "libdeflate",
@@ -3804,8 +3804,8 @@
       "level": 2,
       "out_size": 13374,
       "ratio": 0.3497,
-      "compress_mbps": 349.65,
-      "decompress_mbps": 881.97
+      "compress_mbps": 366.5,
+      "decompress_mbps": 874.67
     },
     {
       "compressor": "libdeflate",
@@ -3814,8 +3814,8 @@
       "level": 3,
       "out_size": 13293,
       "ratio": 0.3476,
-      "compress_mbps": 283.4,
-      "decompress_mbps": 970.94
+      "compress_mbps": 286.42,
+      "decompress_mbps": 959.7
     },
     {
       "compressor": "libdeflate",
@@ -3824,8 +3824,8 @@
       "level": 4,
       "out_size": 13259,
       "ratio": 0.3467,
-      "compress_mbps": 258.71,
-      "decompress_mbps": 977.66
+      "compress_mbps": 270.04,
+      "decompress_mbps": 967.15
     },
     {
       "compressor": "libdeflate",
@@ -3834,8 +3834,8 @@
       "level": 5,
       "out_size": 12641,
       "ratio": 0.3306,
-      "compress_mbps": 193.57,
-      "decompress_mbps": 1023.1
+      "compress_mbps": 187.57,
+      "decompress_mbps": 998.48
     },
     {
       "compressor": "libdeflate",
@@ -3844,8 +3844,8 @@
       "level": 6,
       "out_size": 12432,
       "ratio": 0.3251,
-      "compress_mbps": 166.22,
-      "decompress_mbps": 1026.76
+      "compress_mbps": 159.12,
+      "decompress_mbps": 1025.78
     },
     {
       "compressor": "libdeflate",
@@ -3854,8 +3854,8 @@
       "level": 7,
       "out_size": 12439,
       "ratio": 0.3253,
-      "compress_mbps": 124.01,
-      "decompress_mbps": 1044.55
+      "compress_mbps": 122.27,
+      "decompress_mbps": 1037.04
     },
     {
       "compressor": "libdeflate",
@@ -3864,8 +3864,8 @@
       "level": 8,
       "out_size": 12579,
       "ratio": 0.3289,
-      "compress_mbps": 67.42,
-      "decompress_mbps": 1051.97
+      "compress_mbps": 67.01,
+      "decompress_mbps": 1048.91
     },
     {
       "compressor": "libdeflate",
@@ -3874,8 +3874,8 @@
       "level": 9,
       "out_size": 12574,
       "ratio": 0.3288,
-      "compress_mbps": 47.28,
-      "decompress_mbps": 1053.73
+      "compress_mbps": 47.08,
+      "decompress_mbps": 1049.63
     },
     {
       "compressor": "libdeflate",
@@ -3884,8 +3884,8 @@
       "level": 1,
       "out_size": 1777,
       "ratio": 0.4204,
-      "compress_mbps": 386.05,
-      "decompress_mbps": 393.13
+      "compress_mbps": 379.44,
+      "decompress_mbps": 401.91
     },
     {
       "compressor": "libdeflate",
@@ -3894,8 +3894,8 @@
       "level": 2,
       "out_size": 1756,
       "ratio": 0.4154,
-      "compress_mbps": 258.79,
-      "decompress_mbps": 400.28
+      "compress_mbps": 258.03,
+      "decompress_mbps": 405.59
     },
     {
       "compressor": "libdeflate",
@@ -3904,8 +3904,8 @@
       "level": 3,
       "out_size": 1746,
       "ratio": 0.4131,
-      "compress_mbps": 255.06,
-      "decompress_mbps": 401.59
+      "compress_mbps": 254.49,
+      "decompress_mbps": 414.09
     },
     {
       "compressor": "libdeflate",
@@ -3914,8 +3914,8 @@
       "level": 4,
       "out_size": 1740,
       "ratio": 0.4116,
-      "compress_mbps": 252.63,
-      "decompress_mbps": 395.56
+      "compress_mbps": 251.92,
+      "decompress_mbps": 440.28
     },
     {
       "compressor": "libdeflate",
@@ -3924,8 +3924,8 @@
       "level": 5,
       "out_size": 1722,
       "ratio": 0.4074,
-      "compress_mbps": 240.22,
-      "decompress_mbps": 429.12
+      "compress_mbps": 238.4,
+      "decompress_mbps": 423.22
     },
     {
       "compressor": "libdeflate",
@@ -3934,8 +3934,8 @@
       "level": 6,
       "out_size": 1721,
       "ratio": 0.4071,
-      "compress_mbps": 236.46,
-      "decompress_mbps": 432.3
+      "compress_mbps": 234.25,
+      "decompress_mbps": 426.63
     },
     {
       "compressor": "libdeflate",
@@ -3944,8 +3944,8 @@
       "level": 7,
       "out_size": 1720,
       "ratio": 0.4069,
-      "compress_mbps": 234.1,
-      "decompress_mbps": 432.76
+      "compress_mbps": 232.16,
+      "decompress_mbps": 438.08
     },
     {
       "compressor": "libdeflate",
@@ -3954,8 +3954,8 @@
       "level": 8,
       "out_size": 1717,
       "ratio": 0.4062,
-      "compress_mbps": 216.74,
-      "decompress_mbps": 442.02
+      "compress_mbps": 215.31,
+      "decompress_mbps": 449.06
     },
     {
       "compressor": "libdeflate",
@@ -3964,98 +3964,98 @@
       "level": 9,
       "out_size": 1717,
       "ratio": 0.4062,
-      "compress_mbps": 217.37,
-      "decompress_mbps": 441.53
+      "compress_mbps": 215.7,
+      "decompress_mbps": 441.05
     },
     {
       "compressor": "native",
       "pattern": "silesia/dickens",
       "size": 10192446,
       "level": 1,
-      "out_size": 5364132,
-      "ratio": 0.5263,
-      "compress_mbps": 13.08,
-      "decompress_mbps": 83.45
+      "out_size": 4231315,
+      "ratio": 0.4151,
+      "compress_mbps": 13.13,
+      "decompress_mbps": 82.07
     },
     {
       "compressor": "native",
       "pattern": "silesia/dickens",
       "size": 10192446,
       "level": 2,
-      "out_size": 5165701,
-      "ratio": 0.5068,
-      "compress_mbps": 11.55,
-      "decompress_mbps": 90.67
+      "out_size": 4120658,
+      "ratio": 0.4043,
+      "compress_mbps": 11.54,
+      "decompress_mbps": 89.89
     },
     {
       "compressor": "native",
       "pattern": "silesia/dickens",
       "size": 10192446,
       "level": 3,
-      "out_size": 5046240,
-      "ratio": 0.4951,
-      "compress_mbps": 10.09,
-      "decompress_mbps": 97.78
+      "out_size": 4037988,
+      "ratio": 0.3962,
+      "compress_mbps": 10.03,
+      "decompress_mbps": 98.24
     },
     {
       "compressor": "native",
       "pattern": "silesia/dickens",
       "size": 10192446,
       "level": 4,
-      "out_size": 4889382,
-      "ratio": 0.4797,
-      "compress_mbps": 6.05,
-      "decompress_mbps": 98.61
+      "out_size": 3959738,
+      "ratio": 0.3885,
+      "compress_mbps": 6.18,
+      "decompress_mbps": 97.35
     },
     {
       "compressor": "native",
       "pattern": "silesia/dickens",
       "size": 10192446,
       "level": 5,
-      "out_size": 4867273,
-      "ratio": 0.4775,
-      "compress_mbps": 5.54,
-      "decompress_mbps": 100.03
+      "out_size": 3941691,
+      "ratio": 0.3867,
+      "compress_mbps": 5.65,
+      "decompress_mbps": 100.6
     },
     {
       "compressor": "native",
       "pattern": "silesia/dickens",
       "size": 10192446,
       "level": 6,
-      "out_size": 4832420,
-      "ratio": 0.4741,
-      "compress_mbps": 4.77,
-      "decompress_mbps": 101.14
+      "out_size": 3913931,
+      "ratio": 0.384,
+      "compress_mbps": 4.76,
+      "decompress_mbps": 103.76
     },
     {
       "compressor": "native",
       "pattern": "silesia/dickens",
       "size": 10192446,
       "level": 7,
-      "out_size": 3922973,
-      "ratio": 0.3849,
-      "compress_mbps": 1.5,
-      "decompress_mbps": 103.6
+      "out_size": 3902484,
+      "ratio": 0.3829,
+      "compress_mbps": 1.45,
+      "decompress_mbps": 101.21
     },
     {
       "compressor": "native",
       "pattern": "silesia/dickens",
       "size": 10192446,
       "level": 8,
-      "out_size": 3919702,
-      "ratio": 0.3846,
-      "compress_mbps": 1.45,
-      "decompress_mbps": 101.81
+      "out_size": 3899047,
+      "ratio": 0.3825,
+      "compress_mbps": 1.38,
+      "decompress_mbps": 103.12
     },
     {
       "compressor": "native",
       "pattern": "silesia/dickens",
       "size": 10192446,
       "level": 9,
-      "out_size": 3919665,
-      "ratio": 0.3846,
-      "compress_mbps": 1.45,
-      "decompress_mbps": 100.43
+      "out_size": 3898964,
+      "ratio": 0.3825,
+      "compress_mbps": 1.4,
+      "decompress_mbps": 102.74
     },
     {
       "compressor": "native",
@@ -4064,8 +4064,8 @@
       "level": 1,
       "out_size": 20729473,
       "ratio": 0.4047,
-      "compress_mbps": 17.91,
-      "decompress_mbps": 74.33
+      "compress_mbps": 19.01,
+      "decompress_mbps": 74.26
     },
     {
       "compressor": "native",
@@ -4074,8 +4074,8 @@
       "level": 2,
       "out_size": 20500337,
       "ratio": 0.4002,
-      "compress_mbps": 17.05,
-      "decompress_mbps": 76.95
+      "compress_mbps": 17.35,
+      "decompress_mbps": 76.65
     },
     {
       "compressor": "native",
@@ -4084,8 +4084,8 @@
       "level": 3,
       "out_size": 20349978,
       "ratio": 0.3973,
-      "compress_mbps": 15.32,
-      "decompress_mbps": 79.33
+      "compress_mbps": 15.31,
+      "decompress_mbps": 77.73
     },
     {
       "compressor": "native",
@@ -4094,8 +4094,8 @@
       "level": 4,
       "out_size": 19952001,
       "ratio": 0.3895,
-      "compress_mbps": 9.07,
-      "decompress_mbps": 81.35
+      "compress_mbps": 9.16,
+      "decompress_mbps": 78.39
     },
     {
       "compressor": "native",
@@ -4104,8 +4104,8 @@
       "level": 5,
       "out_size": 19925043,
       "ratio": 0.389,
-      "compress_mbps": 8.05,
-      "decompress_mbps": 83.24
+      "compress_mbps": 8.22,
+      "decompress_mbps": 81.43
     },
     {
       "compressor": "native",
@@ -4114,308 +4114,308 @@
       "level": 6,
       "out_size": 19882104,
       "ratio": 0.3882,
-      "compress_mbps": 6.12,
-      "decompress_mbps": 85.21
+      "compress_mbps": 6.19,
+      "decompress_mbps": 83.66
     },
     {
       "compressor": "native",
       "pattern": "silesia/mozilla",
       "size": 51220480,
       "level": 7,
-      "out_size": 19004928,
-      "ratio": 0.371,
-      "compress_mbps": 1.49,
-      "decompress_mbps": 81.03
+      "out_size": 18841079,
+      "ratio": 0.3678,
+      "compress_mbps": 1.37,
+      "decompress_mbps": 84.26
     },
     {
       "compressor": "native",
       "pattern": "silesia/mozilla",
       "size": 51220480,
       "level": 8,
-      "out_size": 19002295,
-      "ratio": 0.371,
-      "compress_mbps": 1.15,
-      "decompress_mbps": 86.38
+      "out_size": 18833163,
+      "ratio": 0.3677,
+      "compress_mbps": 1.09,
+      "decompress_mbps": 85.69
     },
     {
       "compressor": "native",
       "pattern": "silesia/mozilla",
       "size": 51220480,
       "level": 9,
-      "out_size": 19000618,
-      "ratio": 0.371,
-      "compress_mbps": 0.87,
-      "decompress_mbps": 83.24
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 1,
-      "out_size": 4668650,
-      "ratio": 0.4682,
-      "compress_mbps": 18.87,
-      "decompress_mbps": 73.4
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 2,
-      "out_size": 4570500,
-      "ratio": 0.4584,
-      "compress_mbps": 16.62,
-      "decompress_mbps": 76.72
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 3,
-      "out_size": 4510300,
-      "ratio": 0.4524,
-      "compress_mbps": 14.84,
-      "decompress_mbps": 77.95
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 4,
-      "out_size": 4369955,
-      "ratio": 0.4383,
-      "compress_mbps": 8.65,
-      "decompress_mbps": 72.84
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 5,
-      "out_size": 4360147,
-      "ratio": 0.4373,
-      "compress_mbps": 7.81,
-      "decompress_mbps": 74.49
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 6,
-      "out_size": 4349427,
-      "ratio": 0.4362,
-      "compress_mbps": 5.74,
-      "decompress_mbps": 76.61
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 7,
-      "out_size": 3678637,
-      "ratio": 0.3689,
-      "compress_mbps": 1.38,
-      "decompress_mbps": 77.57
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 8,
-      "out_size": 3680111,
-      "ratio": 0.3691,
-      "compress_mbps": 1.06,
-      "decompress_mbps": 78.87
-    },
-    {
-      "compressor": "native",
-      "pattern": "silesia/mr",
-      "size": 9970564,
-      "level": 9,
-      "out_size": 3679584,
-      "ratio": 0.369,
+      "out_size": 18828839,
+      "ratio": 0.3676,
       "compress_mbps": 0.83,
-      "decompress_mbps": 78.13
+      "decompress_mbps": 83.81
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3773613,
+      "ratio": 0.3785,
+      "compress_mbps": 18.9,
+      "decompress_mbps": 75.61
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3728325,
+      "ratio": 0.3739,
+      "compress_mbps": 16.75,
+      "decompress_mbps": 76.7
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3701126,
+      "ratio": 0.3712,
+      "compress_mbps": 14.87,
+      "decompress_mbps": 79.6
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3718920,
+      "ratio": 0.373,
+      "compress_mbps": 8.98,
+      "decompress_mbps": 72.86
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3715907,
+      "ratio": 0.3727,
+      "compress_mbps": 7.91,
+      "decompress_mbps": 75.49
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3715635,
+      "ratio": 0.3727,
+      "compress_mbps": 5.84,
+      "decompress_mbps": 76.48
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3649251,
+      "ratio": 0.366,
+      "compress_mbps": 1.32,
+      "decompress_mbps": 78.64
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3648922,
+      "ratio": 0.366,
+      "compress_mbps": 1.02,
+      "decompress_mbps": 79.84
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3649910,
+      "ratio": 0.3661,
+      "compress_mbps": 0.81,
+      "decompress_mbps": 78.95
     },
     {
       "compressor": "native",
       "pattern": "silesia/nci",
       "size": 33553445,
       "level": 1,
-      "out_size": 4705330,
-      "ratio": 0.1402,
-      "compress_mbps": 41.87,
-      "decompress_mbps": 270.0
+      "out_size": 3957304,
+      "ratio": 0.1179,
+      "compress_mbps": 41.44,
+      "decompress_mbps": 262.49
     },
     {
       "compressor": "native",
       "pattern": "silesia/nci",
       "size": 33553445,
       "level": 2,
-      "out_size": 4457802,
-      "ratio": 0.1329,
-      "compress_mbps": 36.4,
-      "decompress_mbps": 299.34
+      "out_size": 3769595,
+      "ratio": 0.1123,
+      "compress_mbps": 36.35,
+      "decompress_mbps": 304.2
     },
     {
       "compressor": "native",
       "pattern": "silesia/nci",
       "size": 33553445,
       "level": 3,
-      "out_size": 4241801,
-      "ratio": 0.1264,
-      "compress_mbps": 30.42,
-      "decompress_mbps": 330.43
+      "out_size": 3594567,
+      "ratio": 0.1071,
+      "compress_mbps": 30.5,
+      "decompress_mbps": 331.19
     },
     {
       "compressor": "native",
       "pattern": "silesia/nci",
       "size": 33553445,
       "level": 4,
-      "out_size": 3946147,
-      "ratio": 0.1176,
-      "compress_mbps": 17.33,
-      "decompress_mbps": 333.42
+      "out_size": 3339928,
+      "ratio": 0.0995,
+      "compress_mbps": 17.52,
+      "decompress_mbps": 333.66
     },
     {
       "compressor": "native",
       "pattern": "silesia/nci",
       "size": 33553445,
       "level": 5,
-      "out_size": 3917350,
-      "ratio": 0.1167,
-      "compress_mbps": 15.53,
-      "decompress_mbps": 364.13
+      "out_size": 3315513,
+      "ratio": 0.0988,
+      "compress_mbps": 15.59,
+      "decompress_mbps": 365.68
     },
     {
       "compressor": "native",
       "pattern": "silesia/nci",
       "size": 33553445,
       "level": 6,
-      "out_size": 3871740,
-      "ratio": 0.1154,
-      "compress_mbps": 11.66,
-      "decompress_mbps": 385.47
+      "out_size": 3275531,
+      "ratio": 0.0976,
+      "compress_mbps": 11.71,
+      "decompress_mbps": 384.62
     },
     {
       "compressor": "native",
       "pattern": "silesia/nci",
       "size": 33553445,
       "level": 7,
-      "out_size": 3256646,
-      "ratio": 0.0971,
-      "compress_mbps": 2.91,
-      "decompress_mbps": 364.51
+      "out_size": 3249135,
+      "ratio": 0.0968,
+      "compress_mbps": 2.84,
+      "decompress_mbps": 363.34
     },
     {
       "compressor": "native",
       "pattern": "silesia/nci",
       "size": 33553445,
       "level": 8,
-      "out_size": 3232193,
-      "ratio": 0.0963,
-      "compress_mbps": 2.14,
-      "decompress_mbps": 384.87
+      "out_size": 3225205,
+      "ratio": 0.0961,
+      "compress_mbps": 2.09,
+      "decompress_mbps": 380.97
     },
     {
       "compressor": "native",
       "pattern": "silesia/nci",
       "size": 33553445,
       "level": 9,
-      "out_size": 3211270,
-      "ratio": 0.0957,
-      "compress_mbps": 1.64,
-      "decompress_mbps": 360.65
+      "out_size": 3204429,
+      "ratio": 0.0955,
+      "compress_mbps": 1.61,
+      "decompress_mbps": 368.49
     },
     {
       "compressor": "native",
       "pattern": "silesia/ooffice",
       "size": 6152192,
       "level": 1,
-      "out_size": 3632401,
-      "ratio": 0.5904,
-      "compress_mbps": 13.87,
-      "decompress_mbps": 49.82
+      "out_size": 3218639,
+      "ratio": 0.5232,
+      "compress_mbps": 13.92,
+      "decompress_mbps": 49.66
     },
     {
       "compressor": "native",
       "pattern": "silesia/ooffice",
       "size": 6152192,
       "level": 2,
-      "out_size": 3594843,
-      "ratio": 0.5843,
-      "compress_mbps": 13.09,
-      "decompress_mbps": 50.91
+      "out_size": 3192732,
+      "ratio": 0.519,
+      "compress_mbps": 12.93,
+      "decompress_mbps": 50.7
     },
     {
       "compressor": "native",
       "pattern": "silesia/ooffice",
       "size": 6152192,
       "level": 3,
-      "out_size": 3570380,
-      "ratio": 0.5803,
-      "compress_mbps": 11.99,
-      "decompress_mbps": 53.43
+      "out_size": 3174297,
+      "ratio": 0.516,
+      "compress_mbps": 12.06,
+      "decompress_mbps": 54.26
     },
     {
       "compressor": "native",
       "pattern": "silesia/ooffice",
       "size": 6152192,
       "level": 4,
-      "out_size": 3475962,
-      "ratio": 0.565,
-      "compress_mbps": 8.15,
-      "decompress_mbps": 55.08
+      "out_size": 3121308,
+      "ratio": 0.5073,
+      "compress_mbps": 8.17,
+      "decompress_mbps": 54.06
     },
     {
       "compressor": "native",
       "pattern": "silesia/ooffice",
       "size": 6152192,
       "level": 5,
-      "out_size": 3470919,
-      "ratio": 0.5642,
-      "compress_mbps": 7.51,
-      "decompress_mbps": 55.7
+      "out_size": 3117864,
+      "ratio": 0.5068,
+      "compress_mbps": 7.67,
+      "decompress_mbps": 55.41
     },
     {
       "compressor": "native",
       "pattern": "silesia/ooffice",
       "size": 6152192,
       "level": 6,
-      "out_size": 3462594,
-      "ratio": 0.5628,
-      "compress_mbps": 6.32,
-      "decompress_mbps": 56.28
+      "out_size": 3112351,
+      "ratio": 0.5059,
+      "compress_mbps": 6.43,
+      "decompress_mbps": 56.49
     },
     {
       "compressor": "native",
       "pattern": "silesia/ooffice",
       "size": 6152192,
       "level": 7,
-      "out_size": 3100878,
-      "ratio": 0.504,
-      "compress_mbps": 1.68,
-      "decompress_mbps": 56.93
+      "out_size": 3072891,
+      "ratio": 0.4995,
+      "compress_mbps": 1.56,
+      "decompress_mbps": 56.32
     },
     {
       "compressor": "native",
       "pattern": "silesia/ooffice",
       "size": 6152192,
       "level": 8,
-      "out_size": 3099704,
-      "ratio": 0.5038,
-      "compress_mbps": 1.43,
-      "decompress_mbps": 44.35
+      "out_size": 3071839,
+      "ratio": 0.4993,
+      "compress_mbps": 1.39,
+      "decompress_mbps": 56.91
     },
     {
       "compressor": "native",
       "pattern": "silesia/ooffice",
       "size": 6152192,
       "level": 9,
-      "out_size": 3098139,
-      "ratio": 0.5036,
-      "compress_mbps": 1.36,
-      "decompress_mbps": 55.86
+      "out_size": 3071421,
+      "ratio": 0.4992,
+      "compress_mbps": 1.28,
+      "decompress_mbps": 56.83
     },
     {
       "compressor": "native",
@@ -4424,8 +4424,8 @@
       "level": 1,
       "out_size": 3889230,
       "ratio": 0.3856,
-      "compress_mbps": 20.14,
-      "decompress_mbps": 69.18
+      "compress_mbps": 20.96,
+      "decompress_mbps": 68.09
     },
     {
       "compressor": "native",
@@ -4434,8 +4434,8 @@
       "level": 2,
       "out_size": 3811489,
       "ratio": 0.3779,
-      "compress_mbps": 18.81,
-      "decompress_mbps": 71.9
+      "compress_mbps": 19.69,
+      "decompress_mbps": 70.43
     },
     {
       "compressor": "native",
@@ -4444,8 +4444,8 @@
       "level": 3,
       "out_size": 3789217,
       "ratio": 0.3757,
-      "compress_mbps": 18.31,
-      "decompress_mbps": 73.68
+      "compress_mbps": 18.84,
+      "decompress_mbps": 71.51
     },
     {
       "compressor": "native",
@@ -4454,8 +4454,8 @@
       "level": 4,
       "out_size": 3742155,
       "ratio": 0.371,
-      "compress_mbps": 13.8,
-      "decompress_mbps": 74.13
+      "compress_mbps": 14.1,
+      "decompress_mbps": 71.89
     },
     {
       "compressor": "native",
@@ -4464,8 +4464,8 @@
       "level": 5,
       "out_size": 3734147,
       "ratio": 0.3702,
-      "compress_mbps": 13.12,
-      "decompress_mbps": 73.63
+      "compress_mbps": 13.63,
+      "decompress_mbps": 70.47
     },
     {
       "compressor": "native",
@@ -4474,8 +4474,8 @@
       "level": 6,
       "out_size": 3723457,
       "ratio": 0.3692,
-      "compress_mbps": 11.68,
-      "decompress_mbps": 73.03
+      "compress_mbps": 11.96,
+      "decompress_mbps": 66.81
     },
     {
       "compressor": "native",
@@ -4484,8 +4484,8 @@
       "level": 7,
       "out_size": 3723087,
       "ratio": 0.3691,
-      "compress_mbps": 2.89,
-      "decompress_mbps": 71.23
+      "compress_mbps": 2.71,
+      "decompress_mbps": 70.94
     },
     {
       "compressor": "native",
@@ -4494,8 +4494,8 @@
       "level": 8,
       "out_size": 3723909,
       "ratio": 0.3692,
-      "compress_mbps": 2.78,
-      "decompress_mbps": 73.61
+      "compress_mbps": 2.58,
+      "decompress_mbps": 69.12
     },
     {
       "compressor": "native",
@@ -4504,98 +4504,98 @@
       "level": 9,
       "out_size": 3723909,
       "ratio": 0.3692,
-      "compress_mbps": 2.75,
-      "decompress_mbps": 70.9
+      "compress_mbps": 2.57,
+      "decompress_mbps": 70.42
     },
     {
       "compressor": "native",
       "pattern": "silesia/reymont",
       "size": 6627202,
       "level": 1,
-      "out_size": 2592263,
-      "ratio": 0.3912,
-      "compress_mbps": 15.92,
-      "decompress_mbps": 98.95
+      "out_size": 2146953,
+      "ratio": 0.324,
+      "compress_mbps": 16.54,
+      "decompress_mbps": 97.83
     },
     {
       "compressor": "native",
       "pattern": "silesia/reymont",
       "size": 6627202,
       "level": 2,
-      "out_size": 2479835,
-      "ratio": 0.3742,
-      "compress_mbps": 14.06,
-      "decompress_mbps": 106.65
+      "out_size": 2072169,
+      "ratio": 0.3127,
+      "compress_mbps": 14.21,
+      "decompress_mbps": 108.63
     },
     {
       "compressor": "native",
       "pattern": "silesia/reymont",
       "size": 6627202,
       "level": 3,
-      "out_size": 2405060,
-      "ratio": 0.3629,
-      "compress_mbps": 11.74,
-      "decompress_mbps": 119.27
+      "out_size": 2021398,
+      "ratio": 0.305,
+      "compress_mbps": 11.79,
+      "decompress_mbps": 118.64
     },
     {
       "compressor": "native",
       "pattern": "silesia/reymont",
       "size": 6627202,
       "level": 4,
-      "out_size": 2257758,
-      "ratio": 0.3407,
-      "compress_mbps": 6.5,
-      "decompress_mbps": 117.17
+      "out_size": 1934888,
+      "ratio": 0.292,
+      "compress_mbps": 5.77,
+      "decompress_mbps": 119.45
     },
     {
       "compressor": "native",
       "pattern": "silesia/reymont",
       "size": 6627202,
       "level": 5,
-      "out_size": 2239545,
-      "ratio": 0.3379,
-      "compress_mbps": 5.59,
-      "decompress_mbps": 122.62
+      "out_size": 1920522,
+      "ratio": 0.2898,
+      "compress_mbps": 5.7,
+      "decompress_mbps": 125.36
     },
     {
       "compressor": "native",
       "pattern": "silesia/reymont",
       "size": 6627202,
       "level": 6,
-      "out_size": 2207053,
-      "ratio": 0.333,
+      "out_size": 1893334,
+      "ratio": 0.2857,
       "compress_mbps": 3.96,
-      "decompress_mbps": 127.06
+      "decompress_mbps": 130.03
     },
     {
       "compressor": "native",
       "pattern": "silesia/reymont",
       "size": 6627202,
       "level": 7,
-      "out_size": 1865730,
-      "ratio": 0.2815,
-      "compress_mbps": 1.06,
-      "decompress_mbps": 128.26
+      "out_size": 1854694,
+      "ratio": 0.2799,
+      "compress_mbps": 1.03,
+      "decompress_mbps": 132.33
     },
     {
       "compressor": "native",
       "pattern": "silesia/reymont",
       "size": 6627202,
       "level": 8,
-      "out_size": 1860184,
-      "ratio": 0.2807,
-      "compress_mbps": 0.79,
-      "decompress_mbps": 129.87
+      "out_size": 1849481,
+      "ratio": 0.2791,
+      "compress_mbps": 0.62,
+      "decompress_mbps": 136.38
     },
     {
       "compressor": "native",
       "pattern": "silesia/reymont",
       "size": 6627202,
       "level": 9,
-      "out_size": 1858631,
-      "ratio": 0.2805,
-      "compress_mbps": 0.74,
-      "decompress_mbps": 131.23
+      "out_size": 1847919,
+      "ratio": 0.2788,
+      "compress_mbps": 0.62,
+      "decompress_mbps": 64.81
     },
     {
       "compressor": "native",
@@ -4604,8 +4604,8 @@
       "level": 1,
       "out_size": 6185865,
       "ratio": 0.2863,
-      "compress_mbps": 24.21,
-      "decompress_mbps": 131.07
+      "compress_mbps": 25.16,
+      "decompress_mbps": 130.8
     },
     {
       "compressor": "native",
@@ -4614,8 +4614,8 @@
       "level": 2,
       "out_size": 6066146,
       "ratio": 0.2808,
-      "compress_mbps": 22.06,
-      "decompress_mbps": 138.18
+      "compress_mbps": 22.21,
+      "decompress_mbps": 135.71
     },
     {
       "compressor": "native",
@@ -4624,8 +4624,8 @@
       "level": 3,
       "out_size": 5993070,
       "ratio": 0.2774,
-      "compress_mbps": 19.03,
-      "decompress_mbps": 142.93
+      "compress_mbps": 19.01,
+      "decompress_mbps": 141.17
     },
     {
       "compressor": "native",
@@ -4634,8 +4634,8 @@
       "level": 4,
       "out_size": 5847650,
       "ratio": 0.2706,
-      "compress_mbps": 11.46,
-      "decompress_mbps": 145.69
+      "compress_mbps": 11.51,
+      "decompress_mbps": 143.81
     },
     {
       "compressor": "native",
@@ -4644,8 +4644,8 @@
       "level": 5,
       "out_size": 5837234,
       "ratio": 0.2702,
-      "compress_mbps": 10.4,
-      "decompress_mbps": 150.46
+      "compress_mbps": 10.48,
+      "decompress_mbps": 148.2
     },
     {
       "compressor": "native",
@@ -4654,48 +4654,48 @@
       "level": 6,
       "out_size": 5823141,
       "ratio": 0.2695,
-      "compress_mbps": 8.61,
-      "decompress_mbps": 152.11
+      "compress_mbps": 8.65,
+      "decompress_mbps": 150.5
     },
     {
       "compressor": "native",
       "pattern": "silesia/samba",
       "size": 21606400,
       "level": 7,
-      "out_size": 5455440,
-      "ratio": 0.2525,
-      "compress_mbps": 2.35,
-      "decompress_mbps": 151.25
+      "out_size": 5422105,
+      "ratio": 0.2509,
+      "compress_mbps": 2.15,
+      "decompress_mbps": 143.64
     },
     {
       "compressor": "native",
       "pattern": "silesia/samba",
       "size": 21606400,
       "level": 8,
-      "out_size": 5450250,
-      "ratio": 0.2523,
-      "compress_mbps": 1.96,
-      "decompress_mbps": 154.1
+      "out_size": 5419419,
+      "ratio": 0.2508,
+      "compress_mbps": 1.6,
+      "decompress_mbps": 103.0
     },
     {
       "compressor": "native",
       "pattern": "silesia/samba",
       "size": 21606400,
       "level": 9,
-      "out_size": 5449052,
-      "ratio": 0.2522,
-      "compress_mbps": 1.62,
-      "decompress_mbps": 149.3
+      "out_size": 5415178,
+      "ratio": 0.2506,
+      "compress_mbps": 1.54,
+      "decompress_mbps": 149.79
     },
     {
       "compressor": "native",
       "pattern": "silesia/sao",
       "size": 7251944,
       "level": 1,
-      "out_size": 5514279,
+      "out_size": 5514155,
       "ratio": 0.7604,
-      "compress_mbps": 13.16,
-      "decompress_mbps": 53.52
+      "compress_mbps": 13.04,
+      "decompress_mbps": 53.35
     },
     {
       "compressor": "native",
@@ -4704,8 +4704,8 @@
       "level": 2,
       "out_size": 5472540,
       "ratio": 0.7546,
-      "compress_mbps": 11.94,
-      "decompress_mbps": 54.48
+      "compress_mbps": 12.15,
+      "decompress_mbps": 54.99
     },
     {
       "compressor": "native",
@@ -4714,8 +4714,8 @@
       "level": 3,
       "out_size": 5448811,
       "ratio": 0.7514,
-      "compress_mbps": 11.13,
-      "decompress_mbps": 55.64
+      "compress_mbps": 11.0,
+      "decompress_mbps": 56.11
     },
     {
       "compressor": "native",
@@ -4724,8 +4724,8 @@
       "level": 4,
       "out_size": 5375802,
       "ratio": 0.7413,
-      "compress_mbps": 7.28,
-      "decompress_mbps": 56.04
+      "compress_mbps": 7.26,
+      "decompress_mbps": 56.36
     },
     {
       "compressor": "native",
@@ -4734,8 +4734,8 @@
       "level": 5,
       "out_size": 5370794,
       "ratio": 0.7406,
-      "compress_mbps": 6.75,
-      "decompress_mbps": 57.08
+      "compress_mbps": 6.73,
+      "decompress_mbps": 56.9
     },
     {
       "compressor": "native",
@@ -4744,148 +4744,148 @@
       "level": 6,
       "out_size": 5362339,
       "ratio": 0.7394,
-      "compress_mbps": 5.63,
-      "decompress_mbps": 56.64
+      "compress_mbps": 5.67,
+      "decompress_mbps": 58.44
     },
     {
       "compressor": "native",
       "pattern": "silesia/sao",
       "size": 7251944,
       "level": 7,
-      "out_size": 5358816,
-      "ratio": 0.7389,
-      "compress_mbps": 1.54,
-      "decompress_mbps": 58.53
+      "out_size": 5352075,
+      "ratio": 0.738,
+      "compress_mbps": 1.46,
+      "decompress_mbps": 57.44
     },
     {
       "compressor": "native",
       "pattern": "silesia/sao",
       "size": 7251944,
       "level": 8,
-      "out_size": 5358607,
-      "ratio": 0.7389,
-      "compress_mbps": 1.54,
-      "decompress_mbps": 56.77
+      "out_size": 5351892,
+      "ratio": 0.738,
+      "compress_mbps": 1.43,
+      "decompress_mbps": 56.68
     },
     {
       "compressor": "native",
       "pattern": "silesia/sao",
       "size": 7251944,
       "level": 9,
-      "out_size": 5358607,
-      "ratio": 0.7389,
-      "compress_mbps": 1.53,
-      "decompress_mbps": 56.99
+      "out_size": 5351892,
+      "ratio": 0.738,
+      "compress_mbps": 1.42,
+      "decompress_mbps": 58.09
     },
     {
       "compressor": "native",
       "pattern": "silesia/webster",
       "size": 41458703,
       "level": 1,
-      "out_size": 16232235,
-      "ratio": 0.3915,
-      "compress_mbps": 17.41,
-      "decompress_mbps": 104.18
+      "out_size": 13389198,
+      "ratio": 0.323,
+      "compress_mbps": 17.27,
+      "decompress_mbps": 104.36
     },
     {
       "compressor": "native",
       "pattern": "silesia/webster",
       "size": 41458703,
       "level": 2,
-      "out_size": 15659043,
-      "ratio": 0.3777,
-      "compress_mbps": 15.68,
-      "decompress_mbps": 108.38
+      "out_size": 12991470,
+      "ratio": 0.3134,
+      "compress_mbps": 15.5,
+      "decompress_mbps": 110.31
     },
     {
       "compressor": "native",
       "pattern": "silesia/webster",
       "size": 41458703,
       "level": 3,
-      "out_size": 15341951,
-      "ratio": 0.3701,
-      "compress_mbps": 13.44,
-      "decompress_mbps": 115.73
+      "out_size": 12756198,
+      "ratio": 0.3077,
+      "compress_mbps": 13.73,
+      "decompress_mbps": 117.16
     },
     {
       "compressor": "native",
       "pattern": "silesia/webster",
       "size": 41458703,
       "level": 4,
-      "out_size": 14794018,
-      "ratio": 0.3568,
-      "compress_mbps": 8.39,
-      "decompress_mbps": 118.09
+      "out_size": 12441121,
+      "ratio": 0.3001,
+      "compress_mbps": 8.53,
+      "decompress_mbps": 119.57
     },
     {
       "compressor": "native",
       "pattern": "silesia/webster",
       "size": 41458703,
       "level": 5,
-      "out_size": 14735437,
-      "ratio": 0.3554,
-      "compress_mbps": 7.85,
-      "decompress_mbps": 120.7
+      "out_size": 12392694,
+      "ratio": 0.2989,
+      "compress_mbps": 7.79,
+      "decompress_mbps": 120.98
     },
     {
       "compressor": "native",
       "pattern": "silesia/webster",
       "size": 41458703,
       "level": 6,
-      "out_size": 14635001,
-      "ratio": 0.353,
-      "compress_mbps": 6.3,
-      "decompress_mbps": 124.95
+      "out_size": 12309254,
+      "ratio": 0.2969,
+      "compress_mbps": 6.31,
+      "decompress_mbps": 125.84
     },
     {
       "compressor": "native",
       "pattern": "silesia/webster",
       "size": 41458703,
       "level": 7,
-      "out_size": 12345372,
-      "ratio": 0.2978,
-      "compress_mbps": 1.9,
-      "decompress_mbps": 126.78
+      "out_size": 12265937,
+      "ratio": 0.2959,
+      "compress_mbps": 1.65,
+      "decompress_mbps": 124.12
     },
     {
       "compressor": "native",
       "pattern": "silesia/webster",
       "size": 41458703,
       "level": 8,
-      "out_size": 12327847,
-      "ratio": 0.2974,
-      "compress_mbps": 1.76,
-      "decompress_mbps": 126.23
+      "out_size": 12249548,
+      "ratio": 0.2955,
+      "compress_mbps": 1.61,
+      "decompress_mbps": 128.27
     },
     {
       "compressor": "native",
       "pattern": "silesia/webster",
       "size": 41458703,
       "level": 9,
-      "out_size": 12327819,
-      "ratio": 0.2974,
-      "compress_mbps": 1.75,
-      "decompress_mbps": 127.05
+      "out_size": 12249508,
+      "ratio": 0.2955,
+      "compress_mbps": 1.69,
+      "decompress_mbps": 125.5
     },
     {
       "compressor": "native",
       "pattern": "silesia/x-ray",
       "size": 8474240,
       "level": 1,
-      "out_size": 7300743,
-      "ratio": 0.8615,
-      "compress_mbps": 12.03,
-      "decompress_mbps": 40.27
+      "out_size": 6018712,
+      "ratio": 0.7102,
+      "compress_mbps": 12.2,
+      "decompress_mbps": 39.52
     },
     {
       "compressor": "native",
       "pattern": "silesia/x-ray",
       "size": 8474240,
       "level": 2,
-      "out_size": 7258514,
-      "ratio": 0.8565,
-      "compress_mbps": 11.3,
-      "decompress_mbps": 43.56
+      "out_size": 5998688,
+      "ratio": 0.7079,
+      "compress_mbps": 11.35,
+      "decompress_mbps": 43.28
     },
     {
       "compressor": "native",
@@ -4894,8 +4894,8 @@
       "level": 3,
       "out_size": 5983501,
       "ratio": 0.7061,
-      "compress_mbps": 10.89,
-      "decompress_mbps": 45.78
+      "compress_mbps": 10.75,
+      "decompress_mbps": 46.14
     },
     {
       "compressor": "native",
@@ -4904,8 +4904,8 @@
       "level": 4,
       "out_size": 5965382,
       "ratio": 0.7039,
-      "compress_mbps": 9.06,
-      "decompress_mbps": 42.72
+      "compress_mbps": 9.07,
+      "decompress_mbps": 42.22
     },
     {
       "compressor": "native",
@@ -4914,8 +4914,8 @@
       "level": 5,
       "out_size": 5964821,
       "ratio": 0.7039,
-      "compress_mbps": 8.92,
-      "decompress_mbps": 43.83
+      "compress_mbps": 8.9,
+      "decompress_mbps": 43.35
     },
     {
       "compressor": "native",
@@ -4924,128 +4924,128 @@
       "level": 6,
       "out_size": 5964654,
       "ratio": 0.7039,
-      "compress_mbps": 8.42,
-      "decompress_mbps": 43.64
+      "compress_mbps": 8.73,
+      "decompress_mbps": 44.14
     },
     {
       "compressor": "native",
       "pattern": "silesia/x-ray",
       "size": 8474240,
       "level": 7,
-      "out_size": 5964649,
-      "ratio": 0.7039,
-      "compress_mbps": 2.36,
-      "decompress_mbps": 43.93
+      "out_size": 5937524,
+      "ratio": 0.7007,
+      "compress_mbps": 2.17,
+      "decompress_mbps": 43.45
     },
     {
       "compressor": "native",
       "pattern": "silesia/x-ray",
       "size": 8474240,
       "level": 8,
-      "out_size": 5964649,
-      "ratio": 0.7039,
-      "compress_mbps": 2.37,
-      "decompress_mbps": 44.4
+      "out_size": 5937524,
+      "ratio": 0.7007,
+      "compress_mbps": 2.17,
+      "decompress_mbps": 43.55
     },
     {
       "compressor": "native",
       "pattern": "silesia/x-ray",
       "size": 8474240,
       "level": 9,
-      "out_size": 5964649,
-      "ratio": 0.7039,
-      "compress_mbps": 2.38,
-      "decompress_mbps": 43.14
+      "out_size": 5937524,
+      "ratio": 0.7007,
+      "compress_mbps": 2.19,
+      "decompress_mbps": 43.85
     },
     {
       "compressor": "native",
       "pattern": "silesia/xml",
       "size": 5345280,
       "level": 1,
-      "out_size": 968373,
-      "ratio": 0.1812,
-      "compress_mbps": 33.45,
-      "decompress_mbps": 202.31
+      "out_size": 841047,
+      "ratio": 0.1573,
+      "compress_mbps": 33.2,
+      "decompress_mbps": 199.07
     },
     {
       "compressor": "native",
       "pattern": "silesia/xml",
       "size": 5345280,
       "level": 2,
-      "out_size": 912756,
-      "ratio": 0.1708,
-      "compress_mbps": 29.32,
-      "decompress_mbps": 221.01
+      "out_size": 796222,
+      "ratio": 0.149,
+      "compress_mbps": 30.3,
+      "decompress_mbps": 221.46
     },
     {
       "compressor": "native",
       "pattern": "silesia/xml",
       "size": 5345280,
       "level": 3,
-      "out_size": 875269,
-      "ratio": 0.1637,
-      "compress_mbps": 25.13,
-      "decompress_mbps": 237.45
+      "out_size": 765435,
+      "ratio": 0.1432,
+      "compress_mbps": 25.57,
+      "decompress_mbps": 241.53
     },
     {
       "compressor": "native",
       "pattern": "silesia/xml",
       "size": 5345280,
       "level": 4,
-      "out_size": 826760,
-      "ratio": 0.1547,
-      "compress_mbps": 14.45,
-      "decompress_mbps": 232.3
+      "out_size": 730001,
+      "ratio": 0.1366,
+      "compress_mbps": 14.71,
+      "decompress_mbps": 235.29
     },
     {
       "compressor": "native",
       "pattern": "silesia/xml",
       "size": 5345280,
       "level": 5,
-      "out_size": 818408,
-      "ratio": 0.1531,
-      "compress_mbps": 13.03,
-      "decompress_mbps": 260.58
+      "out_size": 722548,
+      "ratio": 0.1352,
+      "compress_mbps": 13.28,
+      "decompress_mbps": 258.68
     },
     {
       "compressor": "native",
       "pattern": "silesia/xml",
       "size": 5345280,
       "level": 6,
-      "out_size": 805917,
-      "ratio": 0.1508,
+      "out_size": 711223,
+      "ratio": 0.1331,
       "compress_mbps": 10.6,
-      "decompress_mbps": 274.84
+      "decompress_mbps": 275.71
     },
     {
       "compressor": "native",
       "pattern": "silesia/xml",
       "size": 5345280,
       "level": 7,
-      "out_size": 685265,
-      "ratio": 0.1282,
-      "compress_mbps": 3.02,
-      "decompress_mbps": 276.85
+      "out_size": 682684,
+      "ratio": 0.1277,
+      "compress_mbps": 2.92,
+      "decompress_mbps": 289.58
     },
     {
       "compressor": "native",
       "pattern": "silesia/xml",
       "size": 5345280,
       "level": 8,
-      "out_size": 683484,
-      "ratio": 0.1279,
-      "compress_mbps": 2.66,
-      "decompress_mbps": 258.16
+      "out_size": 681103,
+      "ratio": 0.1274,
+      "compress_mbps": 2.59,
+      "decompress_mbps": 284.42
     },
     {
       "compressor": "native",
       "pattern": "silesia/xml",
       "size": 5345280,
       "level": 9,
-      "out_size": 683122,
-      "ratio": 0.1278,
-      "compress_mbps": 2.59,
-      "decompress_mbps": 281.89
+      "out_size": 680820,
+      "ratio": 0.1274,
+      "compress_mbps": 2.51,
+      "decompress_mbps": 288.36
     },
     {
       "compressor": "zlib",
@@ -5054,8 +5054,8 @@
       "level": 1,
       "out_size": 4585612,
       "ratio": 0.4499,
-      "compress_mbps": 112.62,
-      "decompress_mbps": 326.51
+      "compress_mbps": 107.27,
+      "decompress_mbps": 330.58
     },
     {
       "compressor": "zlib",
@@ -5064,8 +5064,8 @@
       "level": 2,
       "out_size": 4389474,
       "ratio": 0.4307,
-      "compress_mbps": 94.58,
-      "decompress_mbps": 345.63
+      "compress_mbps": 91.43,
+      "decompress_mbps": 349.87
     },
     {
       "compressor": "zlib",
@@ -5074,8 +5074,8 @@
       "level": 3,
       "out_size": 4192079,
       "ratio": 0.4113,
-      "compress_mbps": 58.99,
-      "decompress_mbps": 377.25
+      "compress_mbps": 58.51,
+      "decompress_mbps": 381.71
     },
     {
       "compressor": "zlib",
@@ -5084,8 +5084,8 @@
       "level": 4,
       "out_size": 4095021,
       "ratio": 0.4018,
-      "compress_mbps": 64.89,
-      "decompress_mbps": 362.75
+      "compress_mbps": 62.55,
+      "decompress_mbps": 361.02
     },
     {
       "compressor": "zlib",
@@ -5094,8 +5094,8 @@
       "level": 5,
       "out_size": 3949169,
       "ratio": 0.3875,
-      "compress_mbps": 35.69,
-      "decompress_mbps": 347.67
+      "compress_mbps": 34.09,
+      "decompress_mbps": 352.19
     },
     {
       "compressor": "zlib",
@@ -5104,8 +5104,8 @@
       "level": 6,
       "out_size": 3871628,
       "ratio": 0.3799,
-      "compress_mbps": 21.16,
-      "decompress_mbps": 350.65
+      "compress_mbps": 20.63,
+      "decompress_mbps": 361.18
     },
     {
       "compressor": "zlib",
@@ -5114,8 +5114,8 @@
       "level": 7,
       "out_size": 3858876,
       "ratio": 0.3786,
-      "compress_mbps": 17.65,
-      "decompress_mbps": 353.82
+      "compress_mbps": 17.26,
+      "decompress_mbps": 360.85
     },
     {
       "compressor": "zlib",
@@ -5124,8 +5124,8 @@
       "level": 8,
       "out_size": 3854729,
       "ratio": 0.3782,
-      "compress_mbps": 15.05,
-      "decompress_mbps": 363.76
+      "compress_mbps": 14.76,
+      "decompress_mbps": 361.95
     },
     {
       "compressor": "zlib",
@@ -5134,8 +5134,8 @@
       "level": 9,
       "out_size": 3854729,
       "ratio": 0.3782,
-      "compress_mbps": 15.01,
-      "decompress_mbps": 361.96
+      "compress_mbps": 14.74,
+      "decompress_mbps": 358.57
     },
     {
       "compressor": "zlib",
@@ -5144,8 +5144,8 @@
       "level": 1,
       "out_size": 20577220,
       "ratio": 0.4017,
-      "compress_mbps": 110.99,
-      "decompress_mbps": 365.77
+      "compress_mbps": 102.33,
+      "decompress_mbps": 356.82
     },
     {
       "compressor": "zlib",
@@ -5154,8 +5154,8 @@
       "level": 2,
       "out_size": 20247697,
       "ratio": 0.3953,
-      "compress_mbps": 99.66,
-      "decompress_mbps": 374.56
+      "compress_mbps": 92.52,
+      "decompress_mbps": 366.3
     },
     {
       "compressor": "zlib",
@@ -5164,8 +5164,8 @@
       "level": 3,
       "out_size": 19987880,
       "ratio": 0.3902,
-      "compress_mbps": 75.72,
-      "decompress_mbps": 378.61
+      "compress_mbps": 72.91,
+      "decompress_mbps": 372.66
     },
     {
       "compressor": "zlib",
@@ -5174,8 +5174,8 @@
       "level": 4,
       "out_size": 19512665,
       "ratio": 0.381,
-      "compress_mbps": 74.0,
-      "decompress_mbps": 364.35
+      "compress_mbps": 71.73,
+      "decompress_mbps": 363.82
     },
     {
       "compressor": "zlib",
@@ -5184,8 +5184,8 @@
       "level": 5,
       "out_size": 19213507,
       "ratio": 0.3751,
-      "compress_mbps": 52.58,
-      "decompress_mbps": 370.25
+      "compress_mbps": 51.08,
+      "decompress_mbps": 373.71
     },
     {
       "compressor": "zlib",
@@ -5194,8 +5194,8 @@
       "level": 6,
       "out_size": 19089118,
       "ratio": 0.3727,
-      "compress_mbps": 34.13,
-      "decompress_mbps": 380.67
+      "compress_mbps": 33.3,
+      "decompress_mbps": 378.1
     },
     {
       "compressor": "zlib",
@@ -5204,8 +5204,8 @@
       "level": 7,
       "out_size": 19061204,
       "ratio": 0.3721,
-      "compress_mbps": 27.07,
-      "decompress_mbps": 380.06
+      "compress_mbps": 26.77,
+      "decompress_mbps": 376.18
     },
     {
       "compressor": "zlib",
@@ -5214,8 +5214,8 @@
       "level": 8,
       "out_size": 19040998,
       "ratio": 0.3717,
-      "compress_mbps": 15.33,
-      "decompress_mbps": 382.97
+      "compress_mbps": 15.18,
+      "decompress_mbps": 375.66
     },
     {
       "compressor": "zlib",
@@ -5224,8 +5224,8 @@
       "level": 9,
       "out_size": 19044390,
       "ratio": 0.3718,
-      "compress_mbps": 9.35,
-      "decompress_mbps": 354.76
+      "compress_mbps": 9.45,
+      "decompress_mbps": 383.97
     },
     {
       "compressor": "zlib",
@@ -5234,8 +5234,8 @@
       "level": 1,
       "out_size": 3828360,
       "ratio": 0.384,
-      "compress_mbps": 137.17,
-      "decompress_mbps": 438.18
+      "compress_mbps": 134.85,
+      "decompress_mbps": 450.25
     },
     {
       "compressor": "zlib",
@@ -5244,8 +5244,8 @@
       "level": 2,
       "out_size": 3798539,
       "ratio": 0.381,
-      "compress_mbps": 126.24,
-      "decompress_mbps": 413.39
+      "compress_mbps": 120.89,
+      "decompress_mbps": 462.56
     },
     {
       "compressor": "zlib",
@@ -5254,8 +5254,8 @@
       "level": 3,
       "out_size": 3674568,
       "ratio": 0.3685,
-      "compress_mbps": 79.0,
-      "decompress_mbps": 475.84
+      "compress_mbps": 77.92,
+      "decompress_mbps": 479.97
     },
     {
       "compressor": "zlib",
@@ -5264,8 +5264,8 @@
       "level": 4,
       "out_size": 3680923,
       "ratio": 0.3692,
-      "compress_mbps": 87.01,
-      "decompress_mbps": 417.33
+      "compress_mbps": 84.7,
+      "decompress_mbps": 425.7
     },
     {
       "compressor": "zlib",
@@ -5274,8 +5274,8 @@
       "level": 5,
       "out_size": 3698707,
       "ratio": 0.371,
-      "compress_mbps": 47.26,
-      "decompress_mbps": 391.61
+      "compress_mbps": 46.13,
+      "decompress_mbps": 402.58
     },
     {
       "compressor": "zlib",
@@ -5284,8 +5284,8 @@
       "level": 6,
       "out_size": 3675935,
       "ratio": 0.3687,
-      "compress_mbps": 26.19,
-      "decompress_mbps": 407.4
+      "compress_mbps": 25.85,
+      "decompress_mbps": 412.89
     },
     {
       "compressor": "zlib",
@@ -5294,8 +5294,8 @@
       "level": 7,
       "out_size": 3670281,
       "ratio": 0.3681,
-      "compress_mbps": 20.54,
-      "decompress_mbps": 416.49
+      "compress_mbps": 20.41,
+      "decompress_mbps": 411.66
     },
     {
       "compressor": "zlib",
@@ -5304,8 +5304,8 @@
       "level": 8,
       "out_size": 3661103,
       "ratio": 0.3672,
-      "compress_mbps": 10.84,
-      "decompress_mbps": 415.62
+      "compress_mbps": 10.87,
+      "decompress_mbps": 422.16
     },
     {
       "compressor": "zlib",
@@ -5314,8 +5314,8 @@
       "level": 9,
       "out_size": 3660788,
       "ratio": 0.3672,
-      "compress_mbps": 9.28,
-      "decompress_mbps": 422.39
+      "compress_mbps": 9.26,
+      "decompress_mbps": 417.75
     },
     {
       "compressor": "zlib",
@@ -5324,8 +5324,8 @@
       "level": 1,
       "out_size": 4624591,
       "ratio": 0.1378,
-      "compress_mbps": 329.8,
-      "decompress_mbps": 821.38
+      "compress_mbps": 310.76,
+      "decompress_mbps": 811.52
     },
     {
       "compressor": "zlib",
@@ -5334,8 +5334,8 @@
       "level": 2,
       "out_size": 4303176,
       "ratio": 0.1282,
-      "compress_mbps": 305.84,
-      "decompress_mbps": 842.86
+      "compress_mbps": 289.13,
+      "decompress_mbps": 837.83
     },
     {
       "compressor": "zlib",
@@ -5344,8 +5344,8 @@
       "level": 3,
       "out_size": 4010156,
       "ratio": 0.1195,
-      "compress_mbps": 256.42,
-      "decompress_mbps": 919.56
+      "compress_mbps": 244.77,
+      "decompress_mbps": 919.62
     },
     {
       "compressor": "zlib",
@@ -5354,8 +5354,8 @@
       "level": 4,
       "out_size": 3713866,
       "ratio": 0.1107,
-      "compress_mbps": 208.42,
-      "decompress_mbps": 879.91
+      "compress_mbps": 201.21,
+      "decompress_mbps": 884.58
     },
     {
       "compressor": "zlib",
@@ -5364,8 +5364,8 @@
       "level": 5,
       "out_size": 3378136,
       "ratio": 0.1007,
-      "compress_mbps": 163.75,
-      "decompress_mbps": 938.51
+      "compress_mbps": 156.91,
+      "decompress_mbps": 946.9
     },
     {
       "compressor": "zlib",
@@ -5374,8 +5374,8 @@
       "level": 6,
       "out_size": 3200182,
       "ratio": 0.0954,
-      "compress_mbps": 112.93,
-      "decompress_mbps": 983.84
+      "compress_mbps": 108.78,
+      "decompress_mbps": 983.64
     },
     {
       "compressor": "zlib",
@@ -5384,8 +5384,8 @@
       "level": 7,
       "out_size": 3141278,
       "ratio": 0.0936,
-      "compress_mbps": 89.57,
-      "decompress_mbps": 1006.14
+      "compress_mbps": 86.52,
+      "decompress_mbps": 988.33
     },
     {
       "compressor": "zlib",
@@ -5394,8 +5394,8 @@
       "level": 8,
       "out_size": 3031199,
       "ratio": 0.0903,
-      "compress_mbps": 37.22,
-      "decompress_mbps": 1029.02
+      "compress_mbps": 38.09,
+      "decompress_mbps": 1004.86
     },
     {
       "compressor": "zlib",
@@ -5404,8 +5404,8 @@
       "level": 9,
       "out_size": 2987995,
       "ratio": 0.0891,
-      "compress_mbps": 21.3,
-      "decompress_mbps": 871.38
+      "compress_mbps": 20.88,
+      "decompress_mbps": 1006.8
     },
     {
       "compressor": "zlib",
@@ -5414,8 +5414,8 @@
       "level": 1,
       "out_size": 3290526,
       "ratio": 0.5349,
-      "compress_mbps": 75.98,
-      "decompress_mbps": 244.57
+      "compress_mbps": 71.86,
+      "decompress_mbps": 250.7
     },
     {
       "compressor": "zlib",
@@ -5424,8 +5424,8 @@
       "level": 2,
       "out_size": 3238282,
       "ratio": 0.5264,
-      "compress_mbps": 66.84,
-      "decompress_mbps": 252.61
+      "compress_mbps": 65.87,
+      "decompress_mbps": 254.78
     },
     {
       "compressor": "zlib",
@@ -5434,8 +5434,8 @@
       "level": 3,
       "out_size": 3193366,
       "ratio": 0.5191,
-      "compress_mbps": 55.63,
-      "decompress_mbps": 258.22
+      "compress_mbps": 53.29,
+      "decompress_mbps": 261.42
     },
     {
       "compressor": "zlib",
@@ -5444,8 +5444,8 @@
       "level": 4,
       "out_size": 3158012,
       "ratio": 0.5133,
-      "compress_mbps": 54.19,
-      "decompress_mbps": 262.52
+      "compress_mbps": 51.0,
+      "decompress_mbps": 260.7
     },
     {
       "compressor": "zlib",
@@ -5454,8 +5454,8 @@
       "level": 5,
       "out_size": 3115309,
       "ratio": 0.5064,
-      "compress_mbps": 38.44,
-      "decompress_mbps": 260.2
+      "compress_mbps": 36.32,
+      "decompress_mbps": 264.76
     },
     {
       "compressor": "zlib",
@@ -5464,8 +5464,8 @@
       "level": 6,
       "out_size": 3097288,
       "ratio": 0.5034,
-      "compress_mbps": 24.37,
-      "decompress_mbps": 228.41
+      "compress_mbps": 25.09,
+      "decompress_mbps": 254.06
     },
     {
       "compressor": "zlib",
@@ -5474,8 +5474,8 @@
       "level": 7,
       "out_size": 3094363,
       "ratio": 0.503,
-      "compress_mbps": 20.91,
-      "decompress_mbps": 260.98
+      "compress_mbps": 20.82,
+      "decompress_mbps": 255.41
     },
     {
       "compressor": "zlib",
@@ -5484,8 +5484,8 @@
       "level": 8,
       "out_size": 3093026,
       "ratio": 0.5028,
-      "compress_mbps": 16.17,
-      "decompress_mbps": 263.86
+      "compress_mbps": 16.43,
+      "decompress_mbps": 256.17
     },
     {
       "compressor": "zlib",
@@ -5494,8 +5494,8 @@
       "level": 9,
       "out_size": 3092920,
       "ratio": 0.5027,
-      "compress_mbps": 15.4,
-      "decompress_mbps": 261.98
+      "compress_mbps": 14.97,
+      "decompress_mbps": 257.38
     },
     {
       "compressor": "zlib",
@@ -5504,8 +5504,8 @@
       "level": 1,
       "out_size": 4076385,
       "ratio": 0.4042,
-      "compress_mbps": 123.6,
-      "decompress_mbps": 439.26
+      "compress_mbps": 114.37,
+      "decompress_mbps": 428.29
     },
     {
       "compressor": "zlib",
@@ -5514,8 +5514,8 @@
       "level": 2,
       "out_size": 3991014,
       "ratio": 0.3957,
-      "compress_mbps": 115.11,
-      "decompress_mbps": 457.42
+      "compress_mbps": 106.88,
+      "decompress_mbps": 456.8
     },
     {
       "compressor": "zlib",
@@ -5524,8 +5524,8 @@
       "level": 3,
       "out_size": 3934055,
       "ratio": 0.3901,
-      "compress_mbps": 92.19,
-      "decompress_mbps": 467.32
+      "compress_mbps": 89.81,
+      "decompress_mbps": 473.87
     },
     {
       "compressor": "zlib",
@@ -5534,8 +5534,8 @@
       "level": 4,
       "out_size": 3825092,
       "ratio": 0.3793,
-      "compress_mbps": 83.17,
-      "decompress_mbps": 464.28
+      "compress_mbps": 80.68,
+      "decompress_mbps": 471.71
     },
     {
       "compressor": "zlib",
@@ -5544,8 +5544,8 @@
       "level": 5,
       "out_size": 3752932,
       "ratio": 0.3721,
-      "compress_mbps": 63.86,
-      "decompress_mbps": 459.59
+      "compress_mbps": 61.91,
+      "decompress_mbps": 466.59
     },
     {
       "compressor": "zlib",
@@ -5554,8 +5554,8 @@
       "level": 6,
       "out_size": 3695164,
       "ratio": 0.3664,
-      "compress_mbps": 48.87,
-      "decompress_mbps": 465.98
+      "compress_mbps": 47.77,
+      "decompress_mbps": 472.61
     },
     {
       "compressor": "zlib",
@@ -5564,8 +5564,8 @@
       "level": 7,
       "out_size": 3676881,
       "ratio": 0.3646,
-      "compress_mbps": 37.86,
-      "decompress_mbps": 451.9
+      "compress_mbps": 37.09,
+      "decompress_mbps": 478.57
     },
     {
       "compressor": "zlib",
@@ -5574,8 +5574,8 @@
       "level": 8,
       "out_size": 3673171,
       "ratio": 0.3642,
-      "compress_mbps": 30.38,
-      "decompress_mbps": 468.86
+      "compress_mbps": 31.15,
+      "decompress_mbps": 482.66
     },
     {
       "compressor": "zlib",
@@ -5584,8 +5584,8 @@
       "level": 9,
       "out_size": 3673171,
       "ratio": 0.3642,
-      "compress_mbps": 27.98,
-      "decompress_mbps": 469.77
+      "compress_mbps": 31.18,
+      "decompress_mbps": 484.83
     },
     {
       "compressor": "zlib",
@@ -5594,8 +5594,8 @@
       "level": 1,
       "out_size": 2376424,
       "ratio": 0.3586,
-      "compress_mbps": 121.31,
-      "decompress_mbps": 376.43
+      "compress_mbps": 122.85,
+      "decompress_mbps": 390.82
     },
     {
       "compressor": "zlib",
@@ -5604,8 +5604,8 @@
       "level": 2,
       "out_size": 2259060,
       "ratio": 0.3409,
-      "compress_mbps": 84.63,
-      "decompress_mbps": 390.11
+      "compress_mbps": 107.52,
+      "decompress_mbps": 409.18
     },
     {
       "compressor": "zlib",
@@ -5614,8 +5614,8 @@
       "level": 3,
       "out_size": 2135664,
       "ratio": 0.3223,
-      "compress_mbps": 64.79,
-      "decompress_mbps": 398.49
+      "compress_mbps": 70.9,
+      "decompress_mbps": 429.11
     },
     {
       "compressor": "zlib",
@@ -5624,8 +5624,8 @@
       "level": 4,
       "out_size": 2052793,
       "ratio": 0.3098,
-      "compress_mbps": 76.89,
-      "decompress_mbps": 375.45
+      "compress_mbps": 79.58,
+      "decompress_mbps": 421.04
     },
     {
       "compressor": "zlib",
@@ -5634,8 +5634,8 @@
       "level": 5,
       "out_size": 1932127,
       "ratio": 0.2915,
-      "compress_mbps": 43.59,
-      "decompress_mbps": 417.83
+      "compress_mbps": 43.83,
+      "decompress_mbps": 422.28
     },
     {
       "compressor": "zlib",
@@ -5644,8 +5644,8 @@
       "level": 6,
       "out_size": 1860865,
       "ratio": 0.2808,
-      "compress_mbps": 22.36,
-      "decompress_mbps": 418.24
+      "compress_mbps": 22.4,
+      "decompress_mbps": 429.09
     },
     {
       "compressor": "zlib",
@@ -5654,8 +5654,8 @@
       "level": 7,
       "out_size": 1838671,
       "ratio": 0.2774,
-      "compress_mbps": 14.72,
-      "decompress_mbps": 331.73
+      "compress_mbps": 15.71,
+      "decompress_mbps": 334.52
     },
     {
       "compressor": "zlib",
@@ -5664,8 +5664,8 @@
       "level": 8,
       "out_size": 1823235,
       "ratio": 0.2751,
-      "compress_mbps": 7.0,
-      "decompress_mbps": 377.34
+      "compress_mbps": 8.11,
+      "decompress_mbps": 426.37
     },
     {
       "compressor": "zlib",
@@ -5674,8 +5674,8 @@
       "level": 9,
       "out_size": 1823190,
       "ratio": 0.2751,
-      "compress_mbps": 7.79,
-      "decompress_mbps": 419.25
+      "compress_mbps": 8.04,
+      "decompress_mbps": 431.27
     },
     {
       "compressor": "zlib",
@@ -5684,8 +5684,8 @@
       "level": 1,
       "out_size": 6329449,
       "ratio": 0.2929,
-      "compress_mbps": 158.73,
-      "decompress_mbps": 465.39
+      "compress_mbps": 155.06,
+      "decompress_mbps": 457.77
     },
     {
       "compressor": "zlib",
@@ -5694,8 +5694,8 @@
       "level": 2,
       "out_size": 6128866,
       "ratio": 0.2837,
-      "compress_mbps": 132.8,
-      "decompress_mbps": 501.83
+      "compress_mbps": 143.45,
+      "decompress_mbps": 544.3
     },
     {
       "compressor": "zlib",
@@ -5704,8 +5704,8 @@
       "level": 3,
       "out_size": 5982546,
       "ratio": 0.2769,
-      "compress_mbps": 105.5,
-      "decompress_mbps": 546.09
+      "compress_mbps": 117.06,
+      "decompress_mbps": 568.25
     },
     {
       "compressor": "zlib",
@@ -5714,8 +5714,8 @@
       "level": 4,
       "out_size": 5656400,
       "ratio": 0.2618,
-      "compress_mbps": 111.69,
-      "decompress_mbps": 554.52
+      "compress_mbps": 109.13,
+      "decompress_mbps": 566.73
     },
     {
       "compressor": "zlib",
@@ -5724,8 +5724,8 @@
       "level": 5,
       "out_size": 5511352,
       "ratio": 0.2551,
-      "compress_mbps": 75.4,
-      "decompress_mbps": 570.37
+      "compress_mbps": 77.09,
+      "decompress_mbps": 575.77
     },
     {
       "compressor": "zlib",
@@ -5734,8 +5734,8 @@
       "level": 6,
       "out_size": 5451399,
       "ratio": 0.2523,
-      "compress_mbps": 48.48,
-      "decompress_mbps": 506.08
+      "compress_mbps": 53.24,
+      "decompress_mbps": 565.76
     },
     {
       "compressor": "zlib",
@@ -5744,8 +5744,8 @@
       "level": 7,
       "out_size": 5417123,
       "ratio": 0.2507,
-      "compress_mbps": 39.99,
-      "decompress_mbps": 563.3
+      "compress_mbps": 44.15,
+      "decompress_mbps": 590.59
     },
     {
       "compressor": "zlib",
@@ -5754,8 +5754,8 @@
       "level": 8,
       "out_size": 5404364,
       "ratio": 0.2501,
-      "compress_mbps": 28.4,
-      "decompress_mbps": 556.8
+      "compress_mbps": 31.71,
+      "decompress_mbps": 596.4
     },
     {
       "compressor": "zlib",
@@ -5764,8 +5764,8 @@
       "level": 9,
       "out_size": 5402704,
       "ratio": 0.2501,
-      "compress_mbps": 26.12,
-      "decompress_mbps": 544.55
+      "compress_mbps": 28.96,
+      "decompress_mbps": 595.49
     },
     {
       "compressor": "zlib",
@@ -5774,8 +5774,8 @@
       "level": 1,
       "out_size": 5567768,
       "ratio": 0.7678,
-      "compress_mbps": 56.02,
-      "decompress_mbps": 285.78
+      "compress_mbps": 58.04,
+      "decompress_mbps": 310.55
     },
     {
       "compressor": "zlib",
@@ -5784,8 +5784,8 @@
       "level": 2,
       "out_size": 5504009,
       "ratio": 0.759,
-      "compress_mbps": 45.85,
-      "decompress_mbps": 276.42
+      "compress_mbps": 53.22,
+      "decompress_mbps": 320.1
     },
     {
       "compressor": "zlib",
@@ -5794,8 +5794,8 @@
       "level": 3,
       "out_size": 5439339,
       "ratio": 0.7501,
-      "compress_mbps": 37.94,
-      "decompress_mbps": 263.59
+      "compress_mbps": 43.23,
+      "decompress_mbps": 327.2
     },
     {
       "compressor": "zlib",
@@ -5804,8 +5804,8 @@
       "level": 4,
       "out_size": 5394604,
       "ratio": 0.7439,
-      "compress_mbps": 40.81,
-      "decompress_mbps": 293.75
+      "compress_mbps": 44.14,
+      "decompress_mbps": 335.76
     },
     {
       "compressor": "zlib",
@@ -5814,8 +5814,8 @@
       "level": 5,
       "out_size": 5370116,
       "ratio": 0.7405,
-      "compress_mbps": 27.23,
-      "decompress_mbps": 278.18
+      "compress_mbps": 30.84,
+      "decompress_mbps": 329.13
     },
     {
       "compressor": "zlib",
@@ -5824,8 +5824,8 @@
       "level": 6,
       "out_size": 5331793,
       "ratio": 0.7352,
-      "compress_mbps": 21.13,
-      "decompress_mbps": 323.35
+      "compress_mbps": 21.91,
+      "decompress_mbps": 338.71
     },
     {
       "compressor": "zlib",
@@ -5834,8 +5834,8 @@
       "level": 7,
       "out_size": 5327677,
       "ratio": 0.7347,
-      "compress_mbps": 19.45,
-      "decompress_mbps": 329.72
+      "compress_mbps": 20.17,
+      "decompress_mbps": 338.51
     },
     {
       "compressor": "zlib",
@@ -5844,8 +5844,8 @@
       "level": 8,
       "out_size": 5325914,
       "ratio": 0.7344,
-      "compress_mbps": 16.66,
-      "decompress_mbps": 337.85
+      "compress_mbps": 18.17,
+      "decompress_mbps": 342.17
     },
     {
       "compressor": "zlib",
@@ -5854,8 +5854,8 @@
       "level": 9,
       "out_size": 5325914,
       "ratio": 0.7344,
-      "compress_mbps": 18.3,
-      "decompress_mbps": 337.72
+      "compress_mbps": 18.14,
+      "decompress_mbps": 341.45
     },
     {
       "compressor": "zlib",
@@ -5864,8 +5864,8 @@
       "level": 1,
       "out_size": 14991236,
       "ratio": 0.3616,
-      "compress_mbps": 123.03,
-      "decompress_mbps": 370.76
+      "compress_mbps": 126.34,
+      "decompress_mbps": 363.52
     },
     {
       "compressor": "zlib",
@@ -5874,8 +5874,8 @@
       "level": 2,
       "out_size": 14249692,
       "ratio": 0.3437,
-      "compress_mbps": 115.23,
-      "decompress_mbps": 393.87
+      "compress_mbps": 112.36,
+      "decompress_mbps": 395.19
     },
     {
       "compressor": "zlib",
@@ -5884,8 +5884,8 @@
       "level": 3,
       "out_size": 13627761,
       "ratio": 0.3287,
-      "compress_mbps": 84.99,
-      "decompress_mbps": 407.18
+      "compress_mbps": 83.7,
+      "decompress_mbps": 410.26
     },
     {
       "compressor": "zlib",
@@ -5894,8 +5894,8 @@
       "level": 4,
       "out_size": 13001990,
       "ratio": 0.3136,
-      "compress_mbps": 81.23,
-      "decompress_mbps": 386.22
+      "compress_mbps": 82.44,
+      "decompress_mbps": 390.49
     },
     {
       "compressor": "zlib",
@@ -5904,8 +5904,8 @@
       "level": 5,
       "out_size": 12445991,
       "ratio": 0.3002,
-      "compress_mbps": 52.25,
-      "decompress_mbps": 378.08
+      "compress_mbps": 53.16,
+      "decompress_mbps": 385.36
     },
     {
       "compressor": "zlib",
@@ -5914,8 +5914,8 @@
       "level": 6,
       "out_size": 12213941,
       "ratio": 0.2946,
-      "compress_mbps": 35.92,
-      "decompress_mbps": 389.79
+      "compress_mbps": 35.59,
+      "decompress_mbps": 393.52
     },
     {
       "compressor": "zlib",
@@ -5924,8 +5924,8 @@
       "level": 7,
       "out_size": 12130416,
       "ratio": 0.2926,
-      "compress_mbps": 27.88,
-      "decompress_mbps": 393.35
+      "compress_mbps": 29.08,
+      "decompress_mbps": 393.06
     },
     {
       "compressor": "zlib",
@@ -5934,8 +5934,8 @@
       "level": 8,
       "out_size": 12073697,
       "ratio": 0.2912,
-      "compress_mbps": 21.0,
-      "decompress_mbps": 386.34
+      "compress_mbps": 21.06,
+      "decompress_mbps": 395.3
     },
     {
       "compressor": "zlib",
@@ -5944,8 +5944,8 @@
       "level": 9,
       "out_size": 12073469,
       "ratio": 0.2912,
-      "compress_mbps": 20.59,
-      "decompress_mbps": 400.02
+      "compress_mbps": 21.04,
+      "decompress_mbps": 397.86
     },
     {
       "compressor": "zlib",
@@ -5954,8 +5954,8 @@
       "level": 1,
       "out_size": 6033926,
       "ratio": 0.712,
-      "compress_mbps": 72.67,
-      "decompress_mbps": 278.51
+      "compress_mbps": 70.22,
+      "decompress_mbps": 281.53
     },
     {
       "compressor": "zlib",
@@ -5964,8 +5964,8 @@
       "level": 2,
       "out_size": 5997474,
       "ratio": 0.7077,
-      "compress_mbps": 66.99,
-      "decompress_mbps": 284.65
+      "compress_mbps": 63.82,
+      "decompress_mbps": 288.13
     },
     {
       "compressor": "zlib",
@@ -5974,8 +5974,8 @@
       "level": 3,
       "out_size": 5966621,
       "ratio": 0.7041,
-      "compress_mbps": 54.17,
-      "decompress_mbps": 287.51
+      "compress_mbps": 52.42,
+      "decompress_mbps": 293.81
     },
     {
       "compressor": "zlib",
@@ -5984,8 +5984,8 @@
       "level": 4,
       "out_size": 6091108,
       "ratio": 0.7188,
-      "compress_mbps": 44.66,
-      "decompress_mbps": 248.2
+      "compress_mbps": 42.66,
+      "decompress_mbps": 254.05
     },
     {
       "compressor": "zlib",
@@ -5994,8 +5994,8 @@
       "level": 5,
       "out_size": 6053566,
       "ratio": 0.7143,
-      "compress_mbps": 36.13,
-      "decompress_mbps": 257.67
+      "compress_mbps": 34.94,
+      "decompress_mbps": 261.32
     },
     {
       "compressor": "zlib",
@@ -6004,8 +6004,8 @@
       "level": 6,
       "out_size": 6045111,
       "ratio": 0.7134,
-      "compress_mbps": 34.12,
-      "decompress_mbps": 262.19
+      "compress_mbps": 32.99,
+      "decompress_mbps": 266.11
     },
     {
       "compressor": "zlib",
@@ -6014,8 +6014,8 @@
       "level": 7,
       "out_size": 6045034,
       "ratio": 0.7133,
-      "compress_mbps": 34.03,
-      "decompress_mbps": 261.12
+      "compress_mbps": 32.93,
+      "decompress_mbps": 266.69
     },
     {
       "compressor": "zlib",
@@ -6024,8 +6024,8 @@
       "level": 8,
       "out_size": 6045032,
       "ratio": 0.7133,
-      "compress_mbps": 34.07,
-      "decompress_mbps": 260.63
+      "compress_mbps": 32.88,
+      "decompress_mbps": 265.38
     },
     {
       "compressor": "zlib",
@@ -6034,8 +6034,8 @@
       "level": 9,
       "out_size": 6045032,
       "ratio": 0.7133,
-      "compress_mbps": 33.96,
-      "decompress_mbps": 259.4
+      "compress_mbps": 32.84,
+      "decompress_mbps": 264.96
     },
     {
       "compressor": "zlib",
@@ -6044,8 +6044,8 @@
       "level": 1,
       "out_size": 965242,
       "ratio": 0.1806,
-      "compress_mbps": 255.68,
-      "decompress_mbps": 672.39
+      "compress_mbps": 249.06,
+      "decompress_mbps": 681.5
     },
     {
       "compressor": "zlib",
@@ -6054,8 +6054,8 @@
       "level": 2,
       "out_size": 887265,
       "ratio": 0.166,
-      "compress_mbps": 239.8,
-      "decompress_mbps": 722.07
+      "compress_mbps": 236.34,
+      "decompress_mbps": 740.77
     },
     {
       "compressor": "zlib",
@@ -6064,8 +6064,8 @@
       "level": 3,
       "out_size": 822167,
       "ratio": 0.1538,
-      "compress_mbps": 186.8,
-      "decompress_mbps": 766.33
+      "compress_mbps": 186.86,
+      "decompress_mbps": 793.29
     },
     {
       "compressor": "zlib",
@@ -6074,8 +6074,8 @@
       "level": 4,
       "out_size": 807518,
       "ratio": 0.1511,
-      "compress_mbps": 164.2,
-      "decompress_mbps": 735.56
+      "compress_mbps": 164.32,
+      "decompress_mbps": 760.37
     },
     {
       "compressor": "zlib",
@@ -6084,8 +6084,8 @@
       "level": 5,
       "out_size": 730574,
       "ratio": 0.1367,
-      "compress_mbps": 119.02,
-      "decompress_mbps": 777.13
+      "compress_mbps": 118.47,
+      "decompress_mbps": 809.92
     },
     {
       "compressor": "zlib",
@@ -6094,8 +6094,8 @@
       "level": 6,
       "out_size": 687991,
       "ratio": 0.1287,
-      "compress_mbps": 77.84,
-      "decompress_mbps": 831.54
+      "compress_mbps": 78.1,
+      "decompress_mbps": 861.04
     },
     {
       "compressor": "zlib",
@@ -6104,8 +6104,8 @@
       "level": 7,
       "out_size": 673933,
       "ratio": 0.1261,
-      "compress_mbps": 63.95,
-      "decompress_mbps": 846.38
+      "compress_mbps": 63.99,
+      "decompress_mbps": 847.99
     },
     {
       "compressor": "zlib",
@@ -6114,8 +6114,8 @@
       "level": 8,
       "out_size": 659518,
       "ratio": 0.1234,
-      "compress_mbps": 40.84,
-      "decompress_mbps": 853.31
+      "compress_mbps": 42.58,
+      "decompress_mbps": 875.52
     },
     {
       "compressor": "zlib",
@@ -6124,8 +6124,8 @@
       "level": 9,
       "out_size": 658899,
       "ratio": 0.1233,
-      "compress_mbps": 39.29,
-      "decompress_mbps": 862.18
+      "compress_mbps": 39.37,
+      "decompress_mbps": 853.15
     },
     {
       "compressor": "miniz_oxide",
@@ -6134,8 +6134,8 @@
       "level": 1,
       "out_size": 5363862,
       "ratio": 0.5263,
-      "compress_mbps": 139.04,
-      "decompress_mbps": 375.89
+      "compress_mbps": 134.99,
+      "decompress_mbps": 379.58
     },
     {
       "compressor": "miniz_oxide",
@@ -6144,8 +6144,8 @@
       "level": 2,
       "out_size": 4438205,
       "ratio": 0.4354,
-      "compress_mbps": 126.11,
-      "decompress_mbps": 433.9
+      "compress_mbps": 127.1,
+      "decompress_mbps": 441.91
     },
     {
       "compressor": "miniz_oxide",
@@ -6154,8 +6154,8 @@
       "level": 3,
       "out_size": 4054333,
       "ratio": 0.3978,
-      "compress_mbps": 63.54,
-      "decompress_mbps": 478.51
+      "compress_mbps": 63.31,
+      "decompress_mbps": 487.32
     },
     {
       "compressor": "miniz_oxide",
@@ -6164,8 +6164,8 @@
       "level": 4,
       "out_size": 4038550,
       "ratio": 0.3962,
-      "compress_mbps": 57.13,
-      "decompress_mbps": 474.12
+      "compress_mbps": 57.26,
+      "decompress_mbps": 476.57
     },
     {
       "compressor": "miniz_oxide",
@@ -6174,8 +6174,8 @@
       "level": 5,
       "out_size": 3954920,
       "ratio": 0.388,
-      "compress_mbps": 40.06,
-      "decompress_mbps": 464.75
+      "compress_mbps": 40.05,
+      "decompress_mbps": 466.34
     },
     {
       "compressor": "miniz_oxide",
@@ -6184,8 +6184,8 @@
       "level": 6,
       "out_size": 3872874,
       "ratio": 0.38,
-      "compress_mbps": 22.43,
-      "decompress_mbps": 472.67
+      "compress_mbps": 22.47,
+      "decompress_mbps": 470.44
     },
     {
       "compressor": "miniz_oxide",
@@ -6194,8 +6194,8 @@
       "level": 7,
       "out_size": 3859937,
       "ratio": 0.3787,
-      "compress_mbps": 18.69,
-      "decompress_mbps": 475.29
+      "compress_mbps": 18.78,
+      "decompress_mbps": 478.74
     },
     {
       "compressor": "miniz_oxide",
@@ -6204,8 +6204,8 @@
       "level": 8,
       "out_size": 3855935,
       "ratio": 0.3783,
-      "compress_mbps": 16.97,
-      "decompress_mbps": 475.0
+      "compress_mbps": 16.99,
+      "decompress_mbps": 448.73
     },
     {
       "compressor": "miniz_oxide",
@@ -6214,8 +6214,8 @@
       "level": 9,
       "out_size": 3855791,
       "ratio": 0.3783,
-      "compress_mbps": 16.9,
-      "decompress_mbps": 479.35
+      "compress_mbps": 16.97,
+      "decompress_mbps": 478.36
     },
     {
       "compressor": "miniz_oxide",
@@ -6224,8 +6224,8 @@
       "level": 1,
       "out_size": 22334882,
       "ratio": 0.4361,
-      "compress_mbps": 227.78,
-      "decompress_mbps": 354.07
+      "compress_mbps": 223.39,
+      "decompress_mbps": 366.86
     },
     {
       "compressor": "miniz_oxide",
@@ -6234,8 +6234,8 @@
       "level": 2,
       "out_size": 20150366,
       "ratio": 0.3934,
-      "compress_mbps": 118.53,
-      "decompress_mbps": 336.44
+      "compress_mbps": 117.6,
+      "decompress_mbps": 379.77
     },
     {
       "compressor": "miniz_oxide",
@@ -6244,8 +6244,8 @@
       "level": 3,
       "out_size": 19495014,
       "ratio": 0.3806,
-      "compress_mbps": 65.06,
-      "decompress_mbps": 383.43
+      "compress_mbps": 69.0,
+      "decompress_mbps": 386.62
     },
     {
       "compressor": "miniz_oxide",
@@ -6254,8 +6254,8 @@
       "level": 4,
       "out_size": 19424978,
       "ratio": 0.3792,
-      "compress_mbps": 66.11,
-      "decompress_mbps": 369.38
+      "compress_mbps": 69.84,
+      "decompress_mbps": 403.53
     },
     {
       "compressor": "miniz_oxide",
@@ -6264,8 +6264,8 @@
       "level": 5,
       "out_size": 19298736,
       "ratio": 0.3768,
-      "compress_mbps": 47.07,
-      "decompress_mbps": 398.69
+      "compress_mbps": 53.39,
+      "decompress_mbps": 419.37
     },
     {
       "compressor": "miniz_oxide",
@@ -6274,8 +6274,8 @@
       "level": 6,
       "out_size": 19179167,
       "ratio": 0.3744,
-      "compress_mbps": 29.28,
-      "decompress_mbps": 420.54
+      "compress_mbps": 29.4,
+      "decompress_mbps": 422.35
     },
     {
       "compressor": "miniz_oxide",
@@ -6284,8 +6284,8 @@
       "level": 7,
       "out_size": 19151324,
       "ratio": 0.3739,
-      "compress_mbps": 20.91,
-      "decompress_mbps": 426.61
+      "compress_mbps": 21.75,
+      "decompress_mbps": 426.42
     },
     {
       "compressor": "miniz_oxide",
@@ -6294,8 +6294,8 @@
       "level": 8,
       "out_size": 19144373,
       "ratio": 0.3738,
-      "compress_mbps": 16.5,
-      "decompress_mbps": 436.21
+      "compress_mbps": 16.49,
+      "decompress_mbps": 429.57
     },
     {
       "compressor": "miniz_oxide",
@@ -6304,8 +6304,8 @@
       "level": 9,
       "out_size": 19141383,
       "ratio": 0.3737,
-      "compress_mbps": 14.14,
-      "decompress_mbps": 428.25
+      "compress_mbps": 14.11,
+      "decompress_mbps": 429.29
     },
     {
       "compressor": "miniz_oxide",
@@ -6314,8 +6314,8 @@
       "level": 1,
       "out_size": 4249731,
       "ratio": 0.4262,
-      "compress_mbps": 305.01,
-      "decompress_mbps": 504.63
+      "compress_mbps": 300.16,
+      "decompress_mbps": 529.58
     },
     {
       "compressor": "miniz_oxide",
@@ -6324,8 +6324,8 @@
       "level": 2,
       "out_size": 3775479,
       "ratio": 0.3787,
-      "compress_mbps": 156.53,
-      "decompress_mbps": 562.67
+      "compress_mbps": 153.86,
+      "decompress_mbps": 562.42
     },
     {
       "compressor": "miniz_oxide",
@@ -6334,8 +6334,8 @@
       "level": 3,
       "out_size": 3656966,
       "ratio": 0.3668,
-      "compress_mbps": 79.35,
-      "decompress_mbps": 585.17
+      "compress_mbps": 78.5,
+      "decompress_mbps": 580.41
     },
     {
       "compressor": "miniz_oxide",
@@ -6344,8 +6344,8 @@
       "level": 4,
       "out_size": 3740378,
       "ratio": 0.3751,
-      "compress_mbps": 67.08,
-      "decompress_mbps": 544.17
+      "compress_mbps": 66.77,
+      "decompress_mbps": 545.78
     },
     {
       "compressor": "miniz_oxide",
@@ -6355,7 +6355,7 @@
       "out_size": 3713604,
       "ratio": 0.3725,
       "compress_mbps": 48.05,
-      "decompress_mbps": 511.73
+      "decompress_mbps": 506.44
     },
     {
       "compressor": "miniz_oxide",
@@ -6364,8 +6364,8 @@
       "level": 6,
       "out_size": 3683556,
       "ratio": 0.3694,
-      "compress_mbps": 24.79,
-      "decompress_mbps": 526.3
+      "compress_mbps": 24.86,
+      "decompress_mbps": 529.27
     },
     {
       "compressor": "miniz_oxide",
@@ -6374,8 +6374,8 @@
       "level": 7,
       "out_size": 3683797,
       "ratio": 0.3695,
-      "compress_mbps": 18.85,
-      "decompress_mbps": 533.91
+      "compress_mbps": 18.92,
+      "decompress_mbps": 537.91
     },
     {
       "compressor": "miniz_oxide",
@@ -6384,8 +6384,8 @@
       "level": 8,
       "out_size": 3684477,
       "ratio": 0.3695,
-      "compress_mbps": 14.27,
-      "decompress_mbps": 538.36
+      "compress_mbps": 14.33,
+      "decompress_mbps": 541.65
     },
     {
       "compressor": "miniz_oxide",
@@ -6394,8 +6394,8 @@
       "level": 9,
       "out_size": 3679414,
       "ratio": 0.369,
-      "compress_mbps": 12.27,
-      "decompress_mbps": 543.61
+      "compress_mbps": 12.36,
+      "decompress_mbps": 549.04
     },
     {
       "compressor": "miniz_oxide",
@@ -6404,8 +6404,8 @@
       "level": 1,
       "out_size": 5594622,
       "ratio": 0.1667,
-      "compress_mbps": 423.35,
-      "decompress_mbps": 844.53
+      "compress_mbps": 417.44,
+      "decompress_mbps": 844.7
     },
     {
       "compressor": "miniz_oxide",
@@ -6414,8 +6414,8 @@
       "level": 2,
       "out_size": 4179532,
       "ratio": 0.1246,
-      "compress_mbps": 322.13,
-      "decompress_mbps": 947.74
+      "compress_mbps": 322.7,
+      "decompress_mbps": 944.77
     },
     {
       "compressor": "miniz_oxide",
@@ -6424,8 +6424,8 @@
       "level": 3,
       "out_size": 3542329,
       "ratio": 0.1056,
-      "compress_mbps": 205.73,
-      "decompress_mbps": 855.88
+      "compress_mbps": 208.3,
+      "decompress_mbps": 846.73
     },
     {
       "compressor": "miniz_oxide",
@@ -6434,8 +6434,8 @@
       "level": 4,
       "out_size": 3323363,
       "ratio": 0.099,
-      "compress_mbps": 191.3,
-      "decompress_mbps": 874.69
+      "compress_mbps": 195.22,
+      "decompress_mbps": 903.56
     },
     {
       "compressor": "miniz_oxide",
@@ -6444,8 +6444,8 @@
       "level": 5,
       "out_size": 3230343,
       "ratio": 0.0963,
-      "compress_mbps": 157.45,
-      "decompress_mbps": 981.2
+      "compress_mbps": 159.85,
+      "decompress_mbps": 967.38
     },
     {
       "compressor": "miniz_oxide",
@@ -6454,8 +6454,8 @@
       "level": 6,
       "out_size": 3123421,
       "ratio": 0.0931,
-      "compress_mbps": 95.04,
-      "decompress_mbps": 1065.4
+      "compress_mbps": 94.68,
+      "decompress_mbps": 1003.27
     },
     {
       "compressor": "miniz_oxide",
@@ -6464,8 +6464,8 @@
       "level": 7,
       "out_size": 3093778,
       "ratio": 0.0922,
-      "compress_mbps": 70.52,
-      "decompress_mbps": 1050.76
+      "compress_mbps": 69.78,
+      "decompress_mbps": 979.47
     },
     {
       "compressor": "miniz_oxide",
@@ -6474,8 +6474,8 @@
       "level": 8,
       "out_size": 3067318,
       "ratio": 0.0914,
-      "compress_mbps": 49.97,
-      "decompress_mbps": 1118.33
+      "compress_mbps": 49.76,
+      "decompress_mbps": 1033.23
     },
     {
       "compressor": "miniz_oxide",
@@ -6484,8 +6484,8 @@
       "level": 9,
       "out_size": 3050695,
       "ratio": 0.0909,
-      "compress_mbps": 41.95,
-      "decompress_mbps": 1091.36
+      "compress_mbps": 41.73,
+      "decompress_mbps": 1033.95
     },
     {
       "compressor": "miniz_oxide",
@@ -6494,8 +6494,8 @@
       "level": 1,
       "out_size": 3543611,
       "ratio": 0.576,
-      "compress_mbps": 164.77,
-      "decompress_mbps": 288.52
+      "compress_mbps": 161.78,
+      "decompress_mbps": 286.89
     },
     {
       "compressor": "miniz_oxide",
@@ -6504,8 +6504,8 @@
       "level": 2,
       "out_size": 3226818,
       "ratio": 0.5245,
-      "compress_mbps": 86.18,
-      "decompress_mbps": 295.12
+      "compress_mbps": 84.37,
+      "decompress_mbps": 293.32
     },
     {
       "compressor": "miniz_oxide",
@@ -6514,8 +6514,8 @@
       "level": 3,
       "out_size": 3144140,
       "ratio": 0.5111,
-      "compress_mbps": 52.91,
-      "decompress_mbps": 308.07
+      "compress_mbps": 52.23,
+      "decompress_mbps": 293.29
     },
     {
       "compressor": "miniz_oxide",
@@ -6524,8 +6524,8 @@
       "level": 4,
       "out_size": 3129833,
       "ratio": 0.5087,
-      "compress_mbps": 51.83,
-      "decompress_mbps": 334.69
+      "compress_mbps": 50.37,
+      "decompress_mbps": 322.18
     },
     {
       "compressor": "miniz_oxide",
@@ -6534,8 +6534,8 @@
       "level": 5,
       "out_size": 3114809,
       "ratio": 0.5063,
-      "compress_mbps": 40.48,
-      "decompress_mbps": 343.23
+      "compress_mbps": 39.42,
+      "decompress_mbps": 334.01
     },
     {
       "compressor": "miniz_oxide",
@@ -6544,8 +6544,8 @@
       "level": 6,
       "out_size": 3095705,
       "ratio": 0.5032,
-      "compress_mbps": 25.17,
-      "decompress_mbps": 352.4
+      "compress_mbps": 24.81,
+      "decompress_mbps": 340.08
     },
     {
       "compressor": "miniz_oxide",
@@ -6554,8 +6554,8 @@
       "level": 7,
       "out_size": 3090055,
       "ratio": 0.5023,
-      "compress_mbps": 20.45,
-      "decompress_mbps": 348.8
+      "compress_mbps": 20.18,
+      "decompress_mbps": 342.48
     },
     {
       "compressor": "miniz_oxide",
@@ -6564,8 +6564,8 @@
       "level": 8,
       "out_size": 3087665,
       "ratio": 0.5019,
-      "compress_mbps": 17.39,
-      "decompress_mbps": 356.27
+      "compress_mbps": 17.23,
+      "decompress_mbps": 341.93
     },
     {
       "compressor": "miniz_oxide",
@@ -6574,8 +6574,8 @@
       "level": 9,
       "out_size": 3087158,
       "ratio": 0.5018,
-      "compress_mbps": 16.3,
-      "decompress_mbps": 354.71
+      "compress_mbps": 16.22,
+      "decompress_mbps": 352.01
     },
     {
       "compressor": "miniz_oxide",
@@ -6584,8 +6584,8 @@
       "level": 1,
       "out_size": 5419510,
       "ratio": 0.5373,
-      "compress_mbps": 239.86,
-      "decompress_mbps": 544.67
+      "compress_mbps": 231.56,
+      "decompress_mbps": 539.21
     },
     {
       "compressor": "miniz_oxide",
@@ -6594,8 +6594,8 @@
       "level": 2,
       "out_size": 3982547,
       "ratio": 0.3949,
-      "compress_mbps": 122.82,
-      "decompress_mbps": 559.61
+      "compress_mbps": 123.99,
+      "decompress_mbps": 559.22
     },
     {
       "compressor": "miniz_oxide",
@@ -6604,8 +6604,8 @@
       "level": 3,
       "out_size": 3806102,
       "ratio": 0.3774,
-      "compress_mbps": 81.81,
-      "decompress_mbps": 580.67
+      "compress_mbps": 82.47,
+      "decompress_mbps": 577.1
     },
     {
       "compressor": "miniz_oxide",
@@ -6614,8 +6614,8 @@
       "level": 4,
       "out_size": 3761477,
       "ratio": 0.373,
-      "compress_mbps": 77.87,
-      "decompress_mbps": 611.44
+      "compress_mbps": 78.54,
+      "decompress_mbps": 612.56
     },
     {
       "compressor": "miniz_oxide",
@@ -6624,8 +6624,8 @@
       "level": 5,
       "out_size": 3740298,
       "ratio": 0.3709,
-      "compress_mbps": 67.18,
-      "decompress_mbps": 616.54
+      "compress_mbps": 67.16,
+      "decompress_mbps": 613.17
     },
     {
       "compressor": "miniz_oxide",
@@ -6634,8 +6634,8 @@
       "level": 6,
       "out_size": 3686116,
       "ratio": 0.3655,
-      "compress_mbps": 49.15,
-      "decompress_mbps": 650.16
+      "compress_mbps": 49.27,
+      "decompress_mbps": 644.43
     },
     {
       "compressor": "miniz_oxide",
@@ -6644,8 +6644,8 @@
       "level": 7,
       "out_size": 3668442,
       "ratio": 0.3637,
-      "compress_mbps": 38.68,
-      "decompress_mbps": 659.91
+      "compress_mbps": 38.57,
+      "decompress_mbps": 663.62
     },
     {
       "compressor": "miniz_oxide",
@@ -6654,8 +6654,8 @@
       "level": 8,
       "out_size": 3665072,
       "ratio": 0.3634,
-      "compress_mbps": 33.04,
-      "decompress_mbps": 662.37
+      "compress_mbps": 33.09,
+      "decompress_mbps": 662.46
     },
     {
       "compressor": "miniz_oxide",
@@ -6664,8 +6664,8 @@
       "level": 9,
       "out_size": 3665057,
       "ratio": 0.3634,
-      "compress_mbps": 32.94,
-      "decompress_mbps": 663.53
+      "compress_mbps": 32.93,
+      "decompress_mbps": 662.34
     },
     {
       "compressor": "miniz_oxide",
@@ -6674,8 +6674,8 @@
       "level": 1,
       "out_size": 2842321,
       "ratio": 0.4289,
-      "compress_mbps": 187.4,
-      "decompress_mbps": 489.65
+      "compress_mbps": 183.56,
+      "decompress_mbps": 489.54
     },
     {
       "compressor": "miniz_oxide",
@@ -6684,8 +6684,8 @@
       "level": 2,
       "out_size": 2232180,
       "ratio": 0.3368,
-      "compress_mbps": 152.13,
-      "decompress_mbps": 528.55
+      "compress_mbps": 151.08,
+      "decompress_mbps": 528.34
     },
     {
       "compressor": "miniz_oxide",
@@ -6694,8 +6694,8 @@
       "level": 3,
       "out_size": 2003056,
       "ratio": 0.3022,
-      "compress_mbps": 81.88,
-      "decompress_mbps": 560.53
+      "compress_mbps": 81.18,
+      "decompress_mbps": 559.29
     },
     {
       "compressor": "miniz_oxide",
@@ -6704,8 +6704,8 @@
       "level": 4,
       "out_size": 1985375,
       "ratio": 0.2996,
-      "compress_mbps": 73.83,
-      "decompress_mbps": 571.01
+      "compress_mbps": 73.26,
+      "decompress_mbps": 571.47
     },
     {
       "compressor": "miniz_oxide",
@@ -6714,8 +6714,8 @@
       "level": 5,
       "out_size": 1933775,
       "ratio": 0.2918,
-      "compress_mbps": 51.69,
-      "decompress_mbps": 546.33
+      "compress_mbps": 51.41,
+      "decompress_mbps": 543.8
     },
     {
       "compressor": "miniz_oxide",
@@ -6724,8 +6724,8 @@
       "level": 6,
       "out_size": 1858103,
       "ratio": 0.2804,
-      "compress_mbps": 21.92,
-      "decompress_mbps": 544.65
+      "compress_mbps": 21.86,
+      "decompress_mbps": 552.4
     },
     {
       "compressor": "miniz_oxide",
@@ -6734,8 +6734,8 @@
       "level": 7,
       "out_size": 1840414,
       "ratio": 0.2777,
-      "compress_mbps": 15.05,
-      "decompress_mbps": 551.6
+      "compress_mbps": 15.03,
+      "decompress_mbps": 552.79
     },
     {
       "compressor": "miniz_oxide",
@@ -6745,7 +6745,7 @@
       "out_size": 1831679,
       "ratio": 0.2764,
       "compress_mbps": 11.68,
-      "decompress_mbps": 551.19
+      "decompress_mbps": 544.6
     },
     {
       "compressor": "miniz_oxide",
@@ -6754,8 +6754,8 @@
       "level": 9,
       "out_size": 1827137,
       "ratio": 0.2757,
-      "compress_mbps": 10.11,
-      "decompress_mbps": 542.95
+      "compress_mbps": 10.1,
+      "decompress_mbps": 548.57
     },
     {
       "compressor": "miniz_oxide",
@@ -6764,8 +6764,8 @@
       "level": 1,
       "out_size": 7089759,
       "ratio": 0.3281,
-      "compress_mbps": 285.04,
-      "decompress_mbps": 573.95
+      "compress_mbps": 278.7,
+      "decompress_mbps": 610.05
     },
     {
       "compressor": "miniz_oxide",
@@ -6774,8 +6774,8 @@
       "level": 2,
       "out_size": 5966231,
       "ratio": 0.2761,
-      "compress_mbps": 174.05,
-      "decompress_mbps": 640.07
+      "compress_mbps": 171.25,
+      "decompress_mbps": 639.24
     },
     {
       "compressor": "miniz_oxide",
@@ -6784,8 +6784,8 @@
       "level": 3,
       "out_size": 5611838,
       "ratio": 0.2597,
-      "compress_mbps": 111.36,
-      "decompress_mbps": 665.34
+      "compress_mbps": 110.58,
+      "decompress_mbps": 665.2
     },
     {
       "compressor": "miniz_oxide",
@@ -6794,8 +6794,8 @@
       "level": 4,
       "out_size": 5535436,
       "ratio": 0.2562,
-      "compress_mbps": 104.76,
-      "decompress_mbps": 683.4
+      "compress_mbps": 104.06,
+      "decompress_mbps": 682.52
     },
     {
       "compressor": "miniz_oxide",
@@ -6804,8 +6804,8 @@
       "level": 5,
       "out_size": 5480971,
       "ratio": 0.2537,
-      "compress_mbps": 81.05,
-      "decompress_mbps": 700.12
+      "compress_mbps": 80.88,
+      "decompress_mbps": 696.67
     },
     {
       "compressor": "miniz_oxide",
@@ -6814,8 +6814,8 @@
       "level": 6,
       "out_size": 5437556,
       "ratio": 0.2517,
-      "compress_mbps": 49.34,
-      "decompress_mbps": 711.27
+      "compress_mbps": 49.33,
+      "decompress_mbps": 709.96
     },
     {
       "compressor": "miniz_oxide",
@@ -6824,8 +6824,8 @@
       "level": 7,
       "out_size": 5432108,
       "ratio": 0.2514,
-      "compress_mbps": 40.22,
-      "decompress_mbps": 708.24
+      "compress_mbps": 40.23,
+      "decompress_mbps": 713.98
     },
     {
       "compressor": "miniz_oxide",
@@ -6834,8 +6834,8 @@
       "level": 8,
       "out_size": 5428571,
       "ratio": 0.2512,
-      "compress_mbps": 33.47,
-      "decompress_mbps": 713.49
+      "compress_mbps": 33.07,
+      "decompress_mbps": 694.49
     },
     {
       "compressor": "miniz_oxide",
@@ -6844,8 +6844,8 @@
       "level": 9,
       "out_size": 5425526,
       "ratio": 0.2511,
-      "compress_mbps": 30.35,
-      "decompress_mbps": 712.25
+      "compress_mbps": 30.05,
+      "decompress_mbps": 685.0
     },
     {
       "compressor": "miniz_oxide",
@@ -6854,8 +6854,8 @@
       "level": 1,
       "out_size": 5900800,
       "ratio": 0.8137,
-      "compress_mbps": 187.56,
-      "decompress_mbps": 333.03
+      "compress_mbps": 181.83,
+      "decompress_mbps": 321.9
     },
     {
       "compressor": "miniz_oxide",
@@ -6864,8 +6864,8 @@
       "level": 2,
       "out_size": 5523611,
       "ratio": 0.7617,
-      "compress_mbps": 68.0,
-      "decompress_mbps": 345.35
+      "compress_mbps": 65.68,
+      "decompress_mbps": 335.81
     },
     {
       "compressor": "miniz_oxide",
@@ -6874,8 +6874,8 @@
       "level": 3,
       "out_size": 5393086,
       "ratio": 0.7437,
-      "compress_mbps": 40.15,
-      "decompress_mbps": 356.22
+      "compress_mbps": 39.25,
+      "decompress_mbps": 344.19
     },
     {
       "compressor": "miniz_oxide",
@@ -6884,8 +6884,8 @@
       "level": 4,
       "out_size": 5401582,
       "ratio": 0.7448,
-      "compress_mbps": 40.16,
-      "decompress_mbps": 371.06
+      "compress_mbps": 39.61,
+      "decompress_mbps": 361.05
     },
     {
       "compressor": "miniz_oxide",
@@ -6894,8 +6894,8 @@
       "level": 5,
       "out_size": 5371274,
       "ratio": 0.7407,
-      "compress_mbps": 31.1,
-      "decompress_mbps": 363.04
+      "compress_mbps": 30.63,
+      "decompress_mbps": 354.36
     },
     {
       "compressor": "miniz_oxide",
@@ -6904,8 +6904,8 @@
       "level": 6,
       "out_size": 5330096,
       "ratio": 0.735,
-      "compress_mbps": 20.7,
-      "decompress_mbps": 368.17
+      "compress_mbps": 20.36,
+      "decompress_mbps": 360.35
     },
     {
       "compressor": "miniz_oxide",
@@ -6914,8 +6914,8 @@
       "level": 7,
       "out_size": 5325437,
       "ratio": 0.7343,
-      "compress_mbps": 18.91,
-      "decompress_mbps": 367.52
+      "compress_mbps": 18.71,
+      "decompress_mbps": 362.11
     },
     {
       "compressor": "miniz_oxide",
@@ -6924,8 +6924,8 @@
       "level": 8,
       "out_size": 5323934,
       "ratio": 0.7341,
-      "compress_mbps": 17.95,
-      "decompress_mbps": 367.63
+      "compress_mbps": 17.7,
+      "decompress_mbps": 351.02
     },
     {
       "compressor": "miniz_oxide",
@@ -6934,8 +6934,8 @@
       "level": 9,
       "out_size": 5323621,
       "ratio": 0.7341,
-      "compress_mbps": 17.64,
-      "decompress_mbps": 368.64
+      "compress_mbps": 17.48,
+      "decompress_mbps": 361.75
     },
     {
       "compressor": "miniz_oxide",
@@ -6944,8 +6944,8 @@
       "level": 1,
       "out_size": 17587173,
       "ratio": 0.4242,
-      "compress_mbps": 180.18,
-      "decompress_mbps": 389.26
+      "compress_mbps": 175.29,
+      "decompress_mbps": 370.13
     },
     {
       "compressor": "miniz_oxide",
@@ -6954,8 +6954,8 @@
       "level": 2,
       "out_size": 14171707,
       "ratio": 0.3418,
-      "compress_mbps": 148.31,
-      "decompress_mbps": 425.81
+      "compress_mbps": 143.66,
+      "decompress_mbps": 402.29
     },
     {
       "compressor": "miniz_oxide",
@@ -6964,8 +6964,8 @@
       "level": 3,
       "out_size": 12774851,
       "ratio": 0.3081,
-      "compress_mbps": 85.44,
-      "decompress_mbps": 456.86
+      "compress_mbps": 83.92,
+      "decompress_mbps": 428.25
     },
     {
       "compressor": "miniz_oxide",
@@ -6974,8 +6974,8 @@
       "level": 4,
       "out_size": 12612554,
       "ratio": 0.3042,
-      "compress_mbps": 75.98,
-      "decompress_mbps": 449.1
+      "compress_mbps": 73.78,
+      "decompress_mbps": 426.82
     },
     {
       "compressor": "miniz_oxide",
@@ -6984,8 +6984,8 @@
       "level": 5,
       "out_size": 12392339,
       "ratio": 0.2989,
-      "compress_mbps": 57.8,
-      "decompress_mbps": 456.12
+      "compress_mbps": 56.33,
+      "decompress_mbps": 435.67
     },
     {
       "compressor": "miniz_oxide",
@@ -6994,8 +6994,8 @@
       "level": 6,
       "out_size": 12158314,
       "ratio": 0.2933,
-      "compress_mbps": 34.2,
-      "decompress_mbps": 465.75
+      "compress_mbps": 33.78,
+      "decompress_mbps": 447.54
     },
     {
       "compressor": "miniz_oxide",
@@ -7004,8 +7004,8 @@
       "level": 7,
       "out_size": 12107840,
       "ratio": 0.292,
-      "compress_mbps": 27.45,
-      "decompress_mbps": 473.6
+      "compress_mbps": 27.25,
+      "decompress_mbps": 454.48
     },
     {
       "compressor": "miniz_oxide",
@@ -7014,8 +7014,8 @@
       "level": 8,
       "out_size": 12081311,
       "ratio": 0.2914,
-      "compress_mbps": 22.76,
-      "decompress_mbps": 470.85
+      "compress_mbps": 22.56,
+      "decompress_mbps": 448.12
     },
     {
       "compressor": "miniz_oxide",
@@ -7024,8 +7024,8 @@
       "level": 9,
       "out_size": 12081011,
       "ratio": 0.2914,
-      "compress_mbps": 22.61,
-      "decompress_mbps": 467.6
+      "compress_mbps": 22.51,
+      "decompress_mbps": 455.67
     },
     {
       "compressor": "miniz_oxide",
@@ -7034,8 +7034,8 @@
       "level": 1,
       "out_size": 6527324,
       "ratio": 0.7703,
-      "compress_mbps": 236.95,
-      "decompress_mbps": 328.89
+      "compress_mbps": 233.53,
+      "decompress_mbps": 325.99
     },
     {
       "compressor": "miniz_oxide",
@@ -7044,8 +7044,8 @@
       "level": 2,
       "out_size": 6051483,
       "ratio": 0.7141,
-      "compress_mbps": 74.7,
-      "decompress_mbps": 331.93
+      "compress_mbps": 73.44,
+      "decompress_mbps": 329.35
     },
     {
       "compressor": "miniz_oxide",
@@ -7054,8 +7054,8 @@
       "level": 3,
       "out_size": 6010123,
       "ratio": 0.7092,
-      "compress_mbps": 51.91,
-      "decompress_mbps": 334.06
+      "compress_mbps": 50.7,
+      "decompress_mbps": 328.17
     },
     {
       "compressor": "miniz_oxide",
@@ -7064,8 +7064,8 @@
       "level": 4,
       "out_size": 6024815,
       "ratio": 0.711,
-      "compress_mbps": 44.46,
-      "decompress_mbps": 287.06
+      "compress_mbps": 43.24,
+      "decompress_mbps": 272.73
     },
     {
       "compressor": "miniz_oxide",
@@ -7074,8 +7074,8 @@
       "level": 5,
       "out_size": 6005181,
       "ratio": 0.7086,
-      "compress_mbps": 40.22,
-      "decompress_mbps": 295.72
+      "compress_mbps": 39.28,
+      "decompress_mbps": 283.63
     },
     {
       "compressor": "miniz_oxide",
@@ -7084,8 +7084,8 @@
       "level": 6,
       "out_size": 5997508,
       "ratio": 0.7077,
-      "compress_mbps": 37.79,
-      "decompress_mbps": 298.45
+      "compress_mbps": 36.77,
+      "decompress_mbps": 286.53
     },
     {
       "compressor": "miniz_oxide",
@@ -7094,8 +7094,8 @@
       "level": 7,
       "out_size": 5997403,
       "ratio": 0.7077,
-      "compress_mbps": 37.57,
-      "decompress_mbps": 298.37
+      "compress_mbps": 36.84,
+      "decompress_mbps": 290.78
     },
     {
       "compressor": "miniz_oxide",
@@ -7104,8 +7104,8 @@
       "level": 8,
       "out_size": 5997403,
       "ratio": 0.7077,
-      "compress_mbps": 37.65,
-      "decompress_mbps": 298.26
+      "compress_mbps": 37.58,
+      "decompress_mbps": 298.43
     },
     {
       "compressor": "miniz_oxide",
@@ -7114,8 +7114,8 @@
       "level": 9,
       "out_size": 5997403,
       "ratio": 0.7077,
-      "compress_mbps": 37.65,
-      "decompress_mbps": 299.12
+      "compress_mbps": 37.61,
+      "decompress_mbps": 298.96
     },
     {
       "compressor": "miniz_oxide",
@@ -7124,8 +7124,8 @@
       "level": 1,
       "out_size": 1147652,
       "ratio": 0.2147,
-      "compress_mbps": 384.12,
-      "decompress_mbps": 856.94
+      "compress_mbps": 375.91,
+      "decompress_mbps": 855.21
     },
     {
       "compressor": "miniz_oxide",
@@ -7134,8 +7134,8 @@
       "level": 2,
       "out_size": 919639,
       "ratio": 0.172,
-      "compress_mbps": 261.16,
-      "decompress_mbps": 978.65
+      "compress_mbps": 259.25,
+      "decompress_mbps": 977.05
     },
     {
       "compressor": "miniz_oxide",
@@ -7144,8 +7144,8 @@
       "level": 3,
       "out_size": 752341,
       "ratio": 0.1407,
-      "compress_mbps": 166.88,
-      "decompress_mbps": 1070.46
+      "compress_mbps": 165.37,
+      "decompress_mbps": 1073.85
     },
     {
       "compressor": "miniz_oxide",
@@ -7154,8 +7154,8 @@
       "level": 4,
       "out_size": 735537,
       "ratio": 0.1376,
-      "compress_mbps": 156.35,
-      "decompress_mbps": 1044.87
+      "compress_mbps": 159.28,
+      "decompress_mbps": 1045.34
     },
     {
       "compressor": "miniz_oxide",
@@ -7164,8 +7164,8 @@
       "level": 5,
       "out_size": 706789,
       "ratio": 0.1322,
-      "compress_mbps": 122.74,
-      "decompress_mbps": 1142.63
+      "compress_mbps": 122.38,
+      "decompress_mbps": 1150.12
     },
     {
       "compressor": "miniz_oxide",
@@ -7174,8 +7174,8 @@
       "level": 6,
       "out_size": 676279,
       "ratio": 0.1265,
-      "compress_mbps": 69.3,
-      "decompress_mbps": 1220.66
+      "compress_mbps": 69.05,
+      "decompress_mbps": 1192.68
     },
     {
       "compressor": "miniz_oxide",
@@ -7184,8 +7184,8 @@
       "level": 7,
       "out_size": 668772,
       "ratio": 0.1251,
-      "compress_mbps": 55.79,
-      "decompress_mbps": 1233.21
+      "compress_mbps": 55.78,
+      "decompress_mbps": 1226.89
     },
     {
       "compressor": "miniz_oxide",
@@ -7194,8 +7194,8 @@
       "level": 8,
       "out_size": 665340,
       "ratio": 0.1245,
-      "compress_mbps": 47.4,
-      "decompress_mbps": 1209.49
+      "compress_mbps": 47.26,
+      "decompress_mbps": 1208.01
     },
     {
       "compressor": "miniz_oxide",
@@ -7204,8 +7204,8 @@
       "level": 9,
       "out_size": 664273,
       "ratio": 0.1243,
-      "compress_mbps": 45.65,
-      "decompress_mbps": 1219.0
+      "compress_mbps": 45.64,
+      "decompress_mbps": 1175.92
     },
     {
       "compressor": "libdeflate",
@@ -7214,8 +7214,8 @@
       "level": 1,
       "out_size": 4217525,
       "ratio": 0.4138,
-      "compress_mbps": 243.29,
-      "decompress_mbps": 797.03
+      "compress_mbps": 239.07,
+      "decompress_mbps": 782.38
     },
     {
       "compressor": "libdeflate",
@@ -7224,8 +7224,8 @@
       "level": 2,
       "out_size": 4053259,
       "ratio": 0.3977,
-      "compress_mbps": 169.73,
-      "decompress_mbps": 851.55
+      "compress_mbps": 169.08,
+      "decompress_mbps": 856.68
     },
     {
       "compressor": "libdeflate",
@@ -7234,8 +7234,8 @@
       "level": 3,
       "out_size": 3989875,
       "ratio": 0.3915,
-      "compress_mbps": 139.96,
-      "decompress_mbps": 930.1
+      "compress_mbps": 138.84,
+      "decompress_mbps": 914.94
     },
     {
       "compressor": "libdeflate",
@@ -7244,8 +7244,8 @@
       "level": 4,
       "out_size": 3972869,
       "ratio": 0.3898,
-      "compress_mbps": 127.86,
-      "decompress_mbps": 818.19
+      "compress_mbps": 127.54,
+      "decompress_mbps": 802.38
     },
     {
       "compressor": "libdeflate",
@@ -7255,7 +7255,7 @@
       "out_size": 3894026,
       "ratio": 0.3821,
       "compress_mbps": 99.23,
-      "decompress_mbps": 789.01
+      "decompress_mbps": 779.83
     },
     {
       "compressor": "libdeflate",
@@ -7265,7 +7265,7 @@
       "out_size": 3859436,
       "ratio": 0.3787,
       "compress_mbps": 75.07,
-      "decompress_mbps": 790.07
+      "decompress_mbps": 786.2
     },
     {
       "compressor": "libdeflate",
@@ -7274,8 +7274,8 @@
       "level": 7,
       "out_size": 3837515,
       "ratio": 0.3765,
-      "compress_mbps": 55.26,
-      "decompress_mbps": 802.24
+      "compress_mbps": 55.52,
+      "decompress_mbps": 801.9
     },
     {
       "compressor": "libdeflate",
@@ -7284,8 +7284,8 @@
       "level": 8,
       "out_size": 3811467,
       "ratio": 0.374,
-      "compress_mbps": 35.89,
-      "decompress_mbps": 813.38
+      "compress_mbps": 35.88,
+      "decompress_mbps": 794.06
     },
     {
       "compressor": "libdeflate",
@@ -7294,8 +7294,8 @@
       "level": 9,
       "out_size": 3810354,
       "ratio": 0.3738,
-      "compress_mbps": 32.59,
-      "decompress_mbps": 803.0
+      "compress_mbps": 32.63,
+      "decompress_mbps": 794.36
     },
     {
       "compressor": "libdeflate",
@@ -7304,8 +7304,8 @@
       "level": 1,
       "out_size": 20192961,
       "ratio": 0.3942,
-      "compress_mbps": 240.39,
-      "decompress_mbps": 694.43
+      "compress_mbps": 239.8,
+      "decompress_mbps": 698.58
     },
     {
       "compressor": "libdeflate",
@@ -7314,8 +7314,8 @@
       "level": 2,
       "out_size": 19374226,
       "ratio": 0.3783,
-      "compress_mbps": 183.88,
-      "decompress_mbps": 670.42
+      "compress_mbps": 185.69,
+      "decompress_mbps": 713.08
     },
     {
       "compressor": "libdeflate",
@@ -7324,8 +7324,8 @@
       "level": 3,
       "out_size": 19234937,
       "ratio": 0.3755,
-      "compress_mbps": 172.74,
-      "decompress_mbps": 723.81
+      "compress_mbps": 173.16,
+      "decompress_mbps": 732.25
     },
     {
       "compressor": "libdeflate",
@@ -7334,8 +7334,8 @@
       "level": 4,
       "out_size": 19145385,
       "ratio": 0.3738,
-      "compress_mbps": 162.19,
-      "decompress_mbps": 722.39
+      "compress_mbps": 162.29,
+      "decompress_mbps": 728.14
     },
     {
       "compressor": "libdeflate",
@@ -7344,8 +7344,8 @@
       "level": 5,
       "out_size": 18878875,
       "ratio": 0.3686,
-      "compress_mbps": 143.5,
-      "decompress_mbps": 763.05
+      "compress_mbps": 143.24,
+      "decompress_mbps": 733.21
     },
     {
       "compressor": "libdeflate",
@@ -7354,8 +7354,8 @@
       "level": 6,
       "out_size": 18805391,
       "ratio": 0.3671,
-      "compress_mbps": 120.35,
-      "decompress_mbps": 773.88
+      "compress_mbps": 118.54,
+      "decompress_mbps": 749.04
     },
     {
       "compressor": "libdeflate",
@@ -7364,8 +7364,8 @@
       "level": 7,
       "out_size": 18749947,
       "ratio": 0.3661,
-      "compress_mbps": 86.77,
-      "decompress_mbps": 774.41
+      "compress_mbps": 86.86,
+      "decompress_mbps": 758.65
     },
     {
       "compressor": "libdeflate",
@@ -7374,8 +7374,8 @@
       "level": 8,
       "out_size": 18718540,
       "ratio": 0.3655,
-      "compress_mbps": 46.91,
-      "decompress_mbps": 748.2
+      "compress_mbps": 47.37,
+      "decompress_mbps": 760.69
     },
     {
       "compressor": "libdeflate",
@@ -7384,8 +7384,8 @@
       "level": 9,
       "out_size": 18713659,
       "ratio": 0.3654,
-      "compress_mbps": 33.47,
-      "decompress_mbps": 771.79
+      "compress_mbps": 33.44,
+      "decompress_mbps": 765.27
     },
     {
       "compressor": "libdeflate",
@@ -7394,8 +7394,8 @@
       "level": 1,
       "out_size": 3740775,
       "ratio": 0.3752,
-      "compress_mbps": 293.26,
-      "decompress_mbps": 855.15
+      "compress_mbps": 292.07,
+      "decompress_mbps": 831.67
     },
     {
       "compressor": "libdeflate",
@@ -7404,8 +7404,8 @@
       "level": 2,
       "out_size": 3707407,
       "ratio": 0.3718,
-      "compress_mbps": 214.61,
-      "decompress_mbps": 880.78
+      "compress_mbps": 216.59,
+      "decompress_mbps": 866.65
     },
     {
       "compressor": "libdeflate",
@@ -7414,8 +7414,8 @@
       "level": 3,
       "out_size": 3672389,
       "ratio": 0.3683,
-      "compress_mbps": 183.36,
-      "decompress_mbps": 928.12
+      "compress_mbps": 183.02,
+      "decompress_mbps": 896.31
     },
     {
       "compressor": "libdeflate",
@@ -7424,8 +7424,8 @@
       "level": 4,
       "out_size": 3660011,
       "ratio": 0.3671,
-      "compress_mbps": 170.6,
-      "decompress_mbps": 850.97
+      "compress_mbps": 169.06,
+      "decompress_mbps": 815.77
     },
     {
       "compressor": "libdeflate",
@@ -7434,8 +7434,8 @@
       "level": 5,
       "out_size": 3664245,
       "ratio": 0.3675,
-      "compress_mbps": 141.29,
-      "decompress_mbps": 787.01
+      "compress_mbps": 140.68,
+      "decompress_mbps": 765.0
     },
     {
       "compressor": "libdeflate",
@@ -7444,8 +7444,8 @@
       "level": 6,
       "out_size": 3648644,
       "ratio": 0.3659,
-      "compress_mbps": 105.55,
-      "decompress_mbps": 826.34
+      "compress_mbps": 105.31,
+      "decompress_mbps": 786.79
     },
     {
       "compressor": "libdeflate",
@@ -7454,8 +7454,8 @@
       "level": 7,
       "out_size": 3635323,
       "ratio": 0.3646,
-      "compress_mbps": 68.62,
-      "decompress_mbps": 838.25
+      "compress_mbps": 68.12,
+      "decompress_mbps": 810.17
     },
     {
       "compressor": "libdeflate",
@@ -7464,8 +7464,8 @@
       "level": 8,
       "out_size": 3624778,
       "ratio": 0.3635,
-      "compress_mbps": 43.15,
-      "decompress_mbps": 870.35
+      "compress_mbps": 42.68,
+      "decompress_mbps": 819.95
     },
     {
       "compressor": "libdeflate",
@@ -7474,8 +7474,8 @@
       "level": 9,
       "out_size": 3625176,
       "ratio": 0.3636,
-      "compress_mbps": 38.98,
-      "decompress_mbps": 857.37
+      "compress_mbps": 38.63,
+      "decompress_mbps": 819.06
     },
     {
       "compressor": "libdeflate",
@@ -7484,8 +7484,8 @@
       "level": 1,
       "out_size": 3837577,
       "ratio": 0.1144,
-      "compress_mbps": 603.69,
-      "decompress_mbps": 1533.02
+      "compress_mbps": 593.13,
+      "decompress_mbps": 1516.34
     },
     {
       "compressor": "libdeflate",
@@ -7494,8 +7494,8 @@
       "level": 2,
       "out_size": 3714632,
       "ratio": 0.1107,
-      "compress_mbps": 459.47,
-      "decompress_mbps": 1774.49
+      "compress_mbps": 449.33,
+      "decompress_mbps": 1711.67
     },
     {
       "compressor": "libdeflate",
@@ -7504,8 +7504,8 @@
       "level": 3,
       "out_size": 3599455,
       "ratio": 0.1073,
-      "compress_mbps": 425.98,
-      "decompress_mbps": 1883.68
+      "compress_mbps": 420.65,
+      "decompress_mbps": 1842.59
     },
     {
       "compressor": "libdeflate",
@@ -7514,8 +7514,8 @@
       "level": 4,
       "out_size": 3431843,
       "ratio": 0.1023,
-      "compress_mbps": 387.89,
-      "decompress_mbps": 1790.83
+      "compress_mbps": 382.87,
+      "decompress_mbps": 1758.24
     },
     {
       "compressor": "libdeflate",
@@ -7524,8 +7524,8 @@
       "level": 5,
       "out_size": 3268188,
       "ratio": 0.0974,
-      "compress_mbps": 348.16,
-      "decompress_mbps": 1767.64
+      "compress_mbps": 344.31,
+      "decompress_mbps": 1732.02
     },
     {
       "compressor": "libdeflate",
@@ -7534,8 +7534,8 @@
       "level": 6,
       "out_size": 3091741,
       "ratio": 0.0921,
-      "compress_mbps": 262.56,
-      "decompress_mbps": 1819.82
+      "compress_mbps": 261.68,
+      "decompress_mbps": 1766.35
     },
     {
       "compressor": "libdeflate",
@@ -7544,8 +7544,8 @@
       "level": 7,
       "out_size": 3032499,
       "ratio": 0.0904,
-      "compress_mbps": 185.73,
-      "decompress_mbps": 1791.95
+      "compress_mbps": 182.95,
+      "decompress_mbps": 1759.97
     },
     {
       "compressor": "libdeflate",
@@ -7554,8 +7554,8 @@
       "level": 8,
       "out_size": 2949097,
       "ratio": 0.0879,
-      "compress_mbps": 96.62,
-      "decompress_mbps": 1663.55
+      "compress_mbps": 95.65,
+      "decompress_mbps": 1726.06
     },
     {
       "compressor": "libdeflate",
@@ -7564,8 +7564,8 @@
       "level": 9,
       "out_size": 2925243,
       "ratio": 0.0872,
-      "compress_mbps": 68.7,
-      "decompress_mbps": 1774.14
+      "compress_mbps": 68.75,
+      "decompress_mbps": 1465.08
     },
     {
       "compressor": "libdeflate",
@@ -7574,8 +7574,8 @@
       "level": 1,
       "out_size": 3275124,
       "ratio": 0.5324,
-      "compress_mbps": 164.97,
-      "decompress_mbps": 497.31
+      "compress_mbps": 165.44,
+      "decompress_mbps": 473.88
     },
     {
       "compressor": "libdeflate",
@@ -7584,8 +7584,8 @@
       "level": 2,
       "out_size": 3150806,
       "ratio": 0.5121,
-      "compress_mbps": 128.03,
-      "decompress_mbps": 518.07
+      "compress_mbps": 127.36,
+      "decompress_mbps": 484.93
     },
     {
       "compressor": "libdeflate",
@@ -7594,8 +7594,8 @@
       "level": 3,
       "out_size": 3137061,
       "ratio": 0.5099,
-      "compress_mbps": 120.29,
-      "decompress_mbps": 529.46
+      "compress_mbps": 120.54,
+      "decompress_mbps": 520.87
     },
     {
       "compressor": "libdeflate",
@@ -7604,8 +7604,8 @@
       "level": 4,
       "out_size": 3129676,
       "ratio": 0.5087,
-      "compress_mbps": 116.52,
-      "decompress_mbps": 547.49
+      "compress_mbps": 117.7,
+      "decompress_mbps": 548.84
     },
     {
       "compressor": "libdeflate",
@@ -7614,8 +7614,8 @@
       "level": 5,
       "out_size": 3079277,
       "ratio": 0.5005,
-      "compress_mbps": 99.85,
-      "decompress_mbps": 568.97
+      "compress_mbps": 99.32,
+      "decompress_mbps": 551.19
     },
     {
       "compressor": "libdeflate",
@@ -7624,8 +7624,8 @@
       "level": 6,
       "out_size": 3072378,
       "ratio": 0.4994,
-      "compress_mbps": 89.34,
-      "decompress_mbps": 576.18
+      "compress_mbps": 88.56,
+      "decompress_mbps": 562.46
     },
     {
       "compressor": "libdeflate",
@@ -7634,8 +7634,8 @@
       "level": 7,
       "out_size": 3068123,
       "ratio": 0.4987,
-      "compress_mbps": 76.24,
-      "decompress_mbps": 574.94
+      "compress_mbps": 75.84,
+      "decompress_mbps": 564.74
     },
     {
       "compressor": "libdeflate",
@@ -7644,8 +7644,8 @@
       "level": 8,
       "out_size": 3067299,
       "ratio": 0.4986,
-      "compress_mbps": 55.29,
-      "decompress_mbps": 581.37
+      "compress_mbps": 55.11,
+      "decompress_mbps": 558.89
     },
     {
       "compressor": "libdeflate",
@@ -7654,8 +7654,8 @@
       "level": 9,
       "out_size": 3066968,
       "ratio": 0.4985,
-      "compress_mbps": 49.96,
-      "decompress_mbps": 569.48
+      "compress_mbps": 49.78,
+      "decompress_mbps": 549.57
     },
     {
       "compressor": "libdeflate",
@@ -7664,8 +7664,8 @@
       "level": 1,
       "out_size": 3868663,
       "ratio": 0.3836,
-      "compress_mbps": 284.63,
-      "decompress_mbps": 888.01
+      "compress_mbps": 285.78,
+      "decompress_mbps": 825.21
     },
     {
       "compressor": "libdeflate",
@@ -7674,8 +7674,8 @@
       "level": 2,
       "out_size": 3839158,
       "ratio": 0.3807,
-      "compress_mbps": 211.44,
-      "decompress_mbps": 922.17
+      "compress_mbps": 210.91,
+      "decompress_mbps": 894.28
     },
     {
       "compressor": "libdeflate",
@@ -7684,8 +7684,8 @@
       "level": 3,
       "out_size": 3818964,
       "ratio": 0.3787,
-      "compress_mbps": 195.54,
-      "decompress_mbps": 932.84
+      "compress_mbps": 196.92,
+      "decompress_mbps": 926.69
     },
     {
       "compressor": "libdeflate",
@@ -7694,8 +7694,8 @@
       "level": 4,
       "out_size": 3789325,
       "ratio": 0.3757,
-      "compress_mbps": 178.26,
-      "decompress_mbps": 921.23
+      "compress_mbps": 179.49,
+      "decompress_mbps": 974.23
     },
     {
       "compressor": "libdeflate",
@@ -7704,8 +7704,8 @@
       "level": 5,
       "out_size": 3666476,
       "ratio": 0.3635,
-      "compress_mbps": 156.34,
-      "decompress_mbps": 953.76
+      "compress_mbps": 157.2,
+      "decompress_mbps": 937.71
     },
     {
       "compressor": "libdeflate",
@@ -7714,8 +7714,8 @@
       "level": 6,
       "out_size": 3660266,
       "ratio": 0.3629,
-      "compress_mbps": 140.72,
-      "decompress_mbps": 974.67
+      "compress_mbps": 142.19,
+      "decompress_mbps": 973.45
     },
     {
       "compressor": "libdeflate",
@@ -7724,8 +7724,8 @@
       "level": 7,
       "out_size": 3659491,
       "ratio": 0.3628,
-      "compress_mbps": 133.16,
-      "decompress_mbps": 988.19
+      "compress_mbps": 135.14,
+      "decompress_mbps": 1018.71
     },
     {
       "compressor": "libdeflate",
@@ -7734,8 +7734,8 @@
       "level": 8,
       "out_size": 3654863,
       "ratio": 0.3624,
-      "compress_mbps": 114.82,
-      "decompress_mbps": 978.25
+      "compress_mbps": 114.35,
+      "decompress_mbps": 970.62
     },
     {
       "compressor": "libdeflate",
@@ -7744,8 +7744,8 @@
       "level": 9,
       "out_size": 3654860,
       "ratio": 0.3624,
-      "compress_mbps": 114.65,
-      "decompress_mbps": 988.42
+      "compress_mbps": 113.96,
+      "decompress_mbps": 976.95
     },
     {
       "compressor": "libdeflate",
@@ -7754,8 +7754,8 @@
       "level": 1,
       "out_size": 2197055,
       "ratio": 0.3315,
-      "compress_mbps": 301.15,
-      "decompress_mbps": 984.04
+      "compress_mbps": 299.39,
+      "decompress_mbps": 962.29
     },
     {
       "compressor": "libdeflate",
@@ -7764,8 +7764,8 @@
       "level": 2,
       "out_size": 2082309,
       "ratio": 0.3142,
-      "compress_mbps": 215.11,
-      "decompress_mbps": 1127.34
+      "compress_mbps": 210.35,
+      "decompress_mbps": 1054.18
     },
     {
       "compressor": "libdeflate",
@@ -7774,8 +7774,8 @@
       "level": 3,
       "out_size": 2021047,
       "ratio": 0.305,
-      "compress_mbps": 179.15,
-      "decompress_mbps": 1251.51
+      "compress_mbps": 178.2,
+      "decompress_mbps": 1182.54
     },
     {
       "compressor": "libdeflate",
@@ -7784,8 +7784,8 @@
       "level": 4,
       "out_size": 1990952,
       "ratio": 0.3004,
-      "compress_mbps": 158.82,
-      "decompress_mbps": 1163.95
+      "compress_mbps": 157.93,
+      "decompress_mbps": 1069.43
     },
     {
       "compressor": "libdeflate",
@@ -7794,8 +7794,8 @@
       "level": 5,
       "out_size": 1921113,
       "ratio": 0.2899,
-      "compress_mbps": 127.74,
-      "decompress_mbps": 1071.58
+      "compress_mbps": 127.36,
+      "decompress_mbps": 1055.37
     },
     {
       "compressor": "libdeflate",
@@ -7805,7 +7805,7 @@
       "out_size": 1876257,
       "ratio": 0.2831,
       "compress_mbps": 87.08,
-      "decompress_mbps": 1084.78
+      "decompress_mbps": 1038.26
     },
     {
       "compressor": "libdeflate",
@@ -7814,8 +7814,8 @@
       "level": 7,
       "out_size": 1832695,
       "ratio": 0.2765,
-      "compress_mbps": 46.59,
-      "decompress_mbps": 1095.57
+      "compress_mbps": 46.56,
+      "decompress_mbps": 1047.34
     },
     {
       "compressor": "libdeflate",
@@ -7824,8 +7824,8 @@
       "level": 8,
       "out_size": 1809967,
       "ratio": 0.2731,
-      "compress_mbps": 24.24,
-      "decompress_mbps": 974.17
+      "compress_mbps": 24.19,
+      "decompress_mbps": 1020.62
     },
     {
       "compressor": "libdeflate",
@@ -7834,8 +7834,8 @@
       "level": 9,
       "out_size": 1806374,
       "ratio": 0.2726,
-      "compress_mbps": 19.81,
-      "decompress_mbps": 997.88
+      "compress_mbps": 19.88,
+      "decompress_mbps": 1023.98
     },
     {
       "compressor": "libdeflate",
@@ -7844,8 +7844,8 @@
       "level": 1,
       "out_size": 5866517,
       "ratio": 0.2715,
-      "compress_mbps": 340.3,
-      "decompress_mbps": 977.81
+      "compress_mbps": 339.26,
+      "decompress_mbps": 912.82
     },
     {
       "compressor": "libdeflate",
@@ -7854,8 +7854,8 @@
       "level": 2,
       "out_size": 5695942,
       "ratio": 0.2636,
-      "compress_mbps": 255.95,
-      "decompress_mbps": 1047.54
+      "compress_mbps": 257.65,
+      "decompress_mbps": 1060.81
     },
     {
       "compressor": "libdeflate",
@@ -7864,8 +7864,8 @@
       "level": 3,
       "out_size": 5605878,
       "ratio": 0.2595,
-      "compress_mbps": 233.55,
-      "decompress_mbps": 1068.86
+      "compress_mbps": 233.32,
+      "decompress_mbps": 1090.02
     },
     {
       "compressor": "libdeflate",
@@ -7874,8 +7874,8 @@
       "level": 4,
       "out_size": 5553432,
       "ratio": 0.257,
-      "compress_mbps": 216.23,
-      "decompress_mbps": 1060.53
+      "compress_mbps": 217.56,
+      "decompress_mbps": 1083.93
     },
     {
       "compressor": "libdeflate",
@@ -7884,8 +7884,8 @@
       "level": 5,
       "out_size": 5416713,
       "ratio": 0.2507,
-      "compress_mbps": 186.98,
-      "decompress_mbps": 1059.64
+      "compress_mbps": 187.67,
+      "decompress_mbps": 1079.76
     },
     {
       "compressor": "libdeflate",
@@ -7894,8 +7894,8 @@
       "level": 6,
       "out_size": 5337149,
       "ratio": 0.247,
-      "compress_mbps": 142.95,
-      "decompress_mbps": 1068.62
+      "compress_mbps": 144.28,
+      "decompress_mbps": 1089.63
     },
     {
       "compressor": "libdeflate",
@@ -7904,8 +7904,8 @@
       "level": 7,
       "out_size": 5310181,
       "ratio": 0.2458,
-      "compress_mbps": 100.2,
-      "decompress_mbps": 1087.86
+      "compress_mbps": 100.46,
+      "decompress_mbps": 1090.72
     },
     {
       "compressor": "libdeflate",
@@ -7914,8 +7914,8 @@
       "level": 8,
       "out_size": 5272761,
       "ratio": 0.244,
-      "compress_mbps": 62.1,
-      "decompress_mbps": 1081.73
+      "compress_mbps": 62.18,
+      "decompress_mbps": 1091.48
     },
     {
       "compressor": "libdeflate",
@@ -7924,8 +7924,8 @@
       "level": 9,
       "out_size": 5270405,
       "ratio": 0.2439,
-      "compress_mbps": 49.97,
-      "decompress_mbps": 1089.58
+      "compress_mbps": 50.2,
+      "decompress_mbps": 1091.25
     },
     {
       "compressor": "libdeflate",
@@ -7934,8 +7934,8 @@
       "level": 1,
       "out_size": 5575128,
       "ratio": 0.7688,
-      "compress_mbps": 162.78,
-      "decompress_mbps": 488.87
+      "compress_mbps": 161.58,
+      "decompress_mbps": 487.13
     },
     {
       "compressor": "libdeflate",
@@ -7944,8 +7944,8 @@
       "level": 2,
       "out_size": 5417142,
       "ratio": 0.747,
-      "compress_mbps": 117.0,
-      "decompress_mbps": 524.12
+      "compress_mbps": 116.32,
+      "decompress_mbps": 511.86
     },
     {
       "compressor": "libdeflate",
@@ -7954,8 +7954,8 @@
       "level": 3,
       "out_size": 5397999,
       "ratio": 0.7444,
-      "compress_mbps": 105.12,
-      "decompress_mbps": 529.28
+      "compress_mbps": 105.06,
+      "decompress_mbps": 513.87
     },
     {
       "compressor": "libdeflate",
@@ -7964,8 +7964,8 @@
       "level": 4,
       "out_size": 5391125,
       "ratio": 0.7434,
-      "compress_mbps": 99.07,
-      "decompress_mbps": 537.31
+      "compress_mbps": 99.26,
+      "decompress_mbps": 531.26
     },
     {
       "compressor": "libdeflate",
@@ -7974,8 +7974,8 @@
       "level": 5,
       "out_size": 5352212,
       "ratio": 0.738,
-      "compress_mbps": 87.92,
-      "decompress_mbps": 511.43
+      "compress_mbps": 87.74,
+      "decompress_mbps": 492.82
     },
     {
       "compressor": "libdeflate",
@@ -7984,8 +7984,8 @@
       "level": 6,
       "out_size": 5335405,
       "ratio": 0.7357,
-      "compress_mbps": 73.79,
-      "decompress_mbps": 519.95
+      "compress_mbps": 73.07,
+      "decompress_mbps": 513.44
     },
     {
       "compressor": "libdeflate",
@@ -7994,8 +7994,8 @@
       "level": 7,
       "out_size": 5325697,
       "ratio": 0.7344,
-      "compress_mbps": 61.48,
-      "decompress_mbps": 501.6
+      "compress_mbps": 63.47,
+      "decompress_mbps": 515.07
     },
     {
       "compressor": "libdeflate",
@@ -8004,8 +8004,8 @@
       "level": 8,
       "out_size": 5324004,
       "ratio": 0.7341,
-      "compress_mbps": 52.41,
-      "decompress_mbps": 522.54
+      "compress_mbps": 52.57,
+      "decompress_mbps": 519.34
     },
     {
       "compressor": "libdeflate",
@@ -8014,8 +8014,8 @@
       "level": 9,
       "out_size": 5323197,
       "ratio": 0.734,
-      "compress_mbps": 50.88,
-      "decompress_mbps": 518.99
+      "compress_mbps": 51.1,
+      "decompress_mbps": 518.42
     },
     {
       "compressor": "libdeflate",
@@ -8024,8 +8024,8 @@
       "level": 1,
       "out_size": 13550569,
       "ratio": 0.3268,
-      "compress_mbps": 265.61,
-      "decompress_mbps": 825.34
+      "compress_mbps": 265.81,
+      "decompress_mbps": 880.0
     },
     {
       "compressor": "libdeflate",
@@ -8034,8 +8034,8 @@
       "level": 2,
       "out_size": 13130705,
       "ratio": 0.3167,
-      "compress_mbps": 200.16,
-      "decompress_mbps": 992.24
+      "compress_mbps": 201.05,
+      "decompress_mbps": 968.77
     },
     {
       "compressor": "libdeflate",
@@ -8044,8 +8044,8 @@
       "level": 3,
       "out_size": 12839361,
       "ratio": 0.3097,
-      "compress_mbps": 178.18,
-      "decompress_mbps": 1029.93
+      "compress_mbps": 177.9,
+      "decompress_mbps": 1016.67
     },
     {
       "compressor": "libdeflate",
@@ -8054,8 +8054,8 @@
       "level": 4,
       "out_size": 12601933,
       "ratio": 0.304,
-      "compress_mbps": 163.16,
-      "decompress_mbps": 900.81
+      "compress_mbps": 163.39,
+      "decompress_mbps": 917.14
     },
     {
       "compressor": "libdeflate",
@@ -8064,8 +8064,8 @@
       "level": 5,
       "out_size": 12310776,
       "ratio": 0.2969,
-      "compress_mbps": 131.5,
-      "decompress_mbps": 900.98
+      "compress_mbps": 131.35,
+      "decompress_mbps": 863.11
     },
     {
       "compressor": "libdeflate",
@@ -8074,8 +8074,8 @@
       "level": 6,
       "out_size": 12140474,
       "ratio": 0.2928,
-      "compress_mbps": 105.33,
-      "decompress_mbps": 920.24
+      "compress_mbps": 103.62,
+      "decompress_mbps": 914.14
     },
     {
       "compressor": "libdeflate",
@@ -8084,8 +8084,8 @@
       "level": 7,
       "out_size": 12025296,
       "ratio": 0.2901,
-      "compress_mbps": 74.8,
-      "decompress_mbps": 917.47
+      "compress_mbps": 75.25,
+      "decompress_mbps": 913.12
     },
     {
       "compressor": "libdeflate",
@@ -8094,8 +8094,8 @@
       "level": 8,
       "out_size": 11893824,
       "ratio": 0.2869,
-      "compress_mbps": 45.95,
-      "decompress_mbps": 885.58
+      "compress_mbps": 46.03,
+      "decompress_mbps": 904.52
     },
     {
       "compressor": "libdeflate",
@@ -8104,8 +8104,8 @@
       "level": 9,
       "out_size": 11882496,
       "ratio": 0.2866,
-      "compress_mbps": 39.48,
-      "decompress_mbps": 925.38
+      "compress_mbps": 39.59,
+      "decompress_mbps": 901.06
     },
     {
       "compressor": "libdeflate",
@@ -8114,8 +8114,8 @@
       "level": 1,
       "out_size": 6293390,
       "ratio": 0.7426,
-      "compress_mbps": 144.82,
-      "decompress_mbps": 518.13
+      "compress_mbps": 143.89,
+      "decompress_mbps": 504.02
     },
     {
       "compressor": "libdeflate",
@@ -8124,8 +8124,8 @@
       "level": 2,
       "out_size": 6058412,
       "ratio": 0.7149,
-      "compress_mbps": 120.42,
-      "decompress_mbps": 540.62
+      "compress_mbps": 119.96,
+      "decompress_mbps": 517.13
     },
     {
       "compressor": "libdeflate",
@@ -8134,8 +8134,8 @@
       "level": 3,
       "out_size": 6058381,
       "ratio": 0.7149,
-      "compress_mbps": 120.28,
-      "decompress_mbps": 553.08
+      "compress_mbps": 119.74,
+      "decompress_mbps": 537.99
     },
     {
       "compressor": "libdeflate",
@@ -8144,8 +8144,8 @@
       "level": 4,
       "out_size": 6058363,
       "ratio": 0.7149,
-      "compress_mbps": 120.29,
-      "decompress_mbps": 439.55
+      "compress_mbps": 119.76,
+      "decompress_mbps": 427.84
     },
     {
       "compressor": "libdeflate",
@@ -8154,8 +8154,8 @@
       "level": 5,
       "out_size": 5998400,
       "ratio": 0.7078,
-      "compress_mbps": 108.19,
-      "decompress_mbps": 460.08
+      "compress_mbps": 107.52,
+      "decompress_mbps": 440.03
     },
     {
       "compressor": "libdeflate",
@@ -8164,8 +8164,8 @@
       "level": 6,
       "out_size": 5998438,
       "ratio": 0.7078,
-      "compress_mbps": 108.08,
-      "decompress_mbps": 468.25
+      "compress_mbps": 107.46,
+      "decompress_mbps": 455.59
     },
     {
       "compressor": "libdeflate",
@@ -8174,8 +8174,8 @@
       "level": 7,
       "out_size": 5998439,
       "ratio": 0.7078,
-      "compress_mbps": 108.02,
-      "decompress_mbps": 470.24
+      "compress_mbps": 107.61,
+      "decompress_mbps": 454.22
     },
     {
       "compressor": "libdeflate",
@@ -8184,8 +8184,8 @@
       "level": 8,
       "out_size": 5986859,
       "ratio": 0.7065,
-      "compress_mbps": 90.02,
-      "decompress_mbps": 465.29
+      "compress_mbps": 89.9,
+      "decompress_mbps": 454.43
     },
     {
       "compressor": "libdeflate",
@@ -8194,8 +8194,8 @@
       "level": 9,
       "out_size": 5986859,
       "ratio": 0.7065,
-      "compress_mbps": 90.17,
-      "decompress_mbps": 469.12
+      "compress_mbps": 89.99,
+      "decompress_mbps": 445.55
     },
     {
       "compressor": "libdeflate",
@@ -8204,8 +8204,8 @@
       "level": 1,
       "out_size": 887708,
       "ratio": 0.1661,
-      "compress_mbps": 490.57,
-      "decompress_mbps": 1311.4
+      "compress_mbps": 488.65,
+      "decompress_mbps": 1261.59
     },
     {
       "compressor": "libdeflate",
@@ -8214,8 +8214,8 @@
       "level": 2,
       "out_size": 843475,
       "ratio": 0.1578,
-      "compress_mbps": 364.45,
-      "decompress_mbps": 1482.65
+      "compress_mbps": 362.09,
+      "decompress_mbps": 1378.97
     },
     {
       "compressor": "libdeflate",
@@ -8224,8 +8224,8 @@
       "level": 3,
       "out_size": 793388,
       "ratio": 0.1484,
-      "compress_mbps": 337.01,
-      "decompress_mbps": 1599.5
+      "compress_mbps": 332.55,
+      "decompress_mbps": 1491.38
     },
     {
       "compressor": "libdeflate",
@@ -8234,8 +8234,8 @@
       "level": 4,
       "out_size": 747602,
       "ratio": 0.1399,
-      "compress_mbps": 302.92,
-      "decompress_mbps": 1539.85
+      "compress_mbps": 299.6,
+      "decompress_mbps": 1422.14
     },
     {
       "compressor": "libdeflate",
@@ -8244,8 +8244,8 @@
       "level": 5,
       "out_size": 718615,
       "ratio": 0.1344,
-      "compress_mbps": 262.19,
-      "decompress_mbps": 1548.89
+      "compress_mbps": 261.89,
+      "decompress_mbps": 1416.24
     },
     {
       "compressor": "libdeflate",
@@ -8254,8 +8254,8 @@
       "level": 6,
       "out_size": 684405,
       "ratio": 0.128,
-      "compress_mbps": 206.13,
-      "decompress_mbps": 1542.88
+      "compress_mbps": 205.92,
+      "decompress_mbps": 1419.54
     },
     {
       "compressor": "libdeflate",
@@ -8264,8 +8264,8 @@
       "level": 7,
       "out_size": 664859,
       "ratio": 0.1244,
-      "compress_mbps": 142.3,
-      "decompress_mbps": 1559.83
+      "compress_mbps": 142.51,
+      "decompress_mbps": 1507.27
     },
     {
       "compressor": "libdeflate",
@@ -8274,8 +8274,8 @@
       "level": 8,
       "out_size": 650835,
       "ratio": 0.1218,
-      "compress_mbps": 84.4,
-      "decompress_mbps": 1568.02
+      "compress_mbps": 84.62,
+      "decompress_mbps": 1572.37
     },
     {
       "compressor": "libdeflate",
@@ -8284,8 +8284,8 @@
       "level": 9,
       "out_size": 649494,
       "ratio": 0.1215,
-      "compress_mbps": 68.12,
-      "decompress_mbps": 1548.79
+      "compress_mbps": 68.31,
+      "decompress_mbps": 1432.98
     },
     {
       "compressor": "go",


### PR DESCRIPTION
This PR replace the fixed 4096-token cadence in deflateRaw's shared-window block splitter with entropy-divergence split points (closes https://github.com/kim-em/lean-zip/issues/2528): a one-pass, integer-only observation-divergence heuristic (libdeflate's `observe_literal`/`observe_match`/`do_end_block_check`, adapted to the token stream) cuts blocks where the symbol statistics shift, and an exact-bit arbitration (`sharedPartitionBits`, conformance-pinned to the emitter) keeps whichever of the heuristic and fixed-cadence partitions sizes smaller, ties → fixed — so the shared-window candidate can never regress versus the old cadence, and `pickSmaller` still guards it against the single-block base. The proofs needed no new ideas: `emitSharedBlocksAt` clamps every cut to `(pos, toks.size]` so *any* selector yields a total, valid partition, the six roundtrip theorems are mechanical copies of the fixed-cadence ones, and the `deflateRaw` spec changes are three one-line lemma swaps.

The new heterogeneous-input test exposed a pre-existing zlib-interop bug, fixed here: the dynamic-Huffman length-limiter's `bl_count` repair both lost leaves (chained `set!`s reading the stale array, overwriting the `+2` when `bits + 1 = maxBits`) and under-repaired (capped-pair counting instead of the actual Kraft excess), so `fixKraftList` flattened trees to *incomplete* codes that zlib's inflate rejects even though the native/spec decoders tolerate them — on master, `deflateRaw` at the default level emits zlib-undecodable output for e.g. text followed by incompressible bytes. The repair is now driven by the exact Kraft excess with sequential histogram updates, landing on complete codes; a regression test pins FFI (zlib) interop on the triggering input.

Measured on Canterbury + Silesia (dashboard regenerated; ratios deterministic): 98 native rows improve, none regress. The splitter narrows the level-9 prose gap to zlib by about a third (dickens +1.68% → +1.15%, webster +2.11% → +1.46%, reymont +1.94% → +1.36%; mozilla/ooffice −0.9%), and the limiter fix is dramatic at levels 1–6 where flattened trees had been losing the sizing dispatch outright (dickens −19.0%, webster −15.9%, nci −15.4% at the default level 6). Median level-9 compress throughput is unchanged (1.61 → 1.62 MB/s), so the arbitration's two sizing passes cost nothing measurable next to the matcher.

🤖 Prepared with Claude Code