### PR TITLE
doc(track-d): #2501 close — wide-buffer decoder satisfies all acceptance criteria (verified)

### DIFF
--- a/progress/2026-06-13T063247Z_9f936dd4.md
+++ b/progress/2026-06-13T063247Z_9f936dd4.md
@@ -1,0 +1,55 @@
+# Session 9f936dd4 — #2501 buffered bit reader: verify + close
+
+**UTC:** 2026-06-13T06:32Z
+**Type:** feature (one-shot, `pod once 2501`)
+**Issue:** #2501 — perf: buffered bit reader to amortize per-read allocation (Track D, decode)
+
+## Verdict
+
+**Closed #2501 as completed.** Every acceptance criterion is already satisfied
+by merged code (approach 1, the wide-buffer Huffman decoder), landed across
+PR #2505 (decoder, proven equal) and PR #2506/#2507 (made the default). This
+session independently re-verified the landed state rather than re-implementing
+it, and recorded the approach-2 verdict.
+
+## What I verified this session
+
+- **Build green** (inside `nix-shell`; the bare-shell link failure was the
+  documented cached-link-flags / libdeflate issue, not a code regression):
+  `lake -R build test` → `Build completed successfully (249 jobs)`.
+- **All tests pass**, including correctness + the decode fuzz harness:
+  `lake exe test` → 1000-iter `FuzzInflate`, 256 compress→FFI, 256
+  differential header-mutation iterations, all green; `All tests passed!`.
+- **Decode speedup realized** (this machine, native decompress): 256 KiB
+  `text` lvl 6 **2750 MB/s**, lvl 1 1964 MB/s; 64 KiB text lvl 6 1203 MB/s —
+  consistent with the D-13 dashboard's recorded ~1.7–2.2× over the
+  pre-flip `BitReader` decoder.
+- **0 sorries** in `Zip/`; **no** `native_decide` / `@[extern]` /
+  `@[implemented_by]` / `maxHeartbeats` on the decode path (the only textual
+  hits are docstrings asserting their *absence*).
+
+## Why not approach 2 (the ST/linear mutable reader)
+
+The issue says to spike approach 1 first and *then* decide on approach 2.
+Post-spike verdict: **not worth its cost.**
+
+- Approach 1 delivered the win the issue targeted (per-read struct-allocation
+  churn collapsed; 1.7–2.2× decode) with a fully verified refinement
+  (`decodeHuffmanFastBuf = decodeHuffmanFastBR = decodeHuffman`, 0 sorries).
+- The remaining decode cost is no longer bit-reading: D-10 already noted the
+  new top decode cost is `copyLoop` (bulk back-reference memcpy, ~15%). A
+  mutable *bit* reader (approach 2) does **not** touch that, so its expected
+  marginal gain over approach 1 is small.
+- Approach 2 carries the issue's heaviest proof obligation — relating an `ST`
+  trace to the functional `inflate` — and a half-finished version would carry
+  `sorry`s, violating the issue's own 0-sorry bar. Per the project's
+  iso-cost discipline (record the verdict; don't chase sub-margin wins at
+  large proof cost), this is a clear defer.
+
+If a future planner wants the mutable-reader experiment, it should be a fresh,
+independently-scoped research issue — not left tracked open under #2501, whose
+stated acceptance criteria are all met.
+
+## Files touched
+
+None (verification + issue close only). No PR.


### PR DESCRIPTION
Closes #2501

Session: `9f936dd4-3380-4093-ac18-2a9f9a97edf4`

8ab9b41 doc(track-d): #2501 verification verdict — approach 1 landed, approach 2 deferred

🤖 Prepared with Claude Code