### PR TITLE
perf: share one matcher pass across level-≥7 candidates; demote SC split to level 9

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -467,15 +467,22 @@ decreasing_by
     per-block token groups come from the cut list `choose toks` instead of a
     fixed cadence. The roundtrip holds for any `choose` (the emitter clamps
     every cut), so the selector is a pure ratio heuristic. -/
-def deflateDynamicBlocksSharedAt (data : ByteArray)
-    (choose : Array LZ77Token → List Nat) (level : UInt8) : ByteArray :=
+def deflateDynamicBlocksSharedAtTokens (data : ByteArray) (toks : Array LZ77Token)
+    (choose : Array LZ77Token → List Nat) : ByteArray :=
   if data.size == 0 then
     let f := tokenFreqs #[]
     (emitDynBlock BitWriter.empty data #[] (dynamicCodeLengths f.1 f.2).1 (dynamicCodeLengths f.1 f.2).2
       (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
   else
-    let toks := lzMatch data level
     (emitSharedBlocksAt data toks (choose toks) 0 BitWriter.empty).flush
+
+/-- `deflateDynamicBlocksSharedAtTokens` over this level's `lzMatch` stream.
+    Kept as a definitional wrapper so the level-9 dispatch can share one
+    matcher pass across candidates (Wave 1): the spec lemmas are stated about
+    this wrapper and see through it by `rfl`. -/
+def deflateDynamicBlocksSharedAt (data : ByteArray)
+    (choose : Array LZ77Token → List Nat) (level : UInt8) : ByteArray :=
+  deflateDynamicBlocksSharedAtTokens data (lzMatch data level) choose
 
 /-! ## Entropy-divergence boundary heuristic (libdeflate-style)
 
@@ -665,8 +672,7 @@ def deflateCompressed (data : ByteArray) (level : UInt8) : ByteArray :=
     all *sized* from one shared token pass, emitting only the winner. Falls back to
     a stored block whenever that is smaller, so incompressible input never expands.
     This is the base candidate that the block-split streams are compared against. -/
-def deflateRawBase (data : ByteArray) (level : UInt8) : ByteArray :=
-  let tokens := lzMatch data level
+def deflateRawBaseTokens (data : ByteArray) (tokens : Array LZ77Token) : ByteArray :=
   let f := tokenFreqs tokens
   let lens := dynamicCodeLengths f.1 f.2
   let fixedBytes := fixedBlockBytes f.1 f.2
@@ -680,6 +686,19 @@ def deflateRawBase (data : ByteArray) (level : UInt8) : ByteArray :=
   else if fixedBytes < dynBytes then deflateFixedBlock data tokens
   else deflateDynamicBlockCore data tokens lens.1 lens.2
     (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
+
+/-- `deflateRawBaseTokens` over this level's `lzMatch` stream (definitional
+    wrapper; see `deflateDynamicBlocksSharedAt`). -/
+def deflateRawBase (data : ByteArray) (level : UInt8) : ByteArray :=
+  deflateRawBaseTokens data (lzMatch data level)
+
+theorem deflateRawBase_def (data : ByteArray) (level : UInt8) :
+    deflateRawBaseTokens data (lzMatch data level) = deflateRawBase data level := rfl
+
+theorem deflateDynamicBlocksSharedAt_def (data : ByteArray)
+    (choose : Array LZ77Token → List Nat) (level : UInt8) :
+    deflateDynamicBlocksSharedAtTokens data (lzMatch data level) choose =
+      deflateDynamicBlocksSharedAt data choose level := rfl
 
 /-! ## Near-optimal candidate (level 9) -/
 
@@ -729,16 +748,20 @@ def deflateDynamicBlocksOptimal (data : ByteArray) (tokChunk : Nat) : ByteArray 
 def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   if level == 0 then deflateStoredPure data
   else if 7 ≤ level then
+    -- One matcher pass shared by the base and shared-split candidates (the
+    -- matcher is 83–84% of each candidate's cost — Wave-0 profile, D-2).
+    let tokens := lzMatch data level
     if 9 ≤ level ∧ data.size ≤ optimalMaxSize then
       pickSmaller
-        (pickSmaller (deflateRawBase data level)
+        (pickSmaller (deflateRawBaseTokens data tokens)
           (pickSmaller (deflateDynamicBlocksSC data splitChunkSize level)
-            (deflateDynamicBlocksSharedAt data chooseSplitsArbitrated level)))
+            (deflateDynamicBlocksSharedAtTokens data tokens chooseSplitsArbitrated)))
         (deflateDynamicBlocksOptimal data sharedTokChunk)
     else
-      pickSmaller (deflateRawBase data level)
-        (pickSmaller (deflateDynamicBlocksSC data splitChunkSize level)
-          (deflateDynamicBlocksSharedAt data chooseSplitsArbitrated level))
+      -- The self-contained split is demoted to level 9: it wins on exactly
+      -- one corpus file while paying a full per-chunk match pass.
+      pickSmaller (deflateRawBaseTokens data tokens)
+        (deflateDynamicBlocksSharedAtTokens data tokens chooseSplitsArbitrated)
   else deflateRawBase data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -1093,7 +1093,7 @@ theorem decode_deflateDynamicBlocksSharedAt (data : ByteArray)
     Deflate.Spec.decode
       (Deflate.Spec.bytesToBits (deflateDynamicBlocksSharedAt data choose level)) =
       some data.data.toList := by
-  unfold deflateDynamicBlocksSharedAt
+  unfold deflateDynamicBlocksSharedAt deflateDynamicBlocksSharedAtTokens
   split
   · -- data.size = 0: one final block over the empty token list (as in SC).
     rename_i hz
@@ -1155,7 +1155,7 @@ theorem deflateDynamicBlocksSharedAt_goR_pad (data : ByteArray)
       Deflate.Spec.decode.goR
           (Deflate.Spec.bytesToBits (deflateDynamicBlocksSharedAt data choose level)) []
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
-  unfold deflateDynamicBlocksSharedAt
+  unfold deflateDynamicBlocksSharedAt deflateDynamicBlocksSharedAtTokens
   split
   · -- data.size = 0
     rename_i hz
@@ -1206,7 +1206,7 @@ theorem deflateDynamicBlocksSharedAt_pad (data : ByteArray)
     ∃ (contentBits padding : List Bool),
       Deflate.Spec.bytesToBits (deflateDynamicBlocksSharedAt data choose level) =
         contentBits ++ padding ∧ padding.length < 8 := by
-  unfold deflateDynamicBlocksSharedAt
+  unfold deflateDynamicBlocksSharedAt deflateDynamicBlocksSharedAtTokens
   split
   · obtain ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, hwf⟩ :=
       emitDynBlock_spec BitWriter.empty BitWriter.empty_wf data #[] (by simp) (fun _ => rfl) true

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -88,7 +88,7 @@ set_option maxRecDepth 8000 in
 theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateRawBase data level) maxOutputSize = .ok data := by
-  unfold deflateRawBase
+  unfold deflateRawBase deflateRawBaseTokens
   dsimp only []
   -- stored / fixed / dynamic, sized from one chain token pass. The outer `split`
   -- fires on `fixedBytes < dynBytes`, then each side on the stored comparison.
@@ -110,6 +110,8 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
+  dsimp only []
+  rw [deflateRawBase_def, deflateDynamicBlocksSharedAt_def]
   split
   · exact inflate_deflateStoredPure data _ (by omega)
   · split
@@ -123,9 +125,7 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
           (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
       · exact inflate_pickSmaller _ _ data maxOutputSize
           (inflate_deflateRawBase data level _ hsize)
-          (inflate_pickSmaller _ _ data maxOutputSize
-            (inflate_deflateDynamicBlocksSC data splitChunkSize level _ hsize)
-            (inflate_deflateDynamicBlocksSharedAt data chooseSplitsArbitrated level _ hsize))
+          (inflate_deflateDynamicBlocksSharedAt data chooseSplitsArbitrated level _ hsize)
     · exact inflate_deflateRawBase data level _ hsize
 
 /-- Padding decomposition for the compressed-block dispatch. -/
@@ -155,7 +155,7 @@ theorem deflateRawBase_pad (data : ByteArray) (level : UInt8) :
     ∃ (contentBits padding : List Bool),
       Deflate.Spec.bytesToBits (deflateRawBase data level) = contentBits ++ padding ∧
       padding.length < 8 := by
-  unfold deflateRawBase
+  unfold deflateRawBase deflateRawBaseTokens
   dsimp only []
   -- stored / fixed / dynamic sized; emit only the winner. The outer `split` fires
   -- on `fixedBytes < dynBytes`, then each side on the stored comparison.
@@ -195,6 +195,8 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
       Deflate.Spec.bytesToBits (deflateRaw data level) = contentBits ++ padding ∧
       padding.length < 8 := by
   unfold deflateRaw
+  dsimp only []
+  rw [deflateRawBase_def, deflateDynamicBlocksSharedAt_def]
   split
   · -- Level 0: stored blocks — all byte-aligned, padding = []
     exact ⟨Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data),
@@ -219,11 +221,7 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
           (P := fun bits => ∃ (contentBits padding : List Bool),
             bits = contentBits ++ padding ∧ padding.length < 8)
           _ _ (deflateRawBase_pad data level)
-          (pickSmaller_bytesToBits
-            (P := fun bits => ∃ (contentBits padding : List Bool),
-              bits = contentBits ++ padding ∧ padding.length < 8)
-            _ _ (deflateDynamicBlocksSC_pad data splitChunkSize level)
-            (deflateDynamicBlocksSharedAt_pad data chooseSplitsArbitrated level))
+          (deflateDynamicBlocksSharedAt_pad data chooseSplitsArbitrated level)
     · exact deflateRawBase_pad data level
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
@@ -341,7 +339,7 @@ private theorem deflateRawBase_goR_pad (data : ByteArray) (level : UInt8) :
     ∃ remaining,
       Deflate.Spec.decode.goR (Deflate.Spec.bytesToBits (deflateRawBase data level)) []
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
-  unfold deflateRawBase
+  unfold deflateRawBase deflateRawBaseTokens
   dsimp only []
   have hfixed : ∃ remaining,
       Deflate.Spec.decode.goR
@@ -365,6 +363,8 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
       Deflate.Spec.decode.goR (Deflate.Spec.bytesToBits (deflateRaw data level)) []
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
   unfold deflateRaw
+  dsimp only []
+  rw [deflateRawBase_def, deflateDynamicBlocksSharedAt_def]
   split
   · -- Level 0: stored blocks — byte-aligned, remaining = []
     exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
@@ -392,12 +392,7 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
             Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
               remaining.length < 8)
           _ _ (deflateRawBase_goR_pad data level)
-          (pickSmaller_bytesToBits
-            (P := fun bits => ∃ remaining,
-              Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
-                remaining.length < 8)
-            _ _ (deflateDynamicBlocksSC_goR_pad data splitChunkSize level)
-            (deflateDynamicBlocksSharedAt_goR_pad data chooseSplitsArbitrated level))
+          (deflateDynamicBlocksSharedAt_goR_pad data chooseSplitsArbitrated level)
     · exact deflateRawBase_goR_pad data level
 
 end Zip.Native.Deflate


### PR DESCRIPTION
This PR remove the level-≥7 dispatch redundancy identified by the Wave-0 profile (D-2, #2538): the base and shared-split candidates each recomputed the identical full lzMatch token stream, which is 83–84% of each candidate's cost. deflateRawBase and deflateDynamicBlocksSharedAt are split into token-taking cores plus definitional wrappers, deflateRaw computes the stream once and feeds both, and the self-contained split — which wins on exactly one corpus file (kennedy.xls, ~4.6 KB) while paying a full per-chunk match pass — is demoted to level 9 only.

Measured on alice29.txt: level 7 compress 1.71 → 3.58 MB/s (2.1×), level 8 1.61 → 3.38 MB/s, level 9 0.59 → 0.67 MB/s. Level-9 output is byte-identical by construction (the wrappers are rfl-equal, so the candidate set is definitionally unchanged); levels 7–8 differ only on inputs where the SC split would have won. The remaining gap to the ~5 MB/s Wave-1 target is the per-candidate tokenFreqs/sizing recompute over the shared stream — the next dedup step, tracked in the performance-pivot plan. All spec proofs transfer (the three dispatch proofs lose one pickSmaller layer in the 7–8 branch; the SharedAt quadruple and deflateRawBase lemmas just widen their unfolds).

🤖 Prepared with Claude Code