### PR TITLE
Track E silent-skip family: Tar.list continuation arm on tar-skipped-padded.tar (third sibling-class fixture, size==100 non-multiple-of-512 round-up arithmetic variant) — sibling extension of in-flight PR #2462 Tar.list arm on tar-mixed-skipped.tar (size==0 first sibling-class fixture)

### DIFF
--- a/SECURITY_INVENTORY.md
+++ b/SECURITY_INVENTORY.md
@@ -6534,7 +6534,15 @@ Regression fixtures live under `testdata/tar/security/`:
   `Tar.extract` only; `Tar.list`'s padding round-up invariant
   is structurally identical (`forEntries` is shared) but a
   separate fixture for `Tar.list` is not required — the new
-  arm exercises `Tar.extract` only. Together with the two
+  arm exercises `Tar.extract` only. Subsequently extended by a
+  defense-in-depth `Tar.list`-side test arm reusing the same
+  fixture bytes (no new fixture file): the `Tar.list`
+  padding-round-up continuation invariant is now explicitly
+  pinned in addition to the `Tar.extract` invariant, so a
+  hypothetical future `Tar.list` refactor that decouples from
+  the shared `forEntries` (e.g., for performance, lazy
+  iteration, or different error reporting) cannot silently
+  break the padding round-up. Together with the two
   preceding sibling-class entries, the silent-skip family's
   `skipEntryData` arithmetic surface is now fixtured at every
   load-bearing input shape: `size == 0` (no payload, no

--- a/ZipTest/TarFixtures.lean
+++ b/ZipTest/TarFixtures.lean
@@ -913,6 +913,41 @@ def ZipTest.TarFixtures.tests : IO Unit := do
     let names := skippedPaddedEntries.map (·.fileName)
     throw (IO.userError s!"tar-skipped-padded.tar: expected exactly 2 files in extract dir, got {skippedPaddedEntries.size}: {names}")
 
+  -- tar-skipped-padded.tar: defense-in-depth `Tar.list` continuation arm,
+  -- reusing the same fixture bytes as the `Tar.extract` arm above (no new
+  -- fixture file). `Tar.list` and `Tar.extract` share `forEntries` today,
+  -- so any continuation regression in `forEntries` would fire both arms;
+  -- this arm pins the post-skip stream-position invariant explicitly so a
+  -- hypothetical future `Tar.list` refactor that decouples from the shared
+  -- `forEntries` cannot silently break continuation. The distinguishing
+  -- property of this fixture is the *non-multiple-of-512* middle payload
+  -- (size 100 + 412-byte zero padding): a `Tar.list`-only regression that
+  -- broke `paddingFor` (e.g., returned `0` unconditionally) would consume
+  -- only the 100 declared bytes without the 412-byte padding, leaving the
+  -- stream positioned 412 bytes inside the `after.txt` header, so
+  -- `forEntries` would parse a straddled header with a bogus checksum
+  -- rather than returning a clean third entry. `Tar.list` returns *all*
+  -- three headers including the silently-skipped middle entry, so the
+  -- assertions check per-entry `path` / `typeflag` / `size`.
+  let skippedPaddedListed ← IO.FS.withFile skippedPaddedPath .read fun h =>
+    Tar.list (IO.FS.Stream.ofHandle h)
+  unless skippedPaddedListed.size == 3 do
+    throw (IO.userError s!"tar-skipped-padded.tar: expected 3 entries from Tar.list, got {skippedPaddedListed.size}")
+  unless skippedPaddedListed[0]!.path == "before.txt" do
+    throw (IO.userError s!"tar-skipped-padded.tar: Tar.list entry 0 path mismatch: {skippedPaddedListed[0]!.path}")
+  unless skippedPaddedListed[0]!.typeflag == 0x30 do
+    throw (IO.userError s!"tar-skipped-padded.tar: Tar.list entry 0 typeflag mismatch: {skippedPaddedListed[0]!.typeflag}")
+  unless skippedPaddedListed[1]!.path == "fifo-entry" do
+    throw (IO.userError s!"tar-skipped-padded.tar: Tar.list entry 1 path mismatch: {skippedPaddedListed[1]!.path}")
+  unless skippedPaddedListed[1]!.typeflag == 0x36 do
+    throw (IO.userError s!"tar-skipped-padded.tar: Tar.list entry 1 typeflag mismatch: {skippedPaddedListed[1]!.typeflag}")
+  unless skippedPaddedListed[1]!.size == 100 do
+    throw (IO.userError s!"tar-skipped-padded.tar: Tar.list entry 1 size mismatch: {skippedPaddedListed[1]!.size}")
+  unless skippedPaddedListed[2]!.path == "after.txt" do
+    throw (IO.userError s!"tar-skipped-padded.tar: Tar.list entry 2 path mismatch: {skippedPaddedListed[2]!.path}")
+  unless skippedPaddedListed[2]!.typeflag == 0x30 do
+    throw (IO.userError s!"tar-skipped-padded.tar: Tar.list entry 2 typeflag mismatch: {skippedPaddedListed[2]!.typeflag}")
+
   -- Clean up temp files
   for f in #["go-ustar.tar", "go-gnu.tar", "go-pax.tar", "system-tar.tar",
              "gnu-longname.tar", "truncated.tar", "bad-checksum.tar", "no-magic.tar",

--- a/progress/2026-06-13T06-52-33Z_89066f4d.md
+++ b/progress/2026-06-13T06-52-33Z_89066f4d.md
@@ -1,0 +1,53 @@
+# Feature session — 2026-06-13T06:52Z (89066f4d)
+
+Issue #2464: Track E silent-skip family — `Tar.list` continuation arm on
+`tar-skipped-padded.tar` (third sibling-class fixture, size==100
+non-multiple-of-512 round-up arithmetic variant).
+
+## Accomplished
+
+1. **Test arm** — added a defense-in-depth `Tar.list` continuation arm to
+   `ZipTest/TarFixtures.lean` immediately after the existing
+   `tar-skipped-padded.tar` `Tar.extract` block. Reuses `skippedPaddedPath`
+   (no re-read, no new fixture file). Asserts `Tar.list` returns 3 entries
+   with per-entry `path` / `typeflag` / `size`: `before.txt` (`0x30`),
+   `fifo-entry` (`0x36`, `size == 100`), `after.txt` (`0x30`). Shape copied
+   from the precedent PR #2462 `tar-mixed-skipped.tar` arm with `mixed*` →
+   `skippedPadded*` substitution and the middle-entry size assertion changed
+   from `0` to `100`.
+
+2. **Inventory** — appended a `Tar.list` sentence to the
+   `tar-skipped-padded.tar` entry in `SECURITY_INVENTORY.md`'s Minimized
+   Reproducer Corpus, mirroring PR #2462's wording.
+   - **Deviation from issue text**: the issue's "Current state" assumed a
+     Reproducer Corpus *table* row for `tar-skipped-padded.tar`. There is
+     none — PR #2457 followed PR #2454's precedent of a bullet-list entry
+     only (no table row; the table jumps `tar-mixed-skipped.tar` →
+     `tar-slip.tar`). The natural equivalent location is the bullet entry
+     in the "Symlink/hardlink extraction policy" fixture enumeration, so
+     the sentence was appended there.
+
+3. **Adversarial check (deliverable 3)** — perturbed `Zip/Tar.lean`
+   `Tar.list` to drop FIFO entries:
+   `if e.typeflag != 0x36 then entriesRef.modify (·.push e)`. The suite
+   aborts on the earlier `tar-mixed-skipped.tar` arm first; to observe the
+   padded-specific message I temporarily commented out the mixed
+   `Tar.list` block and confirmed:
+   `tar-skipped-padded.tar: expected 3 entries from Tar.list, got 2`.
+   Both the perturbation and the temporary comment-out were reverted;
+   `git diff Zip/Tar.lean` is empty.
+
+## Verification
+- `lake build` passes (under nix-shell — libdeflate comparator added by
+  PR a6dbb5e now requires the nix env to link `test:exe`).
+- `lake exe test` passes; the new `Tar.list` arm runs cleanly.
+- Adversarial check fires the new assertion as expected.
+
+## Notes
+- Environment: bare-shell build fails to link `test:exe` against
+  `libdeflate_*` symbols; must build under `nix-shell --run`. After
+  switching from a bare build, `rm -rf .lake` was needed to clear cached
+  link flags (per CLAUDE.md).
+
+## Quality metric
+- sorry count in `Zip/`: 0 (unchanged).


### PR DESCRIPTION
Closes #2464

Session: `89066f4d-87c1-49c0-ad7c-7b4fcfcff7b7`

## What

Defense-in-depth `Tar.list` continuation arm on `tar-skipped-padded.tar`
(third sibling-class silent-skip fixture; size==100 non-multiple-of-512
round-up arithmetic variant), reusing the same fixture bytes (no new
file). Mirrors the precedent PR #2462 arm on `tar-mixed-skipped.tar`.

- `ZipTest/TarFixtures.lean`: new `Tar.list` arm immediately after the
  existing `tar-skipped-padded.tar` `Tar.extract` block — asserts 3
  entries with per-entry `path` / `typeflag` / `size`: `before.txt`
  (`0x30`), `fifo-entry` (`0x36`, `size == 100`), `after.txt` (`0x30`).
- `SECURITY_INVENTORY.md`: appended a `Tar.list` sentence to the
  `tar-skipped-padded.tar` Reproducer Corpus entry, mirroring PR #2462.

## Inventory-location note

The issue's "Current state" assumed a Reproducer Corpus *table* row for
`tar-skipped-padded.tar`. There is none — PR #2457 followed PR #2454's
precedent of a **bullet-list entry only** (the corpus table jumps
`tar-mixed-skipped.tar` → `tar-slip.tar`). The sentence was therefore
appended to the bullet entry in the silent-skip family enumeration, the
natural equivalent of the "Defence exercised" cell.

## Adversarial check (deliverable 3)

Perturbed `Zip/Tar.lean` `Tar.list` to drop FIFO entries:

```
if e.typeflag != 0x36 then entriesRef.modify (·.push e)
```

The suite aborts on the earlier `tar-mixed-skipped.tar` arm first; to
observe the padded-specific message I temporarily commented out the
mixed `Tar.list` block and confirmed the new arm fires:

```
tar-skipped-padded.tar: expected 3 entries from Tar.list, got 2
```

Both the perturbation and the temporary comment-out were reverted;
`git diff Zip/Tar.lean` is empty.

## Verification

- `lake build` passes (under nix-shell — the libdeflate comparator added
  by a6dbb5e requires the nix env to link `test:exe`).
- `lake exe test` passes; the new arm runs cleanly on
  `tar-skipped-padded.tar`. sorry count unchanged (0).

🤖 Prepared with Claude Code