### PR TITLE
feat: packed token producer + view equivalence (Wave 3b stage A)

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -56,6 +56,7 @@ import Zip.Spec.DeflateDynamicHeader
 import Zip.Spec.DeflateDynamicFreqs
 import Zip.Spec.DeflateDynamicCorrect
 import Zip.Spec.DeflateRoundtrip
+import Zip.Spec.LZ77PackedCorrect
 import Zip.Spec.BitReaderInvariant
 import Zip.Spec.InflateLoopBounds
 import Zip.Spec.InflateRawSuffix

--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1,5 +1,6 @@
 import Zip.Native.BitWriter
 import Zip.Native.Inflate
+import Std.Tactic.BVDecide
 
 /-!
   Pure Lean DEFLATE compressor.
@@ -190,6 +191,66 @@ inductive LZ77Token where
   | literal : UInt8 → LZ77Token
   | reference : (length : Nat) → (distance : Nat) → LZ77Token
   deriving BEq, Inhabited
+
+/-! ## Packed tokens (Wave 3b)
+
+Every `LZ77Token` push in the matcher hot loops allocates a boxed
+constructor cell. `packTok` encodes a token in one unboxed `UInt32` instead:
+literals are the byte value (tag bit 31 clear); references set bit 31 and
+carry the length in bits 16–30 and the distance in bits 0–15. The field
+split is forced by the DEFLATE ranges: `dist ≤ 32768 = 2^15` needs 16 bits
+exactly (32768 itself does not fit in 15), so the distance owns bits 0–15
+and the length (`≤ 258 < 2^15`) sits at bit 16 with 15 bits of room below
+the tag. `unpackTok` is the boxed *spec-level view* of a packed token;
+`unpackTok_packTok` shows the view recovers every encodable token, which is
+what lets `Zip/Spec/LZ77PackedCorrect.lean` prove the packed matcher twins
+(`lz77ChainIterP`/`lz77ChainLazyIterP`) equal to the boxed matchers viewed
+through `unpackTok`. -/
+
+/-- Pack a token into one `UInt32`: literal `b` ↦ `b`; reference ↦
+    `1<<<31 ||| len<<<16 ||| dist`. Lossless on encodable tokens
+    (`unpackTok_packTok`). -/
+@[inline] def packTok : LZ77Token → UInt32
+  | .literal b => b.toUInt32
+  | .reference len dist => ((1 : UInt32) <<< 31) ||| (len.toUInt32 <<< 16) ||| dist.toUInt32
+
+/-- Boxed view of a packed token (left inverse of `packTok` on encodable
+    tokens: `unpackTok_packTok`). -/
+@[inline] def unpackTok (w : UInt32) : LZ77Token :=
+  if w &&& ((1 : UInt32) <<< 31) = 0 then
+    .literal w.toUInt8
+  else
+    .reference ((w >>> 16) &&& 0x7FFF).toNat (w &&& 0xFFFF).toNat
+
+/-- `unpackTok` recovers every token within the encoder bounds (literals
+    unconditionally; references with `3 ≤ len ≤ 258`, `1 ≤ dist ≤ 32768` —
+    exactly the `Enc` predicate of the matcher encodability theorems). The
+    bit-level facts are discharged by `bv_decide` after `generalize`-ing the
+    `Nat → UInt32` casts into variables carrying their `≤` bounds. -/
+theorem unpackTok_packTok (t : LZ77Token)
+    (h : match t with
+      | .literal _ => True
+      | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768) :
+    unpackTok (packTok t) = t := by
+  match t with
+  | .literal b =>
+    have h1 : (b.toUInt32 &&& ((1 : UInt32) <<< 31)) = 0 := by bv_decide
+    have h2 : b.toUInt32.toUInt8 = b := by bv_decide
+    simp [unpackTok, packTok, h1, h2]
+  | .reference len dist =>
+    obtain ⟨_, h258, h1d, h32768⟩ := h
+    have hl : len.toUInt32.toNat = len := by simp [Nat.toUInt32]; omega
+    have hd : dist.toUInt32.toNat = dist := by simp [Nat.toUInt32]; omega
+    simp only [packTok, unpackTok]
+    generalize len.toUInt32 = l at hl
+    generalize dist.toUInt32 = d at hd
+    have hlu : l ≤ 258 := by rw [UInt32.le_iff_toNat_le]; show l.toNat ≤ 258; omega
+    have hdu : d ≤ 32768 := by rw [UInt32.le_iff_toNat_le]; show d.toNat ≤ 32768; omega
+    have hcond : ¬((((1 : UInt32) <<< 31) ||| l <<< 16 ||| d) &&& ((1 : UInt32) <<< 31)) = 0 := by
+      bv_decide
+    have hlen : ((((1 : UInt32) <<< 31) ||| l <<< 16 ||| d) >>> 16) &&& 0x7FFF = l := by bv_decide
+    have hdist : (((1 : UInt32) <<< 31) ||| l <<< 16 ||| d) &&& 0xFFFF = d := by bv_decide
+    rw [if_neg hcond, hlen, hdist, hl, hd]
 
 /-- Simple hash-based greedy LZ77 matcher.
     Scans input left-to-right, emitting literals or back-references. -/
@@ -766,6 +827,132 @@ where
           (acc.push (.literal (data[pos]'(by omega))))
     else
       lz77GreedyIter.trailing data pos acc
+  termination_by data.size - pos
+  decreasing_by all_goals omega
+
+/-! ## Packed-token matcher twins (Wave 3b stage A)
+
+`lz77ChainIterP`/`lz77ChainLazyIterP` are copies of the iterative matchers
+whose accumulator holds `packTok`-encoded `UInt32`s instead of boxed
+`LZ77Token`s. The chain state (`hashTable`/`prev : Array Nat`) is untouched
+(the Wave-3a verdict: a `UInt32` chain state measured slower); only the
+emission side changes, and each push is literally `packTok` of the token the
+boxed loop pushes, so `Zip/Spec/LZ77PackedCorrect.lean` proves them equal to
+`(·.map packTok)` of the boxed matchers by lockstep induction. -/
+
+/-- Packed-token form of `lz77GreedyIter.trailing`: pushes
+    `packTok (.literal _)` for each remaining byte. -/
+def trailingP (data : ByteArray) (pos : Nat) (acc : Array UInt32) : Array UInt32 :=
+  if h : pos < data.size then
+    trailingP data (pos + 1) (acc.push (packTok (.literal data[pos])))
+  else acc
+termination_by data.size - pos
+
+/-- Packed-token twin of `lz77ChainIter` (greedy hash-chain matcher):
+    identical control flow and chain state, `Array UInt32` accumulator.
+    Equal to `(lz77ChainIter ..).map packTok` (`lz77ChainIterP_eq`). -/
+def lz77ChainIterP (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
+    (insertCap : Nat := 1000000000) :
+    Array UInt32 :=
+  if data.size < 3 then
+    trailingP data 0 #[]
+  else
+    let hashSize := 65536
+    mainLoop data windowSize hashSize maxChain insertCap
+      (.replicate hashSize data.size) (.replicate data.size data.size) 0 #[]
+where
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+      (hashTable prev : Array Nat) (pos : Nat) (acc : Array UInt32) :
+      Array UInt32 :=
+    if hlt : pos + 2 < data.size then
+      let h := lz77Greedy.hash3 data pos hashSize hlt
+      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
+      let maxLen := min 258 (data.size - pos)
+      have hmaxLenP : pos + maxLen ≤ data.size := by omega
+      let (matchLen, matchPos) :=
+        chainWalkGuarded data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      if hge : matchLen ≥ 3 then
+        if hle : pos + matchLen ≤ data.size then
+          have : data.size - (pos + matchLen) < data.size - pos := by omega
+          let (hashTable, prev) :=
+            updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
+          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+            (acc.push (packTok (.reference matchLen (pos - matchPos))))
+        else
+          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+            (acc.push (packTok (.literal (data[pos]'(by omega)))))
+      else
+        mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+          (acc.push (packTok (.literal (data[pos]'(by omega)))))
+    else
+      trailingP data pos acc
+  termination_by data.size - pos
+  decreasing_by all_goals omega
+
+/-- Packed-token twin of `lz77ChainLazyIter` (lazy one-byte-lookahead matcher):
+    identical control flow and chain state, `Array UInt32` accumulator.
+    Equal to `(lz77ChainLazyIter ..).map packTok` (`lz77ChainLazyIterP_eq`). -/
+def lz77ChainLazyIterP (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
+    (insertCap : Nat := 1000000000) :
+    Array UInt32 :=
+  if data.size < 3 then
+    trailingP data 0 #[]
+  else
+    let hashSize := 65536
+    mainLoop data windowSize hashSize maxChain insertCap
+      (.replicate hashSize data.size) (.replicate data.size data.size) 0 #[]
+where
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+      (hashTable prev : Array Nat) (pos : Nat) (acc : Array UInt32) :
+      Array UInt32 :=
+    if hlt : pos + 2 < data.size then
+      let h := lz77Greedy.hash3 data pos hashSize hlt
+      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
+      let maxLen := min 258 (data.size - pos)
+      have hmaxLenP : pos + maxLen ≤ data.size := by omega
+      let (matchLen, matchPos) :=
+        chainWalkGuarded data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      if hge : matchLen ≥ 3 then
+        if hle : pos + matchLen ≤ data.size then
+          if h3lt : pos + 3 < data.size then
+            let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
+            let head2 := headProbeGuarded hashTable h2
+            let maxLen2 := min 258 (data.size - (pos + 1))
+            have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
+            let (matchLen2, matchPos2) :=
+              chainWalkGuarded data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+            if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
+              if hle2 : pos + 1 + matchLen2 ≤ data.size then
+                have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
+                let (hashTable, prev) :=
+                  updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
+                mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1 + matchLen2)
+                  (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
+                    (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
+              else
+                have : data.size - (pos + matchLen) < data.size - pos := by omega
+                let (hashTable, prev) :=
+                  updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
+                mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+                  (acc.push (packTok (.reference matchLen (pos - matchPos))))
+            else
+              have : data.size - (pos + matchLen) < data.size - pos := by omega
+              let (hashTable, prev) :=
+                updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
+              mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+                (acc.push (packTok (.reference matchLen (pos - matchPos))))
+          else
+            have : data.size - (pos + matchLen) < data.size - pos := by omega
+            mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+              (acc.push (packTok (.reference matchLen (pos - matchPos))))
+        else
+          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+            (acc.push (packTok (.literal (data[pos]'(by omega)))))
+      else
+        mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+          (acc.push (packTok (.literal (data[pos]'(by omega)))))
+    else
+      trailingP data pos acc
   termination_by data.size - pos
   decreasing_by all_goals omega
 

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -331,6 +331,15 @@ def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
   if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level)
   else lz77ChainIter data (chainDepth level) 32768 (insertCap level)
 
+/-- Packed-token form of `lzMatch` (Wave 3b stage A): the same per-level
+    dispatch over the packed matcher twins, producing one unboxed `UInt32`
+    per token instead of a boxed `LZ77Token`. The boxed view recovers
+    `lzMatch` exactly (`lzMatchP_map` in `Zip/Spec/LZ77PackedCorrect.lean`);
+    downstream consumers still run on `lzMatch` — stage B moves them here. -/
+def lzMatchP (data : ByteArray) (level : UInt8) : Array UInt32 :=
+  if 4 ≤ level then lz77ChainLazyIterP data (chainDepth level) 32768 (insertCap level)
+  else lz77ChainIterP data (chainDepth level) 32768 (insertCap level)
+
 /-! ## Self-contained block-split dynamic compression
 
 Split `data` into `chunkSize`-byte chunks, match each chunk independently (fresh

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -1,0 +1,168 @@
+import Zip.Spec.LZ77ChainCorrect
+import Zip.Spec.LZ77ChainLazyCorrect
+import Zip.Native.DeflateDynamic
+
+/-!
+# Correctness of the packed-token matcher twins (Wave 3b stage A)
+
+`lz77ChainIterP`/`lz77ChainLazyIterP` are the iterative matchers with a
+`packTok`-encoded `Array UInt32` accumulator in place of the boxed
+`Array LZ77Token`. This file proves the boxed view recovers the boxed
+matchers exactly:
+
+    (lz77ChainIterP data mc ws ic).map unpackTok = lz77ChainIter data mc ws ic
+
+(and the lazy twin, and the `lzMatch`/`lzMatchP` dispatch pair).
+
+The proof goes through the *pack* direction first: a lockstep accumulator
+induction (the `mainLoop_eq_chain` shape) shows each packed loop equals
+`(·.map packTok)` of its boxed twin — every push site is literally
+`packTok` of the boxed push, so `Array.map_push` commutes the map through
+each push with **no** side conditions, and the chain state never enters the
+argument. The `unpackTok` view theorems then follow by composing with
+`unpackTok_packTok`, whose encodability hypotheses (`3 ≤ len ≤ 258`,
+`1 ≤ dist ≤ 32768`) are discharged *wholesale* by the existing
+`lz77ChainIter_encodable`/`lz77ChainLazyIter_encodable` theorems — no replay
+of the `chainWalk_spec` emission-guard analysis is needed.
+-/
+
+namespace Zip.Native.Deflate
+
+open Zip.Native.Deflate (lz77ChainIter lz77ChainLazyIter lz77ChainIterP lz77ChainLazyIterP)
+
+/-! ## Pack direction: lockstep accumulator inductions -/
+
+/-- `trailingP` is the packed image of the boxed trailing-literals loop. -/
+private theorem trailingP_eq (data : ByteArray) (pos : Nat) (acc : Array LZ77Token) :
+    trailingP data pos (acc.map packTok) =
+      (lz77GreedyIter.trailing data pos acc).map packTok := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc with
+  | _ n ih =>
+    unfold trailingP lz77GreedyIter.trailing
+    by_cases hp : pos < data.size
+    · simp only [hp, ↓reduceDIte]
+      rw [← Array.map_push, ih _ (by omega) _ _ rfl]
+    · simp only [hp, ↓reduceDIte]
+
+/-- The packed greedy `mainLoop` is the packed image of the boxed one:
+    identical control flow and chain state, `packTok` at each push. -/
+private theorem mainLoopP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+    (hashTable prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+    lz77ChainIterP.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos
+        (acc.map packTok) =
+      (lz77ChainIter.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos
+        acc).map packTok := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
+  | _ n ih =>
+    unfold lz77ChainIterP.mainLoop lz77ChainIter.mainLoop
+    by_cases hlt : pos + 2 < data.size
+    · simp only [hlt, ↓reduceDIte]
+      split
+      · split
+        · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+        · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+      · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+    · simp only [hlt, ↓reduceDIte]
+      exact trailingP_eq data pos acc
+
+/-- `lz77ChainIterP` produces exactly the `packTok` image of `lz77ChainIter`. -/
+theorem lz77ChainIterP_eq (data : ByteArray) (maxChain windowSize insertCap : Nat) :
+    lz77ChainIterP data maxChain windowSize insertCap =
+      (lz77ChainIter data maxChain windowSize insertCap).map packTok := by
+  unfold lz77ChainIterP lz77ChainIter
+  split
+  · simpa using trailingP_eq data 0 #[]
+  · simpa using mainLoopP_eq data windowSize 65536 maxChain insertCap _ _ 0 #[]
+
+/-- The packed lazy `mainLoop` is the packed image of the boxed one (two
+    pushes in the deferral arm). -/
+private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+    (hashTable prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
+    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos
+        (acc.map packTok) =
+      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos
+        acc).map packTok := by
+  induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
+  | _ n ih =>
+    unfold lz77ChainLazyIterP.mainLoop lz77ChainLazyIter.mainLoop
+    by_cases hlt : pos + 2 < data.size
+    · simp only [hlt, ↓reduceDIte]
+      -- Branch tree: hge / hle / h3lt / deferral / hle2
+      split
+      · split
+        · split
+          · split
+            · split
+              · -- deferral arm: literal + reference, two pushes
+                rw [← Array.map_push, ← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+              · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+            · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+          · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+        · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+      · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+    · simp only [hlt, ↓reduceDIte]
+      exact trailingP_eq data pos acc
+
+/-- `lz77ChainLazyIterP` produces exactly the `packTok` image of
+    `lz77ChainLazyIter`. -/
+theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap : Nat) :
+    lz77ChainLazyIterP data maxChain windowSize insertCap =
+      (lz77ChainLazyIter data maxChain windowSize insertCap).map packTok := by
+  unfold lz77ChainLazyIterP lz77ChainLazyIter
+  split
+  · simpa using trailingP_eq data 0 #[]
+  · simpa using mainLoopLazyP_eq data windowSize 65536 maxChain insertCap _ _ 0 #[]
+
+/-! ## View direction: the boxed view recovers the boxed matchers
+
+`unpackTok_packTok` needs the encoder bounds on each token, which the
+existing encodability theorems provide for the whole stream. -/
+
+/-- The boxed view of the packed greedy matcher is the boxed greedy matcher. -/
+theorem lz77ChainIterP_map (data : ByteArray) (maxChain windowSize insertCap : Nat)
+    (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    (lz77ChainIterP data maxChain windowSize insertCap).map unpackTok =
+      lz77ChainIter data maxChain windowSize insertCap := by
+  have henc := lz77ChainIter_encodable data maxChain windowSize insertCap hw hws
+  rw [lz77ChainIterP_eq, Array.map_map]
+  have hcongr : Array.map (unpackTok ∘ packTok) (lz77ChainIter data maxChain windowSize insertCap) =
+      Array.map id (lz77ChainIter data maxChain windowSize insertCap) :=
+    Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa using ht))
+  rw [hcongr, Array.map_id]
+
+/-- The boxed view of the packed lazy matcher is the boxed lazy matcher. -/
+theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap : Nat)
+    (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    (lz77ChainLazyIterP data maxChain windowSize insertCap).map unpackTok =
+      lz77ChainLazyIter data maxChain windowSize insertCap := by
+  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap hw hws
+  rw [lz77ChainLazyIterP_eq, Array.map_map]
+  have hcongr : Array.map (unpackTok ∘ packTok)
+        (lz77ChainLazyIter data maxChain windowSize insertCap) =
+      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap) :=
+    Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa using ht))
+  rw [hcongr, Array.map_id]
+
+/-! ## Dispatch boundary -/
+
+/-- `lzMatchP` is the `packTok` image of `lzMatch` at every level. -/
+theorem lzMatchP_eq (data : ByteArray) (level : UInt8) :
+    lzMatchP data level = (lzMatch data level).map packTok := by
+  unfold lzMatchP lzMatch
+  split
+  · exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level)
+  · exact lz77ChainIterP_eq data (chainDepth level) 32768 (insertCap level)
+
+/-- The boxed view of the packed token stream is exactly `lzMatch`'s stream:
+    stage B+ consumers of `lzMatchP` inherit every `lzMatch` contract through
+    this equation. -/
+theorem lzMatchP_map (data : ByteArray) (level : UInt8) :
+    (lzMatchP data level).map unpackTok = lzMatch data level := by
+  unfold lzMatchP lzMatch
+  split
+  · exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level)
+      (by omega) (by omega)
+  · exact lz77ChainIterP_map data (chainDepth level) 32768 (insertCap level)
+      (by omega) (by omega)
+
+end Zip.Native.Deflate

--- a/ZipTest.lean
+++ b/ZipTest.lean
@@ -27,6 +27,7 @@ import ZipTest.FuzzHandleRead
 import ZipTest.BoundedReadTest
 import ZipTest.InflateTable
 import ZipTest.OptimalParse
+import ZipTest.PackedTokens
 
 def main : IO Unit := do
   unless ← System.FilePath.pathExists "testdata" do
@@ -54,6 +55,7 @@ def main : IO Unit := do
   ZipTest.NativeScale.tests
   ZipTest.NativeDeflate.tests
   ZipTest.OptimalParse.tests
+  ZipTest.PackedTokens.tests
   ZipTest.NativeCompressBench.tests
   ZipTest.Benchmark.tests
   ZipTest.FuzzInflate.tests

--- a/ZipTest/PackedTokens.lean
+++ b/ZipTest/PackedTokens.lean
@@ -1,0 +1,44 @@
+import ZipTest.Helpers
+import Zip.Native.DeflateDynamic
+
+/-! Element-wise identity between the packed token stream and the boxed one
+    (Wave 3b stage A): `(lzMatchP data level).map unpackTok` must equal
+    `lzMatch data level` token-for-token. The theorem `lzMatchP_map`
+    (`Zip/Spec/LZ77PackedCorrect.lean`) proves exactly this; the test keeps
+    the *compiled* packed twins honest against the proof-level statement
+    (codegen, `@[inline]` packing, accumulator reuse) on real text and the
+    synthetic edge shapes at one level per matcher tier. -/
+
+namespace ZipTest.PackedTokens
+
+open Zip.Native.Deflate
+
+/-- Check `(lzMatchP data level).map unpackTok == lzMatch data level`
+    element-wise at levels 1 (greedy fast), 4 (lazy shallow), 6 (lazy
+    default) and 9 (lazy deep). -/
+private def checkView (label : String) (data : ByteArray) : IO Unit := do
+  for level in [(1 : UInt8), 4, 6, 9] do
+    let boxed := lzMatch data level
+    let packed := lzMatchP data level
+    unless packed.size == boxed.size do
+      throw (IO.userError
+        s!"{label} level {level}: size mismatch ({packed.size} packed vs {boxed.size} boxed)")
+    for i in [0:boxed.size] do
+      unless unpackTok packed[i]! == boxed[i]! do
+        throw (IO.userError s!"{label} level {level}: token mismatch at index {i}")
+
+def tests : IO Unit := do
+  IO.println "  PackedTokens tests..."
+  let alice ← IO.FS.readBinFile "bench/corpora/canterbury/alice29.txt"
+  checkView "alice29" alice
+  checkView "text64k" (mkTextData 65536)
+  checkView "cyclic64k" (mkCyclicData 65536)
+  checkView "prng64k" (mkPrngData 65536)
+  checkView "constant64k" (mkConstantData 65536)
+  checkView "size0" ByteArray.empty
+  checkView "size1" (ByteArray.mk #[42])
+  checkView "size2" (ByteArray.mk #[42, 42])
+  checkView "size3" (ByteArray.mk #[7, 7, 7])
+  IO.println "  PackedTokens tests passed"
+
+end ZipTest.PackedTokens


### PR DESCRIPTION
This PR add the Wave-3b stage-A infrastructure: a packed UInt32-per-token producer for both runtime matchers (tag bit 31, length at bit 16, distance at bit 0), a proven packTok/unpackTok roundtrip under the encoder bounds, and view-equivalence theorems culminating in (lzMatchP data level).map unpackTok = lzMatch data level. The chain state is untouched per the recorded Wave-3a verdict; each packed loop is the boxed loop with packTok at the push sites, proven equal by a lockstep pack-direction induction with zero side conditions, after which the unpack view follows from Array.map_map plus the existing encodable theorems. No production consumer changes in this stage, so the profile is neutral by design; stage B moves tokenFreqs and the dispatch onto the packed stream, where the allocation and traversal wins land. An element-wise packed-vs-boxed identity test gates the equivalence on real and synthetic corpora at levels 1/4/6/9.

🤖 Prepared with Claude Code