### PR TITLE
perf: unbox the LZ77 match-compare loop with USize indices (W7 P1a)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -301,6 +301,22 @@ theorem findDistCodeFast_eq (dist : Nat) :
   · simp only [distCodeTab, Array.getElem_map, Array.getElem_range]
   · rfl
 
+/-! ## USize-addressability helpers (Wave 7 P1a)
+
+The matcher's `countMatch` byte-compare loop runs in `USize` (one machine
+word add + `ByteArray.uget`, no boxed-`Nat` arithmetic or reference-count
+traffic per byte — see `lz77Greedy.goU`). These two lemmas bridge `USize`
+indexing back to `Nat` `getElem` so the fast loop is proven equal to the
+original `Nat` loop (`goU_eq`). -/
+
+/-- A `Nat` below `USize.size` round-trips through `USize` unchanged. -/
+theorem toUSize_toNat_of_lt {n : Nat} (h : n < USize.size) : n.toUSize.toNat = n := by
+  simp only [Nat.toUSize]; exact Nat.mod_eq_of_lt h
+
+/-- `ByteArray.uget` at `i` is `getElem` at `i.toNat` (definitional). -/
+theorem uget_eq_getElem (data : ByteArray) (i : USize) (h : i.toNat < data.size) :
+    data.uget i h = data[i.toNat]'h := rfl
+
 inductive LZ77Token where
   | literal : UInt8 → LZ77Token
   | reference : (length : Nat) → (distance : Nat) → LZ77Token
@@ -388,7 +404,16 @@ where
     ((a ^^^ (b <<< 5) ^^^ (c <<< 10)).toNat % hashSize)
   countMatch (data : ByteArray) (p1 p2 maxLen : Nat)
       (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) : Nat :=
-    go data p1 p2 0 maxLen h1 h2
+    -- P1a: when the buffer is `USize`-addressable (always true at runtime; the
+    -- check is one `USize` round-trip, no bignum), run the unboxed `USize` loop
+    -- `goU` — proven equal to the `Nat` `go` by `goU_eq`. Else fall back to `go`.
+    if hg : data.size.toUSize.toNat = data.size then
+      have hsz : data.size < USize.size := by
+        rw [← hg]; exact USize.toNat_lt_two_pow_numBits _
+      (goU data p1.toUSize p2.toUSize 0 maxLen.toUSize hsz
+        (by rw [toUSize_toNat_of_lt (by omega), toUSize_toNat_of_lt (by omega)]; omega)
+        (by rw [toUSize_toNat_of_lt (by omega), toUSize_toNat_of_lt (by omega)]; omega)).toNat
+    else go data p1 p2 0 maxLen h1 h2
   go (data : ByteArray) (p1 p2 i maxLen : Nat)
       (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) : Nat :=
     if hi : i < maxLen then
@@ -397,6 +422,30 @@ where
       else i
     else i
   termination_by maxLen - i
+  goU (data : ByteArray) (p1 p2 i maxLen : USize)
+      (hsz : data.size < USize.size)
+      (h1 : p1.toNat + maxLen.toNat ≤ data.size)
+      (h2 : p2.toNat + maxLen.toNat ≤ data.size) : USize :=
+    if hlt : i < maxLen then
+      have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+      have him : i.toNat < maxLen.toNat := USize.lt_iff_toNat_lt.mp hlt
+      have e1 : (p1 + i).toNat = p1.toNat + i.toNat := by
+        rw [USize.toNat_add]; apply Nat.mod_eq_of_lt; omega
+      have e2 : (p2 + i).toNat = p2.toNat + i.toNat := by
+        rw [USize.toNat_add]; apply Nat.mod_eq_of_lt; omega
+      have hb1 : (p1 + i).toNat < data.size := by omega
+      have hb2 : (p2 + i).toNat < data.size := by omega
+      if data.uget (p1 + i) hb1 == data.uget (p2 + i) hb2 then
+        goU data p1 p2 (i + 1) maxLen hsz h1 h2
+      else i
+    else i
+  termination_by maxLen.toNat - i.toNat
+  decreasing_by
+    have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+    have him : i.toNat < maxLen.toNat := USize.lt_iff_toNat_lt.mp hlt
+    have e : (i + 1).toNat = i.toNat + 1 := by
+      rw [USize.toNat_add, USize.toNat_one]; apply Nat.mod_eq_of_lt; omega
+    omega
   trailing (data : ByteArray) (pos : Nat) : List LZ77Token :=
     if h : pos < data.size then
       .literal (data[pos]'h) :: trailing data (pos + 1)

--- a/Zip/Spec/DeflateFixedCorrect.lean
+++ b/Zip/Spec/DeflateFixedCorrect.lean
@@ -439,7 +439,15 @@ private theorem countMatch_eq (data : ByteArray) (p1 p2 maxLen : Nat)
     (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) :
     lz77GreedyIter.countMatch data p1 p2 maxLen h1 h2 =
     lz77Greedy.countMatch data p1 p2 maxLen h1 h2 := by
-  simp only [lz77GreedyIter.countMatch, lz77Greedy.countMatch]
+  -- P1a: `lz77Greedy.countMatch` now dispatches to the `USize` loop `goU`,
+  -- proven equal to `lz77Greedy.go` by `goU_eq`; both dite branches reduce to it.
+  have hgo : lz77Greedy.countMatch data p1 p2 maxLen h1 h2
+      = lz77Greedy.go data p1 p2 0 maxLen h1 h2 := by
+    rw [lz77Greedy.countMatch]
+    split
+    · exact lz77Greedy.goU_eq data p1 p2 0 maxLen _ h1 h2 (by omega) _ _
+    · rfl
+  simp only [lz77GreedyIter.countMatch, hgo]
   exact go_eq data p1 p2 0 maxLen h1 h2
 
 /-- The `updateHashes` helper is identical between `lz77GreedyIter` and `lz77Greedy`. -/

--- a/Zip/Spec/LZ77NativeCorrect.lean
+++ b/Zip/Spec/LZ77NativeCorrect.lean
@@ -60,13 +60,58 @@ theorem lz77Greedy.go_matches (data : ByteArray) (p1 p2 i maxLen : Nat)
   · exact ⟨fun j hj hjn => by omega, by omega, by omega⟩
 termination_by maxLen - i
 
+/-- P1a: the unboxed `USize` byte-compare loop computes the same count as the
+    `Nat` loop `go`, whenever the buffer is `USize`-addressable. The `goU`
+    bound arguments are proof-irrelevant, so any valid witnesses unify. -/
+theorem lz77Greedy.goU_eq (data : ByteArray) (p1 p2 i maxLen : Nat)
+    (hsz : data.size < USize.size)
+    (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size)
+    (hile : i ≤ maxLen)
+    (hu1 : p1.toUSize.toNat + maxLen.toUSize.toNat ≤ data.size)
+    (hu2 : p2.toUSize.toNat + maxLen.toUSize.toNat ≤ data.size) :
+    (lz77Greedy.goU data p1.toUSize p2.toUSize i.toUSize maxLen.toUSize hsz hu1 hu2).toNat
+      = lz77Greedy.go data p1 p2 i maxLen h1 h2 := by
+  have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+  have hp1 : p1.toUSize.toNat = p1 := toUSize_toNat_of_lt (by omega)
+  have hp2 : p2.toUSize.toNat = p2 := toUSize_toNat_of_lt (by omega)
+  have hmax : maxLen.toUSize.toNat = maxLen := toUSize_toNat_of_lt (by omega)
+  have hi : i.toUSize.toNat = i := toUSize_toNat_of_lt (by omega)
+  rw [lz77Greedy.goU, lz77Greedy.go]
+  by_cases hlt : i < maxLen
+  · have hltU : i.toUSize < maxLen.toUSize := USize.lt_iff_toNat_lt.mpr (by omega)
+    rw [dif_pos hlt, dif_pos hltU]
+    have hadd1 : (p1.toUSize + i.toUSize).toNat = p1 + i := by
+      rw [USize.toNat_add, hp1, hi]; apply Nat.mod_eq_of_lt; omega
+    have hadd2 : (p2.toUSize + i.toUSize).toNat = p2 + i := by
+      rw [USize.toNat_add, hp2, hi]; apply Nat.mod_eq_of_lt; omega
+    simp only [uget_eq_getElem, hadd1, hadd2]
+    by_cases heq : data[p1 + i] == data[p2 + i]
+    · rw [if_pos heq, if_pos heq]
+      have hi1 : (i + 1).toUSize = i.toUSize + 1 := by
+        apply USize.toNat_inj.mp
+        rw [USize.toNat_add, USize.toNat_one, hi, toUSize_toNat_of_lt (by omega)]
+        symm; apply Nat.mod_eq_of_lt; omega
+      rw [← hi1]
+      exact lz77Greedy.goU_eq data p1 p2 (i + 1) maxLen hsz h1 h2 (by omega) hu1 hu2
+    · rw [if_neg heq, if_neg heq, hi]
+  · rw [dif_neg hlt,
+        dif_neg (by rw [USize.lt_iff_toNat_lt]; omega : ¬ i.toUSize < maxLen.toUSize), hi]
+termination_by maxLen - i
+
 /-- `countMatch` returns a count of consecutive matching bytes starting from
     position 0, with all counted positions verified equal. -/
 theorem lz77Greedy.countMatch_matches (data : ByteArray) (p1 p2 maxLen : Nat)
     (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) :
     let n := lz77Greedy.countMatch data p1 p2 maxLen h1 h2
     (∀ j, j < n → data[p1 + j]! = data[p2 + j]!) ∧ n ≤ maxLen := by
-  simp only [lz77Greedy.countMatch]
+  have hgo : lz77Greedy.countMatch data p1 p2 maxLen h1 h2
+      = lz77Greedy.go data p1 p2 0 maxLen h1 h2 := by
+    rw [lz77Greedy.countMatch]
+    split
+    · rename_i hg
+      exact lz77Greedy.goU_eq data p1 p2 0 maxLen _ h1 h2 (by omega) _ _
+    · rfl
+  simp only [hgo]
   have h := lz77Greedy.go_matches data p1 p2 0 maxLen h1 h2 (by omega)
   exact ⟨fun j hj => h.1 j (by omega) hj, h.2.2⟩
 

--- a/ZipBench.lean
+++ b/ZipBench.lean
@@ -92,7 +92,11 @@ def generateData (pattern : String) (size : Nat) : IO ByteArray :=
   | "cyclic"   => pure (mkCyclicData size)
   | "prng"     => pure (mkPrngData size)
   | "text"     => pure (mkTextData size)
-  | other      => throw (IO.userError s!"unknown pattern: {other}")
+  -- "@<path>": read a real corpus file (size arg ignored). Synthetic generators
+  -- (esp. `text`) are degenerate for matcher measurement — use real data here.
+  | p          =>
+    if p.startsWith "@" then IO.FS.readBinFile (p.drop 1).toString
+    else throw (IO.userError s!"unknown pattern: {p}")
 
 def main (args : List String) : IO Unit := do
   match args with
@@ -221,6 +225,64 @@ where
     | "compress-libdeflate" =>
       let _ ← Libdeflate.compress data level.toUInt8
       pure ()
+    -- P0 diagnostic: separate the one-time dense-table CAF build (paid on the
+    -- first distance lookup of the process) from steady-state per-call cost.
+    -- Builds `nin` distinct inputs (perturb one byte) to defeat CSE/memoisation,
+    -- times each `deflateRaw` at `level`, and reports first-call vs mean-of-rest.
+    | "profile-raw" =>
+      let nin := 64
+      let reps := 60
+      let mut inputs : Array ByteArray := #[]
+      for i in [0:nin] do
+        let d := if data.size == 0 then data else
+          (data.extract 0 data.size).set! (i % data.size) (data[i % data.size]!.toNat.toUInt8 ^^^ 1)
+        inputs := inputs.push d
+      -- Force the result through IO so each compression is fully evaluated
+      -- *between* the timestamps (a pure `let` would defer evaluation past `b`).
+      let sink (x : ByteArray) : IO UInt64 :=
+        pure (x.size.toUInt64 + (if x.size > 0 then x[0]!.toUInt64 else 0))
+      let mut acc : UInt64 := 0
+      let mut times : Array Nat := #[]
+      for c in inputs do
+        let a ← IO.monoNanosNow
+        acc := acc + (← sink (Zip.Native.Deflate.deflateRaw c level.toUInt8))
+        let b ← IO.monoNanosNow
+        times := times.push (b - a)
+      -- Extra unmeasured passes for profiler sample volume (steady state only).
+      for _ in [0:reps] do
+        for c in inputs do
+          acc := acc + (← sink (Zip.Native.Deflate.deflateRaw c level.toUInt8))
+      if acc == 0xFFFFFFFFFFFFFFFF then IO.println "x"
+      let first := times[0]!
+      let rest := times.toList.drop 1
+      let restMean := (rest.foldl (· + ·) 0).toFloat / rest.length.toFloat
+      IO.println s!"size={data.size} lvl={level}: first={first}ns restMean={restMean.toString.take 9}ns ratio={(first.toFloat/restMean).toString.take 5}x"
+    -- P1 gate 2: match-length histogram of the packed matcher stream at `level`.
+    -- A reference token has bit 31 set; length sits in bits 16..30. Reports the
+    -- literal/reference split and how many references have ≥8 bytes of runway
+    -- (the threshold below which word-at-a-time compare cannot pay).
+    | "match-hist" =>
+      let ptoks := Zip.Native.Deflate.lzMatchP data level.toUInt8
+      let mut lits : Nat := 0
+      let mut refs : Nat := 0
+      let mut totLen : Nat := 0
+      let mut ge8 : Nat := 0
+      let mut ge16 : Nat := 0
+      let mut buckets : Array Nat := Array.replicate 9 0  -- len 3..10 then 11+
+      for w in ptoks do
+        if w &&& ((1 : UInt32) <<< 31) == 0 then
+          lits := lits + 1
+        else
+          let len := ((w >>> 16) &&& 0x7FFF).toNat
+          refs := refs + 1
+          totLen := totLen + len
+          if len ≥ 8 then ge8 := ge8 + 1
+          if len ≥ 16 then ge16 := ge16 + 1
+          let b := if len ≤ 10 then len - 3 else 8
+          buckets := buckets.set! b (buckets[b]! + 1)
+      let refsF := if refs == 0 then 1.0 else refs.toFloat
+      IO.println s!"size={data.size} lvl={level}: lits={lits} refs={refs} avgLen={(totLen.toFloat/refsF).toString.take 5} ge8={ge8}({(100.0*ge8.toFloat/refsF).toString.take 4}%) ge16={ge16}({(100.0*ge16.toFloat/refsF).toString.take 4}%)"
+      IO.println s!"  len-buckets [3,4,5,6,7,8,9,10,11+]: {buckets.toList}"
     -- Checksum benchmarks
     | "crc32" =>
       let _ := Crc32.Native.crc32 0 data


### PR DESCRIPTION
This PR runs the matcher's `countMatch` byte-by-byte compare loop in `USize` rather than `Nat`. On the real Canterbury corpus (not the synthetic generator) `lz77Greedy.countMatch`'s inner loop is the single hottest symbol — 29% of level-1 and 65% of level-6 attributable samples — and its generated C spends three `lean_nat_add` plus three `lean_dec` on tagged-`Nat` arithmetic per byte (the offsets `p1+i`, `p2+i`, and the counter `i+1`). The new `goU` helper carries the indices as `USize`, so the loop compiles to raw `size_t` adds and `ByteArray.uget` with no boxed-`Nat` traffic or reference-count churn. `countMatch` dispatches to it behind a one-`USize` round-trip addressability check (no bignum compare), falling back to the original `Nat` loop otherwise.

The fast loop is proven equal to the original `Nat` loop (`lz77Greedy.goU_eq`), so output stays byte-identical and the existing `countMatch_matches` / `countMatch_eq` consumers carry through with unchanged statements. 0 sorries; full build, conformance, and fuzz suites pass.

Measured on alice29 (restMean per compress, this machine, same `profile-raw` methodology, master `Nat` matcher vs this branch), the speedup grows with level as the matcher's `countMatch` share rises:

| level | master | this PR | speedup |
|---|---|---|---|
| 1 | 6.25 ms | 5.07 ms | 1.23x |
| 2 | 7.76 ms | 5.82 ms | 1.33x |
| 3 | 9.52 ms | 6.74 ms | 1.41x |
| 4 | 17.68 ms | 10.83 ms | 1.63x |
| 5 | 19.39 ms | 11.63 ms | 1.67x |
| 6 | ~24.6 ms | 13.58 ms | ~1.8x |

A same-process microbench of the loop in isolation shows 1.6x, and the generated C confirms the unboxed `size_t` loop. Ratio is untouched (byte-identical output). The branch also adds small reusable bench tooling (`profile-raw`, `match-hist`, and `@<path>` real-corpus input) used to measure this.

🤖 Prepared with Claude Code