### PR TITLE
perf: guarded proven-bounds head-inserts in the matcher mainLoops

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -383,6 +383,30 @@ where
   termination_by data.size - pos
   decreasing_by all_goals omega
 
+/-- Per-position chain-head insertion with one runtime bounds check (Wave 3
+    Step 0.2, same pattern as `chainWalkGuarded`/`updateHashesGuarded` below):
+    read the old head of bucket `h`, point the bucket at `pos`, and link
+    `prev[pos]` to the old head. The single guard discharges all three accesses
+    statically; the fallback keeps the original panic-checked operations and is
+    dead in practice — `hashTable`/`prev` sizes are fixed at allocation.
+    Provably equal to the panic-checked sequence (`headInsertGuarded_eq` in
+    `LZ77ChainCorrect`). -/
+@[inline] def headInsertGuarded (hashTable prev : Array Nat) (h pos : Nat) :
+    Nat × Array Nat × Array Nat :=
+  if hg : h < hashTable.size ∧ pos < prev.size then
+    let head := hashTable[h]'hg.1
+    (head, hashTable.set h pos hg.1, prev.set pos head hg.2)
+  else
+    let head := hashTable[h]!
+    (head, hashTable.set! h pos, prev.set! pos head)
+
+/-- Single guarded chain-head probe (for the lazy matcher's lookahead position,
+    which reads a bucket head without inserting): one runtime bounds check,
+    panic-checked fallback (dead in practice). Provably equal to `hashTable[h]!`
+    (`headProbeGuarded_eq` in `LZ77ChainCorrect`). -/
+@[inline] def headProbeGuarded (hashTable : Array Nat) (h : Nat) : Nat :=
+  if hb : h < hashTable.size then hashTable[h]'hb else hashTable[h]!
+
 /-- Greedy LZ77 with bounded-depth hash chains: at each position, walk the
     `prev` chain from the bucket head up to `maxChain` candidates and keep the
     longest in-window match. This finds far longer matches than the single-probe
@@ -446,9 +470,7 @@ where
       (hashTable prev : Array Nat) (pos insertCap : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let head := hashTable[h]!
-      let hashTable := hashTable.set! h pos
-      let prev := prev.set! pos head
+      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
       let (matchLen, matchPos) :=
@@ -566,9 +588,7 @@ where
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let head := hashTable[h]!
-      let hashTable := hashTable.set! h pos
-      let prev := prev.set! pos head
+      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
       let (matchLen, matchPos) :=
@@ -626,9 +646,7 @@ where
       (hashTable prev : Array Nat) (pos insertCap : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let head := hashTable[h]!
-      let hashTable := hashTable.set! h pos
-      let prev := prev.set! pos head
+      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
       let (matchLen, matchPos) :=
@@ -638,7 +656,7 @@ where
           -- Lazy: probe pos+1 for a longer, no-farther match (distance-guarded deferral)
           if h3lt : pos + 3 < data.size then
             let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
-            let head2 := hashTable[h2]!
+            let head2 := headProbeGuarded hashTable h2
             let maxLen2 := min 258 (data.size - (pos + 1))
             have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
             let (matchLen2, matchPos2) :=
@@ -702,9 +720,7 @@ where
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let head := hashTable[h]!
-      let hashTable := hashTable.set! h pos
-      let prev := prev.set! pos head
+      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
       let (matchLen, matchPos) :=
@@ -713,7 +729,7 @@ where
         if hle : pos + matchLen ≤ data.size then
           if h3lt : pos + 3 < data.size then
             let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
-            let head2 := hashTable[h2]!
+            let head2 := headProbeGuarded hashTable h2
             let maxLen2 := min 258 (data.size - (pos + 1))
             have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
             let (matchLen2, matchPos2) :=

--- a/Zip/Spec/LZ77ChainCorrect.lean
+++ b/Zip/Spec/LZ77ChainCorrect.lean
@@ -47,6 +47,37 @@ theorem chainWalk_spec (data : ByteArray) (prev : Array Nat)
         · exact ih (prev[cand]!) _ _ hb
     · exact hb
 
+/-! ## Guarded per-position head insertion (Wave 3 Step 0.2)
+
+The mainLoops perform their per-position chain-head insertion (and, in the
+lazy variants, the lookahead head probe) through `headInsertGuarded`/
+`headProbeGuarded`, which trade the panic-checked `[..]!`/`set!` operations
+for one runtime bounds check. The lemmas below rewrite them back to the
+original panic-checked operations, so every proof that unfolds a mainLoop
+proceeds exactly as before the conversion. -/
+
+/-- The guarded head insertion computes exactly the panic-checked triple:
+    in bounds, `getElem!_pos` and `setIfInBounds_def` bridge `[..]'h`/`set`
+    to `[..]!`/`set!`; out of bounds, the fallback *is* the panic-checked
+    sequence. -/
+theorem headInsertGuarded_eq (hashTable prev : Array Nat) (h pos : Nat) :
+    headInsertGuarded hashTable prev h pos =
+      (hashTable[h]!, hashTable.set! h pos, prev.set! pos hashTable[h]!) := by
+  unfold headInsertGuarded
+  split
+  · rename_i hg
+    simp only [getElem!_pos hashTable h hg.1, Array.set!_eq_setIfInBounds,
+      Array.setIfInBounds_def, dif_pos hg.1, dif_pos hg.2]
+  · rfl
+
+/-- The guarded head probe computes exactly the panic-checked read. -/
+theorem headProbeGuarded_eq (hashTable : Array Nat) (h : Nat) :
+    headProbeGuarded hashTable h = hashTable[h]! := by
+  unfold headProbeGuarded
+  split
+  · rename_i hb; exact (getElem!_pos hashTable h hb).symm
+  · rfl
+
 /-- `lz77Chain.mainLoop` produces a valid decomposition from `pos`. Mirrors
     `lz77Greedy.mainLoop_valid`; the reference case uses `chainWalk_spec` (which
     holds for *any* `prev` array) in place of the inline single-probe match. -/
@@ -58,6 +89,7 @@ theorem lz77Chain_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChai
   split
   · rename_i hlt
     dsimp only
+    simp only [headInsertGuarded_eq]
     have hspec := chainWalk_spec data
       (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) (by omega)
@@ -113,6 +145,7 @@ theorem lz77Chain_mainLoop_encodable (data : ByteArray) (windowSize hashSize max
   split
   · rename_i hlt
     dsimp only
+    simp only [headInsertGuarded_eq]
     have hspec := chainWalk_spec data
       (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) (by omega)
@@ -251,7 +284,7 @@ private theorem mainLoop_eq_chain (data : ByteArray) (windowSize hashSize maxCha
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainIter.mainLoop lz77Chain.mainLoop
-    simp only [chainWalkGuarded_eq, updateHashesGuarded_eq]
+    simp only [chainWalkGuarded_eq, updateHashesGuarded_eq, headInsertGuarded_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
       split

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -32,6 +32,7 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
   split
   · rename_i hlt
     dsimp only
+    simp only [headInsertGuarded_eq, headProbeGuarded_eq]
     have hspec := chainWalk_spec data
       (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) (by omega)
@@ -105,6 +106,7 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
   split
   · rename_i hlt
     dsimp only
+    simp only [headInsertGuarded_eq, headProbeGuarded_eq]
     have hspec := chainWalk_spec data
       (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) (by omega)
@@ -198,7 +200,8 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
-    simp only [chainWalkGuarded_eq, updateHashesGuarded_eq]
+    simp only [chainWalkGuarded_eq, updateHashesGuarded_eq, headInsertGuarded_eq,
+      headProbeGuarded_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
       -- Branch tree: hge / hle / h3lt / (matchLen2 > matchLen) / hle2


### PR DESCRIPTION
This PR extend the #2548 Guarded pattern to the last panic-checked per-position sites in the four matcher mainLoops — the head read/update + prev link and the lazy lookahead probe — via headInsertGuarded/headProbeGuarded: one runtime bounds check per position, proven access inside, the original panic-checked sequence in the dead else branch. Output is byte-identical (ratio canaries unchanged), every theorem statement is unchanged (each affected proof gains one simp only [headInsertGuarded_eq] rewrite), and the measured matcher-phase gain is ~1–3% at L4–6 on alice29 — within shared-machine noise, banked as a free win per the Wave-3 policy.

🤖 Prepared with Claude Code