### PR TITLE
feat: BitWriter bitLength accounting foundation for block-size model (#2489 partial)

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -24,6 +24,7 @@ import Zip.Spec.BitstreamCorrect
 import Zip.Spec.BitstreamComplete
 import Zip.Spec.BitstreamWriteCorrect
 import Zip.Spec.BitWriterCorrect
+import Zip.Spec.BlockSizeModel
 import Zip.Spec.HuffmanCorrect
 import Zip.Spec.HuffmanCorrectLoop
 import Zip.Spec.InflateTable

--- a/Zip/Spec/BlockSizeModel.lean
+++ b/Zip/Spec/BlockSizeModel.lean
@@ -1,0 +1,71 @@
+import Zip.Spec.BitWriterCorrect
+import Zip.Spec.BitstreamWriteCorrect
+
+/-!
+# BitWriter `bitLength` accounting — foundation for the block-size model
+
+The level-≥5 DEFLATE dispatch sizes each candidate block (stored / fixed /
+dynamic) from a single token pass and emits only the predicted-smallest
+(`fixedBlockBytes` / `dynBlockBytes`, `Zip/Native/DeflateDynamic.lean`).
+The emitted `.size` of a block is `⌈bitLength/8⌉` of the final writer after
+`flush`, and `bitLength` accumulates additively across each field write.
+
+This file establishes that additive accounting at the `BitWriter` level —
+the "natural bridge" between `BitWriter.bitLength` and the existing
+`BitWriterCorrect` `toBits` lemmas (issue #2489). The key observation is that
+`toBits` lists *exactly* `bitLength` bits, so every `toBits` correspondence
+lemma (`writeBits_toBits`, `writeHuffCode_toBits`, …) transfers to a `bitLength`
+increment by reading off the appended segment's length.
+
+The downstream block-byte identities (`fixedBlockBytes = (deflateFixedBlock …).size`
+and `dynBlockBytes = (deflateDynamicBlockCore …).size`) are built on these
+lemmas plus a frequency-dot-product ↔ token-sequence counting identity; that
+remaining work is tracked separately.
+-/
+
+namespace Zip.Native.BitWriter
+
+/-- `toBits` lists exactly `bitLength` bits: `bitLength` counts `8` bits per
+    flushed byte plus the `bitCount` partial bits, and `toBits` materialises
+    each of those. Holds unconditionally (no well-formedness needed) — it is a
+    pure length count. This is the bridge that lets every `toBits`
+    correspondence lemma pin down a `bitLength` increment. -/
+theorem toBits_length (bw : BitWriter) : bw.toBits.length = bw.bitLength := by
+  -- `toBits = bytesToBits bw.data ++ (partial bits)`; the first segment has
+  -- length `data.size * 8`, the second `bitCount`.
+  show ((bw.data.data.toList.flatMap Deflate.Spec.bytesToBits.byteToBits) ++
+      (List.range bw.bitCount.toNat).map (fun i => bw.bitBuf.toNat.testBit i)).length = _
+  rw [List.length_append, List.length_map, List.length_range]
+  have hfst : (bw.data.data.toList.flatMap Deflate.Spec.bytesToBits.byteToBits).length
+      = bw.data.size * 8 := Deflate.Spec.bytesToBits_length bw.data
+  rw [hfst]
+  rfl
+
+/-- `bitLength` after `writeBits` grows by exactly the field width `n`. -/
+theorem bitLength_writeBits (bw : BitWriter) (n : Nat) (val : UInt32)
+    (hwf : bw.wf) (hn : n ≤ 25) :
+    (bw.writeBits n val).bitLength = bw.bitLength + n := by
+  rw [← toBits_length, writeBits_toBits bw n val hwf hn, List.length_append,
+    Deflate.Correctness.writeBitsLSB_length, toBits_length]
+
+/-- `bitLength` after `writeHuffCode` grows by exactly the code length `len`. -/
+theorem bitLength_writeHuffCode (bw : BitWriter) (code : UInt16) (len : UInt8)
+    (hwf : bw.wf) (hlen : len.toNat ≤ 15) :
+    (bw.writeHuffCode code len).bitLength = bw.bitLength + len.toNat := by
+  rw [← toBits_length, writeHuffCode_toBits bw code len hwf hlen, List.length_append,
+    Huffman.Spec.natToBits_length, toBits_length]
+
+/-- The flushed byte size of a (well-formed) writer is `⌈bitLength/8⌉`. `flush`
+    pushes one final partial byte iff `bitCount > 0`; since `bitCount < 8`, that
+    is exactly the ceiling division of the total bit count. -/
+theorem flush_size (bw : BitWriter) (hwf : bw.wf) :
+    bw.flush.size = (bw.bitLength + 7) / 8 := by
+  obtain ⟨hbc_lt, _⟩ := hwf
+  unfold flush bitLength
+  by_cases hbc0 : bw.bitCount.toNat = 0
+  · have hcond : ¬(bw.bitCount > 0) := by show ¬(0 < bw.bitCount.toNat); omega
+    rw [if_neg hcond, hbc0]; omega
+  · have hcond : bw.bitCount > 0 := by show 0 < bw.bitCount.toNat; omega
+    rw [if_pos hcond, ByteArray.size_push]; omega
+
+end Zip.Native.BitWriter

--- a/progress/20260613T070840Z_a60be4aa.md
+++ b/progress/20260613T070840Z_a60be4aa.md
@@ -1,0 +1,55 @@
+# Session 20260613T070840Z — feature (a60be4aa)
+
+## Issue
+#2489 — proof: formalize the block-size model so size-then-emit's 'smallest
+block' is proven, not just conformance-tested.
+
+## Outcome: PARTIAL
+
+Landed the BitWriter `bitLength` accounting foundation that #2489 names as the
+"natural bridge" between the size-then-emit cost models and emitted `.size`.
+New file `Zip/Spec/BlockSizeModel.lean` (0 sorry):
+
+- `toBits_length : bw.toBits.length = bw.bitLength` — the bridge. `toBits` is
+  `bytesToBits bw.data ++ partial`, so its length is `data.size*8 + bitCount =
+  bitLength`, unconditionally (no `wf` needed). This lets every existing
+  `*_toBits` correspondence lemma pin a `bitLength` increment.
+- `bitLength_writeBits : (bw.writeBits n val).bitLength = bw.bitLength + n`
+  (n ≤ 25, wf) — via `writeBits_toBits` + `writeBitsLSB_length`.
+- `bitLength_writeHuffCode : (bw.writeHuffCode code len).bitLength =
+  bw.bitLength + len.toNat` (len ≤ 15, wf) — via `writeHuffCode_toBits` +
+  `natToBits_length`.
+- `flush_size : bw.wf → bw.flush.size = (bw.bitLength + 7) / 8` — `flush`
+  pushes one partial byte iff `bitCount > 0`; `bitCount < 8` ⇒ ceiling div.
+
+## NOT completed (→ successor issue #2604, depends-on #2489)
+
+The two target theorems `fixedBlockBytes = (deflateFixedBlock …).size` and
+`dynBlockBytes = (deflateDynamicBlockCore …).size`. These additionally need:
+1. `writeDynamicHeader` bitLength is `wf`-preserving / base-independent.
+2. The **counting identity**: emitted token-body bits = `symbolBitCount` minus
+   the EOB contribution — i.e. per-token Σ(codeLen+extra) = freq-dot-product.
+   This is the genuinely large core (per-symbol encode width = code length;
+   sequence-sum = freq-dot-product via `tokenFreqs`; canonical code length =
+   assigned length for the dynamic case). No existing support found
+   (`symbolBitCount` had zero references in `Zip/Spec/`).
+3. Assemble (3)+(4) from the foundation + (1)+(2).
+Full detail and gotchas captured in #2604.
+
+## Decisions / patterns
+- `toBits.length = bitLength` is the leverage point: route all `bitLength`
+  reasoning through the rich `toBits` infrastructure rather than re-deriving.
+- Scoped to a self-contained, reusable foundation rather than a heroic
+  single-session attempt at the counting identity (Step 4b assessment).
+
+## Environment note
+`lake exe test` / `test:exe` does **not link** in this local worktree —
+unresolved `lean_libdeflate_decompress_ffi` (libdeflate not installed locally;
+introduced by Track D Phase 0a commit a6dbb5e). Confirmed pre-existing on clean
+master via `git stash`. The `Zip` library target builds green; this change is a
+pure proof addition with no runtime/test impact. CI (with libdeflate) covers
+the test link.
+
+## Quality metrics
+- sorry count in `Zip/`: 0 → 0 (unchanged).
+- `lake build Zip` green.


### PR DESCRIPTION
Partial progress on #2489

Session: `a60be4aa-3a1b-41d0-a71b-5476c8d47c37`

d052bfb doc: progress entry for #2489 partial (bitLength foundation)
c74e969 feat: BitWriter bitLength accounting foundation for block-size model (#2489 partial)

🤖 Prepared with Claude Code