### PR TITLE
Review: GzipCorrect.lean + ZlibCorrect.lean wrapper-spec proof-quality + spec-taxonomy audit (settled #2469; compress_crc32/isize/adler32/header characterizations never dedicated-reviewed)

### DIFF
--- a/Zip/Spec/GzipCorrect.lean
+++ b/Zip/Spec/GzipCorrect.lean
@@ -161,6 +161,47 @@ theorem inflate_to_spec_decode (deflated : ByteArray) (result : ByteArray)
       some p.1.data.toList
     exact hdec
 
+/-! ## Framing endPos exactness -/
+
+/-- For a stream decomposed as `header ++ deflateRaw data level ++ trailer` with
+    `header.size = H`, native `inflateRaw` starting at `H` consumes exactly the
+    embedded DEFLATE stream: it returns the original `data` and ends at
+    `H + (deflateRaw data level).size`, ignoring the trailing bytes.
+
+    This is the shared core of the gzip (H = 10) and zlib (H = 2) roundtrip
+    capstones — the endPos-exactness derivation that would otherwise be
+    duplicated in each. -/
+theorem inflateRaw_framing (data : ByteArray) (level : UInt8) (maxOutputSize : Nat)
+    (header trailer : ByteArray) (H : Nat) (hhsz : header.size = H)
+    (hdata_le : data.data.toList.length ≤ maxOutputSize)
+    (hspec_go : Deflate.Spec.decode.go
+      (Deflate.Spec.bytesToBits (Deflate.deflateRaw data level)) [] =
+      some data.data.toList) :
+    Inflate.inflateRaw (header ++ Deflate.deflateRaw data level ++ trailer) H maxOutputSize =
+      .ok (⟨⟨data.data.toList⟩⟩, H + (Deflate.deflateRaw data level).size) := by
+  -- Spec decode on (header ++ deflated) at offset H, via prefix drop
+  have hspec_hd : Deflate.Spec.decode.go
+      ((Deflate.Spec.bytesToBits (header ++ Deflate.deflateRaw data level)).drop (H * 8))
+      [] = some data.data.toList := by
+    rw [show H * 8 = header.size * 8 from by omega,
+      bytesToBits_append, ← Deflate.Spec.bytesToBits_length header, List.drop_left]
+    exact hspec_go
+  obtain ⟨endPos', hinflRaw'⟩ :=
+    inflateRaw_complete (header ++ Deflate.deflateRaw data level) H _
+      data.data.toList hdata_le hspec_hd
+  -- endPos' is exactly the size of (header ++ deflated)
+  have hep_exact : endPos' = (header ++ Deflate.deflateRaw data level).size := by
+    have h' : Inflate.inflateRaw (header ++ Deflate.deflateRaw data level)
+        header.size maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') := by
+      rw [hhsz]; exact hinflRaw'
+    exact inflateRaw_endPos_eq header (Deflate.deflateRaw data level) _ _ _ h'
+      hspec_go (Deflate.deflateRaw_goR_pad data level) hdata_le
+  -- Suffix invariance extends the result to the full stream with trailer
+  rw [show H + (Deflate.deflateRaw data level).size
+      = (header ++ Deflate.deflateRaw data level).size from by
+        rw [ByteArray.size_append, hhsz], ← hep_exact]
+  exact inflateRaw_append_suffix _ trailer H _ _ _ hinflRaw'
+
 /-! ## Gzip roundtrip -/
 
 /-- Gzip roundtrip: decompressing the output of compress returns the original data.
@@ -177,80 +218,34 @@ theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
       (Deflate.Spec.bytesToBits (Deflate.deflateRaw data level)) [] =
       some data.data.toList :=
     inflate_to_spec_decode _ data maxOutputSize hinfl
-  -- Suffix invariance: spec decode ignores trailer bits after the DEFLATE stream
-  have hspec_compressed : ∀ (header trailer : ByteArray) (hh : header.size = 10),
-      Deflate.Spec.decode.go
-        ((Deflate.Spec.bytesToBits (header ++ Deflate.deflateRaw data level ++ trailer)).drop
-          (10 * 8)) [] = some data.data.toList := by
-    intro header trailer hh
-    rw [show 10 * 8 = header.size * 8 from by omega,
-        bytesToBits_drop_prefix_three]
-    exact Deflate.Spec.decode_go_suffix _ _ [] _
-      (by rw [Deflate.Spec.bytesToBits_length]; omega)
-      hspec_go
   -- Use data.size bound to get result.length ≤ maxOutputSize
   have hdata_le : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega
-  -- Spec decode on compressed bits at offset 10 (via compress_eq decomposition)
-  have hspec_at10 : Deflate.Spec.decode.go
-      ((Deflate.Spec.bytesToBits (GzipEncode.compress data level)).drop (10 * 8))
-      [] = some data.data.toList := by
-    obtain ⟨header, trailer, hhsz, _, hceq⟩ := GzipEncode.compress_eq data level
-    rw [hceq]
-    exact hspec_compressed header trailer hhsz
-  -- Apply inflateRaw_complete to get native inflateRaw at offset 10
-  obtain ⟨endPos, hinflRaw⟩ :=
-    inflateRaw_complete _ 10 _ data.data.toList hdata_le hspec_at10
   -- compressed size ≥ 18 (from compress = 10 + deflated + 8)
   have hcsz18 : ¬ (GzipEncode.compress data level).size < 18 := by
     rw [GzipEncode.compress_size]; omega
-  -- Tight endPos bound: endPos + 8 ≤ compressed.size
-  -- Strategy: run inflateRaw on (header ++ deflated) without trailer, get endPos' ≤ its size.
-  -- Then inflateRaw_append_suffix shows the full compressed data gives the same endPos.
-  obtain ⟨header, trailer, hhsz, htsz, hceq⟩ := GzipEncode.compress_eq data level
-  -- Spec decode on (header ++ deflated) at offset 10
-  have hspec_hd : Deflate.Spec.decode.go
-      ((Deflate.Spec.bytesToBits (header ++ Deflate.deflateRaw data level)).drop (10 * 8))
-      [] = some data.data.toList := by
-    rw [show 10 * 8 = header.size * 8 from by omega,
-      bytesToBits_append, ← Deflate.Spec.bytesToBits_length header, List.drop_left]
-    exact hspec_go
-  -- Apply inflateRaw_complete on (header ++ deflated) to get endPos' and tight bound
-  obtain ⟨endPos', hinflRaw'⟩ :=
-    inflateRaw_complete (header ++ Deflate.deflateRaw data level) 10 _
-      data.data.toList hdata_le hspec_hd
-  -- By suffix invariance, inflateRaw on (header ++ deflated) ++ trailer gives same endPos'
-  have hinflRaw'' : Inflate.inflateRaw ((header ++ Deflate.deflateRaw data level) ++ trailer)
-      10 maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') :=
-    inflateRaw_append_suffix _ trailer 10 _ _ _ hinflRaw'
-  rw [hceq.symm] at hinflRaw''
-  -- endPos' = endPos by injectivity
-  have hep_eq : endPos = endPos' := by
-    have := hinflRaw.symm.trans hinflRaw''
-    simp only [Except.ok.injEq, Prod.mk.injEq] at this
-    exact this.2
-  -- endPos exactness: endPos = (header ++ deflated).size
-  have hep_exact : endPos' = (header ++ Deflate.deflateRaw data level).size := by
-    have h' : Inflate.inflateRaw (header ++ Deflate.deflateRaw data level)
-        header.size maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') := by
-      rw [hhsz]; exact hinflRaw'
-    exact inflateRaw_endPos_eq header (Deflate.deflateRaw data level) _ _ _ h'
-      hspec_go (Deflate.deflateRaw_goR_pad data level) hdata_le
-  have hep_val : endPos = 10 + (Deflate.deflateRaw data level).size := by
-    rw [hep_eq, hep_exact, ByteArray.size_append, hhsz]
-  have hendPos8 : ¬ (endPos + 8 > (GzipEncode.compress data level).size) := by
-    rw [hep_val, hceq]; simp only [ByteArray.size_append, htsz, hhsz]; omega
+  -- Native inflate at offset 10 consumes exactly the DEFLATE stream (framing lemma)
+  obtain ⟨header, trailer, hhsz, _, hceq⟩ := GzipEncode.compress_eq data level
+  have hinflRaw : Inflate.inflateRaw (GzipEncode.compress data level) 10 maxOutputSize =
+      .ok (⟨⟨data.data.toList⟩⟩, 10 + (Deflate.deflateRaw data level).size) := by
+    rw [hceq]
+    exact inflateRaw_framing data level maxOutputSize header trailer 10 hhsz hdata_le hspec_go
+  have hendPos8 : ¬ (10 + (Deflate.deflateRaw data level).size + 8 >
+      (GzipEncode.compress data level).size) := by
+    rw [GzipEncode.compress_size]; omega
   have hba_eq : (⟨⟨data.data.toList⟩⟩ : ByteArray) = data := by
     simp only [Array.toArray_toList]
-  -- CRC32 trailer match: use endPos = 10 + deflated.size to read trailer bytes
+  -- CRC32 trailer match: the trailer at 10 + deflated.size reads crc32 0 data
   have hcrc : (Crc32.Native.crc32 0 data ==
-    Binary.readUInt32LE (GzipEncode.compress data level) endPos) = true := by
-    rw [hep_val, GzipEncode.compress_crc32]
+    Binary.readUInt32LE (GzipEncode.compress data level)
+      (10 + (Deflate.deflateRaw data level).size)) = true := by
+    rw [GzipEncode.compress_crc32]
     simp only [BEq.beq, decide_true]
   -- ISIZE trailer match
   have hisize : (data.size.toUInt32 ==
-    Binary.readUInt32LE (GzipEncode.compress data level) (endPos + 4)) = true := by
-    rw [hep_val, GzipEncode.compress_isize]
+    Binary.readUInt32LE (GzipEncode.compress data level)
+      (10 + (Deflate.deflateRaw data level).size + 4)) = true := by
+    rw [GzipEncode.compress_isize]
     simp only [BEq.beq, Nat.toUInt32_eq, decide_true]
   set_option maxRecDepth 8192 in
   simp (config := { decide := true }) only [GzipDecode.decompressSingle,

--- a/Zip/Spec/ZlibCorrect.lean
+++ b/Zip/Spec/ZlibCorrect.lean
@@ -155,75 +155,29 @@ theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
       (Deflate.Spec.bytesToBits (Deflate.deflateRaw data level)) [] =
       some data.data.toList :=
     inflate_to_spec_decode _ data maxOutputSize hinfl
-  -- Suffix invariance: spec decode ignores trailer bits after the DEFLATE stream
-  have hspec_compressed : ∀ (header trailer : ByteArray) (hh : header.size = 2),
-      Deflate.Spec.decode.go
-        ((Deflate.Spec.bytesToBits (header ++ Deflate.deflateRaw data level ++ trailer)).drop
-          (2 * 8)) [] = some data.data.toList := by
-    intro header trailer hh
-    rw [show 2 * 8 = header.size * 8 from by omega,
-        bytesToBits_drop_prefix_three]
-    exact Deflate.Spec.decode_go_suffix _ _ [] _
-      (by rw [Deflate.Spec.bytesToBits_length]; omega)
-      hspec_go
   -- Use data.size bound to get result.length ≤ maxOutputSize
   have hdata_le : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega
-  -- Spec decode on compressed bits at offset 2 (via compress_eq decomposition)
-  have hspec_at2 : Deflate.Spec.decode.go
-      ((Deflate.Spec.bytesToBits (ZlibEncode.compress data level)).drop (2 * 8))
-      [] = some data.data.toList := by
-    obtain ⟨header, trailer, hhsz, _, hceq⟩ := ZlibEncode.compress_eq data level
-    rw [hceq]
-    exact hspec_compressed header trailer hhsz
-  -- Apply inflateRaw_complete to get native inflateRaw at offset 2
-  obtain ⟨endPos, hinflRaw⟩ :=
-    inflateRaw_complete _ 2 _ data.data.toList hdata_le hspec_at2
   -- compressed size ≥ 6 (from compress = 2 + deflated + 4)
   have hcsz6 : ¬ (ZlibEncode.compress data level).size < 6 := by
     rw [ZlibEncode.compress_size]; omega
-  -- Decompose compress and establish endPos exactness
-  obtain ⟨header, trailer, hhsz, htsz, hceq⟩ := ZlibEncode.compress_eq data level
-  -- Spec decode on (header ++ deflated) at offset 2
-  have hspec_hd : Deflate.Spec.decode.go
-      ((Deflate.Spec.bytesToBits (header ++ Deflate.deflateRaw data level)).drop (2 * 8))
-      [] = some data.data.toList := by
-    rw [show 2 * 8 = header.size * 8 from by omega]
-    rw [bytesToBits_append, ← Deflate.Spec.bytesToBits_length header, List.drop_left]
-    exact hspec_go
-  -- Apply inflateRaw_complete on (header ++ deflated) to get endPos'
-  obtain ⟨endPos', hinflRaw'⟩ :=
-    inflateRaw_complete (header ++ Deflate.deflateRaw data level) 2 _
-      data.data.toList hdata_le hspec_hd
-  -- By suffix invariance, inflateRaw on full compressed data gives same endPos'
-  have hinflRaw'' : Inflate.inflateRaw ((header ++ Deflate.deflateRaw data level) ++ trailer)
-      2 maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') :=
-    inflateRaw_append_suffix _ trailer 2 _ _ _ hinflRaw'
-  -- endPos' = endPos by injectivity
-  have hep_eq : endPos = endPos' := by
-    rw [hceq] at hinflRaw
-    have := hinflRaw.symm.trans hinflRaw''
-    simp only [Except.ok.injEq, Prod.mk.injEq] at this
-    exact this.2
-  -- endPos exactness via inflateRaw_endPos_eq
-  have hep_exact : endPos' = (header ++ Deflate.deflateRaw data level).size := by
-    have h' : Inflate.inflateRaw (header ++ Deflate.deflateRaw data level)
-        header.size maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') := by
-      rw [hhsz]; exact hinflRaw'
-    exact inflateRaw_endPos_eq header (Deflate.deflateRaw data level) _ _ _ h'
-      hspec_go (Deflate.deflateRaw_goR_pad data level) hdata_le
-  have hep_val : endPos = 2 + (Deflate.deflateRaw data level).size := by
-    rw [hep_eq, hep_exact, ByteArray.size_append, hhsz]
-  have hendPos4 : ¬ (endPos + 4 > (ZlibEncode.compress data level).size) := by
-    rw [hep_val, hceq]; simp only [ByteArray.size_append, htsz, hhsz]; omega
+  -- Native inflate at offset 2 consumes exactly the DEFLATE stream (framing lemma)
+  obtain ⟨header, trailer, hhsz, _, hceq⟩ := ZlibEncode.compress_eq data level
+  have hinflRaw : Inflate.inflateRaw (ZlibEncode.compress data level) 2 maxOutputSize =
+      .ok (⟨⟨data.data.toList⟩⟩, 2 + (Deflate.deflateRaw data level).size) := by
+    rw [hceq]
+    exact inflateRaw_framing data level maxOutputSize header trailer 2 hhsz hdata_le hspec_go
+  have hendPos4 : ¬ (2 + (Deflate.deflateRaw data level).size + 4 >
+      (ZlibEncode.compress data level).size) := by
+    rw [ZlibEncode.compress_size]; omega
   have hba_eq : (⟨⟨data.data.toList⟩⟩ : ByteArray) = data := by simp only [Array.toArray_toList]
-  -- Adler32 trailer match: use endPos = 2 + deflated.size to read trailer bytes
+  -- Adler32 trailer match: the trailer at 2 + deflated.size reads adler32 1 data
   have hadler : (Adler32.Native.adler32 1 data ==
-    (ZlibEncode.compress data level)[endPos]!.toUInt32 <<< 24 |||
-      (ZlibEncode.compress data level)[endPos + 1]!.toUInt32 <<< 16 |||
-      (ZlibEncode.compress data level)[endPos + 2]!.toUInt32 <<< 8 |||
-      (ZlibEncode.compress data level)[endPos + 3]!.toUInt32) = true := by
-    rw [hep_val, ZlibEncode.compress_adler32]
+    (ZlibEncode.compress data level)[2 + (Deflate.deflateRaw data level).size]!.toUInt32 <<< 24 |||
+      (ZlibEncode.compress data level)[2 + (Deflate.deflateRaw data level).size + 1]!.toUInt32 <<< 16 |||
+      (ZlibEncode.compress data level)[2 + (Deflate.deflateRaw data level).size + 2]!.toUInt32 <<< 8 |||
+      (ZlibEncode.compress data level)[2 + (Deflate.deflateRaw data level).size + 3]!.toUInt32) = true := by
+    rw [ZlibEncode.compress_adler32]
     simp only [BEq.beq, decide_true]
   set_option maxRecDepth 8192 in
   simp only [ZlibDecode.decompressSingle, - ZlibDecode.decompressSingle.eq_1,

--- a/progress/20260613T071853Z_55e09fa4.md
+++ b/progress/20260613T071853Z_55e09fa4.md
@@ -1,0 +1,113 @@
+# Review session — GzipCorrect.lean + ZlibCorrect.lean wrapper-spec audit (#2578)
+
+**Date:** 2026-06-13 07:18 UTC
+**Type:** review (paired proof-quality + spec-taxonomy audit)
+**Issue:** #2578
+
+## Scope
+
+Dedicated proof-quality + spec-taxonomy audit of the gzip / zlib wrapper
+correctness specs (`Zip/Spec/GzipCorrect.lean`, `Zip/Spec/ZlibCorrect.lean`).
+Review/refactor only — no theorem-statement changes.
+
+## Proof-quality findings
+
+Both files were already pristine on the mechanical metrics (campaign
+already complete here):
+
+| Metric                | GzipCorrect | ZlibCorrect |
+|-----------------------|-------------|-------------|
+| bare `simp`           | 0           | 0           |
+| bare `simpa`          | 0           | 0           |
+| `simp_all`            | 0           | 0           |
+| `native_decide`/`try?`| 0           | 0           |
+
+Remaining `decide` uses are kernel-level on concrete `UInt8`/`UInt16` bit
+ops (`compress_cm`, `compress_cinfo`, the `repeat (first | decide | split)`
+flevel sweeps in `compress_header_check`/`compress_no_fdict`) — all
+legitimate, none `native_decide`.
+
+### Refactor landed: `inflateRaw_framing` shared lemma
+
+The one substantive finding. The two roundtrip capstones
+(`gzip_decompressSingle_compress`, `zlib_decompressSingle_compress`) each
+duplicated ~35 lines of identical endPos-exactness derivation:
+spec-decode-at-offset (`bytesToBits_append` + `drop_left`),
+`inflateRaw_complete` on `(header ++ deflated)`, `inflateRaw_endPos_eq`,
+and `inflateRaw_append_suffix` to extend over the trailer.
+
+Factored into `inflateRaw_framing` (placed in GzipCorrect.lean, which
+ZlibCorrect imports), parameterised over the header size `H` (gzip H=10,
+zlib H=2):
+
+> for `header ++ deflateRaw data level ++ trailer` with `header.size = H`,
+> `inflateRaw ... H` returns `(⟨⟨data.data.toList⟩⟩, H + deflated.size)`.
+
+This strongly meets the extraction heuristic (2 sites, ~35 lines each,
+clean file-independent statement; not premature — the duplication was
+concrete). Each roundtrip now reduces to one framing-lemma application
+plus trailer-match `have`s stated at the concrete endPos `H + deflated.size`,
+dropping the `hspec_compressed` / `hspec_at{N}` / double-`inflateRaw_complete`
+/ `hep_eq` / `hep_exact` / `hep_val` scaffolding.
+
+**Net −51 lines** (72 ins / 123 del across the two files), only addition
+to the theorem surface being `inflateRaw_framing` itself. `git diff`
+confirms no existing `theorem` signature changed.
+
+Note: `bytesToBits_drop_prefix_three` lost its only call site (it was used
+only inside the now-removed `hspec_compressed`). Kept deliberately — it is
+a public characterizing lemma about `bytesToBits`, part of the spec API,
+and CLAUDE.md forbids deleting theorems. `inflateRaw_framing` uses the
+sibling `bytesToBits_append` directly.
+
+## Spec-taxonomy pass (CLAUDE.md §Specifications)
+
+Every `compress_*` theorem is a genuine **characterizing** property
+(level 2) — none are tautological (`field = implFieldExpr`). Verdicts:
+
+**GzipCorrect:**
+- `compress_size` — output size as function of `deflateRaw` size. Characterizing.
+- `compress_header_bytes` — pins bytes 0–3 to the RFC 1952 magic `[0x1f,0x8b,8,0]`. Characterizing (protocol constants).
+- `compress_eq` / `compress_trailer` (private) — structural decomposition. Characterizing.
+- `compress_crc32` — trailer at endPos = `crc32 0 data`: pinned to a function of the **input**, not the implementation expression. Strong characterization.
+- `compress_isize` — trailer+4 = `data.size.toUInt32`. Input-level. Characterizing.
+- `bytesToBits_append` / `bytesToBits_drop_prefix_three` — algebraic building blocks for `bytesToBits`. Characterizing helpers.
+- `inflate_to_spec_decode` — algorithmic correspondence (native inflate ⟹ spec decode); honestly that, not dressed up as characterization.
+- `inflateRaw_framing` (new) — endPos exactness under framing; correspondence-level support lemma.
+- `gzip_decompressSingle_compress` — **real inverse**: `decompressSingle (compress data) = .ok data`, not vacuous.
+
+**ZlibCorrect:**
+- `compress_size` — 2 + deflated + 4. Characterizing.
+- `compress_cmf` — CMF byte = `0x78`. Characterizing.
+- `compress_header_check` — `(CMF*256+FLG) % 31 == 0`: pins the RFC 1950 header-check **invariant**, not the impl expression. Strong characterization.
+- `compress_cm` (low nibble = 8 / DEFLATE), `compress_cinfo` (high nibble ≤ 7), `compress_no_fdict` (FDICT clear) — each pins a protocol-meaningful field constraint. Characterizing.
+- `compress_eq` / `compress_trailer` (private) — structural. Characterizing.
+- `compress_adler32` — big-endian trailer = `adler32 1 data`. Input-level. Characterizing.
+- `zlib_decompressSingle_compress` — **real inverse**. Not vacuous.
+
+No theorem flagged as tautological; no follow-up "strengthen the spec"
+issue warranted.
+
+## Verification
+
+- `nix-shell --run "lake build"` — 249 jobs, green. (Bare `lake build`
+  fails only at the test-exe link step on missing external comparison
+  libs zopfli/miniz_oxide/libdeflate — pre-existing env issue, unrelated
+  to this Lean-only change; nix-shell provides them.)
+- `nix-shell --run "lake exe test"` — **All tests passed!**
+- `grep -rc sorry Zip/` — 0, unchanged.
+- `git diff` — only `inflateRaw_framing` added to the theorem surface;
+  no existing statement modified.
+
+## Metric deltas
+
+- GzipCorrect.lean: 263 → 258 lines (added ~40-line lemma, shortened roundtrip ~45).
+- ZlibCorrect.lean: 237 → 191 lines.
+- Combined proof-body net: −51 lines.
+- Bare simp/simpa/simp_all: 0 → 0 (was already clean).
+- sorry: 0 → 0.
+
+## Remaining / follow-ups
+
+None. Both wrapper specs are settled, fully characterizing, and now share
+their endPos-framing core. No deferred work.


### PR DESCRIPTION
Closes #2578

Session: `55e09fa4-f6f5-4fcc-beb6-d6d113de113f`

32a2229 doc: progress entry for #2578 wrapper-spec review
072efff refactor: extract inflateRaw_framing shared lemma (GzipCorrect/ZlibCorrect #2578)

🤖 Prepared with Claude Code