### PR TITLE
Review: Wave 3b packed-native correctness specs (LZ77PackedCorrect + EmitPackedCorrect, #2555–#2557)

### DIFF
--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -72,8 +72,9 @@ theorem lz77ChainIterP_eq (data : ByteArray) (maxChain windowSize insertCap : Na
       (lz77ChainIter data maxChain windowSize insertCap).map packTok := by
   unfold lz77ChainIterP lz77ChainIter
   split
-  · simpa using trailingP_eq data 0 #[]
-  · simpa using mainLoopP_eq data windowSize 65536 maxChain insertCap _ _ 0 #[]
+  · simpa only [List.map_toArray, List.map_nil] using trailingP_eq data 0 #[]
+  · simpa only [List.map_toArray, List.map_nil] using
+      mainLoopP_eq data windowSize 65536 maxChain insertCap _ _ 0 #[]
 
 /-- The packed lazy `mainLoop` is the packed image of the boxed one (two
     pushes in the deferral arm). -/
@@ -111,8 +112,9 @@ theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap 
       (lz77ChainLazyIter data maxChain windowSize insertCap).map packTok := by
   unfold lz77ChainLazyIterP lz77ChainLazyIter
   split
-  · simpa using trailingP_eq data 0 #[]
-  · simpa using mainLoopLazyP_eq data windowSize 65536 maxChain insertCap _ _ 0 #[]
+  · simpa only [List.map_toArray, List.map_nil] using trailingP_eq data 0 #[]
+  · simpa only [List.map_toArray, List.map_nil] using
+      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap _ _ 0 #[]
 
 /-! ## View direction: the boxed view recovers the boxed matchers
 
@@ -128,7 +130,7 @@ theorem lz77ChainIterP_map (data : ByteArray) (maxChain windowSize insertCap : N
   rw [lz77ChainIterP_eq, Array.map_map]
   have hcongr : Array.map (unpackTok ∘ packTok) (lz77ChainIter data maxChain windowSize insertCap) =
       Array.map id (lz77ChainIter data maxChain windowSize insertCap) :=
-    Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa using ht))
+    Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa only [Array.mem_toList_iff] using ht))
   rw [hcongr, Array.map_id]
 
 /-- The boxed view of the packed lazy matcher is the boxed lazy matcher. -/
@@ -141,7 +143,7 @@ theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap
   have hcongr : Array.map (unpackTok ∘ packTok)
         (lz77ChainLazyIter data maxChain windowSize insertCap) =
       Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap) :=
-    Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa using ht))
+    Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa only [Array.mem_toList_iff] using ht))
   rw [hcongr, Array.map_id]
 
 /-! ## Dispatch boundary -/

--- a/progress/20260613T062136Z_e2650e5a.md
+++ b/progress/20260613T062136Z_e2650e5a.md
@@ -1,0 +1,84 @@
+# Review session — Wave 3b packed-native correctness specs (#2572)
+
+**UTC**: 2026-06-13T06:21Z
+**Type**: review (paired proof-quality + correctness audit)
+**Scope**: `Zip/Spec/LZ77PackedCorrect.lean`, `Zip/Spec/EmitPackedCorrect.lean`
+
+## What was done
+
+Paired review of the two Wave 3b packed-token correctness spec files
+(landed #2555–#2557), never previously dedicated-reviewed.
+
+### Proof-quality audit (deliverable 1)
+
+Ran the `proof-review-checklist` metric greps on both files.
+
+- `EmitPackedCorrect.lean` (265 lines): **already fully clean** — zero bare
+  `simp`, `simpa`, `simp_all`; no `try?`, no `native_decide`. The branch-
+  equation lemmas all use tight `simp only [findLengthCodeFast_eq, ...]`
+  lemma lists. No changes needed.
+- `LZ77PackedCorrect.lean` (190 lines): zero bare `simp`/`simp_all`, but **6
+  bare `simpa`** (the `simpa\b` grep the checklist Phase 0 calls out — easy to
+  miss). Converted all 6 to `simpa only [...]` via `simpa?` batch discovery:
+  - 4× `simpa using {trailing,mainLoop[Lazy]}P_eq …`
+    → `simpa only [List.map_toArray, List.map_nil] using …`
+    (these reduce `(#[].map packTok)` / `(#[] : Array _)` at the base case).
+  - 2× `by simpa using ht` (membership bridge inside `Array.map_congr_left`)
+    → `by simpa only [Array.mem_toList_iff] using ht`.
+
+No `try?` output, no `native_decide`, no bare `simp` remain in either file.
+
+### Spec-taxonomy flag (deliverable 1)
+
+Per CLAUDE.md taxonomy: every theorem in both files is a **level-3
+algorithmic-correspondence / equivalence** spec — `…P` packed implementation
+equals the boxed reference over the `unpackTok` view (`*P_eq`, `*P_map`,
+`emitTokens*P_eq`, `deflate*BlockP_eq`, `deflateRawBase_def`). This is the
+**correct** category for optimized-version specs ("for optimized versions,
+specs are equivalence with the simple version"). None are tautological in the
+bad `f x = fImpl x` sense — each ties a genuinely distinct packed `UInt32`-
+stream implementation back to the boxed `Array LZ77Token` reference. No
+weakening flags.
+
+### Correctness pass (deliverable 2)
+
+Confirmed the view equivalence is **real, not vacuous**:
+- `unpackTok_packTok` (`Zip/Native/Deflate.lean:344`) is the left-inverse on
+  encodable tokens and genuinely *requires* the encoder bounds
+  (`3 ≤ len ≤ 258`, `1 ≤ dist ≤ 32768`) — the bit packing (15-bit length
+  field via `0x7FFF`, 16-bit dist via `0xFFFF`) is lossy in general, so the
+  round-trip is non-trivial. The `*P_map` view theorems discharge those
+  bounds wholesale via `lz77ChainIter_encodable` /
+  `lz77ChainLazyIter_encodable`.
+- Dispatch plumbing from #2556 is covered: `lzMatchP_eq` / `lzMatchP_map`
+  (matcher dispatch), `tokenFreqsP_eq` (packed frequency pass, in
+  `DeflateFreqs.lean`), and `deflateRawBase_def` (the packed freq+emit
+  pipeline = boxed base over `lzMatch`). Downstream consumers
+  `Zip/Spec/DeflateRoundtrip.lean` and `ZipTest/PackedTokens.lean` actually
+  use these equations, so the chain reaches the roundtrip spec and the
+  conformance tests. **No correctness gaps found.**
+
+## Note for a possible follow-up (out of scope here)
+
+`unpackTok_packTok` itself (`Zip/Native/Deflate.lean:353,356`) still uses two
+bare `simp [unpackTok, packTok, h1, h2]` / `simp [Nat.toUInt32]` calls. That
+file is a Native source in the active perf-churn area and outside this issue's
+two-spec-file scope, so left untouched — a candidate for a future Native-side
+proof-quality pass.
+
+## Verification
+
+- `lake build && lake exe test` — green (all tests pass, including FuzzInflate
+  census).
+- `grep -rc sorry Zip/` — **0** (the issue's "currently 4, all XxHash" note is
+  stale; no XxHash files exist in this repo's `Zip/`). No sorry introduced.
+- No `native_decide`, no `try?`, no bare `simp`/`simpa` in either file.
+- Net line delta: +2 (one `simpa only` line-wrapped for the 100-col limit);
+  every theorem statement byte-identical — diff is proof bodies only.
+
+## Metric deltas
+
+| File | bare simp | bare simpa | simp_all |
+|------|-----------|------------|----------|
+| LZ77PackedCorrect.lean | 0 → 0 | 6 → 0 | 0 → 0 |
+| EmitPackedCorrect.lean | 0 → 0 | 0 → 0 | 0 → 0 |


### PR DESCRIPTION
Closes #2572

Session: `e2650e5a-0694-4486-9fd1-8822f6e40b88`

7c66f39 refactor: replace bare simpa with simpa only in LZ77PackedCorrect.lean (#2572)

🤖 Prepared with Claude Code