### PR TITLE
doc: record ladder re-sweep null result (Wave 2e)

### DIFF
--- a/plans/track-d-state.md
+++ b/plans/track-d-state.md
@@ -78,6 +78,14 @@ dickens:
 | 7 | 2013 | 138 | 347 | 2335 | 1312 | 2696 | | 6329 | 1.6 | 111 |
 | 9 | 2156 | 139 | 355 | 2493 | 1314 | 2854 | 10086 | 16591 | 0.6 | 101 |
 
+**Ladder re-sweep verdict (Wave 2e, #2541, post-limiter-fix + post-#2548):**
+the `chainDepth`/`insertCap` ladder is already on the speed/ratio frontier at
+every level — a ×2-step sweep over Canterbury (12 configs/level, dedup-clean,
+deployed single-block path) found no configuration faster than current within
++0.1% geomean ratio; every faster config costs ≥ 0.7% ratio (e.g. L6 at half
+depth: 0.60× time, +1.14% ratio). Null result recorded; the levels' speed
+budget must come from Wave-3 representation work, not knob tuning.
+
 **Named bottlenecks (in priority order):**
 1. **Matcher is 83–84% of the base path at L6** (and the lazy step at L4 costs
    ~2× over L3) — hash-chain maintenance + search; the Wave-3 matcher-state


### PR DESCRIPTION
This PR record the Wave-2e verdict in plans/track-d-state.md: a dedup-clean ×2-step sweep of chainDepth/insertCap over Canterbury (12 configs per level, measured on the deployed single-block path, post-#2548 matcher) finds the current ladder already on the speed/ratio frontier at every level — no faster configuration holds geomean ratio within +0.1%, and every faster configuration costs at least 0.7% ratio. Mid-level speed therefore has to come from the Wave-3 matcher-state representation work, not knob tuning. Sweep table in #2541.

Closes #2541

🤖 Prepared with Claude Code