### PR TITLE
perf: proven-bounds chain-walk + hash-insertion matcher hot loops (Wave 2d part 1)

### DIFF
--- a/.claude/skills/proven-bounds/SKILL.md
+++ b/.claude/skills/proven-bounds/SKILL.md
@@ -93,6 +93,46 @@ def processBlock (data : ByteArray) (pos : Nat) (hpos : pos + 3 ≤ data.size) :
 When the caller has already verified `pos + 3 ≤ data.size`, passing it
 as a hypothesis avoids re-checking at every access site.
 
+## Pattern: Generational guarded wrapper (when threading would cascade)
+
+Caller propagation works only if you can add the size hypothesis to the
+callers too. When the function is a **shared helper whose correctness proofs
+are stated for an *arbitrary* array** (no size hypothesis — common for
+heuristic state like a hash table / `prev` chain / DP cost arrays that
+"never enter the proof"), adding a hypothesis in-place cascades it into every
+one of those proofs (`mainLoop_valid`, `_encodable`, …) and breaks them.
+
+Instead, do generational refinement with a **guarded wrapper** — three pieces:
+
+```lean
+-- 1. Proven-bounds copy: identical body, []! → [], takes the size hypothesis.
+def fooFast (... ) (hps : pos ≤ prev.size) (...) := ... prev[cand]'(by omega) ...
+
+-- 2. Wrapper with the ORIGINAL signature: one runtime check per OUTER
+--    iteration establishes the invariant; fall back to the panic-checked
+--    reference when it can't be shown (the fallback is unreachable at runtime).
+@[inline] def fooGuarded (...) (... no hps ...) :=
+  if hps : pos ≤ prev.size then fooFast ... hps ... else foo ...   -- `foo` = reference
+
+-- 3. Equivalence (in the Spec file): wrapper = reference, by `split`.
+theorem fooFast_eq    ... : fooFast ... = foo ... := by induction ...   -- bridge []'h ↔ []! per step
+theorem fooGuarded_eq ... : fooGuarded ... = foo ... := by unfold fooGuarded; split; · exact fooFast_eq ..; · rfl
+```
+
+The runtime (iterative) functions call `fooGuarded`; the reference functions
+and **all** their proofs stay untouched. Each iter-vs-reference equivalence
+proof gains just one line near the top: `simp only [fooGuarded_eq, ...]`
+rewrites the wrappers back to the reference, then the proof proceeds verbatim.
+The one outer-loop check is amortised over the whole inner loop, so the
+inner accesses are statically unchecked. This is the house style
+(`track-d-state.md` step 4; the `lz77Chain` matcher conversion, Wave 2d).
+
+In `fooFast_eq` (a fuel/measure induction), the only per-step difference is
+`prev[cand]'h` vs `prev[cand]!`; bridge with `getElem!_pos` (see pitfall 10),
+then `simp only [Nat.add_sub_cancel, ih]` closes the recursion. If `fooFast`
+carries a size hypothesis whose type mentions an array you induct on, include
+it in `generalizing` (e.g. `generalizing j hashTable prev hht`).
+
 ## Tactics for Bounds Proofs
 
 - **`omega`**: The primary workhorse. Solves linear arithmetic over `Nat`
@@ -269,6 +309,24 @@ def deflateDynamic ... :=
 Hiding the combinator behind a function symbol stops the unfolder
 cold. Expect to see this when a spec that was `rfl` before a
 proven-bounds conversion now reports `maximum recursion depth`.
+
+### 10. `let`-bound index blocks `rw [getElem!_pos]`
+
+When bridging `a[i]'h` ↔ `a[i]!` in a `*Fast_eq` proof, the index is usually
+a `let`/`have`-bound local from the unfolded body (`let hsh := hash3 …; …
+a[hsh]!`). `rw [getElem!_pos a hsh h]` **fails to fire** — you must spell the
+index as the *unfolded expression* (`hash3 …`), which doesn't syntactically
+match the bound `hsh`. Fix: fold it into a `simp only`, whose default `zeta`
+inlines the `let` first, then the rewrite matches:
+
+```lean
+-- rw [getElem!_pos hashTable hsh hb]            -- ✗ `hsh` is let-bound, no match
+simp only [getElem!_pos hashTable (hash3 data (pos+j) hashSize hd) hb]  -- ✓ zeta then rewrite
+```
+
+The bound `hb : index < a.size` is typically `hash3 … < hashSize ≤ a.size`,
+i.e. `Nat.mod_lt _ hpos` (hash3's body is `_ % hashSize`) chained by `omega`
+with the `hashSize ≤ a.size` invariant.
 
 ## Checklist for Conversion
 

--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -470,6 +470,82 @@ where
   termination_by data.size - pos
   decreasing_by all_goals omega
 
+/-! ### Proven-bounds matcher hot loops (Wave 2d)
+
+The `prev`/`hashTable` chain state is a pure heuristic — its contents never enter
+any correctness proof (validity is re-established at emission by `countMatch` +
+the window guards), so panic-checked `[..]!` access on it is wasted work in the
+two hottest matcher loops (the chain walk and the per-match hash insertion).
+
+`chainWalkFast`/`updateHashesFast` are byte-for-byte copies of
+`lz77Chain.chainWalk`/`lz77Chain.updateHashes` with `[..]!` replaced by
+proven-bounds `[..]`, taking a single array-size hypothesis that, once
+established, discharges every access inside the loop statically. The `*Guarded`
+wrappers establish that hypothesis with one runtime comparison per *outer*
+iteration (amortised over the whole inner loop) and fall back to the original
+panic-checked function when it cannot be shown — so they share the original's
+exact signature and are provably equal to it (`*Guarded_eq` in
+`LZ77ChainCorrect`). The iterative matchers call the wrappers; the recursive
+reference versions and all their proofs are untouched. -/
+
+/-- Proven-bounds copy of `lz77Chain.chainWalk`: `prev[cand]` is in range because
+    the walk guard gives `cand < pos` and `hps : pos ≤ prev.size`. -/
+def chainWalkFast (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen : Nat)
+    (hpm : pos + maxLen ≤ data.size) (hps : pos ≤ prev.size)
+    (cand fuel bestLen bestPos : Nat) : Nat × Nat :=
+  if fuel = 0 then (bestLen, bestPos)
+  else if hc : cand < pos ∧ pos - cand ≤ windowSize then
+    have hcand : cand + maxLen ≤ data.size := by omega
+    let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
+    let (bl, bp) := if ml > bestLen then (ml, cand) else (bestLen, bestPos)
+    if bl ≥ maxLen then (bl, bp)
+    else chainWalkFast data prev windowSize pos maxLen hpm hps
+      (prev[cand]'(by omega)) (fuel - 1) bl bp
+  else (bestLen, bestPos)
+termination_by fuel
+decreasing_by omega
+
+/-- One runtime `pos ≤ prev.size` check guards the whole `chainWalkFast` inner
+    loop; the (unreachable, since `prev` is sized to the input) fallback is the
+    original panic-checked walk, so this equals `lz77Chain.chainWalk`. -/
+@[inline] def chainWalkGuarded (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (cand fuel bestLen bestPos : Nat) : Nat × Nat :=
+  if hps : pos ≤ prev.size then
+    chainWalkFast data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos
+  else
+    lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos
+
+/-- Proven-bounds copy of `lz77Chain.updateHashes`: the bucket index `hsh` is
+    `< hashSize ≤ hashTable.size`, so `hashTable[hsh]` needs no runtime check. -/
+def updateHashesFast (data : ByteArray) (hashSize : Nat)
+    (hashTable prev : Array Nat) (pos j matchLen insertCap : Nat)
+    (hhs : 0 < hashSize) (hht : hashSize ≤ hashTable.size) : Array Nat × Array Nat :=
+  if j < matchLen ∧ j ≤ insertCap then
+    if h : pos + j + 2 < data.size then
+      let hsh := lz77Greedy.hash3 data (pos + j) hashSize h
+      have hb : hsh < hashTable.size := by
+        have : hsh < hashSize := Nat.mod_lt _ hhs
+        omega
+      let head := hashTable[hsh]'hb
+      updateHashesFast data hashSize (hashTable.set! hsh (pos + j)) (prev.set! (pos + j) head)
+        pos (j + 1) matchLen insertCap hhs (by simpa using hht)
+    else
+      updateHashesFast data hashSize hashTable prev pos (j + 1) matchLen insertCap hhs hht
+  else (hashTable, prev)
+termination_by matchLen - j
+decreasing_by all_goals omega
+
+/-- One runtime `0 < hashSize ∧ hashSize ≤ hashTable.size` check guards the whole
+    `updateHashesFast` insertion loop; the fallback is the original panic-checked
+    insertion, so this equals `lz77Chain.updateHashes`. -/
+@[inline] def updateHashesGuarded (data : ByteArray) (hashSize : Nat)
+    (hashTable prev : Array Nat) (pos j matchLen insertCap : Nat) : Array Nat × Array Nat :=
+  if hu : 0 < hashSize ∧ hashSize ≤ hashTable.size then
+    updateHashesFast data hashSize hashTable prev pos j matchLen insertCap hu.1 hu.2
+  else
+    lz77Chain.updateHashes data hashSize hashTable prev pos j matchLen insertCap
+
 /-- Iterative (tail-recursive, `Array`-accumulating) version of `lz77Chain`.
     Same output, but does not overflow the stack on large inputs. Reuses
     `lz77Chain`'s `chainWalk`/`updateHashes` (which accumulate into arrays, not
@@ -496,12 +572,12 @@ where
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
       let (matchLen, matchPos) :=
-        lz77Chain.chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+        chainWalkGuarded data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           have : data.size - (pos + matchLen) < data.size - pos := by omega
           let (hashTable, prev) :=
-            lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+            updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
           mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
             (acc.push (.reference matchLen (pos - matchPos)))
         else
@@ -632,7 +708,7 @@ where
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
       let (matchLen, matchPos) :=
-        lz77Chain.chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+        chainWalkGuarded data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           if h3lt : pos + 3 < data.size then
@@ -641,25 +717,25 @@ where
             let maxLen2 := min 258 (data.size - (pos + 1))
             have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
             let (matchLen2, matchPos2) :=
-              lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+              chainWalkGuarded data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
             if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                 let (hashTable, prev) :=
-                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
+                  updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
                 mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1 + matchLen2)
                   (acc.push (.literal (data[pos]'(by omega))) |>.push
                     (.reference matchLen2 (pos + 1 - matchPos2)))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
-                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+                  updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
                 mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
                   (acc.push (.reference matchLen (pos - matchPos)))
             else
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
-                lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+                updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
               mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
                 (acc.push (.reference matchLen (pos - matchPos)))
           else

--- a/Zip/Spec/LZ77ChainCorrect.lean
+++ b/Zip/Spec/LZ77ChainCorrect.lean
@@ -155,6 +155,79 @@ theorem lz77Chain_encodable (data : ByteArray) (maxChain windowSize insertCap : 
   · intro t ht; simp only [List.toList_toArray] at ht
     exact lz77Chain_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap hw hws t ht
 
+/-! ## Proven-bounds matcher equivalences (Wave 2d)
+
+`chainWalkFast`/`updateHashesFast` are the proven-bounds copies that the
+iterative matchers run in their hot loops; each is provably equal to the
+panic-checked reference helper. The `*Guarded` wrappers add one runtime
+size check and fall back to the reference, so they share the reference's
+signature and equal it. The iterative-vs-recursive equivalence proofs below
+rewrite the guarded wrappers back to the reference helpers and then proceed
+exactly as before the conversion. -/
+
+/-- The proven-bounds chain walk computes the same `(bestLen, bestPos)` as the
+    panic-checked reference walk: the bodies differ only in how `prev[cand]` is
+    accessed (`'h` vs `!`), and `getElem!_pos` bridges the two. -/
+theorem chainWalkFast_eq (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (hps : pos ≤ prev.size)
+    (cand fuel bestLen bestPos : Nat) :
+    chainWalkFast data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos =
+      lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos := by
+  induction fuel generalizing cand bestLen bestPos with
+  | zero => rw [chainWalkFast, lz77Chain.chainWalk]; simp only [↓reduceIte]
+  | succ k ih =>
+    rw [chainWalkFast, lz77Chain.chainWalk, if_neg (by omega : ¬ (k + 1 = 0)),
+      if_neg (by omega : ¬ (k + 1 = 0))]
+    by_cases hc : cand < pos ∧ pos - cand ≤ windowSize
+    · simp only [dif_pos hc, Nat.add_sub_cancel, ih]
+      rw [getElem!_pos prev cand (by omega)]
+    · simp only [dif_neg hc]
+
+/-- One runtime guard collapses to the reference walk. -/
+theorem chainWalkGuarded_eq (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (cand fuel bestLen bestPos : Nat) :
+    chainWalkGuarded data prev windowSize pos maxLen hpm cand fuel bestLen bestPos =
+      lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos := by
+  unfold chainWalkGuarded
+  split
+  · exact chainWalkFast_eq ..
+  · rfl
+
+/-- The proven-bounds hash-insertion loop computes the same arrays as the
+    panic-checked reference: the bodies differ only in how `hashTable[hsh]` is
+    accessed, bridged by `getElem!_pos`. -/
+theorem updateHashesFast_eq (data : ByteArray) (hashSize : Nat)
+    (hashTable prev : Array Nat) (pos j matchLen insertCap : Nat)
+    (hhs : 0 < hashSize) (hht : hashSize ≤ hashTable.size) :
+    updateHashesFast data hashSize hashTable prev pos j matchLen insertCap hhs hht =
+      lz77Chain.updateHashes data hashSize hashTable prev pos j matchLen insertCap := by
+  induction hn : matchLen - j using Nat.strongRecOn generalizing j hashTable prev hht with
+  | _ n ih =>
+    unfold updateHashesFast lz77Chain.updateHashes
+    by_cases hcond : j < matchLen ∧ j ≤ insertCap
+    · rw [if_pos hcond, if_pos hcond]
+      by_cases hd : pos + j + 2 < data.size
+      · rw [dif_pos hd, dif_pos hd]
+        have hb : lz77Greedy.hash3 data (pos + j) hashSize hd < hashTable.size := by
+          have : lz77Greedy.hash3 data (pos + j) hashSize hd < hashSize := Nat.mod_lt _ hhs
+          omega
+        simp only [getElem!_pos hashTable (lz77Greedy.hash3 data (pos + j) hashSize hd) hb]
+        exact ih _ (by omega) _ _ _ (by simpa using hht) rfl
+      · rw [dif_neg hd, dif_neg hd]
+        exact ih _ (by omega) _ _ _ hht rfl
+    · rw [if_neg hcond, if_neg hcond]
+
+/-- One runtime guard collapses to the reference insertion. -/
+theorem updateHashesGuarded_eq (data : ByteArray) (hashSize : Nat)
+    (hashTable prev : Array Nat) (pos j matchLen insertCap : Nat) :
+    updateHashesGuarded data hashSize hashTable prev pos j matchLen insertCap =
+      lz77Chain.updateHashes data hashSize hashTable prev pos j matchLen insertCap := by
+  unfold updateHashesGuarded
+  split
+  · exact updateHashesFast_eq ..
+  · rfl
+
 /-! ## Iterative version: equivalence + transferred contracts -/
 
 /-- The accumulator `trailing` is the array form of the recursive one. -/
@@ -178,6 +251,7 @@ private theorem mainLoop_eq_chain (data : ByteArray) (windowSize hashSize maxCha
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainIter.mainLoop lz77Chain.mainLoop
+    simp only [chainWalkGuarded_eq, updateHashesGuarded_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
       split

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -198,6 +198,7 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
+    simp only [chainWalkGuarded_eq, updateHashesGuarded_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
       -- Branch tree: hge / hle / h3lt / (matchLen2 > matchLen) / hle2

--- a/progress/20260611T070042Z_27828f25.md
+++ b/progress/20260611T070042Z_27828f25.md
@@ -1,0 +1,57 @@
+# Wave 2d part 1 — proven-bounds matcher hot loops (#2540)
+
+**UTC:** 2026-06-11 · **Session type:** feature (one-shot `/once 2540`)
+
+## Accomplished
+Converted the two hottest chain-matcher loops in `Zip/Native/Deflate.lean`
+from panic-checked `[..]!` to proven-bounds `[..]` access:
+- `lz77Chain.chainWalk`'s `prev[cand]!` (the hash-chain walk inner loop)
+- `lz77Chain.updateHashes`' `hashTable[hsh]!` (the per-match hash insertion)
+
+**Technique — generational refinement (zero proof churn on reference matchers):**
+added proven-bounds copies `chainWalkFast`/`updateHashesFast` that take a single
+array-size hypothesis discharging every in-loop access statically, wrapped by
+`chainWalkGuarded`/`updateHashesGuarded` that establish the hypothesis with one
+runtime size check per *outer* iteration (amortised over the inner loop) and fall
+back to the original panic-checked helper when it can't be shown. The wrappers
+share the reference helpers' exact signatures and are proven equal to them
+(`chainWalkFast_eq`/`updateHashesFast_eq`/`*Guarded_eq` in `LZ77ChainCorrect`).
+The runtime matchers `lz77ChainIter`/`lz77ChainLazyIter` call the wrappers; the
+recursive reference matchers and **all** their correctness proofs are untouched —
+the two iter-vs-recursive equivalence proofs each gained one
+`simp only [chainWalkGuarded_eq, updateHashesGuarded_eq]` line.
+
+## Measured (matcher path `lzMatch`, ms/rep, this machine, input perturbed + IO-forced)
+| input   | level | before | after  | speedup |
+|---------|-------|--------|--------|---------|
+| alice29 | L1    |   5.30 |   4.65 |  1.14x  |
+| alice29 | L6    |  30.11 |  22.87 |  1.32x  |
+| alice29 | L9    |  34.87 |  29.56 |  1.18x  |
+| dickens | L1    |  443.2 |  362.2 |  1.22x  |
+| dickens | L6    | 2006.8 | 1687.6 |  1.19x  |
+| dickens | L9    | 2648.8 | 2091.6 |  1.27x  |
+Token streams byte-identical (same token counts before/after). All tests +
+1000-iter fuzz pass. 0 sorries.
+
+## Decisions / patterns
+- Chose generational `*Guarded` wrappers over in-place hypothesis threading: the
+  reference matchers' `mainLoop_valid`/`_encodable`/etc. proofs are stated for
+  *arbitrary* `prev`/`hashTable` (no size hyp); threading a size invariant
+  in-place would cascade a hypothesis into every one of those fragile proofs.
+  The wrapper keeps the reference signatures intact, so the only proof edits are
+  the four new `*_eq` lemmas + a one-line rewrite in each equiv proof. This is
+  also the house style (track-d-state.md step 4; D-10/D-11 precedent).
+- `let`-bound `hsh` blocks `rw [getElem!_pos ...]` (the bound index doesn't match
+  the unfolded expression syntactically) — fold it into `simp only [getElem!_pos
+  hashTable <expr> hb]`, whose default zeta first inlines the let, then rewrites.
+- `updateHashesFast_eq` needs the size hypothesis generalized alongside
+  `hashTable` in the `Nat.strongRecOn` induction (`generalizing j hashTable prev hht`).
+
+## Remaining (deferred to #2547)
+The level-9 optimal parser's hot loops (`chainWalkAll`, `buildCache`, backward-DP
+cost loops) in `Zip/Native/DeflateParse.lean` are a separate front with their own
+proof file `LZ77OptimalCorrect.lean`. Same technique applies (DP state is
+heuristic, outside all proofs). Sub-issue #2547 created; this PR is `--partial`.
+
+## Quality deltas
+sorry count: 0 → 0. No new axioms. All 243 build targets + full test suite green.


### PR DESCRIPTION
Partial progress on #2540

Session: `27828f25-902a-486e-87cb-7e0a3443fcca`

30078fe doc: Wave-2d part-1 progress entry (matcher proven-bounds, #2540)
de6fb05 perf: proven-bounds chain-walk + hash-insertion hot loops (Wave 2d)

🤖 Prepared with Claude Code