### PR TITLE
feat: packed-native frequency pass + packed dispatch plumbing (Wave 3b stage B)

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -696,13 +696,34 @@ def deflateRawBaseTokens (data : ByteArray) (tokens : Array LZ77Token) : ByteArr
   else deflateDynamicBlockCore data tokens lens.1 lens.2
     (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
 
-/-- `deflateRawBaseTokens` over this level's `lzMatch` stream (definitional
-    wrapper; see `deflateDynamicBlocksSharedAt`). -/
-def deflateRawBase (data : ByteArray) (level : UInt8) : ByteArray :=
-  deflateRawBaseTokens data (lzMatch data level)
+/-- `deflateRawBaseTokens` over a *packed* token stream (Wave 3b stage B):
+    the frequency pass runs natively on the packed words (`tokenFreqsP`), and
+    the boxed tokens are materialized (`unpackTok`) only on the emit branches
+    — the stored branch never unpacks. Equal to
+    `deflateRawBaseTokens data (ptokens.map unpackTok)` via `tokenFreqsP_eq`;
+    `deflateRawBaseTokens` stays as the boxed reference implementation
+    (conformance-tested in `ZipTest/PackedTokens.lean`). -/
+def deflateRawBaseP (data : ByteArray) (ptokens : Array UInt32) : ByteArray :=
+  let f := tokenFreqsP ptokens
+  let lens := dynamicCodeLengths f.1 f.2
+  let fixedBytes := fixedBlockBytes f.1 f.2
+  let dynBytes := dynBlockBytes f.1 f.2 lens.1 lens.2
+  let storedBytes := storedBlockBytes data
+  if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
+  else if fixedBytes < dynBytes then deflateFixedBlock data (ptokens.map unpackTok)
+  else deflateDynamicBlockCore data (ptokens.map unpackTok) lens.1 lens.2
+    (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
 
-theorem deflateRawBase_def (data : ByteArray) (level : UInt8) :
-    deflateRawBaseTokens data (lzMatch data level) = deflateRawBase data level := rfl
+/-- `deflateRawBaseP` over this level's *packed* `lzMatchP` stream
+    (definitional wrapper, `deflateRawBaseP_def`). Equal to the boxed
+    `deflateRawBaseTokens data (lzMatch data level)` — that equation is
+    `deflateRawBase_def`, proven in `Zip/Spec/LZ77PackedCorrect.lean` via
+    `tokenFreqsP_eq` + `lzMatchP_map`. -/
+def deflateRawBase (data : ByteArray) (level : UInt8) : ByteArray :=
+  deflateRawBaseP data (lzMatchP data level)
+
+theorem deflateRawBaseP_def (data : ByteArray) (level : UInt8) :
+    deflateRawBaseP data (lzMatchP data level) = deflateRawBase data level := rfl
 
 theorem deflateDynamicBlocksSharedAt_def (data : ByteArray)
     (choose : Array LZ77Token → List Nat) (level : UInt8) :
@@ -760,20 +781,24 @@ def deflateDynamicBlocksOptimal (data : ByteArray) (tokChunk : Nat) : ByteArray 
 def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   if level == 0 then deflateStoredPure data
   else if 7 ≤ level then
-    -- One matcher pass shared by the base and shared-split candidates (the
-    -- matcher is 83–84% of each candidate's cost — Wave-0 profile, D-2).
-    let tokens := lzMatch data level
+    -- One *packed* matcher pass shared by the base and shared-split candidates
+    -- (the matcher is 83–84% of each candidate's cost — Wave-0 profile, D-2).
+    -- The base candidate consumes the packed words directly; the shared-split
+    -- candidate unpacks once (stage C/D push packed further down).
+    let ptokens := lzMatchP data level
     if 9 ≤ level ∧ data.size ≤ optimalMaxSize then
       pickSmaller
-        (pickSmaller (deflateRawBaseTokens data tokens)
+        (pickSmaller (deflateRawBaseP data ptokens)
           (pickSmaller (deflateDynamicBlocksSC data splitChunkSize level)
-            (deflateDynamicBlocksSharedAtTokens data tokens chooseSplitsArbitrated)))
+            (deflateDynamicBlocksSharedAtTokens data (ptokens.map unpackTok)
+              chooseSplitsArbitrated)))
         (deflateDynamicBlocksOptimal data sharedTokChunk)
     else
       -- The self-contained split is demoted to level 9: it wins on exactly
       -- one corpus file while paying a full per-chunk match pass.
-      pickSmaller (deflateRawBaseTokens data tokens)
-        (deflateDynamicBlocksSharedAtTokens data tokens chooseSplitsArbitrated)
+      pickSmaller (deflateRawBaseP data ptokens)
+        (deflateDynamicBlocksSharedAtTokens data (ptokens.map unpackTok)
+          chooseSplitsArbitrated)
   else deflateRawBase data level
 
 end Zip.Native.Deflate

--- a/Zip/Native/DeflateFreqs.lean
+++ b/Zip/Native/DeflateFreqs.lean
@@ -73,6 +73,199 @@ where
     else (litLenFreqs, distFreqs)
   termination_by tokens.size - i
 
+/-! ## Packed-token frequency pass (Wave 3b stage B)
+
+`tokenFreqsP` computes the same histogram as `tokenFreqs` directly from the
+`packTok`-encoded `UInt32` stream (`lzMatchP`), so the frequency pass never
+materializes boxed `LZ77Token`s. The per-token work lives in three
+non-recursive helpers (`bumpLitFreqP`/`bumpRefLitFreqP`/`bumpRefDistFreqP`)
+whose tag-bit test and field reads are the *exact* bit expressions of
+`unpackTok`; the loop body then contains only plain helper applications.
+That shape is load-bearing twice over:
+
+* **Correctness**: each helper step is literally the matching `tokenFreqs.go`
+  arm over `unpackTok w`, so `tokenFreqsP ws = tokenFreqs (ws.map unpackTok)`
+  holds for **every** word array (`tokenFreqsP_eq`) — no encodability side
+  condition and no array-content invariants.
+* **Elaboration**: the well-founded-recursion translation compares the loop
+  body against itself at full transparency, and any match scrutinee or
+  projection over a `>>>`-of-a-stuck-word expression sends that `whnf` into
+  `findTableCode`'s `WellFounded.Nat.fix` fuel, which does not terminate in
+  practical time (deterministic-timeout). Keeping every match *inside* the
+  opaque helper constants and every size invariant in a `Subtype`-wrapped
+  array parameter (erased at runtime — a trivial structure) keeps the loop
+  body free of forced reductions. Do not inline the helpers back into `go`.
+-/
+
+/-- Bump the literal/length histogram for one packed literal token
+    (tag bit clear): increment index `w.toUInt8.toNat`, exactly
+    `tokenFreqs.go`'s literal arm over `unpackTok w`. -/
+@[inline] def bumpLitFreqP (litLenFreqs : {a : Array Nat // a.size = 286}) (w : UInt32) :
+    {a : Array Nat // a.size = 286} :=
+  let idx := w.toUInt8.toNat
+  have hidx : idx < litLenFreqs.val.size := by
+    have := UInt8.toNat_lt w.toUInt8; have := litLenFreqs.property; omega
+  ⟨litLenFreqs.val.set! idx (litLenFreqs.val[idx] + 1),
+    by rw [Array.size_set!]; exact litLenFreqs.property⟩
+
+/-- Bump the literal/length histogram for one packed reference token:
+    decode the length field with `unpackTok`'s bit expression and count its
+    length code, exactly `tokenFreqs.go`'s reference arm (lit/len half). -/
+@[inline] def bumpRefLitFreqP (litLenFreqs : {a : Array Nat // a.size = 286}) (w : UInt32) :
+    {a : Array Nat // a.size = 286} :=
+  match hflc : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) with
+  | none => litLenFreqs
+  | some (lIdx, _, _) =>
+    have hsym : lIdx + 257 < litLenFreqs.val.size := by
+      have := nativeFindLengthCode_idx_bound _ _ _ _ hflc
+      have := litLenFreqs.property; omega
+    ⟨litLenFreqs.val.set! (lIdx + 257) (litLenFreqs.val[lIdx + 257] + 1),
+      by rw [Array.size_set!]; exact litLenFreqs.property⟩
+
+/-- Bump the distance histogram for one packed reference token: decode the
+    distance field with `unpackTok`'s bit expression and count its distance
+    code, exactly `tokenFreqs.go`'s reference arm (distance half). -/
+@[inline] def bumpRefDistFreqP (distFreqs : {a : Array Nat // a.size = 30}) (w : UInt32) :
+    {a : Array Nat // a.size = 30} :=
+  match hfdc : findDistCode ((w &&& 0xFFFF).toNat) with
+  | none => distFreqs
+  | some (dIdx, _, _) =>
+    have hd : dIdx < distFreqs.val.size := by
+      have := nativeFindDistCode_idx_bound _ _ _ _ hfdc
+      have := distFreqs.property; omega
+    ⟨distFreqs.val.set! dIdx (distFreqs.val[dIdx] + 1),
+      by rw [Array.size_set!]; exact distFreqs.property⟩
+
+/-- Packed-token form of `tokenFreqs`: the same histogram (286 lit/len
+    entries, 30 distance entries, end-of-block pre-counted) computed from the
+    packed `UInt32` stream. Equal to `tokenFreqs` over the boxed view for
+    every word array (`tokenFreqsP_eq`). -/
+def tokenFreqsP (tokens : Array UInt32) : Array Nat × Array Nat :=
+  go tokens ⟨(Array.replicate 286 0).set! 256 1,
+      by rw [Array.size_set!, Array.size_replicate]⟩
+    ⟨Array.replicate 30 0, by rw [Array.size_replicate]⟩ 0
+where
+  go (tokens : Array UInt32) (litLenFreqs : {a : Array Nat // a.size = 286})
+      (distFreqs : {a : Array Nat // a.size = 30}) (i : Nat) : Array Nat × Array Nat :=
+    if h : i < tokens.size then
+      let w := tokens[i]
+      if w &&& ((1 : UInt32) <<< 31) = 0 then
+        go tokens (bumpLitFreqP litLenFreqs w) distFreqs (i + 1)
+      else
+        go tokens (bumpRefLitFreqP litLenFreqs w) (bumpRefDistFreqP distFreqs w) (i + 1)
+    else (litLenFreqs.val, distFreqs.val)
+  termination_by tokens.size - i
+
+/-- `bumpRefLitFreqP` when the length field has no length code: no-op. -/
+private theorem bumpRefLitFreqP_none (lf : {a : Array Nat // a.size = 286}) (w : UInt32)
+    (h : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = none) :
+    bumpRefLitFreqP lf w = lf := by
+  unfold bumpRefLitFreqP
+  split
+  · rfl
+  · rename_i heq
+    rw [h] at heq
+    cases heq
+
+/-- `bumpRefLitFreqP` when the length field finds code `lIdx`: bump symbol
+    `lIdx + 257`. -/
+private theorem bumpRefLitFreqP_some (lf : {a : Array Nat // a.size = 286}) (w : UInt32)
+    (lIdx en : Nat) (ev : UInt32)
+    (h : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = some (lIdx, en, ev)) :
+    bumpRefLitFreqP lf w =
+      ⟨lf.val.set! (lIdx + 257) (lf.val[lIdx + 257]'(by
+          have := nativeFindLengthCode_idx_bound _ _ _ _ h
+          have := lf.property; omega) + 1),
+        by rw [Array.size_set!]; exact lf.property⟩ := by
+  unfold bumpRefLitFreqP
+  split
+  · rename_i heq
+    rw [h] at heq
+    cases heq
+  · rename_i lIdx' en' ev' heq
+    rw [h] at heq
+    simp only [Option.some.injEq, Prod.mk.injEq] at heq
+    obtain ⟨rfl, rfl, rfl⟩ := heq
+    rfl
+
+/-- `bumpRefDistFreqP` when the distance field has no distance code: no-op. -/
+private theorem bumpRefDistFreqP_none (df : {a : Array Nat // a.size = 30}) (w : UInt32)
+    (h : findDistCode ((w &&& 0xFFFF).toNat) = none) :
+    bumpRefDistFreqP df w = df := by
+  unfold bumpRefDistFreqP
+  split
+  · rfl
+  · rename_i heq
+    rw [h] at heq
+    cases heq
+
+/-- `bumpRefDistFreqP` when the distance field finds code `dIdx`: bump it. -/
+private theorem bumpRefDistFreqP_some (df : {a : Array Nat // a.size = 30}) (w : UInt32)
+    (dIdx en : Nat) (ev : UInt32)
+    (h : findDistCode ((w &&& 0xFFFF).toNat) = some (dIdx, en, ev)) :
+    bumpRefDistFreqP df w =
+      ⟨df.val.set! dIdx (df.val[dIdx]'(by
+          have := nativeFindDistCode_idx_bound _ _ _ _ h
+          have := df.property; omega) + 1),
+        by rw [Array.size_set!]; exact df.property⟩ := by
+  unfold bumpRefDistFreqP
+  split
+  · rename_i heq
+    rw [h] at heq
+    cases heq
+  · rename_i dIdx' en' ev' heq
+    rw [h] at heq
+    simp only [Option.some.injEq, Prod.mk.injEq] at heq
+    obtain ⟨rfl, rfl, rfl⟩ := heq
+    rfl
+
+/-- The packed histogram loop is the boxed one over the `unpackTok` view:
+    lockstep induction. Per word, the tag-bit test reduces both sides into
+    the same branch; the literal arms agree definitionally, and the
+    reference arms agree by splitting the boxed side's `findLengthCode` /
+    `findDistCode` matches and rewriting the packed helpers with the
+    resulting equations (`bumpRef*FreqP_none`/`_some`). -/
+private theorem tokenFreqsP_go_eq (ws : Array UInt32) (litF distF : Array Nat)
+    (hlit : litF.size = 286) (hdist : distF.size = 30) (i : Nat) :
+    tokenFreqsP.go ws ⟨litF, hlit⟩ ⟨distF, hdist⟩ i =
+      tokenFreqs.go (ws.map unpackTok) litF distF hlit hdist i := by
+  induction h : ws.size - i using Nat.strongRecOn generalizing litF distF hlit hdist i with
+  | _ n ih =>
+    unfold tokenFreqsP.go tokenFreqs.go
+    by_cases hi : i < ws.size
+    · simp only [Array.size_map, hi, ↓reduceDIte, Array.getElem_map, unpackTok]
+      by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
+      · simp only [hc, ↓reduceIte, bumpLitFreqP]
+        exact ih (ws.size - (i + 1)) (by omega) _ _ _ _ _ rfl
+      · simp only [hc, ↓reduceIte]
+        split
+        · rename_i hflc
+          split
+          · rename_i hfdc
+            rw [bumpRefLitFreqP_none _ _ hflc, bumpRefDistFreqP_none _ _ hfdc]
+            exact ih (ws.size - (i + 1)) (by omega) _ _ _ _ _ rfl
+          · rename_i dIdx en ev hfdc
+            rw [bumpRefLitFreqP_none _ _ hflc, bumpRefDistFreqP_some _ _ _ _ _ hfdc]
+            exact ih (ws.size - (i + 1)) (by omega) _ _ _ _ _ rfl
+        · rename_i lIdx en ev hflc
+          split
+          · rename_i hfdc
+            rw [bumpRefLitFreqP_some _ _ _ _ _ hflc, bumpRefDistFreqP_none _ _ hfdc]
+            exact ih (ws.size - (i + 1)) (by omega) _ _ _ _ _ rfl
+          · rename_i dIdx en' ev' hfdc
+            rw [bumpRefLitFreqP_some _ _ _ _ _ hflc, bumpRefDistFreqP_some _ _ _ _ _ hfdc]
+            exact ih (ws.size - (i + 1)) (by omega) _ _ _ _ _ rfl
+    · simp only [Array.size_map, hi, ↓reduceDIte]
+
+/-- `tokenFreqsP` is `tokenFreqs` over the boxed view of the words —
+    unconditionally, for every word array. Producers whose boxed view is a
+    boxed token stream (e.g. `lzMatchP` via `lzMatchP_map`) inherit
+    `tokenFreqsP packed = tokenFreqs boxed` by rewriting the view. -/
+theorem tokenFreqsP_eq (ws : Array UInt32) :
+    tokenFreqsP ws = tokenFreqs (ws.map unpackTok) := by
+  unfold tokenFreqsP tokenFreqs
+  exact tokenFreqsP_go_eq ws _ _ _ _ 0
+
 /-- Build the `(symbol, freq)` pair list for a frequency array. -/
 def freqsToPairs (freqs : Array Nat) : List (Nat × Nat) :=
   (List.range freqs.size).pmap

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -1,6 +1,7 @@
 import Zip.Spec.DeflateFixedCorrect
 import Zip.Spec.DeflateDynamicCorrect
 import Zip.Spec.LZ77ChainCorrect
+import Zip.Spec.LZ77PackedCorrect
 import Zip.Spec.DeflateBlockSplit
 
 /-!
@@ -88,7 +89,8 @@ set_option maxRecDepth 8000 in
 theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflate (deflateRawBase data level) maxOutputSize = .ok data := by
-  unfold deflateRawBase deflateRawBaseTokens
+  rw [← deflateRawBase_def]
+  unfold deflateRawBaseTokens
   dsimp only []
   -- stored / fixed / dynamic, sized from one chain token pass. The outer `split`
   -- fires on `fixedBytes < dynBytes`, then each side on the stored comparison.
@@ -111,7 +113,7 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     Zip.Native.Inflate.inflate (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBase_def, deflateDynamicBlocksSharedAt_def]
+  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedAt_def]
   split
   · exact inflate_deflateStoredPure data _ (by omega)
   · split
@@ -155,7 +157,8 @@ theorem deflateRawBase_pad (data : ByteArray) (level : UInt8) :
     ∃ (contentBits padding : List Bool),
       Deflate.Spec.bytesToBits (deflateRawBase data level) = contentBits ++ padding ∧
       padding.length < 8 := by
-  unfold deflateRawBase deflateRawBaseTokens
+  rw [← deflateRawBase_def]
+  unfold deflateRawBaseTokens
   dsimp only []
   -- stored / fixed / dynamic sized; emit only the winner. The outer `split` fires
   -- on `fixedBytes < dynBytes`, then each side on the stored comparison.
@@ -196,7 +199,7 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
       padding.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBase_def, deflateDynamicBlocksSharedAt_def]
+  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedAt_def]
   split
   · -- Level 0: stored blocks — all byte-aligned, padding = []
     exact ⟨Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data),
@@ -339,7 +342,8 @@ private theorem deflateRawBase_goR_pad (data : ByteArray) (level : UInt8) :
     ∃ remaining,
       Deflate.Spec.decode.goR (Deflate.Spec.bytesToBits (deflateRawBase data level)) []
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
-  unfold deflateRawBase deflateRawBaseTokens
+  rw [← deflateRawBase_def]
+  unfold deflateRawBaseTokens
   dsimp only []
   have hfixed : ∃ remaining,
       Deflate.Spec.decode.goR
@@ -364,7 +368,7 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBase_def, deflateDynamicBlocksSharedAt_def]
+  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedAt_def]
   split
   · -- Level 0: stored blocks — byte-aligned, remaining = []
     exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -165,4 +165,22 @@ theorem lzMatchP_map (data : ByteArray) (level : UInt8) :
   · exact lz77ChainIterP_map data (chainDepth level) 32768 (insertCap level)
       (by omega) (by omega)
 
+/-! ## Stage B: the packed base candidate equals the boxed one
+
+`deflateRawBase` is now *defined* as `deflateRawBaseP data (lzMatchP data
+level)` (packed frequency pass, unpack only at the emit boundary). The
+equation below recovers the boxed formulation — same statement as the old
+definitional `deflateRawBase_def`, now proven from `tokenFreqsP_eq` (the
+packed histogram is the boxed one over the `unpackTok` view) and
+`lzMatchP_map` (the view of the packed stream is `lzMatch`). The three
+`deflateRawBase` spec lemmas in `Zip/Spec/DeflateRoundtrip.lean` keep their
+statements and rewrite through this equation. -/
+
+/-- The boxed base dispatch over `lzMatch` is the (packed-pipeline)
+    `deflateRawBase`. -/
+theorem deflateRawBase_def (data : ByteArray) (level : UInt8) :
+    deflateRawBaseTokens data (lzMatch data level) = deflateRawBase data level := by
+  unfold deflateRawBase deflateRawBaseP deflateRawBaseTokens
+  simp only [tokenFreqsP_eq, lzMatchP_map]
+
 end Zip.Native.Deflate

--- a/ZipTest/PackedTokens.lean
+++ b/ZipTest/PackedTokens.lean
@@ -27,6 +27,23 @@ private def checkView (label : String) (data : ByteArray) : IO Unit := do
       unless unpackTok packed[i]! == boxed[i]! do
         throw (IO.userError s!"{label} level {level}: token mismatch at index {i}")
 
+/-- Stage B gate: the packed base candidate must be byte-identical to the
+    boxed reference dispatch — `deflateRawBaseP data (lzMatchP data level)`
+    (= `deflateRawBase data level` by definition) against
+    `deflateRawBaseTokens data (lzMatch data level)` (the boxed reference,
+    kept for exactly this conformance check). The theorem
+    `deflateRawBase_def` (`Zip/Spec/LZ77PackedCorrect.lean`) proves the
+    equality; this test keeps the compiled packed pipeline (`tokenFreqsP`,
+    emit-boundary unpacking) honest against it. -/
+private def checkBaseP (label : String) (data : ByteArray) : IO Unit := do
+  for level in [(1 : UInt8), 4, 6, 9] do
+    let packed := deflateRawBaseP data (lzMatchP data level)
+    let boxed := deflateRawBaseTokens data (lzMatch data level)
+    unless packed == boxed do
+      throw (IO.userError
+        s!"{label} level {level}: deflateRawBaseP ({packed.size} bytes) ≠ \
+           deflateRawBaseTokens ({boxed.size} bytes)")
+
 def tests : IO Unit := do
   IO.println "  PackedTokens tests..."
   let alice ← IO.FS.readBinFile "bench/corpora/canterbury/alice29.txt"
@@ -39,6 +56,15 @@ def tests : IO Unit := do
   checkView "size1" (ByteArray.mk #[42])
   checkView "size2" (ByteArray.mk #[42, 42])
   checkView "size3" (ByteArray.mk #[7, 7, 7])
+  checkBaseP "alice29" alice
+  checkBaseP "text64k" (mkTextData 65536)
+  checkBaseP "cyclic64k" (mkCyclicData 65536)
+  checkBaseP "prng64k" (mkPrngData 65536)
+  checkBaseP "constant64k" (mkConstantData 65536)
+  checkBaseP "size0" ByteArray.empty
+  checkBaseP "size1" (ByteArray.mk #[42])
+  checkBaseP "size2" (ByteArray.mk #[42, 42])
+  checkBaseP "size3" (ByteArray.mk #[7, 7, 7])
   IO.println "  PackedTokens tests passed"
 
 end ZipTest.PackedTokens


### PR DESCRIPTION
This PR move the production pipeline onto the packed token stream: tokenFreqsP computes lit/dist histograms directly from packed UInt32 words with an unconditional equality lemma tokenFreqsP_eq (no packed-image hypotheses, no content invariants), deflateRawBaseP consumes packed frequencies and materializes boxed tokens only on the emit branches (the stored branch never unpacks), and deflateRaw's level-≥7 dispatch binds the stream packed with one unpack at the shared-split boundary. Output is byte-identical — ratio canaries unchanged and a new test pins deflateRawBaseP against the boxed reference at levels 1/4/6/9 — and every existing theorem statement is untouched (the three deflateRawBase lemmas and three dispatch proofs adjust by one rewrite each).

Measured end-to-end: neutral (≤1%), honestly reported — the matcher-side allocation saving is repaid by the emit-boundary unpack, so this stage is the enabler and the win lands when emission reads packed words natively (stage C). The PR also documents a real elaboration landmine for future packed work: WF-recursive bodies whose match scrutinees contain findLengthCode over stuck bit-extracted words send definition-time whnf into the fuel of nested well-founded fixpoints (40s+ at 1M heartbeats); the fix, used here, is keeping each match inside an opaque non-recursive helper.

🤖 Prepared with Claude Code