### PR TITLE
perf: reuse sized trees across shared-split sizing and emission (W5.P0)

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -751,6 +751,106 @@ def chooseSplitsArbitrated (toks : Array LZ77Token) : List Nat :=
   let f := fixedCadenceCuts sharedTokChunk toks.size
   if sharedPartitionBits toks h 0 < sharedPartitionBits toks f 0 then h else f
 
+/-! ## Sized-tree reuse for the winning partition (Wave 5, #2552)
+
+`chooseSplitsArbitrated` already builds every block's Huffman trees
+(`dynamicCodeLengths` over `tokenFreqs` of the group) while *sizing* the two
+candidate partitions; `emitSharedBlocksAt` then rebuilt the same trees a third
+time for the winning partition at emission. The variants below return the cuts
+*together with* the winner's per-block sized trees and feed them to a
+tree-taking emitter, so emission never re-runs the frequency pass or the
+Huffman build. `emitSharedBlocksAt` stays as the reference emitter:
+`deflateDynamicBlocksSharedSized_eq` (`Zip/Spec/DeflateBlockSplit.lean`) proves
+the sized pipeline byte-identical, so the spec quadruple is untouched. -/
+
+/-- A per-block pair of code-length lists carrying the alphabet-size facts the
+    emitter needs (286 lit/len, 30 distance) — what `dynamicCodeLengths`
+    produces, bundled with `dynamicCodeLengths_length`. -/
+def SizedTrees : Type :=
+  {p : List Nat × List Nat // p.1.length = 286 ∧ p.2.length = 30}
+
+/-- The sized trees `dynamicCodeLengths` selects for the given frequencies. -/
+@[inline] def sizedTrees (litFreqs distFreqs : Array Nat) : SizedTrees :=
+  ⟨dynamicCodeLengths litFreqs distFreqs,
+    (dynamicCodeLengths_length litFreqs distFreqs).1,
+    (dynamicCodeLengths_length litFreqs distFreqs).2⟩
+
+/-- The sized trees of the empty token group: the (never-reached) `headD`
+    default in `emitSharedBlocksAtSized` — the trees list produced by
+    `sharedPartitionSized` always covers every emitted block. -/
+def emptySizedTrees : SizedTrees :=
+  sizedTrees (tokenFreqs #[]).1 (tokenFreqs #[]).2
+
+/-- `sharedPartitionBits` fused with tree collection: walk the partition once,
+    returning the exact bit size **together with** each block's sized trees, so
+    the winning partition's emission can reuse them instead of re-running
+    `tokenFreqs` + `dynamicCodeLengths` per block. Component 1 is exactly
+    `sharedPartitionBits` (`sharedPartitionSized_fst`); component 2's entries
+    are definitionally `dynamicCodeLengths (tokenFreqs group)` of the emitter's
+    groups (`emitSharedBlocksAtSized_eq`). -/
+def sharedPartitionSized (toks : Array LZ77Token) (cuts : List Nat) (pos : Nat) :
+    Nat × List SizedTrees :=
+  let j := min (max (cuts.headD toks.size) (pos + 1)) toks.size
+  let f := tokenFreqs (toks.extract pos j)
+  let t := sizedTrees f.1 f.2
+  let blockBits := 3 + (writeDynamicHeader BitWriter.empty t.val.1 t.val.2).bitLength
+    + symbolBitCount f.1 f.2 t.val.1.toArray t.val.2.toArray
+  if j ≥ toks.size then (blockBits, [t])
+  else
+    let rest := sharedPartitionSized toks cuts.tail j
+    (blockBits + rest.1, t :: rest.2)
+termination_by toks.size - pos
+decreasing_by
+  rename_i h
+  simp only [Nat.not_le] at h
+  omega
+
+/-- Tree-taking twin of `emitSharedBlocksAt`: same clamped cut points, but each
+    block's `(litLens, distLens)` come from the `trees` list (in lockstep with
+    `cuts`) instead of being recomputed from the group. Byte-identical to
+    `emitSharedBlocksAt` when `trees` is the sizing pass's output
+    (`emitSharedBlocksAtSized_eq`). -/
+def emitSharedBlocksAtSized (data : ByteArray) (toks : Array LZ77Token) (cuts : List Nat)
+    (trees : List SizedTrees) (pos : Nat) (bw : BitWriter) : BitWriter :=
+  let j := min (max (cuts.headD toks.size) (pos + 1)) toks.size
+  let t := trees.headD emptySizedTrees
+  let bw := emitDynBlock bw data (toks.extract pos j) t.val.1 t.val.2
+    t.property.1 t.property.2 (decide (j ≥ toks.size))
+  if j ≥ toks.size then bw
+  else emitSharedBlocksAtSized data toks cuts.tail trees.tail j bw
+termination_by toks.size - pos
+decreasing_by
+  rename_i h
+  simp only [Nat.not_le] at h
+  omega
+
+/-- `chooseSplitsArbitrated` returning the winning cuts **with** the winner's
+    per-block sized trees (component 1 is exactly `chooseSplitsArbitrated` —
+    via `sharedPartitionSized_fst`, see `deflateDynamicBlocksSharedSized_eq`).
+    The sizing of both candidates is inherent to arbitration; only the third
+    (emission-time) tree pass is avoidable, and the returned trees are what
+    avoid it. -/
+def chooseSplitsArbitratedSized (toks : Array LZ77Token) : List Nat × List SizedTrees :=
+  let h := chooseSplitsHeuristic toks
+  let f := fixedCadenceCuts sharedTokChunk toks.size
+  let sh := sharedPartitionSized toks h 0
+  let sf := sharedPartitionSized toks f 0
+  if sh.1 < sf.1 then (h, sh.2) else (f, sf.2)
+
+/-- The arbitrated shared-window candidate with sized-tree reuse: byte-identical
+    to `deflateDynamicBlocksSharedAtTokens data toks chooseSplitsArbitrated`
+    (`deflateDynamicBlocksSharedSized_eq`), but the winning partition's
+    per-block `tokenFreqs` + `dynamicCodeLengths` run once (during sizing)
+    instead of twice. -/
+def deflateDynamicBlocksSharedSized (data : ByteArray) (toks : Array LZ77Token) : ByteArray :=
+  if data.size == 0 then
+    let f := tokenFreqs #[]
+    (emitDynBlock BitWriter.empty data #[] (dynamicCodeLengths f.1 f.2).1 (dynamicCodeLengths f.1 f.2).2
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2 true).flush
+  else
+    let c := chooseSplitsArbitratedSized toks
+    (emitSharedBlocksAtSized data toks c.1 c.2 0 BitWriter.empty).flush
+
 /-- The compressed-block dispatch (no stored fallback). Every level ≥ 1 uses the
     hash-chain matcher with the level's search depth (`chainDepth`) and interior
     insertion cap (`insertCap`): low levels defer insertion + search shallowly
@@ -859,7 +959,10 @@ def deflateDynamicBlocksOptimal (data : ByteArray) (tokChunk : Nat) : ByteArray 
         partition comes from the entropy-divergence heuristic arbitrated in
         exact bits against the fixed `sharedTokChunk` cadence
         (`chooseSplitsArbitrated`), so it cuts where the symbol statistics
-        shift and never sizes worse than the fixed cadence.
+        shift and never sizes worse than the fixed cadence; emission reuses
+        the winner's per-block trees from the sizing pass
+        (`deflateDynamicBlocksSharedSized`, = the reference candidate by
+        `deflateDynamicBlocksSharedSized_eq`).
     At level 9 (and within the `optimalMaxSize` memory gate) a fourth candidate
     joins: the cross-block stream over the **near-optimal** cost-model DP parse
     (`deflateDynamicBlocksOptimal`), which chooses the globally cheapest token
@@ -884,15 +987,13 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
       pickSmaller
         (pickSmaller (deflateRawBaseP data ptokens)
           (pickSmaller (deflateDynamicBlocksSC data splitChunkSize level)
-            (deflateDynamicBlocksSharedAtTokens data (ptokens.map unpackTok)
-              chooseSplitsArbitrated)))
+            (deflateDynamicBlocksSharedSized data (ptokens.map unpackTok))))
         (deflateDynamicBlocksOptimal data sharedTokChunk)
     else
       -- The self-contained split is demoted to level 9: it wins on exactly
       -- one corpus file while paying a full per-chunk match pass.
       pickSmaller (deflateRawBaseP data ptokens)
-        (deflateDynamicBlocksSharedAtTokens data (ptokens.map unpackTok)
-          chooseSplitsArbitrated)
+        (deflateDynamicBlocksSharedSized data (ptokens.map unpackTok))
   else deflateRawBase data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -1393,4 +1393,105 @@ theorem deflateDynamicBlocksOptimal_pad (data : ByteArray) (tokChunk : Nat) :
         data.data.toList BitWriter.empty (by omega) htokpos BitWriter.empty_wf hres0
     exact ⟨_, _, flush_toBits_aligned _ hwf, by simp only [List.length_replicate]; omega⟩
 
+/-! ## Sized-tree emitter equality (Wave 5, #2552)
+
+`deflateDynamicBlocksSharedSized` reuses the per-block Huffman trees the
+arbitration sizing pass already built, instead of letting `emitSharedBlocksAt`
+rebuild them at emission. The lemmas below prove the sized pipeline
+byte-identical to the reference
+`deflateDynamicBlocksSharedAtTokens … chooseSplitsArbitrated`, so the
+`deflateDynamicBlocksSharedAt` quadruple above transfers by a rewrite in
+`DeflateRoundtrip` — no statement changes. Each equality is one unfolding step
+per block on both sides: the trees the sizing pass stores are *definitionally*
+`dynamicCodeLengths (tokenFreqs group)` of the same group the reference
+emitter recomputes, so no bit-level reasoning is involved. -/
+
+/-- Component 1 of `sharedPartitionSized` is exactly `sharedPartitionBits`
+    (fuel-quantified form for the induction). -/
+private theorem sharedPartitionSized_fst_fuel (toks : Array LZ77Token) :
+    ∀ (fuel pos : Nat), toks.size - pos < fuel → ∀ (cuts : List Nat),
+      (sharedPartitionSized toks cuts pos).1 = sharedPartitionBits toks cuts pos := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos hf; omega
+  | succ fuel ih =>
+    intro pos hf cuts
+    conv => lhs; unfold sharedPartitionSized
+    conv => rhs; unfold sharedPartitionBits
+    by_cases hend : min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size
+    · simp only [if_pos hend, sizedTrees]
+    · simp only [if_neg hend, sizedTrees]
+      rw [ih (min (max (cuts.headD toks.size) (pos + 1)) toks.size) (by omega)]
+
+/-- Component 1 of `sharedPartitionSized` is exactly `sharedPartitionBits`. -/
+theorem sharedPartitionSized_fst (toks : Array LZ77Token) (cuts : List Nat) (pos : Nat) :
+    (sharedPartitionSized toks cuts pos).1 = sharedPartitionBits toks cuts pos :=
+  sharedPartitionSized_fst_fuel toks (toks.size - pos + 1) pos (by omega) cuts
+
+/-- The tree-taking emitter over the sizing pass's trees equals the reference
+    emitter (fuel-quantified form): the stored trees are definitionally the
+    `dynamicCodeLengths (tokenFreqs group)` the reference recomputes. -/
+private theorem emitSharedBlocksAtSized_eq_fuel (data : ByteArray) (toks : Array LZ77Token) :
+    ∀ (fuel pos : Nat), toks.size - pos < fuel → ∀ (cuts : List Nat) (bw : BitWriter),
+      emitSharedBlocksAtSized data toks cuts (sharedPartitionSized toks cuts pos).2 pos bw
+        = emitSharedBlocksAt data toks cuts pos bw := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos hf; omega
+  | succ fuel ih =>
+    intro pos hf cuts bw
+    by_cases hend : min (max (cuts.headD toks.size) (pos + 1)) toks.size ≥ toks.size
+    · have hsnd : (sharedPartitionSized toks cuts pos).2 =
+          [sizedTrees
+            (tokenFreqs (toks.extract pos
+              (min (max (cuts.headD toks.size) (pos + 1)) toks.size))).1
+            (tokenFreqs (toks.extract pos
+              (min (max (cuts.headD toks.size) (pos + 1)) toks.size))).2] := by
+        conv => lhs; unfold sharedPartitionSized
+        simp only [if_pos hend]
+      rw [hsnd]
+      conv => lhs; unfold emitSharedBlocksAtSized
+      conv => rhs; unfold emitSharedBlocksAt
+      simp only [if_pos hend, List.headD_cons, emitSharedBlock, sizedTrees]
+    · have hsnd : (sharedPartitionSized toks cuts pos).2 =
+          sizedTrees
+            (tokenFreqs (toks.extract pos
+              (min (max (cuts.headD toks.size) (pos + 1)) toks.size))).1
+            (tokenFreqs (toks.extract pos
+              (min (max (cuts.headD toks.size) (pos + 1)) toks.size))).2 ::
+          (sharedPartitionSized toks cuts.tail
+            (min (max (cuts.headD toks.size) (pos + 1)) toks.size)).2 := by
+        conv => lhs; unfold sharedPartitionSized
+        simp only [if_neg hend]
+      rw [hsnd]
+      conv => lhs; unfold emitSharedBlocksAtSized
+      conv => rhs; unfold emitSharedBlocksAt
+      simp only [if_neg hend, List.headD_cons, List.tail_cons, emitSharedBlock, sizedTrees]
+      exact ih (min (max (cuts.headD toks.size) (pos + 1)) toks.size) (by omega) cuts.tail _
+
+/-- The tree-taking emitter over the sizing pass's trees equals the reference
+    emitter, for any cut list and start position. -/
+theorem emitSharedBlocksAtSized_eq (data : ByteArray) (toks : Array LZ77Token)
+    (cuts : List Nat) (pos : Nat) (bw : BitWriter) :
+    emitSharedBlocksAtSized data toks cuts (sharedPartitionSized toks cuts pos).2 pos bw
+      = emitSharedBlocksAt data toks cuts pos bw :=
+  emitSharedBlocksAtSized_eq_fuel data toks (toks.size - pos + 1) pos (by omega) cuts bw
+
+/-- The sized-tree shared-window candidate is byte-identical to the reference
+    arbitrated candidate: `deflateRaw`'s level ≥ 7 branches and the roundtrip
+    proofs see the old `deflateDynamicBlocksSharedAtTokens … chooseSplitsArbitrated`
+    through this rewrite. -/
+theorem deflateDynamicBlocksSharedSized_eq (data : ByteArray) (toks : Array LZ77Token) :
+    deflateDynamicBlocksSharedSized data toks =
+      deflateDynamicBlocksSharedAtTokens data toks chooseSplitsArbitrated := by
+  unfold deflateDynamicBlocksSharedSized deflateDynamicBlocksSharedAtTokens
+  split
+  · rfl
+  · simp only [chooseSplitsArbitratedSized, chooseSplitsArbitrated,
+      sharedPartitionSized_fst]
+    by_cases hlt : sharedPartitionBits toks (chooseSplitsHeuristic toks) 0 <
+        sharedPartitionBits toks (fixedCadenceCuts sharedTokChunk toks.size) 0
+    · simp only [if_pos hlt, emitSharedBlocksAtSized_eq]
+    · simp only [if_neg hlt, emitSharedBlocksAtSized_eq]
+
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -113,7 +113,8 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     Zip.Native.Inflate.inflate (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedAt_def]
+  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedSized_eq,
+    deflateDynamicBlocksSharedAt_def]
   split
   · exact inflate_deflateStoredPure data _ (by omega)
   · split
@@ -199,7 +200,8 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
       padding.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedAt_def]
+  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedSized_eq,
+    deflateDynamicBlocksSharedAt_def]
   split
   · -- Level 0: stored blocks — all byte-aligned, padding = []
     exact ⟨Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data),
@@ -368,7 +370,8 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedAt_def]
+  rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedSized_eq,
+    deflateDynamicBlocksSharedAt_def]
   split
   · -- Level 0: stored blocks — byte-aligned, remaining = []
     exact ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩

--- a/ZipTest/SizeHelpers.lean
+++ b/ZipTest/SizeHelpers.lean
@@ -140,6 +140,20 @@ def tests : IO Unit := do
       throw (IO.userError
         s!"fixedCadenceCuts not byte-identical to fixed-cadence emitter on {name}: \
            {viaCuts.size} vs {viaChunk.size}")
+    -- 6. The sized-tree pipeline (Wave 5, #2552) is byte-identical to the
+    -- reference arbitrated candidate, and the fused sizing pass agrees with
+    -- `sharedPartitionBits` (both proved in `Zip/Spec/DeflateBlockSplit.lean`;
+    -- this pins the compiled code).
+    let toks9 := lzMatch data 9
+    let sizedOut := deflateDynamicBlocksSharedSized data toks9
+    let refOut := deflateDynamicBlocksSharedAtTokens data toks9 chooseSplitsArbitrated
+    unless sizedOut.beq refOut do
+      throw (IO.userError
+        s!"deflateDynamicBlocksSharedSized not byte-identical on {name}: \
+           {sizedOut.size} vs {refOut.size}")
+    let arbCuts := chooseSplitsArbitrated toks9
+    unless (sharedPartitionSized toks9 arbCuts 0).1 == sharedPartitionBits toks9 arbCuts 0 do
+      throw (IO.userError s!"sharedPartitionSized bits mismatch on {name}")
   IO.println "  SizeHelpers tests passed."
 
 end ZipTest.SizeHelpers


### PR DESCRIPTION
This PR carry the winning partition's per-block Huffman trees from the arbitration sizing pass into emission instead of rebuilding them per block, with the sized-tree emitter proven equal to emitSharedBlocksAt by equality transfer — no new bit-level theory, no statement changes, byte-identical output (canaries exact). Measured: ~1–3% at L7/L8 and L9 within noise, against an audited estimate of 8–18% — recorded honestly as another case of estimates exceeding in-situ reality.

Closes #2552

🤖 Prepared with Claude Code