### PR TITLE
human-oversight: Track D Phase 0b — wire zopfli as the compression-ratio quality ceiling

### DIFF
--- a/ZipBench.lean
+++ b/ZipBench.lean
@@ -13,6 +13,9 @@ Operations:
   deflate-lazy   — native DEFLATE compression (lazy matching)
   deflate-ffi    — zlib FFI compression
   compress-miniz — miniz_oxide (Rust) DEFLATE compression (Track D)
+  compress-zopfli — zopfli max-ratio DEFLATE compression (Track D ceiling;
+                    level slot = numiterations, default 15; 64KB size cap,
+                    override with ZOPFLI_BENCH_ALLOW_LARGE=1; prints output size)
   gzip           — native gzip decompression
   gzip-ffi       — zlib FFI gzip decompression
   zlib           — native zlib decompression
@@ -94,7 +97,8 @@ def generateData (pattern : String) (size : Nat) : IO ByteArray :=
 
 def main (args : List String) : IO Unit := do
   match args with
-  | [op, sizeStr, pattern] => run op sizeStr pattern 6
+  -- zopfli's level slot is `numiterations` (default 15); every other op uses 6.
+  | [op, sizeStr, pattern] => run op sizeStr pattern (if op == "compress-zopfli" then 15 else 6)
   | [op, sizeStr, pattern, levelStr] =>
     match levelStr.toNat? with
     | some level => run op sizeStr pattern level
@@ -212,6 +216,18 @@ where
     | "compress-miniz" =>
       let _ ← MinizOxide.compress data level.toUInt8
       pure ()
+    | "compress-zopfli" =>
+      -- zopfli is the Track D ratio *ceiling*: compress-only, ~100x slower than
+      -- zlib. `level` is reused as zopfli's `numiterations` knob (default 15).
+      -- Single calls can take many seconds, so cap default runs at 64KB and gate
+      -- larger inputs behind ZOPFLI_BENCH_ALLOW_LARGE. Print the output size so
+      -- the result is observable as a ratio-ceiling figure, not just a timing.
+      if size > 65536 && !(← IO.getEnv "ZOPFLI_BENCH_ALLOW_LARGE").isSome then
+        throw (IO.userError s!"compress-zopfli: size {size} exceeds the 64KB cap; \
+          set ZOPFLI_BENCH_ALLOW_LARGE=1 to override (zopfli is intentionally very slow)")
+      let z ← Zopfli.compress data level.toUInt32
+      IO.println s!"compress-zopfli size={data.size} pattern={pattern} iters={level} \
+        → {z.size} bytes"
     -- Checksum benchmarks
     | "crc32" =>
       let _ := Crc32.Native.crc32 0 data

--- a/ZipTest/Zopfli.lean
+++ b/ZipTest/Zopfli.lean
@@ -45,6 +45,15 @@ def tests : IO Unit := do
     | .error e => throw (IO.userError s!"native inflate rejected zopfli(iter=50): {e}")
     assert! z50.size ≤ z15.size
 
+    -- Sanity: on 4KB of real-ish text the ratio ceiling must beat zlib level 9.
+    -- If a build silently linked a non-zopfli fallback, zopfli would no longer
+    -- dominate zlib-9 and this would catch it. The output must also roundtrip.
+    let text := mkTextData 4096
+    let zt ← Zopfli.compress text
+    let z9 ← RawDeflate.compress text 9
+    assert! zt.size ≤ z9.size
+    roundtrips "text" text
+
     IO.println "Zopfli tests: OK"
 
 end ZipTest.Zopfli

--- a/progress/2026-06-13T06-13-02Z_578c800a.md
+++ b/progress/2026-06-13T06-13-02Z_578c800a.md
@@ -1,0 +1,64 @@
+# Session 578c800a — feature
+
+**UTC:** 2026-06-13T06:13:02Z
+**Type:** feature (`/feature`)
+**Issue:** #2347 — human-oversight: Track D Phase 0b — wire zopfli as the
+compression-ratio quality ceiling
+
+## Context discovered
+
+Most of #2347 had already landed via PR #2470 ("add Track D benchmark
+dashboard comparing native vs reference compressors"):
+
+- `c/zopfli_ffi.c` (HAVE_ZOPFLI-gated, `lean_zopfli_compress_ffi`) — done
+- `Zip/Zopfli.lean` (`Zopfli.compress data (iterations := 0)` → zopfli
+  default 15) — done
+- `lakefile.lean` `zopfli_ffi` target + `zopfliEnabled` probe — done
+- `shell.nix` `pkgs.zopfli` — done
+- `ZipBenchReport.lean` `zopfliCompress` + `runZopfliCeiling` +
+  `--zopfli-ceiling` — done
+- `ZipTest/Zopfli.lean` roundtrip smoke test (native inflate + zlib FFI,
+  plus iter=50 ≤ iter=15) — done
+
+Two deliverables remained, both completed this session.
+
+## What was done
+
+1. **Deliverable 5 — `compress-zopfli` op in `ZipBench.lean`** (the
+   hyperfine `bench` driver, distinct from the already-wired
+   `ZipBenchReport`). The level positional slot is reused as zopfli's
+   `numiterations` (default 15 — set per-op in `main` so other ops keep
+   their level-6 default). 64KB default size cap; larger inputs gated
+   behind `ZOPFLI_BENCH_ALLOW_LARGE=1` since a single zopfli call can take
+   many seconds. Prints the output size so the ratio-ceiling figure is
+   observable (also satisfies the issue's "produces a number > 0" check).
+
+2. **Deliverable 6 (residual) — zopfli ≤ zlib-9 sanity assertion** in
+   `ZipTest/Zopfli.lean`. The existing smoke test covered roundtrips and
+   iter-monotonicity but not the issue's explicit "on a 4KB text input
+   zopfli output ≤ zlib level 9" check that guards against a silent
+   non-zopfli fallback. Added it (4KB `mkTextData`, `zt.size ≤ z9.size`)
+   plus a text roundtrip.
+
+## Verification
+
+- `lake build` (nix-shell): clean.
+- `lake exe test` (nix-shell): exit 0, "All tests passed!", "Zopfli tests: OK".
+- `lake exe bench compress-zopfli 4096 text` → `… → 172 bytes` (zlib-9 on
+  the same text is larger; asserted in the smoke test).
+- `compress-zopfli 4096 text 30` → 171 bytes (more iters, no larger).
+- `compress-zopfli 70000 prng` → rejected with the 64KB-cap message;
+  `ZOPFLI_BENCH_ALLOW_LARGE=1 … 70000 prng` → runs (stores incompressible).
+
+## Quality metrics
+
+- sorry count: 0 → 0 (no proofs touched; out of scope per issue).
+
+## Notes / patterns
+
+- Building in a bare shell disables zopfli (`zopfli.h` not resolvable);
+  must use `nix-shell --run` to exercise the real path. The smoke test
+  skips cleanly when the comparator is disabled, so CI without zopfli
+  still passes.
+- `.claude/CLAUDE.md` shows as modified in the worktree from a prior
+  step; left unstaged (off-limits to agents, rejected by create-pr).


### PR DESCRIPTION
Closes #2347

Session: `578c800a-b993-48d4-87ac-48791c1e5978`

f10d782 feat: compress-zopfli bench op + zopfli≤zlib-9 sanity check (close #2347 residual)

🤖 Prepared with Claude Code