### PR TITLE
perf: de-box per-position matcher helper returns

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -565,7 +565,9 @@ where
     statically; the fallback keeps the original panic-checked operations and is
     dead in practice — `hashTable`/`prev` sizes are fixed at allocation.
     Provably equal to the panic-checked sequence (`headInsertGuarded_eq` in
-    `LZ77ChainCorrect`). -/
+    `LZ77ChainCorrect`). Superseded in the mainLoops by `headProbeGuarded` +
+    two `guardedSet`s (Wave 5 de-boxing — this tuple return allocated a heap
+    constructor per position); kept with its `_eq` lemma. -/
 @[inline] def headInsertGuarded (hashTable prev : Array Nat) (h pos : Nat) :
     Nat × Array Nat × Array Nat :=
   if hg : h < hashTable.size ∧ pos < prev.size then
@@ -581,6 +583,15 @@ where
     (`headProbeGuarded_eq` in `LZ77ChainCorrect`). -/
 @[inline] def headProbeGuarded (hashTable : Array Nat) (h : Nat) : Nat :=
   if hb : h < hashTable.size then hashTable[h]'hb else hashTable[h]!
+
+/-- Single guarded array write (Wave 5 de-boxing): one runtime bounds check,
+    panic-checked fallback (dead in practice — the matcher arrays have fixed
+    size). Provably equal to `a.set! i v` (`guardedSet_eq` in
+    `LZ77ChainCorrect`). The mainLoops do their per-position head insertion as
+    `headProbeGuarded` + two `guardedSet`s — three single-value steps in place
+    of `headInsertGuarded`'s tuple, so nothing is heap-allocated per position. -/
+@[inline] def guardedSet (a : Array Nat) (i v : Nat) : Array Nat :=
+  if h : i < a.size then a.set i v h else a.set! i v
 
 /-- Greedy LZ77 with bounded-depth hash chains: at each position, walk the
     `prev` chain from the bucket head up to `maxChain` candidates and keep the
@@ -645,11 +656,14 @@ where
       (hashTable prev : Array Nat) (pos insertCap : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
+      let head := headProbeGuarded hashTable h
+      let hashTable := guardedSet hashTable h pos
+      let prev := guardedSet prev pos head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let (matchLen, matchPos) :=
-        chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let m := chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let matchLen := m.1
+      let matchPos := m.2
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           have : data.size - (pos + matchLen) < data.size - pos := by omega
@@ -682,8 +696,10 @@ wrappers establish that hypothesis with one runtime comparison per *outer*
 iteration (amortised over the whole inner loop) and fall back to the original
 panic-checked function when it cannot be shown — so they share the original's
 exact signature and are provably equal to it (`*Guarded_eq` in
-`LZ77ChainCorrect`). The iterative matchers call the wrappers; the recursive
-reference versions and all their proofs are untouched. -/
+`LZ77ChainCorrect`). The recursive reference versions and all their proofs are
+untouched. Wave 5 de-boxing: the iterative matchers call
+`chainWalkGuardedPacked` (the same walk with the result pair packed into one
+small `Nat`) instead of `chainWalkGuarded`, which stays as the proof bridge. -/
 
 /-- Proven-bounds copy of `lz77Chain.chainWalk`: `prev[cand]` is in range because
     the walk guard gives `cand < pos` and `hps : pos ≤ prev.size`. -/
@@ -712,6 +728,43 @@ decreasing_by omega
     chainWalkFast data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos
   else
     lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos
+
+/-- Packed-result copy of `chainWalkFast` (Wave 5 de-boxing): the identical
+    walk, but the `(bestLen, bestPos)` accumulator is carried and returned as
+    the single small `Nat` `bestPos * 512 + bestLen`, so the per-position hot
+    call allocates no pair constructor (and no per-step `(bl, bp)` pair
+    either). `bestLen` never exceeds `maxLen`, which every call site clamps to
+    `min 258 _ < 512`, so the call sites decode exactly with `% 512` / `/ 512`
+    (`chainWalkGuardedPacked_mod`/`_div` in `LZ77ChainCorrect`, via the
+    lockstep equality `chainWalkPacked_eq`). -/
+def chainWalkPacked (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen : Nat)
+    (hpm : pos + maxLen ≤ data.size) (hps : pos ≤ prev.size)
+    (cand fuel bestLen bestPos : Nat) : Nat :=
+  if fuel = 0 then bestPos * 512 + bestLen
+  else if hc : cand < pos ∧ pos - cand ≤ windowSize then
+    have hcand : cand + maxLen ≤ data.size := by omega
+    let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
+    let bl := if ml > bestLen then ml else bestLen
+    let bp := if ml > bestLen then cand else bestPos
+    if bl ≥ maxLen then bp * 512 + bl
+    else chainWalkPacked data prev windowSize pos maxLen hpm hps
+      (prev[cand]'(by omega)) (fuel - 1) bl bp
+  else bestPos * 512 + bestLen
+termination_by fuel
+decreasing_by omega
+
+/-- One runtime `pos ≤ prev.size` check guards the whole `chainWalkPacked`
+    inner loop; the (unreachable) fallback packs the reference walk's pair, so
+    this equals `bestPos * 512 + bestLen` of `lz77Chain.chainWalk`
+    (`chainWalkGuardedPacked_eq`). -/
+@[inline] def chainWalkGuardedPacked (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (cand fuel bestLen bestPos : Nat) : Nat :=
+  if hps : pos ≤ prev.size then
+    chainWalkPacked data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos
+  else
+    let p := lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos
+    p.2 * 512 + p.1
 
 /-- Proven-bounds copy of `lz77Chain.updateHashes`: the bucket index `hsh` is
     `< hashSize ≤ hashTable.size`, so `hashTable[hsh]` needs no runtime check. -/
@@ -763,11 +816,14 @@ where
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
+      let head := headProbeGuarded hashTable h
+      let hashTable := guardedSet hashTable h pos
+      let prev := guardedSet prev pos head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let (matchLen, matchPos) :=
-        chainWalkGuarded data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPacked data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let matchLen := r % 512
+      let matchPos := r / 512
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           have : data.size - (pos + matchLen) < data.size - pos := by omega
@@ -821,11 +877,14 @@ where
       (hashTable prev : Array Nat) (pos insertCap : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
+      let head := headProbeGuarded hashTable h
+      let hashTable := guardedSet hashTable h pos
+      let prev := guardedSet prev pos head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let (matchLen, matchPos) :=
-        lz77Chain.chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let m := lz77Chain.chainWalk data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let matchLen := m.1
+      let matchPos := m.2
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           -- Lazy: probe pos+1 for a longer, no-farther match (distance-guarded deferral)
@@ -834,8 +893,10 @@ where
             let head2 := headProbeGuarded hashTable h2
             let maxLen2 := min 258 (data.size - (pos + 1))
             have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
-            let (matchLen2, matchPos2) :=
+            let m2 :=
               lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+            let matchLen2 := m2.1
+            let matchPos2 := m2.2
             if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 -- Longer & no-farther match at pos+1: emit literal at pos + reference at pos+1
@@ -895,11 +956,14 @@ where
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
+      let head := headProbeGuarded hashTable h
+      let hashTable := guardedSet hashTable h pos
+      let prev := guardedSet prev pos head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let (matchLen, matchPos) :=
-        chainWalkGuarded data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPacked data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let matchLen := r % 512
+      let matchPos := r / 512
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           if h3lt : pos + 3 < data.size then
@@ -907,8 +971,10 @@ where
             let head2 := headProbeGuarded hashTable h2
             let maxLen2 := min 258 (data.size - (pos + 1))
             have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
-            let (matchLen2, matchPos2) :=
-              chainWalkGuarded data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+            let r2 :=
+              chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+            let matchLen2 := r2 % 512
+            let matchPos2 := r2 / 512
             if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
@@ -980,11 +1046,14 @@ where
       Array UInt32 :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
+      let head := headProbeGuarded hashTable h
+      let hashTable := guardedSet hashTable h pos
+      let prev := guardedSet prev pos head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let (matchLen, matchPos) :=
-        chainWalkGuarded data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPacked data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let matchLen := r % 512
+      let matchPos := r / 512
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           have : data.size - (pos + matchLen) < data.size - pos := by omega
@@ -1021,11 +1090,14 @@ where
       Array UInt32 :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
-      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
+      let head := headProbeGuarded hashTable h
+      let hashTable := guardedSet hashTable h pos
+      let prev := guardedSet prev pos head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let (matchLen, matchPos) :=
-        chainWalkGuarded data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPacked data prev windowSize pos maxLen hmaxLenP head maxChain 0 0
+      let matchLen := r % 512
+      let matchPos := r / 512
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           if h3lt : pos + 3 < data.size then
@@ -1033,8 +1105,10 @@ where
             let head2 := headProbeGuarded hashTable h2
             let maxLen2 := min 258 (data.size - (pos + 1))
             have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
-            let (matchLen2, matchPos2) :=
-              chainWalkGuarded data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+            let r2 :=
+              chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+            let matchLen2 := r2 % 512
+            let matchPos2 := r2 / 512
             if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
               if hle2 : pos + 1 + matchLen2 ≤ data.size then
                 have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega

--- a/Zip/Native/DeflateParse.lean
+++ b/Zip/Native/DeflateParse.lean
@@ -156,7 +156,9 @@ def buildCache (data : ByteArray) (hashTable prev : Array Nat) (depth slots base
     let pos := base + j
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos 65536 hlt
-      let (head, hashTable, prev) := headInsertGuarded hashTable prev h pos
+      let head := headProbeGuarded hashTable h
+      let hashTable := guardedSet hashTable h pos
+      let prev := guardedSet prev pos head
       let maxLen := min 258 (data.size - pos)
       have hpm : pos + maxLen ≤ data.size := by omega
       let (lens, dists) := chainWalkAllGuarded data prev pos maxLen hpm head depth

--- a/Zip/Spec/LZ77ChainCorrect.lean
+++ b/Zip/Spec/LZ77ChainCorrect.lean
@@ -47,12 +47,13 @@ theorem chainWalk_spec (data : ByteArray) (prev : Array Nat)
         · exact ih (prev[cand]!) _ _ hb
     · exact hb
 
-/-! ## Guarded per-position head insertion (Wave 3 Step 0.2)
+/-! ## Guarded per-position head insertion (Wave 3 Step 0.2, Wave 5 de-boxing)
 
 The mainLoops perform their per-position chain-head insertion (and, in the
-lazy variants, the lookahead head probe) through `headInsertGuarded`/
-`headProbeGuarded`, which trade the panic-checked `[..]!`/`set!` operations
-for one runtime bounds check. The lemmas below rewrite them back to the
+lazy variants, the lookahead head probe) through `headProbeGuarded` + two
+`guardedSet`s — single-value steps that trade the panic-checked `[..]!`/`set!`
+operations for one runtime bounds check each without allocating
+`headInsertGuarded`'s result tuple. The lemmas below rewrite them back to the
 original panic-checked operations, so every proof that unfolds a mainLoop
 proceeds exactly as before the conversion. -/
 
@@ -78,6 +79,15 @@ theorem headProbeGuarded_eq (hashTable : Array Nat) (h : Nat) :
   · rename_i hb; exact (getElem!_pos hashTable h hb).symm
   · rfl
 
+/-- The guarded single write computes exactly the panic-checked write. -/
+theorem guardedSet_eq (a : Array Nat) (i v : Nat) :
+    guardedSet a i v = a.set! i v := by
+  unfold guardedSet
+  split
+  · rename_i hb
+    simp only [Array.set!_eq_setIfInBounds, Array.setIfInBounds_def, dif_pos hb]
+  · rfl
+
 /-- `lz77Chain.mainLoop` produces a valid decomposition from `pos`. Mirrors
     `lz77Greedy.mainLoop_valid`; the reference case uses `chainWalk_spec` (which
     holds for *any* `prev` array) in place of the inline single-probe match. -/
@@ -89,7 +99,7 @@ theorem lz77Chain_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChai
   split
   · rename_i hlt
     dsimp only
-    simp only [headInsertGuarded_eq]
+    simp only [headProbeGuarded_eq, guardedSet_eq]
     have hspec := chainWalk_spec data
       (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) (by omega)
@@ -145,7 +155,7 @@ theorem lz77Chain_mainLoop_encodable (data : ByteArray) (windowSize hashSize max
   split
   · rename_i hlt
     dsimp only
-    simp only [headInsertGuarded_eq]
+    simp only [headProbeGuarded_eq, guardedSet_eq]
     have hspec := chainWalk_spec data
       (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) (by omega)
@@ -227,6 +237,91 @@ theorem chainWalkGuarded_eq (data : ByteArray) (prev : Array Nat)
   · exact chainWalkFast_eq ..
   · rfl
 
+/-! ## Packed chain walk (Wave 5 de-boxing)
+
+`chainWalkPacked` carries and returns the `(bestLen, bestPos)` accumulator as
+the single small `Nat` `bestPos * 512 + bestLen` so the hot per-position call
+allocates no pair. `chainWalkPacked_eq` is the lockstep equality with
+`chainWalkFast`; since the walk's best length never exceeds `maxLen`
+(`chainWalk_fst_le`, from `chainWalk_spec`) and every matcher call site clamps
+`maxLen` to `min 258 _ < 512`, the `_mod`/`_div` lemmas decode the packed
+result back to the reference walk's components exactly. The iterative-vs-
+recursive mainLoop proofs rewrite with the decode lemmas (side condition
+discharged by `min258_le_511`) and then proceed exactly as before. -/
+
+/-- The packed walk computes exactly the packed image of the proven-bounds
+    walk: identical control flow, with the pair accumulator carried as
+    `bestPos * 512 + bestLen` at every step. -/
+theorem chainWalkPacked_eq (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (hps : pos ≤ prev.size)
+    (cand fuel bestLen bestPos : Nat) :
+    chainWalkPacked data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos =
+      (chainWalkFast data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos).2 * 512 +
+        (chainWalkFast data prev windowSize pos maxLen hpm hps cand fuel bestLen bestPos).1 := by
+  induction fuel generalizing cand bestLen bestPos with
+  | zero => rw [chainWalkPacked, chainWalkFast]; simp only [↓reduceIte]
+  | succ k ih =>
+    rw [chainWalkPacked, chainWalkFast, if_neg (by omega : ¬ (k + 1 = 0)),
+      if_neg (by omega : ¬ (k + 1 = 0))]
+    by_cases hc : cand < pos ∧ pos - cand ≤ windowSize
+    · have hcand : cand + maxLen ≤ data.size := by omega
+      simp only [dif_pos hc, Nat.add_sub_cancel]
+      by_cases hml : lz77Greedy.countMatch data cand pos maxLen hcand hpm > bestLen
+      · by_cases hb : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≥ maxLen
+        · simp only [hml, hb, ↓reduceIte]
+        · simp only [hml, hb, ↓reduceIte, ih]
+      · by_cases hb : bestLen ≥ maxLen
+        · simp only [hml, hb, ↓reduceIte]
+        · simp only [hml, hb, ↓reduceIte, ih]
+    · simp only [dif_neg hc]
+
+/-- One runtime guard collapses the packed walk to the packed image of the
+    reference walk. -/
+theorem chainWalkGuardedPacked_eq (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (cand fuel bestLen bestPos : Nat) :
+    chainWalkGuardedPacked data prev windowSize pos maxLen hpm cand fuel bestLen bestPos =
+      (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos).2 * 512 +
+        (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel bestLen bestPos).1 := by
+  unfold chainWalkGuardedPacked
+  split
+  · rw [chainWalkPacked_eq, chainWalkFast_eq]
+  · rfl
+
+/-- From a zero-initialised best length, the reference walk's best length
+    never exceeds `maxLen` (specialisation of `chainWalk_spec`). -/
+theorem chainWalk_fst_le (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel : Nat) :
+    (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel 0 0).1 ≤ maxLen := by
+  obtain h0 | hQ := chainWalk_spec data prev windowSize pos maxLen hpm cand fuel 0 0 (Or.inl rfl)
+  · omega
+  · exact hQ.2.2.2.2
+
+/-- Decode the packed walk's best length: with `maxLen < 512` the low bits are
+    exactly the reference walk's `bestLen`. -/
+theorem chainWalkGuardedPacked_mod (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel : Nat)
+    (hml : maxLen ≤ 511) :
+    chainWalkGuardedPacked data prev windowSize pos maxLen hpm cand fuel 0 0 % 512 =
+      (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel 0 0).1 := by
+  rw [chainWalkGuardedPacked_eq]
+  have h := chainWalk_fst_le data prev windowSize pos maxLen hpm cand fuel
+  omega
+
+/-- Decode the packed walk's best position (the high bits). -/
+theorem chainWalkGuardedPacked_div (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel : Nat)
+    (hml : maxLen ≤ 511) :
+    chainWalkGuardedPacked data prev windowSize pos maxLen hpm cand fuel 0 0 / 512 =
+      (lz77Chain.chainWalk data prev windowSize pos maxLen hpm cand fuel 0 0).2 := by
+  rw [chainWalkGuardedPacked_eq]
+  have h := chainWalk_fst_le data prev windowSize pos maxLen hpm cand fuel
+  omega
+
+/-- Every matcher call site clamps `maxLen` to `min 258 _`; this discharges
+    the `maxLen ≤ 511` side condition when `simp` applies the decode lemmas. -/
+theorem min258_le_511 (x : Nat) : min 258 x ≤ 511 := by omega
+
 /-- The proven-bounds hash-insertion loop computes the same arrays as the
     panic-checked reference: the bodies differ only in how `hashTable[hsh]` is
     accessed, bridged by `getElem!_pos`. -/
@@ -284,7 +379,8 @@ private theorem mainLoop_eq_chain (data : ByteArray) (windowSize hashSize maxCha
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainIter.mainLoop lz77Chain.mainLoop
-    simp only [chainWalkGuarded_eq, updateHashesGuarded_eq, headInsertGuarded_eq]
+    simp only [chainWalkGuardedPacked_mod, chainWalkGuardedPacked_div, min258_le_511,
+      updateHashesGuarded_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
       split

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -32,7 +32,7 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
   split
   · rename_i hlt
     dsimp only
-    simp only [headInsertGuarded_eq, headProbeGuarded_eq]
+    simp only [headProbeGuarded_eq, guardedSet_eq]
     have hspec := chainWalk_spec data
       (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) (by omega)
@@ -106,7 +106,7 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
   split
   · rename_i hlt
     dsimp only
-    simp only [headInsertGuarded_eq, headProbeGuarded_eq]
+    simp only [headProbeGuarded_eq, guardedSet_eq]
     have hspec := chainWalk_spec data
       (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
       windowSize pos (min 258 (data.size - pos)) (by omega)
@@ -200,8 +200,8 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
-    simp only [chainWalkGuarded_eq, updateHashesGuarded_eq, headInsertGuarded_eq,
-      headProbeGuarded_eq]
+    simp only [chainWalkGuardedPacked_mod, chainWalkGuardedPacked_div, min258_le_511,
+      updateHashesGuarded_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
       -- Branch tree: hge / hle / h3lt / (matchLen2 > matchLen) / hle2


### PR DESCRIPTION
This PR eliminate the per-position heap allocations the W5.P1 profile flagged (runtime/mem = 32% of L1 attributable samples): the chain-walk result packs into one small Nat (bestPos·512+bestLen — compiled body shows zero lean_alloc_ctor), and the per-position head insert becomes three single-value guarded steps, also allocation-free. All six matcher mainLoops and the DP cache builder convert; the tuple-returning helpers remain as proof bridges with their theorems intact, and every exported statement is unchanged. Output is byte-identical (canaries exact).

Measured against the post-W5.0 baseline on alice29: level 1 ≈22 → ~24 MB/s, levels 6–8 +5% each — cumulative campaign effect at level 1 is now ~1.64× (14.6 → 24 MB/s) at identical ratio.

🤖 Prepared with Claude Code