### PR TITLE
feat: packed-native single-block emission (Wave 3b stage C)

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -47,6 +47,7 @@ import Zip.Spec.LZ77NativeCorrect
 import Zip.Spec.LZ77OptimalCorrect
 import Zip.Spec.DeflateFixedTables
 import Zip.Spec.EmitTokensCorrect
+import Zip.Spec.EmitPackedCorrect
 import Zip.Spec.DeflateFixedCorrect
 import Zip.Spec.InflateBufCorrect
 import Zip.Spec.InflateBufRoundtrip

--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -985,6 +985,62 @@ def emitTokens (bw : BitWriter) (tokens : Array LZ77Token) (i : Nat) : BitWriter
   else bw
 termination_by tokens.size - i
 
+/-! ## Packed-token fixed-code emission (Wave 3b stage C)
+
+`emitTokensP` walks the `packTok`-encoded `UInt32` stream directly, so the
+fixed-code emit path never materializes boxed `LZ77Token`s. The reference
+arm lives in the non-recursive helper `emitRefFixedP`, whose field reads
+and `findLengthCode`/`findDistCode` matches are the *exact* bit expressions
+of `unpackTok`'s reference view; the loop body contains only a plain helper
+application. As with `tokenFreqsP` (see the landmine note in
+`Zip/Native/DeflateFreqs.lean`), that shape is load-bearing: a match
+scrutinee over `findLengthCode` applied to a stuck bit-extracted word in a
+well-founded-recursion body sends definition-time `whnf` into
+`findTableCode`'s `WellFounded` fix, which does not terminate in practical
+time. Do not inline `emitRefFixedP` back into `emitTokensP`.
+`Zip/Spec/EmitPackedCorrect.lean` proves
+`emitTokensP bw ws i = emitTokens bw (ws.map unpackTok) i`. -/
+
+/-- Emit one packed *reference* token (tag bit set) as fixed Huffman codes:
+    decode the length/distance fields with `unpackTok`'s bit expressions and
+    write exactly the `writeHuffCode`/`writeBits` sequence of `emitTokens`'s
+    reference arm (including its dead-code `else` fallbacks, so the equality
+    proof in `Zip/Spec/EmitPackedCorrect.lean` aligns branch-for-branch). -/
+@[inline] def emitRefFixedP (bw : BitWriter) (w : UInt32) : BitWriter :=
+  match findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) with
+  | some (idx, extraCount, extraVal) =>
+    if hlit : idx + 257 < fixedLitCodes.size then
+      let (code, len) := fixedLitCodes[idx + 257]
+      let bw := bw.writeHuffCode code len
+      let bw := bw.writeBits extraCount extraVal
+      match findDistCode ((w &&& 0xFFFF).toNat) with
+      | some (dIdx, dExtraCount, dExtraVal) =>
+        if hdist : dIdx < fixedDistCodes.size then
+          let (dCode, dLen) := fixedDistCodes[dIdx]
+          let bw := bw.writeHuffCode dCode dLen
+          bw.writeBits dExtraCount dExtraVal
+        else bw
+      | none => bw
+    else bw
+  | none => bw
+
+/-- Packed-token form of `emitTokens`: emit the packed `UInt32` stream as
+    fixed Huffman codes. Literals (tag bit clear) read the byte field
+    directly; references go through `emitRefFixedP`. Equal to `emitTokens`
+    over the boxed view for every word array (`emitTokensP_eq`). -/
+def emitTokensP (bw : BitWriter) (tokens : Array UInt32) (i : Nat) : BitWriter :=
+  if h : i < tokens.size then
+    let w := tokens[i]
+    if w &&& ((1 : UInt32) <<< 31) = 0 then
+      have : w.toUInt8.toNat < fixedLitCodes.size := by
+        have := UInt8.toNat_lt w.toUInt8; rw [Deflate.fixedLitCodes_size]; omega
+      let (code, len) := fixedLitCodes[w.toUInt8.toNat]
+      emitTokensP (bw.writeHuffCode code len) tokens (i + 1)
+    else
+      emitTokensP (emitRefFixedP bw w) tokens (i + 1)
+  else bw
+termination_by tokens.size - i
+
 /-- Write a fixed Huffman DEFLATE block from LZ77 tokens. -/
 def deflateFixedBlock (data : ByteArray) (tokens : Array LZ77Token) : ByteArray :=
   let bw := BitWriter.empty
@@ -997,6 +1053,26 @@ def deflateFixedBlock (data : ByteArray) (tokens : Array LZ77Token) : ByteArray 
     bw.flush
   else
     let bw := emitTokens bw tokens 0
+    let (code, len) := fixedLitCodes[256]
+    let bw := bw.writeHuffCode code len
+    bw.flush
+
+/-- Packed-token form of `deflateFixedBlock` (Wave 3b stage C): write a
+    fixed Huffman DEFLATE block directly from the packed `UInt32` stream —
+    same body with `emitTokensP` in place of `emitTokens`. Equal to
+    `deflateFixedBlock` over the boxed view (`deflateFixedBlockP_eq` in
+    `Zip/Spec/EmitPackedCorrect.lean`). -/
+def deflateFixedBlockP (data : ByteArray) (tokens : Array UInt32) : ByteArray :=
+  let bw := BitWriter.empty
+  let bw := bw.writeBits 1 1  -- BFINAL
+  let bw := bw.writeBits 2 1  -- BTYPE = 01
+  have h256 : 256 < fixedLitCodes.size := by rw [Deflate.fixedLitCodes_size]; omega
+  if data.size == 0 then
+    let (code, len) := fixedLitCodes[256]
+    let bw := bw.writeHuffCode code len
+    bw.flush
+  else
+    let bw := emitTokensP bw tokens 0
     let (code, len) := fixedLitCodes[256]
     let bw := bw.writeHuffCode code len
     bw.flush

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -56,6 +56,64 @@ def emitTokensWithCodes (bw : BitWriter) (tokens : Array LZ77Token)
   else bw
 termination_by tokens.size - i
 
+/-! ## Packed-token dynamic-code emission (Wave 3b stage C)
+
+`emitTokensWithCodesP` walks the `packTok`-encoded `UInt32` stream directly,
+so the dynamic emit path never materializes boxed `LZ77Token`s. As with
+`emitTokensP`/`emitRefFixedP` (`Zip/Native/Deflate.lean`) and `tokenFreqsP`
+(see the landmine note in `Zip/Native/DeflateFreqs.lean`), the reference arm
+— a match scrutinee over `findLengthCode` applied to a stuck bit-extracted
+word — must live in the non-recursive helper `emitRefWithCodesP`, never
+inline in the well-founded loop body. `Zip/Spec/EmitPackedCorrect.lean`
+proves the loop equal to `emitTokensWithCodes` over the boxed view. -/
+
+/-- Emit one packed *reference* token (tag bit set) with the given Huffman
+    codes: decode the length/distance fields with `unpackTok`'s bit
+    expressions and write exactly the `writeHuffCode`/`writeBits` sequence of
+    `emitTokensWithCodes`'s reference arm (including its dead-code `else`
+    fallbacks, so the equality proof aligns branch-for-branch). -/
+@[inline] def emitRefWithCodesP (bw : BitWriter)
+    (litCodes distCodes : Array (UInt16 × UInt8)) (w : UInt32) : BitWriter :=
+  match findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) with
+  | some (idx, extraCount, extraVal) =>
+    if hlitlt : idx + 257 < litCodes.size then
+      let (code, len) := litCodes[idx + 257]
+      let bw := bw.writeHuffCode code len
+      let bw := bw.writeBits extraCount extraVal
+      match findDistCode ((w &&& 0xFFFF).toNat) with
+      | some (dIdx, dExtraCount, dExtraVal) =>
+        if hdistlt : dIdx < distCodes.size then
+          let (dCode, dLen) := distCodes[dIdx]
+          let bw := bw.writeHuffCode dCode dLen
+          bw.writeBits dExtraCount dExtraVal
+        else bw
+      | none => bw
+    else bw
+  | none => bw
+
+/-- Packed-token form of `emitTokensWithCodes` (same `hlit`/`hdist` size
+    hypotheses): emit the packed `UInt32` stream with the given lit/len and
+    distance Huffman codes. Literals (tag bit clear) read the byte field
+    directly; references go through `emitRefWithCodesP`. Equal to
+    `emitTokensWithCodes` over the boxed view for every word array
+    (`emitTokensWithCodesP_eq`). -/
+def emitTokensWithCodesP (bw : BitWriter) (tokens : Array UInt32)
+    (litCodes distCodes : Array (UInt16 × UInt8))
+    (hlit : litCodes.size ≥ 286) (hdist : distCodes.size ≥ 30)
+    (i : Nat) : BitWriter :=
+  if h : i < tokens.size then
+    let w := tokens[i]
+    if w &&& ((1 : UInt32) <<< 31) = 0 then
+      have : w.toUInt8.toNat < litCodes.size := by
+        have := UInt8.toNat_lt w.toUInt8; omega
+      let (code, len) := litCodes[w.toUInt8.toNat]
+      emitTokensWithCodesP (bw.writeHuffCode code len) tokens litCodes distCodes hlit hdist (i + 1)
+    else
+      emitTokensWithCodesP (emitRefWithCodesP bw litCodes distCodes w) tokens litCodes distCodes
+        hlit hdist (i + 1)
+  else bw
+termination_by tokens.size - i
+
 
 /-- Write the dynamic Huffman tree header via BitWriter.
     This is the native equivalent of spec `encodeDynamicTrees`, writing
@@ -180,6 +238,39 @@ def deflateDynamicBlockCore (data : ByteArray) (tokens : Array LZ77Token)
     bw.flush
   else
     let bw := emitTokensWithCodes bw tokens litCodes distCodes hlit_size hdist_size 0
+    let (code, len) := litCodes[256]'h256
+    let bw := bw.writeHuffCode code len
+    bw.flush
+
+/-- Packed-token form of `deflateDynamicBlockCore` (Wave 3b stage C): emit a
+    dynamic Huffman block directly from the packed `UInt32` stream — same
+    body with `emitTokensWithCodesP` in place of `emitTokensWithCodes`.
+    Equal to `deflateDynamicBlockCore` over the boxed view
+    (`deflateDynamicBlockCoreP_eq` in `Zip/Spec/EmitPackedCorrect.lean`). -/
+def deflateDynamicBlockCoreP (data : ByteArray) (tokens : Array UInt32)
+    (litLens distLens : List Nat)
+    (hlit : litLens.length = 286) (hdist : distLens.length = 30) : ByteArray :=
+  let litCodes := canonicalCodes (litLens.toArray.map Nat.toUInt8)
+  let distCodes := canonicalCodes (distLens.toArray.map Nat.toUInt8)
+  let bw := BitWriter.empty
+  let bw := bw.writeBits 1 1  -- BFINAL
+  let bw := bw.writeBits 2 2  -- BTYPE = 10
+  let bw := writeDynamicHeader bw litLens distLens
+  have hlit_size : litCodes.size ≥ 286 := by
+    show (canonicalCodes (litLens.toArray.map Nat.toUInt8)).size ≥ 286
+    rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  have hdist_size : distCodes.size ≥ 30 := by
+    show (canonicalCodes (distLens.toArray.map Nat.toUInt8)).size ≥ 30
+    rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  have h256 : 256 < litCodes.size := by
+    show 256 < (canonicalCodes (litLens.toArray.map Nat.toUInt8)).size
+    rw [canonicalCodes_size, Array.size_map, List.size_toArray]; omega
+  if data.size == 0 then
+    let (code, len) := litCodes[256]'h256
+    let bw := bw.writeHuffCode code len
+    bw.flush
+  else
+    let bw := emitTokensWithCodesP bw tokens litCodes distCodes hlit_size hdist_size 0
     let (code, len) := litCodes[256]'h256
     let bw := bw.writeHuffCode code len
     bw.flush
@@ -696,11 +787,13 @@ def deflateRawBaseTokens (data : ByteArray) (tokens : Array LZ77Token) : ByteArr
   else deflateDynamicBlockCore data tokens lens.1 lens.2
     (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
 
-/-- `deflateRawBaseTokens` over a *packed* token stream (Wave 3b stage B):
+/-- `deflateRawBaseTokens` over a *packed* token stream (Wave 3b stages B+C):
     the frequency pass runs natively on the packed words (`tokenFreqsP`), and
-    the boxed tokens are materialized (`unpackTok`) only on the emit branches
-    — the stored branch never unpacks. Equal to
-    `deflateRawBaseTokens data (ptokens.map unpackTok)` via `tokenFreqsP_eq`;
+    the emit branches consume the packed words directly
+    (`deflateFixedBlockP`/`deflateDynamicBlockCoreP`) — no branch ever
+    materializes boxed tokens. Equal to
+    `deflateRawBaseTokens data (ptokens.map unpackTok)` via `tokenFreqsP_eq`
+    and the packed-emitter equalities (`Zip/Spec/EmitPackedCorrect.lean`);
     `deflateRawBaseTokens` stays as the boxed reference implementation
     (conformance-tested in `ZipTest/PackedTokens.lean`). -/
 def deflateRawBaseP (data : ByteArray) (ptokens : Array UInt32) : ByteArray :=
@@ -710,8 +803,8 @@ def deflateRawBaseP (data : ByteArray) (ptokens : Array UInt32) : ByteArray :=
   let dynBytes := dynBlockBytes f.1 f.2 lens.1 lens.2
   let storedBytes := storedBlockBytes data
   if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
-  else if fixedBytes < dynBytes then deflateFixedBlock data (ptokens.map unpackTok)
-  else deflateDynamicBlockCore data (ptokens.map unpackTok) lens.1 lens.2
+  else if fixedBytes < dynBytes then deflateFixedBlockP data ptokens
+  else deflateDynamicBlockCoreP data ptokens lens.1 lens.2
     (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
 
 /-- `deflateRawBaseP` over this level's *packed* `lzMatchP` stream
@@ -783,8 +876,9 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
   else if 7 ≤ level then
     -- One *packed* matcher pass shared by the base and shared-split candidates
     -- (the matcher is 83–84% of each candidate's cost — Wave-0 profile, D-2).
-    -- The base candidate consumes the packed words directly; the shared-split
-    -- candidate unpacks once (stage C/D push packed further down).
+    -- The base candidate consumes the packed words end-to-end (freqs *and*
+    -- emit, stage C); the shared-split candidate still unpacks once (stage D
+    -- moves it onto packed words).
     let ptokens := lzMatchP data level
     if 9 ≤ level ∧ data.size ≤ optimalMaxSize then
       pickSmaller

--- a/Zip/Spec/EmitPackedCorrect.lean
+++ b/Zip/Spec/EmitPackedCorrect.lean
@@ -1,0 +1,265 @@
+import Zip.Native.DeflateDynamic
+
+/-!
+# Correctness of the packed-token emitters (Wave 3b stage C)
+
+`emitTokensP` / `emitTokensWithCodesP` are the single-block emitters walking
+the `packTok`-encoded `UInt32` stream directly, with the per-token reference
+work in the opaque non-recursive helpers `emitRefFixedP` /
+`emitRefWithCodesP` (see the WF-elaboration landmine note in
+`Zip/Native/DeflateFreqs.lean`). This file proves they equal the boxed
+emitters over the `unpackTok` view, for **every** word array — no
+encodability side conditions:
+
+    emitTokensP bw ws i = emitTokens bw (ws.map unpackTok) i
+
+(and the `WithCodes` analogue with the same `hlit`/`hdist` hypotheses), then
+lifts the equations to the single-block cores
+(`deflateFixedBlockP_eq`/`deflateDynamicBlockCoreP_eq`).
+
+Proof shape: per helper, one equation lemma per branch of the boxed
+reference arm (`findLengthCode` none/some × lit-bound × `findDistCode`
+none/some × dist-bound), each discharged by `unfold` + `simp only` with the
+branch hypotheses. The loop equality is then a lockstep strong induction on
+`ws.size - i` (the `tokenFreqsP_go_eq` shape): the tag-bit test reduces both
+sides into the same arm; the literal arms agree definitionally, and the
+reference arms agree by `split`ting the boxed side and rewriting the packed
+helper with the resulting branch equations. The bit-level theory
+(`Zip/Spec/EmitTokensCorrect.lean`, `DeflateDynamicEmit.lean`) stays on the
+boxed emitters and transfers through these equalities.
+-/
+
+namespace Zip.Native.Deflate
+
+/-! ## Branch equations for `emitRefFixedP` -/
+
+/-- `emitRefFixedP` when the length field has no length code: no-op. -/
+private theorem emitRefFixedP_none (bw : BitWriter) (w : UInt32)
+    (h : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = none) :
+    emitRefFixedP bw w = bw := by
+  unfold emitRefFixedP
+  simp only [h]
+
+/-- `emitRefFixedP` when the length code is out of table bounds (dead code,
+    kept branch-for-branch with the boxed emitter): no-op. -/
+private theorem emitRefFixedP_oob (bw : BitWriter) (w : UInt32) (idx en : Nat) (ev : UInt32)
+    (hflc : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = some (idx, en, ev))
+    (hl : ¬ idx + 257 < fixedLitCodes.size) :
+    emitRefFixedP bw w = bw := by
+  unfold emitRefFixedP
+  simp only [hflc, hl, ↓reduceDIte]
+
+/-- `emitRefFixedP` when the distance field has no distance code: only the
+    length code and its extra bits are written. -/
+private theorem emitRefFixedP_distNone (bw : BitWriter) (w : UInt32) (idx en : Nat) (ev : UInt32)
+    (hflc : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = some (idx, en, ev))
+    (hl : idx + 257 < fixedLitCodes.size)
+    (hfdc : findDistCode ((w &&& 0xFFFF).toNat) = none) :
+    emitRefFixedP bw w =
+      (bw.writeHuffCode (fixedLitCodes[idx + 257]).1 (fixedLitCodes[idx + 257]).2).writeBits
+        en ev := by
+  unfold emitRefFixedP
+  simp only [hflc, hl, ↓reduceDIte, hfdc]
+  rfl
+
+/-- `emitRefFixedP` when the distance code is out of table bounds (dead
+    code): only the length code and its extra bits are written. -/
+private theorem emitRefFixedP_distOob (bw : BitWriter) (w : UInt32) (idx en : Nat) (ev : UInt32)
+    (dIdx den : Nat) (dev : UInt32)
+    (hflc : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = some (idx, en, ev))
+    (hl : idx + 257 < fixedLitCodes.size)
+    (hfdc : findDistCode ((w &&& 0xFFFF).toNat) = some (dIdx, den, dev))
+    (hd : ¬ dIdx < fixedDistCodes.size) :
+    emitRefFixedP bw w =
+      (bw.writeHuffCode (fixedLitCodes[idx + 257]).1 (fixedLitCodes[idx + 257]).2).writeBits
+        en ev := by
+  unfold emitRefFixedP
+  simp only [hflc, hl, ↓reduceDIte, hfdc, hd]
+  rfl
+
+/-- `emitRefFixedP` on the full path: length code + extra bits, then distance
+    code + extra bits. -/
+private theorem emitRefFixedP_distSome (bw : BitWriter) (w : UInt32) (idx en : Nat) (ev : UInt32)
+    (dIdx den : Nat) (dev : UInt32)
+    (hflc : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = some (idx, en, ev))
+    (hl : idx + 257 < fixedLitCodes.size)
+    (hfdc : findDistCode ((w &&& 0xFFFF).toNat) = some (dIdx, den, dev))
+    (hd : dIdx < fixedDistCodes.size) :
+    emitRefFixedP bw w =
+      ((((bw.writeHuffCode (fixedLitCodes[idx + 257]).1 (fixedLitCodes[idx + 257]).2).writeBits
+          en ev).writeHuffCode (fixedDistCodes[dIdx]).1 (fixedDistCodes[dIdx]).2).writeBits
+        den dev) := by
+  unfold emitRefFixedP
+  simp only [hflc, hl, ↓reduceDIte, hfdc, hd]
+  rfl
+
+/-! ## The packed fixed-code emitter equals the boxed one -/
+
+/-- The packed fixed-code emit loop is the boxed one over the `unpackTok`
+    view: lockstep strong induction; per word, the tag-bit test reduces both
+    sides into the same arm, and the reference arms align by splitting the
+    boxed side and rewriting `emitRefFixedP` with the branch equations. -/
+theorem emitTokensP_eq (bw : BitWriter) (ws : Array UInt32) (i : Nat) :
+    emitTokensP bw ws i = emitTokens bw (ws.map unpackTok) i := by
+  induction h : ws.size - i using Nat.strongRecOn generalizing bw i with
+  | _ n ih =>
+    unfold emitTokensP emitTokens
+    by_cases hi : i < ws.size
+    · simp only [Array.size_map, hi, ↓reduceDIte, Array.getElem_map, unpackTok]
+      by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
+      · simp only [hc, ↓reduceIte]
+        exact ih _ (by omega) _ _ rfl
+      · simp only [hc, ↓reduceIte]
+        split
+        · rename_i idx en ev hflc
+          by_cases hl : idx + 257 < fixedLitCodes.size
+          · simp only [hl, ↓reduceDIte]
+            split
+            · rename_i dIdx den dev hfdc
+              by_cases hd : dIdx < fixedDistCodes.size
+              · simp only [hd, ↓reduceDIte]
+                rw [emitRefFixedP_distSome _ _ _ _ _ _ _ _ hflc hl hfdc hd]
+                exact ih _ (by omega) _ _ rfl
+              · simp only [hd, ↓reduceDIte]
+                rw [emitRefFixedP_distOob _ _ _ _ _ _ _ _ hflc hl hfdc hd]
+                exact ih _ (by omega) _ _ rfl
+            · rename_i hfdc
+              rw [emitRefFixedP_distNone _ _ _ _ _ hflc hl hfdc]
+              exact ih _ (by omega) _ _ rfl
+          · simp only [hl, ↓reduceDIte]
+            rw [emitRefFixedP_oob _ _ _ _ _ hflc hl]
+            exact ih _ (by omega) _ _ rfl
+        · rename_i hflc
+          rw [emitRefFixedP_none _ _ hflc]
+          exact ih _ (by omega) _ _ rfl
+    · simp only [Array.size_map, hi, ↓reduceDIte]
+
+/-! ## Branch equations for `emitRefWithCodesP` -/
+
+/-- `emitRefWithCodesP` when the length field has no length code: no-op. -/
+private theorem emitRefWithCodesP_none (bw : BitWriter)
+    (litCodes distCodes : Array (UInt16 × UInt8)) (w : UInt32)
+    (h : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = none) :
+    emitRefWithCodesP bw litCodes distCodes w = bw := by
+  unfold emitRefWithCodesP
+  simp only [h]
+
+/-- `emitRefWithCodesP` when the length code is out of table bounds (dead
+    code under the callers' `hlit`): no-op. -/
+private theorem emitRefWithCodesP_oob (bw : BitWriter)
+    (litCodes distCodes : Array (UInt16 × UInt8)) (w : UInt32) (idx en : Nat) (ev : UInt32)
+    (hflc : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = some (idx, en, ev))
+    (hl : ¬ idx + 257 < litCodes.size) :
+    emitRefWithCodesP bw litCodes distCodes w = bw := by
+  unfold emitRefWithCodesP
+  simp only [hflc, hl, ↓reduceDIte]
+
+/-- `emitRefWithCodesP` when the distance field has no distance code: only
+    the length code and its extra bits are written. -/
+private theorem emitRefWithCodesP_distNone (bw : BitWriter)
+    (litCodes distCodes : Array (UInt16 × UInt8)) (w : UInt32) (idx en : Nat) (ev : UInt32)
+    (hflc : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = some (idx, en, ev))
+    (hl : idx + 257 < litCodes.size)
+    (hfdc : findDistCode ((w &&& 0xFFFF).toNat) = none) :
+    emitRefWithCodesP bw litCodes distCodes w =
+      (bw.writeHuffCode (litCodes[idx + 257]).1 (litCodes[idx + 257]).2).writeBits en ev := by
+  unfold emitRefWithCodesP
+  simp only [hflc, hl, ↓reduceDIte, hfdc]
+  rfl
+
+/-- `emitRefWithCodesP` when the distance code is out of table bounds (dead
+    code under the callers' `hdist`): only the length code and its extra bits
+    are written. -/
+private theorem emitRefWithCodesP_distOob (bw : BitWriter)
+    (litCodes distCodes : Array (UInt16 × UInt8)) (w : UInt32) (idx en : Nat) (ev : UInt32)
+    (dIdx den : Nat) (dev : UInt32)
+    (hflc : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = some (idx, en, ev))
+    (hl : idx + 257 < litCodes.size)
+    (hfdc : findDistCode ((w &&& 0xFFFF).toNat) = some (dIdx, den, dev))
+    (hd : ¬ dIdx < distCodes.size) :
+    emitRefWithCodesP bw litCodes distCodes w =
+      (bw.writeHuffCode (litCodes[idx + 257]).1 (litCodes[idx + 257]).2).writeBits en ev := by
+  unfold emitRefWithCodesP
+  simp only [hflc, hl, ↓reduceDIte, hfdc, hd]
+  rfl
+
+/-- `emitRefWithCodesP` on the full path: length code + extra bits, then
+    distance code + extra bits. -/
+private theorem emitRefWithCodesP_distSome (bw : BitWriter)
+    (litCodes distCodes : Array (UInt16 × UInt8)) (w : UInt32) (idx en : Nat) (ev : UInt32)
+    (dIdx den : Nat) (dev : UInt32)
+    (hflc : findLengthCode (((w >>> 16) &&& 0x7FFF).toNat) = some (idx, en, ev))
+    (hl : idx + 257 < litCodes.size)
+    (hfdc : findDistCode ((w &&& 0xFFFF).toNat) = some (dIdx, den, dev))
+    (hd : dIdx < distCodes.size) :
+    emitRefWithCodesP bw litCodes distCodes w =
+      ((((bw.writeHuffCode (litCodes[idx + 257]).1 (litCodes[idx + 257]).2).writeBits
+          en ev).writeHuffCode (distCodes[dIdx]).1 (distCodes[dIdx]).2).writeBits den dev) := by
+  unfold emitRefWithCodesP
+  simp only [hflc, hl, ↓reduceDIte, hfdc, hd]
+  rfl
+
+/-! ## The packed dynamic-code emitter equals the boxed one -/
+
+/-- The packed dynamic-code emit loop is the boxed one over the `unpackTok`
+    view (same `hlit`/`hdist` size hypotheses as the boxed emitter): the same
+    lockstep induction as `emitTokensP_eq`. -/
+theorem emitTokensWithCodesP_eq (bw : BitWriter) (ws : Array UInt32)
+    (litCodes distCodes : Array (UInt16 × UInt8))
+    (hlit : litCodes.size ≥ 286) (hdist : distCodes.size ≥ 30) (i : Nat) :
+    emitTokensWithCodesP bw ws litCodes distCodes hlit hdist i =
+      emitTokensWithCodes bw (ws.map unpackTok) litCodes distCodes hlit hdist i := by
+  induction h : ws.size - i using Nat.strongRecOn generalizing bw i with
+  | _ n ih =>
+    unfold emitTokensWithCodesP emitTokensWithCodes
+    by_cases hi : i < ws.size
+    · simp only [Array.size_map, hi, ↓reduceDIte, Array.getElem_map, unpackTok]
+      by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
+      · simp only [hc, ↓reduceIte]
+        exact ih _ (by omega) _ _ rfl
+      · simp only [hc, ↓reduceIte]
+        split
+        · rename_i idx en ev hflc
+          by_cases hl : idx + 257 < litCodes.size
+          · simp only [hl, ↓reduceDIte]
+            split
+            · rename_i dIdx den dev hfdc
+              by_cases hd : dIdx < distCodes.size
+              · simp only [hd, ↓reduceDIte]
+                rw [emitRefWithCodesP_distSome _ _ _ _ _ _ _ _ _ _ hflc hl hfdc hd]
+                exact ih _ (by omega) _ _ rfl
+              · simp only [hd, ↓reduceDIte]
+                rw [emitRefWithCodesP_distOob _ _ _ _ _ _ _ _ _ _ hflc hl hfdc hd]
+                exact ih _ (by omega) _ _ rfl
+            · rename_i hfdc
+              rw [emitRefWithCodesP_distNone _ _ _ _ _ _ _ hflc hl hfdc]
+              exact ih _ (by omega) _ _ rfl
+          · simp only [hl, ↓reduceDIte]
+            rw [emitRefWithCodesP_oob _ _ _ _ _ _ _ hflc hl]
+            exact ih _ (by omega) _ _ rfl
+        · rename_i hflc
+          rw [emitRefWithCodesP_none _ _ _ _ hflc]
+          exact ih _ (by omega) _ _ rfl
+    · simp only [Array.size_map, hi, ↓reduceDIte]
+
+/-! ## The packed single-block cores equal the boxed ones -/
+
+/-- The packed fixed-block core is the boxed one over the `unpackTok` view:
+    the bodies are identical up to `emitTokensP_eq`. -/
+theorem deflateFixedBlockP_eq (data : ByteArray) (ptoks : Array UInt32) :
+    deflateFixedBlockP data ptoks = deflateFixedBlock data (ptoks.map unpackTok) := by
+  unfold deflateFixedBlockP deflateFixedBlock
+  simp only [emitTokensP_eq]
+
+/-- The packed dynamic-block core is the boxed one over the `unpackTok` view
+    (same `hlit`/`hdist` hypotheses): the bodies are identical up to
+    `emitTokensWithCodesP_eq`. -/
+theorem deflateDynamicBlockCoreP_eq (data : ByteArray) (ptoks : Array UInt32)
+    (litLens distLens : List Nat)
+    (hlit : litLens.length = 286) (hdist : distLens.length = 30) :
+    deflateDynamicBlockCoreP data ptoks litLens distLens hlit hdist =
+      deflateDynamicBlockCore data (ptoks.map unpackTok) litLens distLens hlit hdist := by
+  unfold deflateDynamicBlockCoreP deflateDynamicBlockCore
+  simp only [emitTokensWithCodesP_eq]
+
+end Zip.Native.Deflate

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -1,5 +1,6 @@
 import Zip.Spec.LZ77ChainCorrect
 import Zip.Spec.LZ77ChainLazyCorrect
+import Zip.Spec.EmitPackedCorrect
 import Zip.Native.DeflateDynamic
 
 /-!
@@ -165,22 +166,25 @@ theorem lzMatchP_map (data : ByteArray) (level : UInt8) :
   · exact lz77ChainIterP_map data (chainDepth level) 32768 (insertCap level)
       (by omega) (by omega)
 
-/-! ## Stage B: the packed base candidate equals the boxed one
+/-! ## Stages B+C: the packed base candidate equals the boxed one
 
 `deflateRawBase` is now *defined* as `deflateRawBaseP data (lzMatchP data
-level)` (packed frequency pass, unpack only at the emit boundary). The
-equation below recovers the boxed formulation — same statement as the old
-definitional `deflateRawBase_def`, now proven from `tokenFreqsP_eq` (the
-packed histogram is the boxed one over the `unpackTok` view) and
-`lzMatchP_map` (the view of the packed stream is `lzMatch`). The three
-`deflateRawBase` spec lemmas in `Zip/Spec/DeflateRoundtrip.lean` keep their
-statements and rewrite through this equation. -/
+level)` (packed frequency pass *and* packed emit — no unpack anywhere on
+the base path). The equation below recovers the boxed formulation — same
+statement as the old definitional `deflateRawBase_def`, now proven from
+`tokenFreqsP_eq` (the packed histogram is the boxed one over the
+`unpackTok` view), the stage-C packed-emitter equalities
+(`deflateFixedBlockP_eq`/`deflateDynamicBlockCoreP_eq`,
+`Zip/Spec/EmitPackedCorrect.lean`) and `lzMatchP_map` (the view of the
+packed stream is `lzMatch`). The three `deflateRawBase` spec lemmas in
+`Zip/Spec/DeflateRoundtrip.lean` keep their statements and rewrite through
+this equation. -/
 
 /-- The boxed base dispatch over `lzMatch` is the (packed-pipeline)
     `deflateRawBase`. -/
 theorem deflateRawBase_def (data : ByteArray) (level : UInt8) :
     deflateRawBaseTokens data (lzMatch data level) = deflateRawBase data level := by
   unfold deflateRawBase deflateRawBaseP deflateRawBaseTokens
-  simp only [tokenFreqsP_eq, lzMatchP_map]
+  simp only [deflateFixedBlockP_eq, deflateDynamicBlockCoreP_eq, tokenFreqsP_eq, lzMatchP_map]
 
 end Zip.Native.Deflate

--- a/ZipTest/PackedTokens.lean
+++ b/ZipTest/PackedTokens.lean
@@ -44,6 +44,36 @@ private def checkBaseP (label : String) (data : ByteArray) : IO Unit := do
         s!"{label} level {level}: deflateRawBaseP ({packed.size} bytes) ≠ \
            deflateRawBaseTokens ({boxed.size} bytes)")
 
+/-- Stage C gate: the packed single-block cores must be byte-identical to
+    the boxed ones over the same token stream — `deflateFixedBlockP` against
+    `deflateFixedBlock` and `deflateDynamicBlockCoreP` against
+    `deflateDynamicBlockCore`, fed this level's `lzMatchP` stream and its
+    boxed view. The theorems `deflateFixedBlockP_eq` /
+    `deflateDynamicBlockCoreP_eq` (`Zip/Spec/EmitPackedCorrect.lean`) prove
+    the equalities; this test keeps the compiled packed emitters
+    (`emitTokensP`/`emitTokensWithCodesP` and their opaque reference-arm
+    helpers) honest against them. -/
+private def checkCoresP (label : String) (data : ByteArray) : IO Unit := do
+  for level in [(1 : UInt8), 4, 6, 9] do
+    let ptoks := lzMatchP data level
+    let toks := ptoks.map unpackTok
+    let fixedP := deflateFixedBlockP data ptoks
+    let fixedB := deflateFixedBlock data toks
+    unless fixedP == fixedB do
+      throw (IO.userError
+        s!"{label} level {level}: deflateFixedBlockP ({fixedP.size} bytes) ≠ \
+           deflateFixedBlock ({fixedB.size} bytes)")
+    let f := tokenFreqs toks
+    let lens := dynamicCodeLengths f.1 f.2
+    let dynP := deflateDynamicBlockCoreP data ptoks lens.1 lens.2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
+    let dynB := deflateDynamicBlockCore data toks lens.1 lens.2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
+    unless dynP == dynB do
+      throw (IO.userError
+        s!"{label} level {level}: deflateDynamicBlockCoreP ({dynP.size} bytes) ≠ \
+           deflateDynamicBlockCore ({dynB.size} bytes)")
+
 def tests : IO Unit := do
   IO.println "  PackedTokens tests..."
   let alice ← IO.FS.readBinFile "bench/corpora/canterbury/alice29.txt"
@@ -65,6 +95,15 @@ def tests : IO Unit := do
   checkBaseP "size1" (ByteArray.mk #[42])
   checkBaseP "size2" (ByteArray.mk #[42, 42])
   checkBaseP "size3" (ByteArray.mk #[7, 7, 7])
+  checkCoresP "alice29" alice
+  checkCoresP "text64k" (mkTextData 65536)
+  checkCoresP "cyclic64k" (mkCyclicData 65536)
+  checkCoresP "prng64k" (mkPrngData 65536)
+  checkCoresP "constant64k" (mkConstantData 65536)
+  checkCoresP "size0" ByteArray.empty
+  checkCoresP "size1" (ByteArray.mk #[42])
+  checkCoresP "size2" (ByteArray.mk #[42, 42])
+  checkCoresP "size3" (ByteArray.mk #[7, 7, 7])
   IO.println "  PackedTokens tests passed"
 
 end ZipTest.PackedTokens


### PR DESCRIPTION
This PR complete the packed token pipeline for the single-block paths: emitTokensP and emitTokensWithCodesP walk the packed UInt32 words directly (reference arms through opaque non-recursive helpers per the WF-elaboration landmine documented in stage B), proven equal to the boxed emitters by lockstep induction so the bit-level emission theory transfers untouched, and deflateRawBaseP consumes packed words end-to-end — the emit-boundary unpack disappears from the level-<7 path and the base candidate. Output is byte-identical (canaries exact; new packed-vs-boxed core equality tests at levels 1/4/6/9), every existing theorem statement is unchanged, and DeflateRoundtrip.lean needed zero edits.

Measured honestly: −0.7 to −1.7% at levels 2–5, neutral elsewhere — which closes the 3b ledger at roughly 1–2% total. Token boxing and traversal were not a significant cost on this profile; the stage-D remainder (the shared-split unpack at level ≥7, where the split candidates dominate) is bounded by the same diagnosis and is not being pursued. Full accounting lands in the track-d-state D-22 row with the Wave-3 dashboard refresh.

🤖 Prepared with Claude Code