### PR TITLE
bench: Wave-7 dashboard refresh (P1a USize countMatch landed)

### DIFF
--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd1dbf263ad)">
+   <g clip-path="url(#pb0ab6e847f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJGklEQVR4nO3YQYplZx2H4bq3KpVIpIm02I0J4kTBsWNX4NB9uAInrsEFOBDHDh0IgoNMMkvIRBAHhjjQ2Gm6q7tuV1fd4xqE9+NvDs+zgh8cvu+85xzOX/9+u9ij43F6wTq3L6YXrPPmZnrBEtvbu+kJyxwefW96whrvvDe9YJ293o9vT9ML1jns85lt//lyesIy+3xiAACDBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQOzqi8sX0xuWePPwenrCMk+/88PpCct8+/x0esISh9t9nrOLi4uLj2//Oj1hiafXj6cnLHM+309PWOL1+c30hGXuzw/TE5b46QcfTU9Yxh8sAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiB1e3v1hmx6xwu39zfSEZb57eDQ9YZ3TTp/bzVfTC9Z58uPpBUu8ujhNT1jm5u3z6QlLPNn2ezd+ue3zDvnw+X7PmT9YAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAELu6Pr43vWGJ7fI8PWGdm+fTC9Z5+a/pBUtspzfTE5Y5nO+nJyxxPO73+/P9q0fTE5Z4dj5NT1jm8dX3pycssb36dHrCMvu9QQAAhggsAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiB0ePv/1Nj1iifN5egHwTXb0/fmN497n/4gbBAAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGJXv/z3P6Y3LPH16WF6wjKf/PPF9IRl/viLn01PWOLJt34wPWGZn/z2d9MTlvj5jx5PT1jmb89upycs8bBt0xOW+cuf/z49YYnXv/nV9IRl/MECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2OH+/KdtesQKD+f76QnLHA/77eLL0+vpCWtcXk0vWOfVs+kFSzx88HR6Av+jy8N+z9nd+TQ9YYnr+/P0hGX2+6YGABgisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYlfHLz6b3rDE8bDfdtzuTtMTltnu3k5PWOO8TS9Y5/qd6QVLXN58NT1hnZ3ej9vpdnrCMtfvvjs9YYnt5c30hGX2ecoAAAYJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2H8BjdeLdSJDz/AAAAAASUVORK5CYII=" id="image24c285285e" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJD0lEQVR4nO3YQY5lYxyH4bpVVwtBGtEtOhIJGzCU2ICplViAXViCgZEZAzE2sQMhBoLQOqW10nVbVd9raEzeL39unmcFv5Oc8+U932b/20eHE/5fdhfTC9bZPZhesMTh6s/pCctsnrs1PWGNJ5+eXsA/dbWbXrDO6XZ6wRKH8++nJyxzOj0AAODYCCwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj2u8359IYlHj1+OD1hmds3X5uesMxz+1vTE5bYXD6YnrDMF5dfTU9Y4s6Tt6cnLHO1301PWOLi8XE+18nJycnuz6vpCUu89eyr0xOWcYMFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsc2DRx8fpkescHl9MT1hmZeub0xPWGe/n16wxh/n0wvWufXG9IIlHp8d7//nvd2P0xOWuH1yc3rCMj/s705PWOLO/d30hGWO9wQBABgisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYttnfr03vWGJZzZH3I6H3fSCZQ73f5mesMZ+P71gmc1Td6cnLHG2vTE9YZnbN16YnrDGw/vTC5a5czjO9/Hw+8/TE5Y54goBAJghsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2Pdz7aXoD/G2/n17AP3T44dvpCWuc+v/833F+8B/iBAEAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9r17301vWOL+7vH0hGW+/PH36QnLfPLu29MTlnj56demJyzz5ocfTk9Y4p3Xn5+esMzX57vpCUucbTbTE5b59LOvpycs8fCD96cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGKb6/3nh+kRKxwO++kJ/AtnlxfTE9bY3phesM4f59MLltg//8r0hGWO9Xw8O+I7g6vD9fSEJZ64Ps7nOjlxgwUAkBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx7enP30xvWGNzxO346GJ6wTKHy8vpCWvs99MLltncfHF6whKnd7+dnrDOsZ6PV7vpBcs8cbadnrDE4ddfpicsc6RfGQDAHIEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABD7Cy+xibqchBzFAAAAAElFTkSuQmCC" id="imaged3c10148a0" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m62e1085eeb" d="M 0 0 
+       <path id="m9ae49af2a0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m62e1085eeb" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m62e1085eeb" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m62e1085eeb" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m62e1085eeb" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m62e1085eeb" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m62e1085eeb" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m62e1085eeb" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m62e1085eeb" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m62e1085eeb" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m62e1085eeb" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m62e1085eeb" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ae49af2a0" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m89f061dc38" d="M 0 0 
+       <path id="mb78c258f68" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m89f061dc38" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb78c258f68" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m89f061dc38" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb78c258f68" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m89f061dc38" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb78c258f68" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m89f061dc38" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb78c258f68" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m89f061dc38" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb78c258f68" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m89f061dc38" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb78c258f68" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m89f061dc38" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb78c258f68" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m89f061dc38" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb78c258f68" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,19 +1303,9 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -76 -->
+    <!-- -60 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1348,21 +1338,99 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- -56 -->
+    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -76 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_21">
-    <!-- -72 -->
-    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
+   <g id="text_23">
+    <!-- -90 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_22">
-    <!-- -85 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+   <g id="text_24">
+    <!-- -95 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -63 -->
+    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -58 -->
+    <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1405,71 +1473,99 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- -93 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+   <g id="text_27">
+    <!-- -53 -->
+    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_24">
+   <g id="text_28">
+    <!-- -65 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -62 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
     <!-- -95 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- -86 -->
-    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+   <g id="text_31">
+    <!-- +3 -->
+    <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- -74 -->
-    <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
+   <g id="text_32">
+    <!-- +9 -->
+    <g transform="translate(149.761237 104.25537) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +8 -->
+    <g transform="translate(189.012035 104.25537) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -25 -->
+    <g transform="translate(227.74588 104.25537) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -17 -->
+    <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -46 -->
+    <g transform="translate(306.247477 104.25537) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,102 +1588,8 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -71 -->
-    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -86 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -75 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -95 -->
-    <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- +4 -->
-    <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- +9 -->
-    <g transform="translate(149.761237 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +9 -->
-    <g transform="translate(189.012035 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -24 -->
-    <g transform="translate(227.74588 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -17 -->
-    <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -45 -->
-    <g transform="translate(306.247477 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_37">
@@ -1605,10 +1607,10 @@ z
     </g>
    </g>
    <g id="text_39">
-    <!-- -3 -->
+    <!-- -4 -->
     <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_40">
@@ -1628,21 +1630,21 @@ z
     </g>
    </g>
    <g id="text_42">
-    <!-- +226 -->
+    <!-- +227 -->
     <g transform="translate(106.374813 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- +246 -->
+    <!-- +247 -->
     <g transform="translate(145.625612 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_44">
@@ -1663,56 +1665,56 @@ z
     </g>
    </g>
    <g id="text_46">
-    <!-- +24 -->
+    <!-- +25 -->
     <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_47">
-    <!-- +311 -->
+    <!-- +306 -->
     <g transform="translate(302.628805 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_48">
-    <!-- +232 -->
+    <!-- +229 -->
     <g transform="translate(341.879604 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +270 -->
+    <!-- +269 -->
     <g transform="translate(381.130402 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +273 -->
+    <!-- +265 -->
     <g transform="translate(420.381201 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +390 -->
+    <!-- +396 -->
     <g transform="translate(459.631999 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
@@ -1817,130 +1819,131 @@ z
     </g>
    </g>
    <g id="text_64">
-    <!-- +9 -->
-    <g transform="translate(110.510438 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    <!-- -57 -->
+    <g transform="translate(109.993485 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_65">
-    <!-- +26 -->
-    <g transform="translate(147.693424 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    <!-- -55 -->
+    <g transform="translate(149.244284 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_66">
-    <!-- -43 -->
+    <!-- -58 -->
     <g transform="translate(188.495082 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_67">
-    <!-- -77 -->
+    <!-- -90 -->
     <g transform="translate(227.74588 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_68">
-    <!-- -91 -->
+    <!-- -94 -->
     <g transform="translate(266.996679 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_69">
-    <!-- -17 -->
+    <!-- -44 -->
     <g transform="translate(306.247477 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_70">
-    <!-- +21 -->
-    <g transform="translate(343.947416 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    <!-- -35 -->
+    <g transform="translate(345.498276 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_71">
-    <!-- +27 -->
-    <g transform="translate(383.198215 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    <!-- -19 -->
+    <g transform="translate(384.749074 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_72">
-    <!-- +37 -->
-    <g transform="translate(422.449013 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    <!-- -45 -->
+    <g transform="translate(423.999873 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_73">
-    <!-- +17 -->
-    <g transform="translate(461.699812 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    <!-- -48 -->
+    <g transform="translate(463.250671 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_74">
-    <!-- -90 -->
+    <!-- -95 -->
     <g transform="translate(502.50147 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_75">
-    <!-- +24 -->
+    <!-- +27 -->
     <g transform="translate(108.442626 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_76">
-    <!-- +41 -->
+    <!-- +44 -->
     <g transform="translate(147.693424 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_77">
-    <!-- -20 -->
+    <!-- -34 -->
     <g transform="translate(188.495082 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_78">
-    <!-- -37 -->
+    <!-- -38 -->
     <g transform="translate(227.74588 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_79">
-    <!-- -67 -->
+    <!-- -68 -->
     <g transform="translate(266.996679 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_80">
@@ -1952,100 +1955,99 @@ z
     </g>
    </g>
    <g id="text_81">
-    <!-- +24 -->
-    <g transform="translate(343.947416 245.658775) scale(0.065 -0.065)">
+    <!-- +8 -->
+    <g transform="translate(346.015229 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_82">
-    <!-- +48 -->
+    <!-- +47 -->
     <g transform="translate(383.198215 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_83">
-    <!-- -25 -->
-    <g transform="translate(423.999873 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_84">
-    <!-- +55 -->
-    <g transform="translate(461.699812 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_85">
-    <!-- -68 -->
-    <g transform="translate(502.50147 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_86">
-    <!-- +60 -->
-    <g transform="translate(108.442626 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_87">
-    <!-- +74 -->
-    <g transform="translate(147.693424 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_88">
-    <!-- +27 -->
-    <g transform="translate(186.944223 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_83">
+    <!-- -24 -->
+    <g transform="translate(423.999873 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_84">
+    <!-- +56 -->
+    <g transform="translate(461.699812 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_85">
+    <!-- -71 -->
+    <g transform="translate(502.50147 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_86">
+    <!-- +64 -->
+    <g transform="translate(108.442626 281.009626) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_87">
+    <!-- +79 -->
+    <g transform="translate(147.693424 281.009626) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_88">
+    <!-- +28 -->
+    <g transform="translate(186.944223 281.009626) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_89">
-    <!-- -18 -->
+    <!-- -20 -->
     <g transform="translate(227.74588 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_90">
-    <!-- -42 -->
+    <!-- -43 -->
     <g transform="translate(266.996679 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_91">
-    <!-- +112 -->
+    <!-- +113 -->
     <g transform="translate(302.628805 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_92">
-    <!-- +70 -->
+    <!-- +68 -->
     <g transform="translate(343.947416 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_93">
@@ -2057,51 +2059,52 @@ z
     </g>
    </g>
    <g id="text_94">
-    <!-- +93 -->
+    <!-- +98 -->
     <g transform="translate(422.449013 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
-    <!-- +99 -->
-    <g transform="translate(461.699812 281.009626) scale(0.065 -0.065)">
+    <!-- +109 -->
+    <g transform="translate(459.631999 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_96">
-    <!-- -52 -->
+    <!-- -54 -->
     <g transform="translate(502.50147 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_97">
-    <!-- -38 -->
+    <!-- -37 -->
     <g transform="translate(109.993485 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_98">
-    <!-- -36 -->
+    <!-- -35 -->
     <g transform="translate(149.244284 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_99">
-    <!-- -55 -->
+    <!-- -54 -->
     <g transform="translate(188.495082 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_100">
@@ -2113,11 +2116,11 @@ z
     </g>
    </g>
    <g id="text_101">
-    <!-- -85 -->
+    <!-- -84 -->
     <g transform="translate(266.996679 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_102">
@@ -2129,19 +2132,19 @@ z
     </g>
    </g>
    <g id="text_103">
-    <!-- -38 -->
+    <!-- -37 -->
     <g transform="translate(345.498276 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_104">
-    <!-- -35 -->
+    <!-- -34 -->
     <g transform="translate(384.749074 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_105">
@@ -2153,11 +2156,11 @@ z
     </g>
    </g>
    <g id="text_106">
-    <!-- -44 -->
+    <!-- -43 -->
     <g transform="translate(463.250671 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_107">
@@ -2179,23 +2182,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagea0f0c7ad46" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagef7f631ce7b" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m64533e2a51" d="M 0 0 
+       <path id="me2db0268bc" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m64533e2a51" x="547.779688" y="277.801345" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2db0268bc" x="547.779688" y="276.375472" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
       <!-- −3 -->
-      <g transform="translate(554.779688 281.600563) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 280.174691) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2213,12 +2216,12 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m64533e2a51" x="547.779688" y="248.813865" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2db0268bc" x="547.779688" y="247.863283" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
       <!-- −2 -->
-      <g transform="translate(554.779688 252.613083) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 251.662502) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2227,12 +2230,12 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m64533e2a51" x="547.779688" y="219.826385" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2db0268bc" x="547.779688" y="219.351094" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
       <!-- −1 -->
-      <g transform="translate(554.779688 223.625603) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 223.150313) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2241,7 +2244,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m64533e2a51" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2db0268bc" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2254,12 +2257,12 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m64533e2a51" x="547.779688" y="161.851425" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2db0268bc" x="547.779688" y="162.326715" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
       <!-- 1 -->
-      <g transform="translate(554.779688 165.650643) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 166.125934) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2267,12 +2270,12 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m64533e2a51" x="547.779688" y="132.863945" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2db0268bc" x="547.779688" y="133.814526" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
       <!-- 2 -->
-      <g transform="translate(554.779688 136.663163) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 137.613745) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2280,12 +2283,12 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m64533e2a51" x="547.779688" y="103.876465" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me2db0268bc" x="547.779688" y="105.302337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
       <!-- 3 -->
-      <g transform="translate(554.779688 107.675683) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 109.101556) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2941,8 +2944,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-12T23:43:42Z  ·  Linux chungus x86_64  ·  commit 6190fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(21.833828 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.689297 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3009,16 +3012,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3057,108 +3060,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd1dbf263ad">
+  <clipPath id="pb0ab6e847f">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="ma33a8878d7" d="M 0 0 
+       <path id="m3fccace49c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma33a8878d7" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fccace49c" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma33a8878d7" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fccace49c" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma33a8878d7" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fccace49c" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma33a8878d7" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fccace49c" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma33a8878d7" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fccace49c" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma33a8878d7" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fccace49c" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma33a8878d7" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3fccace49c" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -852,23 +852,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 347.805961 
-L 637.2 347.805961 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 347.768205 
+L 637.2 347.768205 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m7e0295d77c" d="M 0 0 
+       <path id="maffba18dc0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7e0295d77c" x="49.078125" y="347.805961" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maffba18dc0" x="49.078125" y="347.768205" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 351.60518) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 351.567424) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -893,18 +893,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 238.709974 
-L 637.2 238.709974 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 238.587166 
+L 637.2 238.587166 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m7e0295d77c" x="49.078125" y="238.709974" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maffba18dc0" x="49.078125" y="238.587166" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 242.509192) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 242.386384) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -913,18 +913,18 @@ L 637.2 238.709974
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 129.613986 
-L 637.2 129.613986 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 129.406126 
+L 637.2 129.406126 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7e0295d77c" x="49.078125" y="129.613986" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maffba18dc0" x="49.078125" y="129.406126" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 133.413205) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 133.205345) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -933,330 +933,330 @@ L 637.2 129.613986
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 404.849935 
-L 637.2 404.849935 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 404.85665 
+L 637.2 404.85665 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m41a7a55916" d="M 0 0 
+       <path id="m1c87952350" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="404.849935" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="404.85665" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 391.21962 
-L 637.2 391.21962 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.215709 
+L 637.2 391.215709 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="391.21962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="391.215709" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 380.647126 
-L 637.2 380.647126 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.634973 
+L 637.2 380.634973 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="380.647126" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="380.634973" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 372.00877 
-L 637.2 372.00877 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 371.989882 
+L 637.2 371.989882 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="372.00877" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="371.989882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 364.705144 
-L 637.2 364.705144 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 364.680562 
+L 637.2 364.680562 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="364.705144" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="364.680562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 358.378455 
-L 637.2 358.378455 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 358.348941 
+L 637.2 358.348941 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="358.378455" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="358.348941" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 352.79792 
-L 637.2 352.79792 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 352.764055 
+L 637.2 352.764055 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="352.79792" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="352.764055" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 314.964797 
-L 637.2 314.964797 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 314.901437 
+L 637.2 314.901437 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="314.964797" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="314.901437" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 295.753947 
-L 637.2 295.753947 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 295.67561 
+L 637.2 295.67561 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="295.753947" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="295.67561" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 282.123632 
-L 637.2 282.123632 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 282.034669 
+L 637.2 282.034669 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="282.123632" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="282.034669" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 271.551138 
-L 637.2 271.551138 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.453933 
+L 637.2 271.453933 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="271.551138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="271.453933" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 262.912782 
-L 637.2 262.912782 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.808843 
+L 637.2 262.808843 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="262.912782" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="262.808843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 255.609156 
-L 637.2 255.609156 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.499523 
+L 637.2 255.499523 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="255.609156" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="255.499523" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 249.282467 
-L 637.2 249.282467 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.167901 
+L 637.2 249.167901 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="249.282467" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="249.167901" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 243.701932 
-L 637.2 243.701932 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.583016 
+L 637.2 243.583016 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="243.701932" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="243.583016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 205.868809 
-L 637.2 205.868809 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.720398 
+L 637.2 205.720398 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="205.868809" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="205.720398" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 186.657959 
-L 637.2 186.657959 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 186.494571 
+L 637.2 186.494571 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="186.657959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="186.494571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 173.027644 
-L 637.2 173.027644 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 172.85363 
+L 637.2 172.85363 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="173.027644" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="172.85363" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 162.455151 
-L 637.2 162.455151 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 162.272894 
+L 637.2 162.272894 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="162.455151" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="162.272894" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 153.816794 
-L 637.2 153.816794 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 153.627803 
+L 637.2 153.627803 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="153.816794" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="153.627803" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 146.513168 
-L 637.2 146.513168 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.318483 
+L 637.2 146.318483 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="146.513168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="146.318483" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 140.186479 
-L 637.2 140.186479 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 139.986862 
+L 637.2 139.986862 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="140.186479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="139.986862" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 134.605944 
-L 637.2 134.605944 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 134.401977 
+L 637.2 134.401977 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="134.605944" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="134.401977" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 49.078125 96.772821 
-L 637.2 96.772821 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 96.539358 
+L 637.2 96.539358 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="96.772821" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="96.539358" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 49.078125 77.561971 
-L 637.2 77.561971 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 77.313532 
+L 637.2 77.313532 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="77.561971" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="77.313532" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 49.078125 63.931656 
-L 637.2 63.931656 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 63.672591 
+L 637.2 63.672591 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="63.931656" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="63.672591" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 49.078125 53.359163 
-L 637.2 53.359163 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 53.091855 
+L 637.2 53.091855 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m41a7a55916" x="49.078125" y="53.359163" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1c87952350" x="49.078125" y="53.091855" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(271.439833 196.471788) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(271.439833 188.758605) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 366.41624) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 345.33651) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1739,124 +1739,124 @@ z
     </g>
    </g>
    <g id="line2d_75">
-    <path d="M 355.479835 95.321161 
-L 308.273931 102.5683 
-L 271.230161 116.26699 
-L 217.83458 119.855647 
-L 177.077692 138.306708 
-L 162.880539 157.746797 
-L 160.741445 165.15132 
-L 153.966678 183.418841 
-L 151.589614 194.471731 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 355.479835 95.278691 
+L 308.273931 102.206002 
+L 271.230161 116.230694 
+L 217.83458 119.782864 
+L 177.077692 138.265045 
+L 162.880539 157.567628 
+L 160.741445 165.005291 
+L 153.966678 183.308691 
+L 151.589614 194.442272 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf1f56766e0" d="M -2.5 2.5 
+     <path id="me8fe847fe0" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p47298df54b)">
-     <use xlink:href="#mf1f56766e0" x="355.479835" y="95.321161" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1f56766e0" x="308.273931" y="102.5683" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1f56766e0" x="271.230161" y="116.26699" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1f56766e0" x="217.83458" y="119.855647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1f56766e0" x="177.077692" y="138.306708" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1f56766e0" x="162.880539" y="157.746797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1f56766e0" x="160.741445" y="165.15132" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1f56766e0" x="153.966678" y="183.418841" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1f56766e0" x="151.589614" y="194.471731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4926299bef)">
+     <use xlink:href="#me8fe847fe0" x="355.479835" y="95.278691" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8fe847fe0" x="308.273931" y="102.206002" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8fe847fe0" x="271.230161" y="116.230694" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8fe847fe0" x="217.83458" y="119.782864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8fe847fe0" x="177.077692" y="138.265045" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8fe847fe0" x="162.880539" y="157.567628" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8fe847fe0" x="160.741445" y="165.005291" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8fe847fe0" x="153.966678" y="183.308691" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8fe847fe0" x="151.589614" y="194.442272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
-    <path d="M 531.649087 75.962963 
-L 283.721324 98.600777 
-L 218.882044 120.838107 
-L 187.447228 126.844061 
-L 176.342474 138.16974 
-L 163.054314 161.220508 
-L 162.210539 168.678316 
-L 159.303811 175.671718 
-L 157.793928 179.465138 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 531.649087 76.330772 
+L 283.721324 99.021337 
+L 218.882044 120.996965 
+L 187.447228 127.017902 
+L 176.342474 138.373995 
+L 163.054314 161.362501 
+L 162.210539 168.791628 
+L 159.303811 175.802394 
+L 157.793928 179.547126 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2afdca41cd" d="M 0 -2.5 
+     <path id="mfe539309d3" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p47298df54b)">
-     <use xlink:href="#m2afdca41cd" x="531.649087" y="75.962963" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2afdca41cd" x="283.721324" y="98.600777" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2afdca41cd" x="218.882044" y="120.838107" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2afdca41cd" x="187.447228" y="126.844061" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2afdca41cd" x="176.342474" y="138.16974" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2afdca41cd" x="163.054314" y="161.220508" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2afdca41cd" x="162.210539" y="168.678316" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2afdca41cd" x="159.303811" y="175.671718" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2afdca41cd" x="157.793928" y="179.465138" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4926299bef)">
+     <use xlink:href="#mfe539309d3" x="531.649087" y="76.330772" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe539309d3" x="283.721324" y="99.021337" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe539309d3" x="218.882044" y="120.996965" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe539309d3" x="187.447228" y="127.017902" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe539309d3" x="176.342474" y="138.373995" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe539309d3" x="163.054314" y="161.362501" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe539309d3" x="162.210539" y="168.791628" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe539309d3" x="159.303811" y="175.802394" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfe539309d3" x="157.793928" y="179.547126" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
     <path d="M 251.559581 64.890426 
-L 203.775848 81.645077 
-L 186.982691 88.27874 
-L 179.779306 91.086628 
-L 157.610419 99.492802 
-L 148.722526 107.965976 
-L 144.388162 121.262683 
-L 127.071247 144.706996 
-L 124.491988 152.208605 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 203.775848 81.617123 
+L 186.982691 88.05226 
+L 179.779306 90.917043 
+L 157.610419 99.408941 
+L 148.722526 107.813396 
+L 144.388162 121.522092 
+L 127.071247 144.494333 
+L 124.491988 152.190225 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me2ba210141" d="M -0 3.535534 
+     <path id="m8b2a39f3ee" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p47298df54b)">
-     <use xlink:href="#me2ba210141" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2ba210141" x="203.775848" y="81.645077" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2ba210141" x="186.982691" y="88.27874" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2ba210141" x="179.779306" y="91.086628" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2ba210141" x="157.610419" y="99.492802" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2ba210141" x="148.722526" y="107.965976" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2ba210141" x="144.388162" y="121.262683" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2ba210141" x="127.071247" y="144.706996" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me2ba210141" x="124.491988" y="152.208605" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4926299bef)">
+     <use xlink:href="#m8b2a39f3ee" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b2a39f3ee" x="203.775848" y="81.617123" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b2a39f3ee" x="186.982691" y="88.05226" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b2a39f3ee" x="179.779306" y="90.917043" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b2a39f3ee" x="157.610419" y="99.408941" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b2a39f3ee" x="148.722526" y="107.813396" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b2a39f3ee" x="144.388162" y="121.522092" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b2a39f3ee" x="127.071247" y="144.494333" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b2a39f3ee" x="124.491988" y="152.190225" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5ac0387c10" d="M -0 2.5 
+     <path id="m4c9f2bbafd" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p47298df54b)">
-     <use xlink:href="#m5ac0387c10" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4926299bef)">
+     <use xlink:href="#m4c9f2bbafd" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
-    <path d="M 362.865999 147.304485 
-L 278.798176 150.894055 
-L 251.17632 154.749308 
-L 200.806828 156.210099 
-L 169.803221 171.250446 
-L 161.916638 181.894588 
-L 158.697104 187.805103 
-L 154.26679 199.463743 
-L 153.096464 210.867108 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 362.865999 182.809456 
+L 278.798176 179.080364 
+L 251.17632 184.93796 
+L 200.806828 189.540566 
+L 169.803221 198.145566 
+L 161.916638 214.740625 
+L 158.697104 219.16589 
+L 154.26679 229.22131 
+L 153.096464 238.528884 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7f5c8e4046" d="M -0.833333 2.5 
+     <path id="m58855acfbb" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,31 +1871,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p47298df54b)">
-     <use xlink:href="#m7f5c8e4046" x="362.865999" y="147.304485" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f5c8e4046" x="278.798176" y="150.894055" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f5c8e4046" x="251.17632" y="154.749308" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f5c8e4046" x="200.806828" y="156.210099" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f5c8e4046" x="169.803221" y="171.250446" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f5c8e4046" x="161.916638" y="181.894588" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f5c8e4046" x="158.697104" y="187.805103" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f5c8e4046" x="154.26679" y="199.463743" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7f5c8e4046" x="153.096464" y="210.867108" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4926299bef)">
+     <use xlink:href="#m58855acfbb" x="362.865999" y="182.809456" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58855acfbb" x="278.798176" y="179.080364" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58855acfbb" x="251.17632" y="184.93796" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58855acfbb" x="200.806828" y="189.540566" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58855acfbb" x="169.803221" y="198.145566" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58855acfbb" x="161.916638" y="214.740625" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58855acfbb" x="158.697104" y="219.16589" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58855acfbb" x="154.26679" y="229.22131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58855acfbb" x="153.096464" y="238.528884" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
-    <path d="M 301.619021 141.206275 
-L 250.236474 147.966786 
-L 225.418659 152.953075 
-L 212.328936 157.208187 
-L 209.030149 157.70919 
-L 197.547749 165.363062 
-L 194.819287 168.964744 
-L 193.12279 176.168228 
-L 192.79794 181.320805 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 301.619021 143.481454 
+L 250.236474 149.524207 
+L 225.418659 152.89052 
+L 212.328936 156.129994 
+L 209.030149 158.171613 
+L 197.547749 166.895646 
+L 194.819287 169.79597 
+L 193.12279 177.428816 
+L 192.79794 184.292145 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m76de6da4df" d="M -1.25 2.5 
+     <path id="me0286527cd" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,31 +1910,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p47298df54b)">
-     <use xlink:href="#m76de6da4df" x="301.619021" y="141.206275" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76de6da4df" x="250.236474" y="147.966786" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76de6da4df" x="225.418659" y="152.953075" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76de6da4df" x="212.328936" y="157.208187" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76de6da4df" x="209.030149" y="157.70919" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76de6da4df" x="197.547749" y="165.363062" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76de6da4df" x="194.819287" y="168.964744" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76de6da4df" x="193.12279" y="176.168228" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m76de6da4df" x="192.79794" y="181.320805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4926299bef)">
+     <use xlink:href="#me0286527cd" x="301.619021" y="143.481454" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me0286527cd" x="250.236474" y="149.524207" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me0286527cd" x="225.418659" y="152.89052" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me0286527cd" x="212.328936" y="156.129994" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me0286527cd" x="209.030149" y="158.171613" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me0286527cd" x="197.547749" y="166.895646" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me0286527cd" x="194.819287" y="169.79597" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me0286527cd" x="193.12279" y="177.428816" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me0286527cd" x="192.79794" y="184.292145" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
-    <path d="M 206.45578 118.247042 
-L 206.45578 119.185807 
-L 206.45578 118.762141 
-L 206.45578 118.403359 
-L 171.767499 134.33203 
-L 163.54283 144.838527 
-L 160.174881 150.952313 
-L 154.179217 168.853195 
-L 152.4406 178.505102 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.242887 
+L 206.45578 118.330806 
+L 206.45578 118.193052 
+L 206.45578 118.085508 
+L 171.767499 133.571824 
+L 163.54283 144.487998 
+L 160.174881 150.52417 
+L 154.179217 168.694796 
+L 152.4406 178.494998 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma291701ab4" d="M 0 -2.5 
+     <path id="m99c90dff6f" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,31 +1947,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p47298df54b)">
-     <use xlink:href="#ma291701ab4" x="206.45578" y="118.247042" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma291701ab4" x="206.45578" y="119.185807" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma291701ab4" x="206.45578" y="118.762141" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma291701ab4" x="206.45578" y="118.403359" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma291701ab4" x="171.767499" y="134.33203" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma291701ab4" x="163.54283" y="144.838527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma291701ab4" x="160.174881" y="150.952313" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma291701ab4" x="154.179217" y="168.853195" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#ma291701ab4" x="152.4406" y="178.505102" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p4926299bef)">
+     <use xlink:href="#m99c90dff6f" x="206.45578" y="118.242887" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m99c90dff6f" x="206.45578" y="118.330806" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m99c90dff6f" x="206.45578" y="118.193052" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m99c90dff6f" x="206.45578" y="118.085508" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m99c90dff6f" x="171.767499" y="133.571824" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m99c90dff6f" x="163.54283" y="144.487998" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m99c90dff6f" x="160.174881" y="150.52417" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m99c90dff6f" x="154.179217" y="168.694796" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m99c90dff6f" x="152.4406" y="178.494998" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
-    <path d="M 610.467188 174.068977 
-L 592.067397 174.978836 
-L 534.807821 181.489231 
-L 327.802209 177.430195 
-L 275.83761 187.795569 
-L 258.25125 199.758091 
-L 256.777056 204.658755 
-L 248.769854 218.431004 
-L 246.264594 228.553762 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467188 172.996304 
+L 592.067397 174.514522 
+L 534.807821 181.346402 
+L 327.802209 176.641094 
+L 275.83761 186.809327 
+L 258.25125 198.928292 
+L 256.777056 204.098979 
+L 248.769854 217.81346 
+L 246.264594 228.015907 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m87955d4e98" d="M 0 -2.5 
+     <path id="m776252f175" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p47298df54b)">
-     <use xlink:href="#m87955d4e98" x="610.467188" y="174.068977" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87955d4e98" x="592.067397" y="174.978836" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87955d4e98" x="534.807821" y="181.489231" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87955d4e98" x="327.802209" y="177.430195" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87955d4e98" x="275.83761" y="187.795569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87955d4e98" x="258.25125" y="199.758091" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87955d4e98" x="256.777056" y="204.658755" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87955d4e98" x="248.769854" y="218.431004" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87955d4e98" x="246.264594" y="228.553762" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p4926299bef)">
+     <use xlink:href="#m776252f175" x="610.467188" y="172.996304" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m776252f175" x="592.067397" y="174.514522" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m776252f175" x="534.807821" y="181.346402" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m776252f175" x="327.802209" y="176.641094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m776252f175" x="275.83761" y="186.809327" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m776252f175" x="258.25125" y="198.928292" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m776252f175" x="256.777056" y="204.098979" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m776252f175" x="248.769854" y="217.81346" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m776252f175" x="246.264594" y="228.015907" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m78a14c74c8" d="M 0 3.5 
+      <path id="m6a60366e9f" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m78a14c74c8" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m6a60366e9f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf1f56766e0" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me8fe847fe0" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2afdca41cd" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfe539309d3" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me2ba210141" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8b2a39f3ee" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5ac0387c10" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4c9f2bbafd" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7f5c8e4046" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m58855acfbb" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m76de6da4df" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me0286527cd" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma291701ab4" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m99c90dff6f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m87955d4e98" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m776252f175" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 266.439833 201.471788 
-L 243.627793 207.949116 
-L 229.515893 214.345461 
-L 184.409647 236.472868 
-L 180.806615 240.459442 
-L 175.118498 249.403038 
-L 162.683902 278.697277 
-L 160.786938 284.423508 
-L 98.348822 371.41624 
-" clip-path="url(#p47298df54b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p47298df54b)">
-     <use xlink:href="#m78a14c74c8" x="266.439833" y="201.471788" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m78a14c74c8" x="243.627793" y="207.949116" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m78a14c74c8" x="229.515893" y="214.345461" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m78a14c74c8" x="184.409647" y="236.472868" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m78a14c74c8" x="180.806615" y="240.459442" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m78a14c74c8" x="175.118498" y="249.403038" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m78a14c74c8" x="162.683902" y="278.697277" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m78a14c74c8" x="160.786938" y="284.423508" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m78a14c74c8" x="98.348822" y="371.41624" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 266.439833 193.758605 
+L 243.627793 198.139471 
+L 229.515893 202.166366 
+L 184.409647 217.469977 
+L 180.806615 220.037622 
+L 175.118498 226.382018 
+L 162.683902 262.929286 
+L 160.786938 266.413087 
+L 98.348822 350.33651 
+" clip-path="url(#p4926299bef)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p4926299bef)">
+     <use xlink:href="#m6a60366e9f" x="266.439833" y="193.758605" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6a60366e9f" x="243.627793" y="198.139471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6a60366e9f" x="229.515893" y="202.166366" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6a60366e9f" x="184.409647" y="217.469977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6a60366e9f" x="180.806615" y="220.037622" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6a60366e9f" x="175.118498" y="226.382018" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6a60366e9f" x="162.683902" y="262.929286" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6a60366e9f" x="160.786938" y="266.413087" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6a60366e9f" x="98.348822" y="350.33651" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,9 +2891,34 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-12T23:43:42Z  ·  Linux chungus x86_64  ·  commit 6190fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(48.833828 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.689297 465.66) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2975,6 +3000,16 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -3043,16 +3078,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3091,108 +3126,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p47298df54b">
+  <clipPath id="p4926299bef">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#paefaf3bdd4)">
+   <g clip-path="url(#p64dc78ff50)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+UlEQVR4nO3YwYqkVx2H4aqe7rYnwUFlEsMshewkuHDjbLL2TnIFWYp7r8PkBgQRMZugZONG3IkbEQkhmSSTmaG7p/orL2ESOPKXep/nCn5nUafe7+y3L3973J2aZ59PL1jq+MVpnWe32+3+/f7vpics9c+/PZ+esNy7H/xyesJy+5/9fHrCWvuz6QXrPf10esF6Vw+mFyz14Y9/Mz1huRP8JQEAfHtiCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbX9z+P1xesRqx902PWGp/Qk268XZ5fSEpW636+kJy138/ZPpCcsdfvp4esJSh+12esJyzw9Ppycs9/DEroeXDx5OT1ju9P5lAQC+AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvH8q+kN6928mF6w1nGbXrDe/QfTC5a6nB7wP3B8+nx6wnIX3zyZnrDUxXaYnrDc/VO8766fTS9Y6uL89G48L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2Px6nR6x2PG7TE5baTuw8u91ud3F2OT1hqbvjYXrCcveePZmesN7335xesNTL7XZ6wnJfXP9nesJyb92cT09Yavvho+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSzv/62Z+nNyx3tttPT1jqjdceTk9Y7m47TE9Y6vLe1fSE5d776OPpCcv9+hdvT09Y6nDcpics96u//GN6wnKPH70+PWGp9955PD1hOS9DAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASNu/vPvDcXrEard319MTlrq/v5qewCvc7g/TE5b7+ubz6QnL/ejqrekJS23HbXrCcl/dfDY9YbknN59OT1jqJw/emZ6wnJchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO237U/H6RHA/6HD7fSC9c4vpxfwCtd3L6YnLHd177XpCbyClyEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkne9uX0xvWO9wO71grXvn0wvWOzuxM+1P8Lviyb+mF6z3g0fTC9Y6tbtut9vtvnc5vWC94za9YK0T7IYTvMEBAL49MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfwb+IB8PIhC4AAAAASUVORK5CYII=" id="image96fb78a279" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+UlEQVR4nO3YwYqkVx2H4aqe7rYnwUFlEsMshewkuHDjbLL2TnIFWYp7r8PkBgQRMZugZONG3IkbEQkhmSSTmaG7p/orL2ESOPKXep/nCn5nUafe7+y3L3973J2aZ59PL1jq+MVpnWe32+3+/f7vpics9c+/PZ+esNy7H/xyesJy+5/9fHrCWvuz6QXrPf10esF6Vw+mFyz14Y9/Mz1huRP8JQEAfHtiCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbX9z+P1xesRqx902PWGp/Qk268XZ5fSEpW636+kJy138/ZPpCcsdfvp4esJSh+12esJyzw9Ppycs9/DEroeXDx5OT1ju9P5lAQC+AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvH8q+kN6928mF6w1nGbXrDe/QfTC5a6nB7wP3B8+nx6wnIX3zyZnrDUxXaYnrDc/VO8766fTS9Y6uL89G48L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2Px6nR6x2PG7TE5baTuw8u91ud3F2OT1hqbvjYXrCcveePZmesN7335xesNTL7XZ6wnJfXP9nesJyb92cT09Yavvho+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSzv/62Z+nNyx3tttPT1jqjdceTk9Y7m47TE9Y6vLe1fSE5d776OPpCcv9+hdvT09Y6nDcpics96u//GN6wnKPH70+PWGp9955PD1hOS9DAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASNu/vPvDcXrEard319MTlrq/v5qewCvc7g/TE5b7+ubz6QnL/ejqrekJS23HbXrCcl/dfDY9YbknN59OT1jqJw/emZ6wnJchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO237U/H6RHA/6HD7fSC9c4vpxfwCtd3L6YnLHd177XpCbyClyEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkne9uX0xvWO9wO71grXvn0wvWOzuxM+1P8Lviyb+mF6z3g0fTC9Y6tbtut9vtvnc5vWC94za9YK0T7IYTvMEBAL49MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfwb+IB8PIhC4AAAAASUVORK5CYII=" id="image6fd0861d98" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m33b356cb55" d="M 0 0 
+       <path id="mde4fc4d5bc" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m33b356cb55" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m33b356cb55" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m33b356cb55" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m33b356cb55" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m33b356cb55" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m33b356cb55" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m33b356cb55" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m33b356cb55" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m33b356cb55" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m33b356cb55" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m33b356cb55" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mde4fc4d5bc" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mbce4fd447e" d="M 0 0 
+       <path id="m18ee76f799" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbce4fd447e" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18ee76f799" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mbce4fd447e" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18ee76f799" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mbce4fd447e" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18ee76f799" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mbce4fd447e" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18ee76f799" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mbce4fd447e" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18ee76f799" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mbce4fd447e" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18ee76f799" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mbce4fd447e" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18ee76f799" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mbce4fd447e" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18ee76f799" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image778c2087a3" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagec0062db962" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m15b3e5d3ac" d="M 0 0 
+       <path id="m7cac281c11" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m15b3e5d3ac" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7cac281c11" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m15b3e5d3ac" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7cac281c11" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m15b3e5d3ac" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7cac281c11" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m15b3e5d3ac" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7cac281c11" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m15b3e5d3ac" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7cac281c11" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m15b3e5d3ac" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7cac281c11" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m15b3e5d3ac" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7cac281c11" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m15b3e5d3ac" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7cac281c11" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m15b3e5d3ac" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7cac281c11" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-12T23:43:42Z  ·  Linux chungus x86_64  ·  commit 6190fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(21.833828 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.689297 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,16 +2950,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2998,108 +2998,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="paefaf3bdd4">
+  <clipPath id="p64dc78ff50">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.732344pt" height="386.202469pt" viewBox="0 0 564.732344 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="571.021406pt" height="386.202469pt" viewBox="0 0 571.021406 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 564.732344 386.202469 
-L 564.732344 0 
+L 571.021406 386.202469 
+L 571.021406 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 184.491172 104.1264 
-L 289.116172 104.1264 
-L 289.116172 74.7432 
-L 184.491172 74.7432 
+    <path d="M 187.635703 104.1264 
+L 292.260703 104.1264 
+L 292.260703 74.7432 
+L 187.635703 74.7432 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 289.116172 104.1264 
-L 393.741172 104.1264 
-L 393.741172 74.7432 
-L 289.116172 74.7432 
+    <path d="M 292.260703 104.1264 
+L 396.885703 104.1264 
+L 396.885703 74.7432 
+L 292.260703 74.7432 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 393.741172 104.1264 
-L 498.366172 104.1264 
-L 498.366172 74.7432 
-L 393.741172 74.7432 
+    <path d="M 396.885703 104.1264 
+L 501.510703 104.1264 
+L 501.510703 74.7432 
+L 396.885703 74.7432 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 184.491172 133.5096 
-L 289.116172 133.5096 
-L 289.116172 104.1264 
-L 184.491172 104.1264 
+    <path d="M 187.635703 133.5096 
+L 292.260703 133.5096 
+L 292.260703 104.1264 
+L 187.635703 104.1264 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 289.116172 133.5096 
-L 393.741172 133.5096 
-L 393.741172 104.1264 
-L 289.116172 104.1264 
+    <path d="M 292.260703 133.5096 
+L 396.885703 133.5096 
+L 396.885703 104.1264 
+L 292.260703 104.1264 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 393.741172 133.5096 
-L 498.366172 133.5096 
-L 498.366172 104.1264 
-L 393.741172 104.1264 
+    <path d="M 396.885703 133.5096 
+L 501.510703 133.5096 
+L 501.510703 104.1264 
+L 396.885703 104.1264 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fdaf62; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #fdb163; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 184.491172 162.8928 
-L 289.116172 162.8928 
-L 289.116172 133.5096 
-L 184.491172 133.5096 
+    <path d="M 187.635703 162.8928 
+L 292.260703 162.8928 
+L 292.260703 133.5096 
+L 187.635703 133.5096 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 289.116172 162.8928 
-L 393.741172 162.8928 
-L 393.741172 133.5096 
-L 289.116172 133.5096 
+    <path d="M 292.260703 162.8928 
+L 396.885703 162.8928 
+L 396.885703 133.5096 
+L 292.260703 133.5096 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 393.741172 162.8928 
-L 498.366172 162.8928 
-L 498.366172 133.5096 
-L 393.741172 133.5096 
+    <path d="M 396.885703 162.8928 
+L 501.510703 162.8928 
+L 501.510703 133.5096 
+L 396.885703 133.5096 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #c5e67e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #c1e57b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 184.491172 192.276 
-L 289.116172 192.276 
-L 289.116172 162.8928 
-L 184.491172 162.8928 
+    <path d="M 187.635703 192.276 
+L 292.260703 192.276 
+L 292.260703 162.8928 
+L 187.635703 162.8928 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 289.116172 192.276 
-L 393.741172 192.276 
-L 393.741172 162.8928 
-L 289.116172 162.8928 
+    <path d="M 292.260703 192.276 
+L 396.885703 192.276 
+L 396.885703 162.8928 
+L 292.260703 162.8928 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 393.741172 192.276 
-L 498.366172 192.276 
-L 498.366172 162.8928 
-L 393.741172 162.8928 
+    <path d="M 396.885703 192.276 
+L 501.510703 192.276 
+L 501.510703 162.8928 
+L 396.885703 162.8928 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #b7e075; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #b5df74; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 184.491172 221.6592 
-L 289.116172 221.6592 
-L 289.116172 192.276 
-L 184.491172 192.276 
+    <path d="M 187.635703 221.6592 
+L 292.260703 221.6592 
+L 292.260703 192.276 
+L 187.635703 192.276 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 289.116172 221.6592 
-L 393.741172 221.6592 
-L 393.741172 192.276 
-L 289.116172 192.276 
+    <path d="M 292.260703 221.6592 
+L 396.885703 221.6592 
+L 396.885703 192.276 
+L 292.260703 192.276 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 393.741172 221.6592 
-L 498.366172 221.6592 
-L 498.366172 192.276 
-L 393.741172 192.276 
+    <path d="M 396.885703 221.6592 
+L 501.510703 221.6592 
+L 501.510703 192.276 
+L 396.885703 192.276 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #f26841; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 184.491172 251.0424 
-L 289.116172 251.0424 
-L 289.116172 221.6592 
-L 184.491172 221.6592 
+    <path d="M 187.635703 251.0424 
+L 292.260703 251.0424 
+L 292.260703 221.6592 
+L 187.635703 221.6592 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 289.116172 251.0424 
-L 393.741172 251.0424 
-L 393.741172 221.6592 
-L 289.116172 221.6592 
+    <path d="M 292.260703 251.0424 
+L 396.885703 251.0424 
+L 396.885703 221.6592 
+L 292.260703 221.6592 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fcaa5f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 393.741172 251.0424 
-L 498.366172 251.0424 
-L 498.366172 221.6592 
-L 393.741172 221.6592 
+    <path d="M 396.885703 251.0424 
+L 501.510703 251.0424 
+L 501.510703 221.6592 
+L 396.885703 221.6592 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fa9656; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 184.491172 280.4256 
-L 289.116172 280.4256 
-L 289.116172 251.0424 
-L 184.491172 251.0424 
+    <path d="M 187.635703 280.4256 
+L 292.260703 280.4256 
+L 292.260703 251.0424 
+L 187.635703 251.0424 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 289.116172 280.4256 
-L 393.741172 280.4256 
-L 393.741172 251.0424 
-L 289.116172 251.0424 
+    <path d="M 292.260703 280.4256 
+L 396.885703 280.4256 
+L 396.885703 251.0424 
+L 292.260703 251.0424 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #f67a49; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 393.741172 280.4256 
-L 498.366172 280.4256 
-L 498.366172 251.0424 
-L 393.741172 251.0424 
+    <path d="M 396.885703 280.4256 
+L 501.510703 280.4256 
+L 501.510703 251.0424 
+L 396.885703 251.0424 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #e65036; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 184.491172 309.8088 
-L 289.116172 309.8088 
-L 289.116172 280.4256 
-L 184.491172 280.4256 
+    <path d="M 187.635703 309.8088 
+L 292.260703 309.8088 
+L 292.260703 280.4256 
+L 187.635703 280.4256 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 289.116172 309.8088 
-L 393.741172 309.8088 
-L 393.741172 280.4256 
-L 289.116172 280.4256 
+    <path d="M 292.260703 309.8088 
+L 396.885703 309.8088 
+L 396.885703 280.4256 
+L 292.260703 280.4256 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #ef633f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #f47044; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 393.741172 309.8088 
-L 498.366172 309.8088 
-L 498.366172 280.4256 
-L 393.741172 280.4256 
+    <path d="M 396.885703 309.8088 
+L 501.510703 309.8088 
+L 501.510703 280.4256 
+L 396.885703 280.4256 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 184.491172 339.192 
-L 289.116172 339.192 
-L 289.116172 309.8088 
-L 184.491172 309.8088 
+    <path d="M 187.635703 339.192 
+L 292.260703 339.192 
+L 292.260703 309.8088 
+L 187.635703 309.8088 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 289.116172 339.192 
-L 393.741172 339.192 
-L 393.741172 309.8088 
-L 289.116172 309.8088 
+    <path d="M 292.260703 339.192 
+L 396.885703 339.192 
+L 396.885703 309.8088 
+L 292.260703 309.8088 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 393.741172 339.192 
-L 498.366172 339.192 
-L 498.366172 309.8088 
-L 393.741172 309.8088 
+    <path d="M 396.885703 339.192 
+L 501.510703 339.192 
+L 501.510703 309.8088 
+L 396.885703 309.8088 
 z
-" clip-path="url(#p8b83b7d1bb)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0a9814b1b2)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(117.478438 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.622969 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(224.762656 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.907188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(303.334766 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.479297 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(401.686484 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.831016 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(113.416172 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.560703 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(225.352422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(333.793672 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.938203 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1033,16 +1033,37 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 955 -->
-    <g transform="translate(438.418672 91.6423) scale(0.08 -0.08)">
+    <!-- 941 -->
+    <g transform="translate(441.563203 91.6423) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(108.054297 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.198828 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1162,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(225.352422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1172,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(336.338672 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1223,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(438.418672 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1231,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(125.317422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.461953 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1255,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(225.352422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,22 +1265,22 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(336.338672 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 697 -->
-    <g transform="translate(438.418672 150.4087) scale(0.08 -0.08)">
+    <!-- 693 -->
+    <g transform="translate(441.563203 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(108.623672 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.768203 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1390,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(225.352422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,22 +1400,22 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(336.338672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 731 -->
-    <g transform="translate(438.418672 179.7919) scale(0.08 -0.08)">
+    <!-- 723 -->
+    <g transform="translate(441.563203 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(116.779922 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.924453 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1475,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(225.352422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1463,68 +1484,64 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- 47 -->
-    <g transform="translate(336.338672 209.1751) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 45 -->
+    <g transform="translate(339.483203 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 148 -->
-    <g transform="translate(438.418672 209.1751) scale(0.08 -0.08)">
+    <!-- 119 -->
+    <g transform="translate(441.563203 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- Go compress/flate -->
-    <g transform="translate(95.747422 238.5583) scale(0.08 -0.08)">
+    <!-- OCaml decompress -->
+    <g transform="translate(96.385078 238.5583) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
+      <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-63" d="M 3122 3366 
@@ -1591,6 +1608,79 @@ Q 2541 3569 2628 3553
 L 2631 2963 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-43" transform="translate(78.710938 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(148.535156 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(209.814453 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(307.226562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(335.009766 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(366.796875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(430.273438 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(491.796875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(546.777344 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(607.958984 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(705.371094 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(768.847656 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(807.710938 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(869.234375 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(921.333984 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 0.321 -->
+    <g transform="translate(228.496953 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 23 -->
+    <g transform="translate(339.483203 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 116 -->
+    <g transform="translate(441.563203 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- Go compress/flate -->
+    <g transform="translate(98.891953 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-2f" d="M 1625 4666 
 L 2156 4666 
 L 531 -594 
@@ -1618,9 +1708,9 @@ z
      <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
     </g>
    </g>
-   <g id="text_26">
+   <g id="text_30">
     <!-- 0.299 -->
-    <g transform="translate(225.352422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1628,114 +1718,24 @@ z
      <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- 33 -->
-    <g transform="translate(336.338672 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- 233 -->
-    <g transform="translate(438.418672 238.5583) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- OCaml decompress -->
-    <g transform="translate(93.240547 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-4f" d="M 2522 4238 
-Q 1834 4238 1429 3725 
-Q 1025 3213 1025 2328 
-Q 1025 1447 1429 934 
-Q 1834 422 2522 422 
-Q 3209 422 3611 934 
-Q 4013 1447 4013 2328 
-Q 4013 3213 3611 3725 
-Q 3209 4238 2522 4238 
-z
-M 2522 4750 
-Q 3503 4750 4090 4092 
-Q 4678 3434 4678 2328 
-Q 4678 1225 4090 567 
-Q 3503 -91 2522 -91 
-Q 1538 -91 948 565 
-Q 359 1222 359 2328 
-Q 359 3434 948 4092 
-Q 1538 4750 2522 4750 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-4f"/>
-     <use xlink:href="#DejaVuSans-43" transform="translate(78.710938 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(148.535156 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(209.814453 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(307.226562 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(335.009766 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(366.796875 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(430.273438 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(491.796875 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(546.777344 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(607.958984 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(705.371094 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(768.847656 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(807.710938 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(869.234375 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(921.333984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 0.321 -->
-    <g transform="translate(225.352422 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
    <g id="text_31">
-    <!-- 23 -->
-    <g transform="translate(336.338672 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+    <!-- 17 -->
+    <g transform="translate(339.483203 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 116 -->
-    <g transform="translate(438.418672 267.9415) scale(0.08 -0.08)">
+    <!-- 100 -->
+    <g transform="translate(441.563203 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(95.125547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.270078 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1844,7 +1844,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.302 -->
-    <g transform="translate(224.151797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.296328 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1937,55 +1937,31 @@ z
     </g>
    </g>
    <g id="text_35">
-    <!-- 8 -->
-    <g transform="translate(338.645547 297.3247) scale(0.08 -0.08)">
+    <!-- 13 -->
+    <g transform="translate(339.006953 297.3247) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
-z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-38"/>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 93 -->
-    <g transform="translate(440.487422 297.3247) scale(0.08 -0.08)">
+    <!-- 92 -->
+    <g transform="translate(443.631953 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -2019,12 +1995,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-39"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(121.461797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.606328 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2035,7 +2011,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(225.352422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2045,13 +2021,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(338.883672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(342.028203 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(442.053672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.198203 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2067,7 +2043,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(131.874922 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(135.019453 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2280,7 +2256,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-12T23:43:42Z  ·  Linux chungus x86_64  ·  commit 6190fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2419,16 +2395,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2467,109 +2443,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8b83b7d1bb">
-   <rect x="79.866172" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p0a9814b1b2">
+   <rect x="83.010703" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pee4b3ff398)">
+   <g clip-path="url(#p876fc6873b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ6klEQVR4nO3Yv45d1R2GYc9wZjyMwUwoJkZELtJEQqIApQ+3wG2kTJUr4BroaVPRpI2oQDSxFClSQEGgKDYKImCM/4zHZ3IFqaz1/qyt57mCb+usfc571sH++4+urm3ZkwfTC9Y6OJxesNb+cnoBz+PZxj+/07PpBWs9uj+9YK3DjX9/Hu6mF6z19PH0grV2x9MLltr42wcAwItGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNrdufx6esNSJ9ePpics9eDi8fSEpd68+avpCUt9/dM30xPW2k0PWOvXJ2fTE5Z6ev1kesJSdx/8e3rCUrdu3JqesNTFs+kFa+2vbfv33Q0oAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2v3y9I3pDUudn96enrDU3Z//OT1hqVsPpxes9fIv3pqesNTu8Hh6As/hxn43PWGpo1e3fT7Prp9PT1jq0bMH0xOWurnf9vl0AwoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2h2/dDK9Yakfn3w3PWGp093N6QlLXby+7ee7d/9v0xOWevj0YnrCUu+cvTs9YamL3fSCte799K/pCUudXT+fnrDUnf/8dXrCUu+e/3Z6wlJuQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSB88++cPV9Iil9vvpBfD/HfoPyAts69+f3j9eZBt//7x9AACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnd+Wd/n96w1PErx9MTlrp75970hKU+/P070xOW+uDTb6cnLPW7269NT1jqT3/5anrCUn98/zfTE5b6+Isfpics9fb5jekJS335/aPpCUu9d/vV6QlLuQEFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSB08u/3w1PWKlo8vL6QlrHZ1ML1jr4uH0grWOT6cXrHWw8f+4V/vpBWtdXkwvWGvr53Pjz/f42rbP58l+25/ftp8OAIAXjgAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC12/3j8+kNS11dPJ2esNbx0fSCte7/PL1grddfm17A83j4aHrBWvur6QVrvXI6vWCtjZ/Pk7Ob0xOWuvruv9MTlnIDCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJD6H47PdWwcvYKVAAAAAElFTkSuQmCC" id="image5a0d611abb" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ5klEQVR4nO3YP44caR3HYXqmZzzYrHcAB4tBIALI0MqEJNyAkxCRcQLuQEbMCRDZJkQrEAFIRANopWVXi5CNBrt7/nACotH7+Q2l5znBt/V2VX2qdndf/Or+S1t2uJ5esNbuZHrBWnc30wvW2vr53RymF6z19HJ6wVrv/j29gIc4PZ9esNbW/59nF9MLltr40w8AgMdGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNp/fLya3rDU+X4/PWGpw+3N9ISlPnjvg+kJS129/vv0hLU2/or7/YvL6QlL3T65mJ6w1F/f/G16wlIvv7zt++e787vpCUvtdm+nJyy18ccDAACPjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO2/9d63pzcs9eLi5fSEpT69vpqesNQ3/7OfnrDUV77+g+kJS+1Pzqcn8ADP7rd9fqfPt31/ef/Ji+kJSx3vDtMTlnp2u+1vhNv+dQAAPDoCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1P7s5Hx6w1KvD/+cnrDU0/3z6QlLHb92OT1hqU9f/3F6wlLXx8P0hKVeXf5wesJSx9Ntf6M4HN5OT+AB/vD5x9MTlvrwxavpCUtt++4CAMCjI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtbj/62f30iKXu7qYXwP924h2QR2zr98+tX3/O7//bxs9v46cHAMBjI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtv/H7v0xv4AE++/Pn0xOW+uVPX01PWOoXv/vH9ISlfvydy+kJS/36o6vpCUv9/Cffm56w1G+v3kxPWOq7lxfTE5b65M276QlL/ejls+kJS/kCCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHbH29/cT49Y6fR4mJ6w1tnF9IK1DtfTC9Y6fzq9YK3dxt9x7++mF6x1fDu9YK2t/z9P9tMLljrutn39nd3cTE9YauNXHwAAj40ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtT/95E/TG9a6v5tesNbZxfSCpe7/9cX0hKV2z786PWGtjV9/9++upyfwALsnT6cnLHV/fDs9Yamz842f3/Wb6QlL+QIKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkPovPSZ5iy+SXHwAAAAASUVORK5CYII=" id="image62068b65a1" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mecf4ae3c6a" d="M 0 0 
+       <path id="mc037f1c601" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mecf4ae3c6a" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc037f1c601" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m35386fe033" d="M 0 0 
+       <path id="mdf8741d2ac" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m35386fe033" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf8741d2ac" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m35386fe033" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf8741d2ac" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m35386fe033" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf8741d2ac" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m35386fe033" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf8741d2ac" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m35386fe033" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf8741d2ac" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m35386fe033" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf8741d2ac" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m35386fe033" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf8741d2ac" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m35386fe033" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf8741d2ac" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,51 +1138,72 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- -72 -->
+    <!-- -56 -->
     <g transform="translate(110.506785 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -79 -->
+    <!-- -59 -->
     <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
@@ -1217,14 +1238,53 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -73 -->
+    <!-- -49 -->
     <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
      <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -73 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1263,9 +1323,229 @@ z
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- -88 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+   <g id="text_25">
+    <!-- -51 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -54 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -65 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -64 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -55 -->
+    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -64 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -52 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -69 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +6 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -13 -->
+    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -4 -->
+    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -16 -->
+    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- -4 -->
+    <g transform="translate(273.684192 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- +0 -->
+    <g transform="translate(312.410731 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- -4 -->
+    <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- -13 -->
+    <g transform="translate(392.448575 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- -10 -->
+    <g transform="translate(432.725974 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- -6 -->
+    <g transform="translate(475.071185 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- +8 -->
+    <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1307,414 +1587,132 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -69 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -69 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -80 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -82 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -69 -->
-    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -80 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -61 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -85 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +8 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_34">
-    <!-- -14 -->
-    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -4 -->
-    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -14 -->
-    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- -4 -->
-    <g transform="translate(273.684192 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- +1 -->
-    <g transform="translate(312.410731 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- -3 -->
-    <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- -12 -->
-    <g transform="translate(392.448575 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- -9 -->
-    <g transform="translate(434.793786 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- -6 -->
-    <g transform="translate(475.071185 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- +14 -->
-    <g transform="translate(511.729912 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
    <g id="text_44">
-    <!-- -11 -->
+    <!-- -13 -->
     <g transform="translate(553.558169 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +260 -->
+    <!-- +252 -->
     <g transform="translate(106.888113 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- +244 -->
+    <!-- +252 -->
     <g transform="translate(147.165512 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_47">
-    <!-- +306 -->
+    <!-- +305 -->
     <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_48">
-    <!-- +136 -->
+    <!-- +133 -->
     <g transform="translate(227.720309 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +239 -->
+    <!-- +237 -->
     <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +190 -->
-    <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_51">
-    <!-- +283 -->
-    <g transform="translate(348.552505 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_52">
-    <!-- +156 -->
-    <g transform="translate(388.829903 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_53">
-    <!-- +223 -->
-    <g transform="translate(429.107302 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_54">
     <!-- +188 -->
-    <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
+    <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
     </g>
    </g>
-   <g id="text_55">
-    <!-- +216 -->
-    <g transform="translate(509.662099 143.2248) scale(0.065 -0.065)">
+   <g id="text_51">
+    <!-- +277 -->
+    <g transform="translate(348.552505 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_52">
+    <!-- +154 -->
+    <g transform="translate(388.829903 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_53">
+    <!-- +212 -->
+    <g transform="translate(429.107302 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_56">
-    <!-- +162 -->
-    <g transform="translate(549.939498 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
+   <g id="text_54">
+    <!-- +187 -->
+    <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_55">
+    <!-- +209 -->
+    <g transform="translate(509.662099 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_56">
+    <!-- +159 -->
+    <g transform="translate(549.939498 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
    <g id="text_57">
-    <!-- -96 -->
+    <!-- -97 -->
     <g transform="translate(110.506785 180.060583) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_58">
@@ -1807,35 +1805,34 @@ z
     </g>
    </g>
    <g id="text_69">
-    <!-- +29 -->
+    <!-- +30 -->
     <g transform="translate(108.955926 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_70">
-    <!-- +27 -->
+    <!-- +28 -->
     <g transform="translate(149.233324 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
-    <!-- +29 -->
+    <!-- +28 -->
     <g transform="translate(189.510723 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_72">
-    <!-- +10 -->
-    <g transform="translate(229.788122 216.896366) scale(0.065 -0.065)">
+    <!-- +9 -->
+    <g transform="translate(231.855934 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_73">
@@ -1847,73 +1844,73 @@ z
     </g>
    </g>
    <g id="text_74">
-    <!-- +75 -->
+    <!-- +74 -->
     <g transform="translate(310.342919 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_75">
-    <!-- -10 -->
+    <!-- -12 -->
     <g transform="translate(352.171177 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_76">
-    <!-- +10 -->
-    <g transform="translate(390.897716 216.896366) scale(0.065 -0.065)">
+    <!-- +9 -->
+    <g transform="translate(392.965528 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_77">
-    <!-- +70 -->
+    <!-- +44 -->
     <g transform="translate(431.175114 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_78">
-    <!-- +7 -->
-    <g transform="translate(473.520325 216.896366) scale(0.065 -0.065)">
+    <!-- +12 -->
+    <g transform="translate(471.452513 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_79">
-    <!-- +89 -->
+    <!-- +86 -->
     <g transform="translate(511.729912 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_80">
-    <!-- +18 -->
+    <!-- +20 -->
     <g transform="translate(552.00731 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_81">
-    <!-- +40 -->
-    <g transform="translate(108.955926 253.732149) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_81">
+    <!-- +38 -->
+    <g transform="translate(108.955926 253.732149) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_82">
-    <!-- +4 -->
+    <!-- +6 -->
     <g transform="translate(151.301137 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_83">
@@ -1925,11 +1922,11 @@ z
     </g>
    </g>
    <g id="text_84">
-    <!-- -40 -->
+    <!-- -39 -->
     <g transform="translate(231.338981 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_85">
@@ -1941,11 +1938,11 @@ z
     </g>
    </g>
    <g id="text_86">
-    <!-- +17 -->
+    <!-- +19 -->
     <g transform="translate(310.342919 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_87">
@@ -1957,34 +1954,35 @@ z
     </g>
    </g>
    <g id="text_88">
-    <!-- -14 -->
+    <!-- -10 -->
     <g transform="translate(392.448575 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_89">
-    <!-- +34 -->
+    <!-- +35 -->
     <g transform="translate(431.175114 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_90">
-    <!-- +9 -->
-    <g transform="translate(473.520325 253.732149) scale(0.065 -0.065)">
+    <!-- +10 -->
+    <g transform="translate(471.452513 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_91">
-    <!-- +24 -->
+    <!-- +19 -->
     <g transform="translate(511.729912 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_92">
@@ -1996,51 +1994,51 @@ z
     </g>
    </g>
    <g id="text_93">
-    <!-- +72 -->
-    <g transform="translate(108.955926 290.567931) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_94">
-    <!-- +63 -->
-    <g transform="translate(149.233324 290.567931) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_95">
     <!-- +77 -->
-    <g transform="translate(189.510723 290.567931) scale(0.065 -0.065)">
+    <g transform="translate(108.955926 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_96">
-    <!-- +39 -->
-    <g transform="translate(229.788122 290.567931) scale(0.065 -0.065)">
+   <g id="text_94">
+    <!-- +69 -->
+    <g transform="translate(149.233324 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_95">
+    <!-- +78 -->
+    <g transform="translate(189.510723 290.567931) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_96">
+    <!-- +44 -->
+    <g transform="translate(229.788122 290.567931) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_97">
-    <!-- +82 -->
+    <!-- +88 -->
     <g transform="translate(270.06552 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_98">
-    <!-- +82 -->
+    <!-- +88 -->
     <g transform="translate(310.342919 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_99">
@@ -2052,35 +2050,35 @@ z
     </g>
    </g>
    <g id="text_100">
-    <!-- +42 -->
+    <!-- +40 -->
     <g transform="translate(390.897716 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_101">
-    <!-- +78 -->
+    <!-- +83 -->
     <g transform="translate(431.175114 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_102">
-    <!-- +43 -->
+    <!-- +47 -->
     <g transform="translate(471.452513 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_103">
-    <!-- +53 -->
+    <!-- +59 -->
     <g transform="translate(511.729912 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_104">
@@ -2092,51 +2090,51 @@ z
     </g>
    </g>
    <g id="text_105">
-    <!-- -33 -->
+    <!-- -34 -->
     <g transform="translate(110.506785 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_106">
-    <!-- -47 -->
+    <!-- -46 -->
     <g transform="translate(150.784184 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_107">
-    <!-- -45 -->
+    <!-- -44 -->
     <g transform="translate(191.061582 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_108">
-    <!-- -49 -->
-    <g transform="translate(231.338981 327.403714) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_109">
     <!-- -48 -->
-    <g transform="translate(271.616379 327.403714) scale(0.065 -0.065)">
+    <g transform="translate(231.338981 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_109">
+    <!-- -47 -->
+    <g transform="translate(271.616379 327.403714) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_110">
-    <!-- -54 -->
+    <!-- -53 -->
     <g transform="translate(311.893778 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_111">
@@ -2164,27 +2162,27 @@ z
     </g>
    </g>
    <g id="text_114">
-    <!-- -43 -->
+    <!-- -42 -->
     <g transform="translate(473.003372 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_115">
-    <!-- -55 -->
+    <!-- -56 -->
     <g transform="translate(513.280771 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_116">
-    <!-- -45 -->
+    <!-- -46 -->
     <g transform="translate(553.558169 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2198,23 +2196,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imageebfd971b59" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagee6a33c4b7e" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m2ad7e93a5b" d="M 0 0 
+       <path id="m1851fbc74e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2ad7e93a5b" x="601.779688" y="320.829411" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1851fbc74e" x="601.779688" y="320.964625" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
       <!-- −3 -->
-      <g transform="translate(608.779688 324.62863) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 324.763844) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2232,12 +2230,12 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2ad7e93a5b" x="601.779688" y="279.447901" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1851fbc74e" x="601.779688" y="279.538044" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
       <!-- −2 -->
-      <g transform="translate(608.779688 283.24712) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 283.337263) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2246,12 +2244,12 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m2ad7e93a5b" x="601.779688" y="238.066391" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1851fbc74e" x="601.779688" y="238.111462" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
       <!-- −1 -->
-      <g transform="translate(608.779688 241.86561) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 241.910681) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2260,7 +2258,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2ad7e93a5b" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1851fbc74e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2273,12 +2271,12 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m2ad7e93a5b" x="601.779688" y="155.303371" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1851fbc74e" x="601.779688" y="155.258299" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
       <!-- 1 -->
-      <g transform="translate(608.779688 159.102589) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 159.057518) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2286,12 +2284,12 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2ad7e93a5b" x="601.779688" y="113.921861" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1851fbc74e" x="601.779688" y="113.831718" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
       <!-- 2 -->
-      <g transform="translate(608.779688 117.721079) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 117.630936) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2299,12 +2297,12 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m2ad7e93a5b" x="601.779688" y="72.540351" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1851fbc74e" x="601.779688" y="72.405136" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
       <!-- 3 -->
-      <g transform="translate(608.779688 76.339569) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 76.204355) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2915,8 +2913,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-12T23:43:42Z  ·  Linux chungus x86_64  ·  commit 6190fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(48.833828 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.689297 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3005,16 +3003,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3053,108 +3051,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pee4b3ff398">
+  <clipPath id="p876fc6873b">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m48538a3ee2" d="M 0 0 
+       <path id="m6629c9d6d7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m48538a3ee2" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6629c9d6d7" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m48538a3ee2" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6629c9d6d7" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m48538a3ee2" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6629c9d6d7" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m48538a3ee2" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6629c9d6d7" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m48538a3ee2" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6629c9d6d7" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m48538a3ee2" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6629c9d6d7" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m48538a3ee2" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6629c9d6d7" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,23 +854,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 358.161335 
-L 637.2 358.161335 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 368.059703 
+L 637.2 368.059703 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m57ab532dbd" d="M 0 0 
+       <path id="m0e79191dd5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m57ab532dbd" x="49.078125" y="358.161335" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e79191dd5" x="49.078125" y="368.059703" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 361.960553) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 371.858922) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -895,18 +895,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 237.626618 
-L 637.2 237.626618 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.320785 
+L 637.2 243.320785 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m57ab532dbd" x="49.078125" y="237.626618" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e79191dd5" x="49.078125" y="243.320785" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 241.425837) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 247.120003) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -915,18 +915,18 @@ L 637.2 237.626618
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 117.091901 
-L 637.2 117.091901 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 118.581866 
+L 637.2 118.581866 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m57ab532dbd" x="49.078125" y="117.091901" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e79191dd5" x="49.078125" y="118.581866" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 120.89112) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 122.381085) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -935,294 +935,282 @@ L 637.2 117.091901
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 406.126921 
-L 637.2 406.126921 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 405.609859 
+L 637.2 405.609859 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mce2de454fb" d="M 0 0 
+       <path id="m6031043c9a" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="406.126921" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="405.609859" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 394.4459 
-L 637.2 394.4459 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 395.732876 
+L 637.2 395.732876 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="394.4459" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="395.732876" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 384.901811 
-L 637.2 384.901811 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 387.382006 
+L 637.2 387.382006 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="384.901811" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="387.382006" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 376.832398 
-L 637.2 376.832398 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.148154 
+L 637.2 380.148154 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="376.832398" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="380.148154" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 369.842356 
-L 637.2 369.842356 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 373.767443 
+L 637.2 373.767443 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="369.842356" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="373.767443" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 363.676701 
-L 637.2 363.676701 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.509547 
+L 637.2 330.509547 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="363.676701" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="330.509547" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 321.876769 
-L 637.2 321.876769 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 308.544114 
+L 637.2 308.544114 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="321.876769" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="308.544114" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 300.651659 
-L 637.2 300.651659 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 292.959391 
+L 637.2 292.959391 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="300.651659" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="292.959391" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 285.592204 
-L 637.2 285.592204 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 280.870941 
+L 637.2 280.870941 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="285.592204" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="280.870941" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 273.911183 
-L 637.2 273.911183 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 270.993958 
+L 637.2 270.993958 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="273.911183" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="270.993958" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 264.367094 
-L 637.2 264.367094 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.643088 
+L 637.2 262.643088 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="264.367094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="262.643088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 256.297682 
-L 637.2 256.297682 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.409235 
+L 637.2 255.409235 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="256.297682" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="255.409235" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 249.307639 
-L 637.2 249.307639 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.028525 
+L 637.2 249.028525 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="249.307639" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="249.028525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 243.141984 
-L 637.2 243.141984 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.770629 
+L 637.2 205.770629 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="243.141984" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="205.770629" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 201.342052 
-L 637.2 201.342052 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 183.805195 
+L 637.2 183.805195 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="201.342052" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="183.805195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 180.116942 
-L 637.2 180.116942 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 168.220473 
+L 637.2 168.220473 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="180.116942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="168.220473" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 165.057487 
-L 637.2 165.057487 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 156.132022 
+L 637.2 156.132022 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="165.057487" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="156.132022" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 153.376466 
-L 637.2 153.376466 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.255039 
+L 637.2 146.255039 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="153.376466" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="146.255039" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 143.832377 
-L 637.2 143.832377 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 137.904169 
+L 637.2 137.904169 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="143.832377" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="137.904169" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 135.762965 
-L 637.2 135.762965 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 130.670316 
+L 637.2 130.670316 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="135.762965" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="130.670316" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 128.772922 
-L 637.2 128.772922 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 124.289606 
+L 637.2 124.289606 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="128.772922" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="124.289606" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 122.607267 
-L 637.2 122.607267 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 81.03171 
+L 637.2 81.03171 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="122.607267" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="81.03171" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 80.807336 
-L 637.2 80.807336 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 59.066277 
+L 637.2 59.066277 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="80.807336" style="stroke: #000000; stroke-width: 0.6"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_27">
-     <g id="line2d_67">
-      <path d="M 49.078125 59.582226 
-L 637.2 59.582226 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_68">
-      <g>
-       <use xlink:href="#mce2de454fb" x="49.078125" y="59.582226" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6031043c9a" x="49.078125" y="59.066277" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1344,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(292.62732 174.484088) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(292.62732 166.925173) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1376,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 391.236449) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 372.040131) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1704,125 +1692,125 @@ z
      <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1145.849609 0)"/>
     </g>
    </g>
-   <g id="line2d_69">
-    <path d="M 377.110281 103.799903 
-L 323.801439 109.336641 
-L 272.665744 124.669512 
-L 235.168828 126.215175 
-L 186.228265 146.961515 
-L 158.303164 168.369037 
-L 149.489547 178.680714 
-L 140.563162 198.267109 
-L 138.984853 204.862513 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_67">
+    <path d="M 377.110281 104.476795 
+L 323.801439 110.1742 
+L 272.665744 126.042664 
+L 235.168828 127.741969 
+L 186.228265 149.260285 
+L 158.303164 171.349246 
+L 149.489547 181.995408 
+L 140.563162 202.380879 
+L 138.984853 209.278136 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m991dbce990" d="M -2.5 2.5 
+     <path id="m3aeea44e58" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c597ace30)">
-     <use xlink:href="#m991dbce990" x="377.110281" y="103.799903" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m991dbce990" x="323.801439" y="109.336641" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m991dbce990" x="272.665744" y="124.669512" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m991dbce990" x="235.168828" y="126.215175" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m991dbce990" x="186.228265" y="146.961515" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m991dbce990" x="158.303164" y="168.369037" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m991dbce990" x="149.489547" y="178.680714" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m991dbce990" x="140.563162" y="198.267109" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m991dbce990" x="138.984853" y="204.862513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa7c61f1ff8)">
+     <use xlink:href="#m3aeea44e58" x="377.110281" y="104.476795" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aeea44e58" x="323.801439" y="110.1742" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aeea44e58" x="272.665744" y="126.042664" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aeea44e58" x="235.168828" y="127.741969" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aeea44e58" x="186.228265" y="149.260285" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aeea44e58" x="158.303164" y="171.349246" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aeea44e58" x="149.489547" y="181.995408" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aeea44e58" x="140.563162" y="202.380879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3aeea44e58" x="138.984853" y="209.278136" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_70">
-    <path d="M 610.467187 71.970523 
-L 319.880958 99.656354 
-L 210.281253 127.103024 
-L 196.287076 130.799832 
-L 176.054419 144.276787 
-L 152.161413 170.933815 
-L 146.720208 182.394305 
-L 143.994022 191.826394 
-L 142.666037 195.55785 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_68">
+    <path d="M 610.467187 72.446247 
+L 319.880958 101.582306 
+L 210.281253 129.577346 
+L 196.287076 133.421684 
+L 176.054419 147.286251 
+L 152.161413 174.673849 
+L 146.720208 186.506557 
+L 143.994022 196.286928 
+L 142.666037 200.119488 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf15a588095" d="M 0 -2.5 
+     <path id="mf0c7d06de1" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c597ace30)">
-     <use xlink:href="#mf15a588095" x="610.467187" y="71.970523" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf15a588095" x="319.880958" y="99.656354" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf15a588095" x="210.281253" y="127.103024" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf15a588095" x="196.287076" y="130.799832" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf15a588095" x="176.054419" y="144.276787" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf15a588095" x="152.161413" y="170.933815" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf15a588095" x="146.720208" y="182.394305" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf15a588095" x="143.994022" y="191.826394" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf15a588095" x="142.666037" y="195.55785" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa7c61f1ff8)">
+     <use xlink:href="#mf0c7d06de1" x="610.467187" y="72.446247" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0c7d06de1" x="319.880958" y="101.582306" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0c7d06de1" x="210.281253" y="129.577346" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0c7d06de1" x="196.287076" y="133.421684" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0c7d06de1" x="176.054419" y="147.286251" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0c7d06de1" x="152.161413" y="174.673849" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0c7d06de1" x="146.720208" y="186.506557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0c7d06de1" x="143.994022" y="196.286928" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0c7d06de1" x="142.666037" y="200.119488" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_71">
+   <g id="line2d_69">
     <path d="M 292.033351 64.890426 
-L 242.839153 79.987318 
-L 218.251194 85.350196 
-L 197.814984 89.251226 
-L 166.378359 97.61365 
-L 145.830392 108.659633 
-L 134.598477 123.807625 
-L 124.077268 146.212493 
-L 122.462976 154.116382 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 242.839153 80.451036 
+L 218.251194 85.933106 
+L 197.814984 89.953903 
+L 166.378359 98.896585 
+L 145.830392 110.0649 
+L 134.598477 125.704711 
+L 124.077268 148.888112 
+L 122.462976 156.968181 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m4158435ed8" d="M -0 3.535534 
+     <path id="m3c28dc27b0" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c597ace30)">
-     <use xlink:href="#m4158435ed8" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4158435ed8" x="242.839153" y="79.987318" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4158435ed8" x="218.251194" y="85.350196" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4158435ed8" x="197.814984" y="89.251226" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4158435ed8" x="166.378359" y="97.61365" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4158435ed8" x="145.830392" y="108.659633" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4158435ed8" x="134.598477" y="123.807625" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4158435ed8" x="124.077268" y="146.212493" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4158435ed8" x="122.462976" y="154.116382" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa7c61f1ff8)">
+     <use xlink:href="#m3c28dc27b0" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c28dc27b0" x="242.839153" y="80.451036" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c28dc27b0" x="218.251194" y="85.933106" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c28dc27b0" x="197.814984" y="89.953903" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c28dc27b0" x="166.378359" y="98.896585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c28dc27b0" x="145.830392" y="110.0649" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c28dc27b0" x="134.598477" y="125.704711" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c28dc27b0" x="124.077268" y="148.888112" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3c28dc27b0" x="122.462976" y="156.968181" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_72">
-    <path d="M 75.810937 385.388411 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_70">
+    <path d="M 75.810937 396.236449 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m32811eb246" d="M -0 2.5 
+     <path id="m670004073f" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c597ace30)">
-     <use xlink:href="#m32811eb246" x="75.810937" y="385.388411" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa7c61f1ff8)">
+     <use xlink:href="#m670004073f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_73">
-    <path d="M 432.495268 95.951067 
-L 300.62247 112.971442 
-L 266.967623 120.050176 
-L 226.040946 121.969382 
-L 180.985721 141.082442 
-L 164.441833 154.042971 
-L 157.761315 162.875917 
-L 151.269082 176.111044 
-L 150.327087 182.344874 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_71">
+    <path d="M 432.495268 105.373939 
+L 300.62247 117.177091 
+L 266.967623 123.759295 
+L 226.040946 126.259461 
+L 180.985721 144.677352 
+L 164.441833 157.23271 
+L 157.761315 167.586504 
+L 151.269082 181.579391 
+L 150.327087 187.56157 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mfa64b61d90" d="M -0.833333 2.5 
+     <path id="mf2ef07587c" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1837,31 +1825,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c597ace30)">
-     <use xlink:href="#mfa64b61d90" x="432.495268" y="95.951067" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa64b61d90" x="300.62247" y="112.971442" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa64b61d90" x="266.967623" y="120.050176" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa64b61d90" x="226.040946" y="121.969382" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa64b61d90" x="180.985721" y="141.082442" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa64b61d90" x="164.441833" y="154.042971" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa64b61d90" x="157.761315" y="162.875917" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa64b61d90" x="151.269082" y="176.111044" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa64b61d90" x="150.327087" y="182.344874" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa7c61f1ff8)">
+     <use xlink:href="#mf2ef07587c" x="432.495268" y="105.373939" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2ef07587c" x="300.62247" y="117.177091" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2ef07587c" x="266.967623" y="123.759295" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2ef07587c" x="226.040946" y="126.259461" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2ef07587c" x="180.985721" y="144.677352" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2ef07587c" x="164.441833" y="157.23271" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2ef07587c" x="157.761315" y="167.586504" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2ef07587c" x="151.269082" y="181.579391" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2ef07587c" x="150.327087" y="187.56157" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_74">
-    <path d="M 345.030867 133.097671 
-L 273.364924 139.908532 
-L 240.719951 145.628579 
-L 221.353978 150.586893 
-L 207.129625 152.870935 
-L 181.064802 163.783305 
-L 179.282169 166.603213 
-L 177.719335 172.12352 
-L 177.643939 177.492935 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_72">
+    <path d="M 345.030867 134.75287 
+L 273.364924 141.598901 
+L 240.719951 147.702825 
+L 221.353978 153.07281 
+L 207.129625 155.347785 
+L 181.064802 166.351853 
+L 179.282169 169.729244 
+L 177.719335 175.157022 
+L 177.643939 180.932541 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb996da7635" d="M -1.25 2.5 
+     <path id="m78d243becf" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1876,31 +1864,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c597ace30)">
-     <use xlink:href="#mb996da7635" x="345.030867" y="133.097671" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb996da7635" x="273.364924" y="139.908532" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb996da7635" x="240.719951" y="145.628579" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb996da7635" x="221.353978" y="150.586893" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb996da7635" x="207.129625" y="152.870935" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb996da7635" x="181.064802" y="163.783305" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb996da7635" x="179.282169" y="166.603213" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb996da7635" x="177.719335" y="172.12352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb996da7635" x="177.643939" y="177.492935" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa7c61f1ff8)">
+     <use xlink:href="#m78d243becf" x="345.030867" y="134.75287" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m78d243becf" x="273.364924" y="141.598901" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m78d243becf" x="240.719951" y="147.702825" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m78d243becf" x="221.353978" y="153.07281" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m78d243becf" x="207.129625" y="155.347785" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m78d243becf" x="181.064802" y="166.351853" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m78d243becf" x="179.282169" y="169.729244" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m78d243becf" x="177.719335" y="175.157022" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m78d243becf" x="177.643939" y="180.932541" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_75">
-    <path d="M 226.871027 113.840199 
-L 226.871027 112.969036 
-L 226.871027 113.334707 
-L 226.871027 113.106322 
-L 177.768423 131.324669 
-L 160.37503 144.041823 
-L 153.995779 150.859389 
-L 147.106887 166.254436 
-L 145.871703 172.666122 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_73">
+    <path d="M 226.871027 112.933127 
+L 226.871027 112.798724 
+L 226.871027 112.876417 
+L 226.871027 112.877898 
+L 177.768423 131.736519 
+L 160.37503 145.049305 
+L 153.995779 152.129164 
+L 147.106887 167.533036 
+L 145.871703 174.69283 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6d172741f4" d="M 0 -2.5 
+     <path id="mb0d7fe242a" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1913,31 +1901,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p8c597ace30)">
-     <use xlink:href="#m6d172741f4" x="226.871027" y="113.840199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6d172741f4" x="226.871027" y="112.969036" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6d172741f4" x="226.871027" y="113.334707" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6d172741f4" x="226.871027" y="113.106322" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6d172741f4" x="177.768423" y="131.324669" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6d172741f4" x="160.37503" y="144.041823" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6d172741f4" x="153.995779" y="150.859389" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6d172741f4" x="147.106887" y="166.254436" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6d172741f4" x="145.871703" y="172.666122" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pa7c61f1ff8)">
+     <use xlink:href="#mb0d7fe242a" x="226.871027" y="112.933127" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb0d7fe242a" x="226.871027" y="112.798724" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb0d7fe242a" x="226.871027" y="112.876417" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb0d7fe242a" x="226.871027" y="112.877898" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb0d7fe242a" x="177.768423" y="131.736519" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb0d7fe242a" x="160.37503" y="145.049305" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb0d7fe242a" x="153.995779" y="152.129164" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb0d7fe242a" x="147.106887" y="167.533036" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb0d7fe242a" x="145.871703" y="174.69283" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
-   <g id="line2d_76">
-    <path d="M 585.66883 171.357108 
-L 527.144592 173.623178 
-L 457.339427 181.420068 
-L 292.124837 176.079897 
-L 243.129344 187.66774 
-L 213.541392 200.921835 
-L 204.551957 208.332575 
-L 195.860087 224.042803 
-L 194.019853 229.506401 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+   <g id="line2d_74">
+    <path d="M 585.66883 173.953565 
+L 527.144592 176.150645 
+L 457.339427 184.575146 
+L 292.124837 178.863413 
+L 243.129344 190.690705 
+L 213.541392 204.774318 
+L 204.551957 212.379925 
+L 195.860087 228.732183 
+L 194.019853 234.158871 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m03fec37f58" d="M 0 -2.5 
+     <path id="m9d398a4719" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1946,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p8c597ace30)">
-     <use xlink:href="#m03fec37f58" x="585.66883" y="171.357108" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03fec37f58" x="527.144592" y="173.623178" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03fec37f58" x="457.339427" y="181.420068" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03fec37f58" x="292.124837" y="176.079897" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03fec37f58" x="243.129344" y="187.66774" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03fec37f58" x="213.541392" y="200.921835" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03fec37f58" x="204.551957" y="208.332575" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03fec37f58" x="195.860087" y="224.042803" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m03fec37f58" x="194.019853" y="229.506401" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pa7c61f1ff8)">
+     <use xlink:href="#m9d398a4719" x="585.66883" y="173.953565" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d398a4719" x="527.144592" y="176.150645" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d398a4719" x="457.339427" y="184.575146" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d398a4719" x="292.124837" y="178.863413" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d398a4719" x="243.129344" y="190.690705" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d398a4719" x="213.541392" y="204.774318" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d398a4719" x="204.551957" y="212.379925" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d398a4719" x="195.860087" y="228.732183" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9d398a4719" x="194.019853" y="234.158871" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1972,13 +1960,13 @@ Q 422.84625 408.80375 424.44625 408.80375
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_77">
+    <g id="line2d_75">
      <path d="M 426.04625 353.9475 
 L 434.04625 353.9475 
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="mc80fa49f2c" d="M 0 3.5 
+      <path id="macd1361e6b" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1991,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mc80fa49f2c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#macd1361e6b" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2048,13 +2036,13 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
      </g>
     </g>
-    <g id="line2d_78">
+    <g id="line2d_76">
      <path d="M 426.04625 365.69 
 L 434.04625 365.69 
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m991dbce990" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3aeea44e58" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2066,13 +2054,13 @@ L 442.04625 365.69
       <use xlink:href="#DejaVuSans-62" transform="translate(108.056641 0)"/>
      </g>
     </g>
-    <g id="line2d_79">
+    <g id="line2d_77">
      <path d="M 426.04625 377.4325 
 L 434.04625 377.4325 
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf15a588095" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf0c7d06de1" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2115,13 +2103,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
      </g>
     </g>
-    <g id="line2d_80">
+    <g id="line2d_78">
      <path d="M 426.04625 389.3975 
 L 434.04625 389.3975 
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m4158435ed8" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3c28dc27b0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2162,13 +2150,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(407.519531 0)"/>
      </g>
     </g>
-    <g id="line2d_81">
+    <g id="line2d_79">
      <path d="M 426.04625 401.14 
 L 434.04625 401.14 
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m32811eb246" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m670004073f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2182,13 +2170,13 @@ L 442.04625 401.14
       <use xlink:href="#DejaVuSans-69" transform="translate(240.136719 0)"/>
      </g>
     </g>
-    <g id="line2d_82">
+    <g id="line2d_80">
      <path d="M 529.72375 353.9475 
 L 537.72375 353.9475 
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mfa64b61d90" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf2ef07587c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2240,13 +2228,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
      </g>
     </g>
-    <g id="line2d_83">
+    <g id="line2d_81">
      <path d="M 529.72375 365.69 
 L 537.72375 365.69 
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb996da7635" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m78d243becf" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2309,13 +2297,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
      </g>
     </g>
-    <g id="line2d_84">
+    <g id="line2d_82">
      <path d="M 529.72375 377.4325 
 L 537.72375 377.4325 
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6d172741f4" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mb0d7fe242a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2351,13 +2339,13 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(541.601562 0)"/>
      </g>
     </g>
-    <g id="line2d_85">
+    <g id="line2d_83">
      <path d="M 529.72375 389.175 
 L 537.72375 389.175 
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m03fec37f58" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9d398a4719" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2426,27 +2414,27 @@ z
      </g>
     </g>
    </g>
-   <g id="line2d_86">
-    <path d="M 287.62732 179.484088 
-L 253.661767 188.256555 
-L 230.111105 197.033188 
-L 195.337271 226.974536 
-L 190.545203 232.470858 
-L 182.839694 245.002479 
-L 155.420659 276.100662 
-L 153.649656 283.001358 
-L 95.319203 396.236449 
-" clip-path="url(#p8c597ace30)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p8c597ace30)">
-     <use xlink:href="#mc80fa49f2c" x="287.62732" y="179.484088" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc80fa49f2c" x="253.661767" y="188.256555" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc80fa49f2c" x="230.111105" y="197.033188" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc80fa49f2c" x="195.337271" y="226.974536" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc80fa49f2c" x="190.545203" y="232.470858" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc80fa49f2c" x="182.839694" y="245.002479" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc80fa49f2c" x="155.420659" y="276.100662" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc80fa49f2c" x="153.649656" y="283.001358" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc80fa49f2c" x="95.319203" y="396.236449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+   <g id="line2d_84">
+    <path d="M 287.62732 171.925173 
+L 253.661767 178.377903 
+L 230.111105 184.430053 
+L 195.337271 206.809398 
+L 190.545203 210.991717 
+L 182.839694 220.762209 
+L 155.420659 260.947327 
+L 153.649656 266.084668 
+L 95.319203 377.040131 
+" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pa7c61f1ff8)">
+     <use xlink:href="#macd1361e6b" x="287.62732" y="171.925173" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#macd1361e6b" x="253.661767" y="178.377903" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#macd1361e6b" x="230.111105" y="184.430053" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#macd1361e6b" x="195.337271" y="206.809398" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#macd1361e6b" x="190.545203" y="210.991717" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#macd1361e6b" x="182.839694" y="220.762209" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#macd1361e6b" x="155.420659" y="260.947327" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#macd1361e6b" x="153.649656" y="266.084668" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#macd1361e6b" x="95.319203" y="377.040131" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2815,9 +2803,34 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-12T23:43:42Z  ·  Linux chungus x86_64  ·  commit 6190fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(48.833828 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.689297 465.66) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2899,6 +2912,16 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -2967,16 +2990,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3015,108 +3038,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8c597ace30">
+  <clipPath id="pa7c61f1ff8">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd4c75cb5f2)">
+   <g clip-path="url(#p49a8e5e518)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKBUlEQVR4nO3Yz4qddx3H8TOdSRMyaSYJGotVFFPcxOpGkLpw1ZXowhtw0ytw48qVeAeuvAHBhRQ3QjZdFqr1X8WFxaqlKiE2TRrTmEwmc7yC90Lqj68cXq8r+MA5fJ/38+yd3vzRdrODjn98Y3rCEmdeemF6wjJ7Vz85PWGJ7W9/Nz1hib0vXp+esMT2wb3pCcvc+u4r0xOWuPqDb0xPWGLvyiemJ6xx/GB6wTKnv9jNe//U9AAAAP5/iUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLev45f2U6PWOHw/VvTE5Z47+L56QnL/Pvk/vSEJT79wfH0hCU++Piz0xOWON2eTk9Y5vLBlekJa9z+6/SCJe5d3s3f65m//HF6wjLbz39lesISviwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJAODm/fnN6wxvlL0wuW2G6Ppycs86lX35iesMZLX59esMTRe/+YnrDG6cn0gnUOd/R+nL0wvWCJi//czefznc9cm56wzOV335yesIQviwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDae/zkxnZ6xAr7t/48PWGJm888PT1hmfuP705PWOLaO3enJyxx8oWvTk9Y4sHJvekJyxztX5qesMT27V9OT1ji4edemJ6wxLk3X5+esMyjL704PWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPezt7+znR6xwpVzh9MTlnjr7u3pCcu8/MNfT09Y4jff/+b0hCWOzh5NT1jie6/9anrCMl977tz0hCW+de3F6QlLvPq316cnLHHhzG7+Dzebzeanf7ozPWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPf4yY3t9IgV7jy6NT1hicODi9MTlnnr7u+nJyzx/KXr0xOW2G5PpycsceFkd9+h/366m3fxucPnpycs8fDJg+kJS+zq7dhsNpv9pw6mJyyxu1cRAICPTCwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6WB/72B6wxIf278yPWGN/aenFyxzdPZoesIShwcXpycs8WR7Mj1hidMzu/sO/ez2/PQE/gu7+nw+3j6cnrDMvUe3picssbtXEQCAj0wsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQDjYfvj+9YYntH96YnrDE3vUvT09Y5rMf7ui7y7mH0wuW2D89mZ6wxo7exM1ms3n8k59PT1hi/+VvT09Y4sz2dHrCEvc3u3kTN5vN5uo7705PWGJHn84AAPwviEUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANJ/AJkNm8+5AYuWAAAAAElFTkSuQmCC" id="image96905e66bb" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKBUlEQVR4nO3Yz4qddx3H8TOdSRMyaSYJGotVFFPcxOpGkLpw1ZXowhtw0ytw48qVeAeuvAHBhRQ3QjZdFqr1X8WFxaqlKiE2TRrTmEwmc7yC90Lqj68cXq8r+MA5fJ/38+yd3vzRdrODjn98Y3rCEmdeemF6wjJ7Vz85PWGJ7W9/Nz1hib0vXp+esMT2wb3pCcvc+u4r0xOWuPqDb0xPWGLvyiemJ6xx/GB6wTKnv9jNe//U9AAAAP5/iUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLev45f2U6PWOHw/VvTE5Z47+L56QnL/Pvk/vSEJT79wfH0hCU++Piz0xOWON2eTk9Y5vLBlekJa9z+6/SCJe5d3s3f65m//HF6wjLbz39lesISviwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJAODm/fnN6wxvlL0wuW2G6Ppycs86lX35iesMZLX59esMTRe/+YnrDG6cn0gnUOd/R+nL0wvWCJi//czefznc9cm56wzOV335yesIQviwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDae/zkxnZ6xAr7t/48PWGJm888PT1hmfuP705PWOLaO3enJyxx8oWvTk9Y4sHJvekJyxztX5qesMT27V9OT1ji4edemJ6wxLk3X5+esMyjL704PWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPezt7+znR6xwpVzh9MTlnjr7u3pCcu8/MNfT09Y4jff/+b0hCWOzh5NT1jie6/9anrCMl977tz0hCW+de3F6QlLvPq316cnLHHhzG7+Dzebzeanf7ozPWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPf4yY3t9IgV7jy6NT1hicODi9MTlnnr7u+nJyzx/KXr0xOW2G5PpycsceFkd9+h/366m3fxucPnpycs8fDJg+kJS+zq7dhsNpv9pw6mJyyxu1cRAICPTCwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6WB/72B6wxIf278yPWGN/aenFyxzdPZoesIShwcXpycs8WR7Mj1hidMzu/sO/ez2/PQE/gu7+nw+3j6cnrDMvUe3picssbtXEQCAj0wsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQDjYfvj+9YYntH96YnrDE3vUvT09Y5rMf7ui7y7mH0wuW2D89mZ6wxo7exM1ms3n8k59PT1hi/+VvT09Y4sz2dHrCEvc3u3kTN5vN5uo7705PWGJHn84AAPwviEUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANJ/AJkNm8+5AYuWAAAAAElFTkSuQmCC" id="imagee611d700c9" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m44cd88d358" d="M 0 0 
+       <path id="m0552f7de56" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m44cd88d358" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m44cd88d358" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m44cd88d358" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m44cd88d358" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m44cd88d358" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m44cd88d358" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m44cd88d358" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m44cd88d358" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m44cd88d358" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m44cd88d358" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m44cd88d358" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m44cd88d358" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0552f7de56" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m2b2e160ead" d="M 0 0 
+       <path id="ma0d14abbe9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2b2e160ead" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0d14abbe9" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2b2e160ead" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0d14abbe9" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m2b2e160ead" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0d14abbe9" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m2b2e160ead" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0d14abbe9" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m2b2e160ead" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0d14abbe9" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m2b2e160ead" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0d14abbe9" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m2b2e160ead" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0d14abbe9" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m2b2e160ead" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma0d14abbe9" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagea9ea04ac94" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagef7f2c29df6" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m0921bbd4c0" d="M 0 0 
+       <path id="m6af03cf0e4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0921bbd4c0" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6af03cf0e4" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m0921bbd4c0" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6af03cf0e4" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m0921bbd4c0" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6af03cf0e4" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0921bbd4c0" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6af03cf0e4" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m0921bbd4c0" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6af03cf0e4" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-12T23:43:42Z  ·  Linux chungus x86_64  ·  commit 6190fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(48.833828 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.689297 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2868,16 +2868,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2916,108 +2916,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd4c75cb5f2">
+  <clipPath id="p49a8e5e518">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.732344pt" height="386.202469pt" viewBox="0 0 564.732344 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="571.021406pt" height="386.202469pt" viewBox="0 0 571.021406 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 564.732344 386.202469 
-L 564.732344 0 
+L 571.021406 386.202469 
+L 571.021406 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 184.491172 104.1264 
-L 289.116172 104.1264 
-L 289.116172 74.7432 
-L 184.491172 74.7432 
+    <path d="M 187.635703 104.1264 
+L 292.260703 104.1264 
+L 292.260703 74.7432 
+L 187.635703 74.7432 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 289.116172 104.1264 
-L 393.741172 104.1264 
-L 393.741172 74.7432 
-L 289.116172 74.7432 
+    <path d="M 292.260703 104.1264 
+L 396.885703 104.1264 
+L 396.885703 74.7432 
+L 292.260703 74.7432 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 393.741172 104.1264 
-L 498.366172 104.1264 
-L 498.366172 74.7432 
-L 393.741172 74.7432 
+    <path d="M 396.885703 104.1264 
+L 501.510703 104.1264 
+L 501.510703 74.7432 
+L 396.885703 74.7432 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 184.491172 133.5096 
-L 289.116172 133.5096 
-L 289.116172 104.1264 
-L 184.491172 104.1264 
+    <path d="M 187.635703 133.5096 
+L 292.260703 133.5096 
+L 292.260703 104.1264 
+L 187.635703 104.1264 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 289.116172 133.5096 
-L 393.741172 133.5096 
-L 393.741172 104.1264 
-L 289.116172 104.1264 
+    <path d="M 292.260703 133.5096 
+L 396.885703 133.5096 
+L 396.885703 104.1264 
+L 292.260703 104.1264 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fdfebc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 393.741172 133.5096 
-L 498.366172 133.5096 
-L 498.366172 104.1264 
-L 393.741172 104.1264 
+    <path d="M 396.885703 133.5096 
+L 501.510703 133.5096 
+L 501.510703 104.1264 
+L 396.885703 104.1264 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fec877; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 184.491172 162.8928 
-L 289.116172 162.8928 
-L 289.116172 133.5096 
-L 184.491172 133.5096 
+    <path d="M 187.635703 162.8928 
+L 292.260703 162.8928 
+L 292.260703 133.5096 
+L 187.635703 133.5096 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 289.116172 162.8928 
-L 393.741172 162.8928 
-L 393.741172 133.5096 
-L 289.116172 133.5096 
+    <path d="M 292.260703 162.8928 
+L 396.885703 162.8928 
+L 396.885703 133.5096 
+L 292.260703 133.5096 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #feeda1; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 393.741172 162.8928 
-L 498.366172 162.8928 
-L 498.366172 133.5096 
-L 393.741172 133.5096 
+    <path d="M 396.885703 162.8928 
+L 501.510703 162.8928 
+L 501.510703 133.5096 
+L 396.885703 133.5096 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 184.491172 192.276 
-L 289.116172 192.276 
-L 289.116172 162.8928 
-L 184.491172 162.8928 
+    <path d="M 187.635703 192.276 
+L 292.260703 192.276 
+L 292.260703 162.8928 
+L 187.635703 162.8928 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 289.116172 192.276 
-L 393.741172 192.276 
-L 393.741172 162.8928 
-L 289.116172 162.8928 
+    <path d="M 292.260703 192.276 
+L 396.885703 192.276 
+L 396.885703 162.8928 
+L 292.260703 162.8928 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 393.741172 192.276 
-L 498.366172 192.276 
-L 498.366172 162.8928 
-L 393.741172 162.8928 
+    <path d="M 396.885703 192.276 
+L 501.510703 192.276 
+L 501.510703 162.8928 
+L 396.885703 162.8928 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 184.491172 221.6592 
-L 289.116172 221.6592 
-L 289.116172 192.276 
-L 184.491172 192.276 
+    <path d="M 187.635703 221.6592 
+L 292.260703 221.6592 
+L 292.260703 192.276 
+L 187.635703 192.276 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 289.116172 221.6592 
-L 393.741172 221.6592 
-L 393.741172 192.276 
-L 289.116172 192.276 
+    <path d="M 292.260703 221.6592 
+L 396.885703 221.6592 
+L 396.885703 192.276 
+L 292.260703 192.276 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 393.741172 221.6592 
-L 498.366172 221.6592 
-L 498.366172 192.276 
-L 393.741172 192.276 
+    <path d="M 396.885703 221.6592 
+L 501.510703 221.6592 
+L 501.510703 192.276 
+L 396.885703 192.276 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fff7b2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 184.491172 251.0424 
-L 289.116172 251.0424 
-L 289.116172 221.6592 
-L 184.491172 221.6592 
+    <path d="M 187.635703 251.0424 
+L 292.260703 251.0424 
+L 292.260703 221.6592 
+L 187.635703 221.6592 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 289.116172 251.0424 
-L 393.741172 251.0424 
-L 393.741172 221.6592 
-L 289.116172 221.6592 
+    <path d="M 292.260703 251.0424 
+L 396.885703 251.0424 
+L 396.885703 221.6592 
+L 292.260703 221.6592 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 393.741172 251.0424 
-L 498.366172 251.0424 
-L 498.366172 221.6592 
-L 393.741172 221.6592 
+    <path d="M 396.885703 251.0424 
+L 501.510703 251.0424 
+L 501.510703 221.6592 
+L 396.885703 221.6592 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #ecf7a6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 184.491172 280.4256 
-L 289.116172 280.4256 
-L 289.116172 251.0424 
-L 184.491172 251.0424 
+    <path d="M 187.635703 280.4256 
+L 292.260703 280.4256 
+L 292.260703 251.0424 
+L 187.635703 251.0424 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 289.116172 280.4256 
-L 393.741172 280.4256 
-L 393.741172 251.0424 
-L 289.116172 251.0424 
+    <path d="M 292.260703 280.4256 
+L 396.885703 280.4256 
+L 396.885703 251.0424 
+L 292.260703 251.0424 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 393.741172 280.4256 
-L 498.366172 280.4256 
-L 498.366172 251.0424 
-L 393.741172 251.0424 
+    <path d="M 396.885703 280.4256 
+L 501.510703 280.4256 
+L 501.510703 251.0424 
+L 396.885703 251.0424 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 184.491172 309.8088 
-L 289.116172 309.8088 
-L 289.116172 280.4256 
-L 184.491172 280.4256 
+    <path d="M 187.635703 309.8088 
+L 292.260703 309.8088 
+L 292.260703 280.4256 
+L 187.635703 280.4256 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #fdb163; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #fdb163; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 289.116172 309.8088 
-L 393.741172 309.8088 
-L 393.741172 280.4256 
-L 289.116172 280.4256 
+    <path d="M 292.260703 309.8088 
+L 396.885703 309.8088 
+L 396.885703 280.4256 
+L 292.260703 280.4256 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 393.741172 309.8088 
-L 498.366172 309.8088 
-L 498.366172 280.4256 
-L 393.741172 280.4256 
+    <path d="M 396.885703 309.8088 
+L 501.510703 309.8088 
+L 501.510703 280.4256 
+L 396.885703 280.4256 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 184.491172 339.192 
-L 289.116172 339.192 
-L 289.116172 309.8088 
-L 184.491172 309.8088 
+    <path d="M 187.635703 339.192 
+L 292.260703 339.192 
+L 292.260703 309.8088 
+L 187.635703 309.8088 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 289.116172 339.192 
-L 393.741172 339.192 
-L 393.741172 309.8088 
-L 289.116172 309.8088 
+    <path d="M 292.260703 339.192 
+L 396.885703 339.192 
+L 396.885703 309.8088 
+L 292.260703 309.8088 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 393.741172 339.192 
-L 498.366172 339.192 
-L 498.366172 309.8088 
-L 393.741172 309.8088 
+    <path d="M 396.885703 339.192 
+L 501.510703 339.192 
+L 501.510703 309.8088 
+L 396.885703 309.8088 
 z
-" clip-path="url(#pae37a622a0)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc7d960504a)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(117.478438 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.622969 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(224.762656 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.907188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(303.334766 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.479297 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(401.686484 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.831016 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(113.416172 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.560703 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(225.352422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(333.793672 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.938203 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -951,8 +951,8 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 893 -->
-    <g transform="translate(438.418672 91.6423) scale(0.08 -0.08)">
+    <!-- 871 -->
+    <g transform="translate(441.563203 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -993,45 +993,15 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(108.054297 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.198828 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1130,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(225.352422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1160,8 +1130,8 @@ z
     </g>
    </g>
    <g id="text_11">
-    <!-- 60 -->
-    <g transform="translate(336.338672 121.0255) scale(0.08 -0.08)">
+    <!-- 61 -->
+    <g transform="translate(339.483203 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,20 +1165,20 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_12">
-    <!-- 309 -->
-    <g transform="translate(438.418672 121.0255) scale(0.08 -0.08)">
+    <!-- 312 -->
+    <g transform="translate(441.563203 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(95.747422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.891953 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1379,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(225.352422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1416,22 +1386,54 @@ z
    </g>
    <g id="text_15">
     <!-- 49 -->
-    <g transform="translate(336.338672 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 150.4087) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 266 -->
-    <g transform="translate(438.418672 150.4087) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-32"/>
+    <!-- 168 -->
+    <g transform="translate(441.563203 150.4087) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(116.779922 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.924453 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1491,7 +1493,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(225.352422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1501,22 +1503,22 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(336.338672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 229 -->
-    <g transform="translate(438.418672 179.7919) scale(0.08 -0.08)">
+    <!-- 203 -->
+    <g transform="translate(441.563203 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(125.317422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.461953 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(225.352422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,22 +1552,22 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(336.338672 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 445 -->
-    <g transform="translate(438.418672 209.1751) scale(0.08 -0.08)">
+    <!-- 442 -->
+    <g transform="translate(441.563203 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(108.623672 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(111.768203 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(225.352422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,22 +1636,22 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(336.338672 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 536 -->
-    <g transform="translate(438.418672 238.5583) scale(0.08 -0.08)">
+    <!-- 529 -->
+    <g transform="translate(441.563203 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(93.240547 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.385078 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1714,7 +1716,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.336 -->
-    <g transform="translate(225.352422 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1724,21 +1726,21 @@ z
    </g>
    <g id="text_31">
     <!-- 20 -->
-    <g transform="translate(336.338672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 68 -->
-    <g transform="translate(440.963672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(444.108203 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(95.125547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.270078 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1847,7 +1849,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.329 -->
-    <g transform="translate(224.151797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.296328 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1970,14 +1972,8 @@ z
     </g>
    </g>
    <g id="text_35">
-    <!-- 9 -->
-    <g transform="translate(338.645547 297.3247) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-Bold-39"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 104 -->
-    <g transform="translate(437.704297 297.3247) scale(0.08 -0.08)">
+    <!-- 15 -->
+    <g transform="translate(339.006953 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1993,34 +1989,47 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 103 -->
+    <g transform="translate(440.848828 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(121.461797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.606328 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2031,7 +2040,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(225.352422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2041,13 +2050,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(338.883672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(342.028203 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(442.053672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.198203 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2063,7 +2072,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(148.967891 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(152.112422 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2207,7 +2216,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-12T23:43:42Z  ·  Linux chungus x86_64  ·  commit 6190fb3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2346,16 +2355,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2394,109 +2403,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3361.425781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3456.835938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3488.623047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.410156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3552.197266 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3583.984375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3611.767578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3673.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3797.949219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3861.425781 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3900.289062 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3961.470703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4020.650391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4082.173828 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4123.287109 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4156.978516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4184.761719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4246.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4370.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4468.257812 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4527.4375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4781.880859 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4881.587891 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4920.451172 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(4975.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5070.841797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5102.628906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.416016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5166.203125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5197.990234 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5237.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5300.578125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5339.441406 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5400.623047 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5464.001953 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5527.478516 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5590.857422 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5654.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5717.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5756.921875 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5788.708984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5872.498047 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5904.285156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6001.697266 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6063.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6154.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6279.138672 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6310.925781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6363.025391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6426.404297 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6551.160156 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6603.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6666.638672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6727.820312 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6767.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6800.720703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6832.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6873.621094 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6974.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7001.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7063.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7094.861328 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7122.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7174.744141 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7206.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7270.007812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7331.53125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7370.740234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7432.263672 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7471.626953 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7569.039062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7596.822266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.201172 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7687.984375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7740.083984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7779.292969 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7807.076172 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pae37a622a0">
-   <rect x="79.866172" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pc7d960504a">
+   <rect x="83.010703" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
 "meta": {
-"date": "2026-06-12T23:43:42Z",
+"date": "2026-06-15T05:16:55Z",
 "machine": "Linux chungus x86_64",
-"git_commit": "6190fb3",
+"git_commit": "1779a506",
 "toolchain": "leanprover/lean4:v4.30.0-rc2",
 "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
 },
@@ -14,8 +14,8 @@
 "level": 1,
 "out_size": 59545,
 "ratio": 0.3915,
-"compress_mbps": 23.31,
-"decompress_mbps": 86.68
+"compress_mbps": 27.47,
+"decompress_mbps": 85.94
 },
 {
 "compressor": "native",
@@ -24,8 +24,8 @@
 "level": 2,
 "out_size": 57936,
 "ratio": 0.3809,
-"compress_mbps": 19.07,
-"decompress_mbps": 94.74
+"compress_mbps": 23.82,
+"decompress_mbps": 94.35
 },
 {
 "compressor": "native",
@@ -34,8 +34,8 @@
 "level": 3,
 "out_size": 56891,
 "ratio": 0.3741,
-"compress_mbps": 15.45,
-"decompress_mbps": 104.39
+"compress_mbps": 20.5,
+"decompress_mbps": 103.65
 },
 {
 "compressor": "native",
@@ -44,8 +44,8 @@
 "level": 4,
 "out_size": 55541,
 "ratio": 0.3652,
-"compress_mbps": 8.51,
-"decompress_mbps": 104.99
+"compress_mbps": 12.8,
+"decompress_mbps": 104.08
 },
 {
 "compressor": "native",
@@ -54,8 +54,8 @@
 "level": 5,
 "out_size": 55282,
 "ratio": 0.3635,
-"compress_mbps": 7.59,
-"decompress_mbps": 107.06
+"compress_mbps": 11.98,
+"decompress_mbps": 106.59
 },
 {
 "compressor": "native",
@@ -64,8 +64,8 @@
 "level": 6,
 "out_size": 54902,
 "ratio": 0.361,
-"compress_mbps": 6.19,
-"decompress_mbps": 111.67
+"compress_mbps": 10.13,
+"decompress_mbps": 111.22
 },
 {
 "compressor": "native",
@@ -74,8 +74,8 @@
 "level": 7,
 "out_size": 54533,
 "ratio": 0.3586,
-"compress_mbps": 4.11,
-"decompress_mbps": 109.54
+"compress_mbps": 5.91,
+"decompress_mbps": 109.14
 },
 {
 "compressor": "native",
@@ -84,8 +84,8 @@
 "level": 8,
 "out_size": 54492,
 "ratio": 0.3583,
-"compress_mbps": 3.83,
-"decompress_mbps": 109.89
+"compress_mbps": 5.61,
+"decompress_mbps": 110.09
 },
 {
 "compressor": "native",
@@ -94,8 +94,8 @@
 "level": 9,
 "out_size": 52111,
 "ratio": 0.3426,
-"compress_mbps": 0.67,
-"decompress_mbps": 109.7
+"compress_mbps": 0.94,
+"decompress_mbps": 110.14
 },
 {
 "compressor": "native",
@@ -104,8 +104,8 @@
 "level": 1,
 "out_size": 52768,
 "ratio": 0.4215,
-"compress_mbps": 22.17,
-"decompress_mbps": 81.09
+"compress_mbps": 26.19,
+"decompress_mbps": 81.75
 },
 {
 "compressor": "native",
@@ -114,8 +114,8 @@
 "level": 2,
 "out_size": 51760,
 "ratio": 0.4135,
-"compress_mbps": 18.19,
-"decompress_mbps": 85.55
+"compress_mbps": 22.62,
+"decompress_mbps": 86.16
 },
 {
 "compressor": "native",
@@ -124,8 +124,8 @@
 "level": 3,
 "out_size": 51056,
 "ratio": 0.4079,
-"compress_mbps": 15.05,
-"decompress_mbps": 91.99
+"compress_mbps": 19.77,
+"decompress_mbps": 92.41
 },
 {
 "compressor": "native",
@@ -134,8 +134,8 @@
 "level": 4,
 "out_size": 49963,
 "ratio": 0.3991,
-"compress_mbps": 8.38,
-"decompress_mbps": 92.88
+"compress_mbps": 12.69,
+"decompress_mbps": 93.12
 },
 {
 "compressor": "native",
@@ -144,8 +144,8 @@
 "level": 5,
 "out_size": 49779,
 "ratio": 0.3977,
-"compress_mbps": 7.57,
-"decompress_mbps": 96.4
+"compress_mbps": 11.7,
+"decompress_mbps": 96.45
 },
 {
 "compressor": "native",
@@ -154,8 +154,8 @@
 "level": 6,
 "out_size": 49540,
 "ratio": 0.3958,
-"compress_mbps": 6.37,
-"decompress_mbps": 97.59
+"compress_mbps": 10.13,
+"decompress_mbps": 97.73
 },
 {
 "compressor": "native",
@@ -164,8 +164,8 @@
 "level": 7,
 "out_size": 49161,
 "ratio": 0.3927,
-"compress_mbps": 4.21,
-"decompress_mbps": 97.18
+"compress_mbps": 5.76,
+"decompress_mbps": 97.71
 },
 {
 "compressor": "native",
@@ -174,8 +174,8 @@
 "level": 8,
 "out_size": 49153,
 "ratio": 0.3927,
-"compress_mbps": 4.07,
-"decompress_mbps": 98.37
+"compress_mbps": 5.63,
+"decompress_mbps": 98.33
 },
 {
 "compressor": "native",
@@ -184,8 +184,8 @@
 "level": 9,
 "out_size": 46881,
 "ratio": 0.3745,
-"compress_mbps": 0.81,
-"decompress_mbps": 97.03
+"compress_mbps": 1.07,
+"decompress_mbps": 97.71
 },
 {
 "compressor": "native",
@@ -194,8 +194,8 @@
 "level": 1,
 "out_size": 8430,
 "ratio": 0.3426,
-"compress_mbps": 23.63,
-"decompress_mbps": 83.96
+"compress_mbps": 26.27,
+"decompress_mbps": 84.46
 },
 {
 "compressor": "native",
@@ -204,8 +204,8 @@
 "level": 2,
 "out_size": 8297,
 "ratio": 0.3372,
-"compress_mbps": 21.63,
-"decompress_mbps": 87.95
+"compress_mbps": 24.94,
+"decompress_mbps": 88.28
 },
 {
 "compressor": "native",
@@ -214,8 +214,8 @@
 "level": 3,
 "out_size": 8218,
 "ratio": 0.334,
-"compress_mbps": 19.62,
-"decompress_mbps": 90.09
+"compress_mbps": 23.87,
+"decompress_mbps": 89.19
 },
 {
 "compressor": "native",
@@ -224,8 +224,8 @@
 "level": 4,
 "out_size": 8055,
 "ratio": 0.3274,
-"compress_mbps": 13.0,
-"decompress_mbps": 88.82
+"compress_mbps": 18.52,
+"decompress_mbps": 88.1
 },
 {
 "compressor": "native",
@@ -234,8 +234,8 @@
 "level": 5,
 "out_size": 8049,
 "ratio": 0.3272,
-"compress_mbps": 12.12,
-"decompress_mbps": 91.3
+"compress_mbps": 17.79,
+"decompress_mbps": 89.91
 },
 {
 "compressor": "native",
@@ -244,8 +244,8 @@
 "level": 6,
 "out_size": 8043,
 "ratio": 0.3269,
-"compress_mbps": 10.69,
-"decompress_mbps": 91.16
+"compress_mbps": 16.63,
+"decompress_mbps": 91.27
 },
 {
 "compressor": "native",
@@ -254,8 +254,8 @@
 "level": 7,
 "out_size": 8038,
 "ratio": 0.3267,
-"compress_mbps": 6.08,
-"decompress_mbps": 92.54
+"compress_mbps": 7.58,
+"decompress_mbps": 91.72
 },
 {
 "compressor": "native",
@@ -264,8 +264,8 @@
 "level": 8,
 "out_size": 8038,
 "ratio": 0.3267,
-"compress_mbps": 6.07,
-"decompress_mbps": 91.64
+"compress_mbps": 7.63,
+"decompress_mbps": 92.03
 },
 {
 "compressor": "native",
@@ -274,8 +274,8 @@
 "level": 9,
 "out_size": 7727,
 "ratio": 0.3141,
-"compress_mbps": 0.83,
-"decompress_mbps": 92.92
+"compress_mbps": 1.25,
+"decompress_mbps": 92.45
 },
 {
 "compressor": "native",
@@ -284,7 +284,7 @@
 "level": 1,
 "out_size": 3325,
 "ratio": 0.2982,
-"compress_mbps": 18.09,
+"compress_mbps": 20.25,
 "decompress_mbps": 75.19
 },
 {
@@ -294,8 +294,8 @@
 "level": 2,
 "out_size": 3251,
 "ratio": 0.2916,
-"compress_mbps": 16.87,
-"decompress_mbps": 77.4
+"compress_mbps": 19.5,
+"decompress_mbps": 77.69
 },
 {
 "compressor": "native",
@@ -304,8 +304,8 @@
 "level": 3,
 "out_size": 3202,
 "ratio": 0.2872,
-"compress_mbps": 15.86,
-"decompress_mbps": 79.55
+"compress_mbps": 18.92,
+"decompress_mbps": 79.79
 },
 {
 "compressor": "native",
@@ -314,8 +314,8 @@
 "level": 4,
 "out_size": 3150,
 "ratio": 0.2825,
-"compress_mbps": 11.68,
-"decompress_mbps": 81.04
+"compress_mbps": 15.86,
+"decompress_mbps": 80.3
 },
 {
 "compressor": "native",
@@ -324,8 +324,8 @@
 "level": 5,
 "out_size": 3141,
 "ratio": 0.2817,
-"compress_mbps": 11.23,
-"decompress_mbps": 82.33
+"compress_mbps": 15.56,
+"decompress_mbps": 81.4
 },
 {
 "compressor": "native",
@@ -334,8 +334,8 @@
 "level": 6,
 "out_size": 3136,
 "ratio": 0.2813,
-"compress_mbps": 10.34,
-"decompress_mbps": 83.01
+"compress_mbps": 14.81,
+"decompress_mbps": 82.21
 },
 {
 "compressor": "native",
@@ -344,8 +344,8 @@
 "level": 7,
 "out_size": 3134,
 "ratio": 0.2811,
-"compress_mbps": 5.17,
-"decompress_mbps": 82.31
+"compress_mbps": 6.07,
+"decompress_mbps": 81.55
 },
 {
 "compressor": "native",
@@ -354,8 +354,8 @@
 "level": 8,
 "out_size": 3134,
 "ratio": 0.2811,
-"compress_mbps": 5.13,
-"decompress_mbps": 82.92
+"compress_mbps": 6.06,
+"decompress_mbps": 83.22
 },
 {
 "compressor": "native",
@@ -364,8 +364,8 @@
 "level": 9,
 "out_size": 3027,
 "ratio": 0.2715,
-"compress_mbps": 1.05,
-"decompress_mbps": 82.51
+"compress_mbps": 1.32,
+"decompress_mbps": 82.54
 },
 {
 "compressor": "native",
@@ -374,8 +374,8 @@
 "level": 1,
 "out_size": 1251,
 "ratio": 0.3362,
-"compress_mbps": 9.96,
-"decompress_mbps": 41.85
+"compress_mbps": 10.57,
+"decompress_mbps": 41.68
 },
 {
 "compressor": "native",
@@ -384,8 +384,8 @@
 "level": 2,
 "out_size": 1241,
 "ratio": 0.3335,
-"compress_mbps": 9.8,
-"decompress_mbps": 42.48
+"compress_mbps": 10.44,
+"decompress_mbps": 41.96
 },
 {
 "compressor": "native",
@@ -394,8 +394,8 @@
 "level": 3,
 "out_size": 1241,
 "ratio": 0.3335,
-"compress_mbps": 9.49,
-"decompress_mbps": 42.44
+"compress_mbps": 10.3,
+"decompress_mbps": 42.73
 },
 {
 "compressor": "native",
@@ -404,8 +404,8 @@
 "level": 4,
 "out_size": 1225,
 "ratio": 0.3292,
-"compress_mbps": 8.39,
-"decompress_mbps": 43.17
+"compress_mbps": 9.79,
+"decompress_mbps": 43.19
 },
 {
 "compressor": "native",
@@ -414,8 +414,8 @@
 "level": 5,
 "out_size": 1224,
 "ratio": 0.3289,
-"compress_mbps": 8.3,
-"decompress_mbps": 43.59
+"compress_mbps": 9.86,
+"decompress_mbps": 43.48
 },
 {
 "compressor": "native",
@@ -424,8 +424,8 @@
 "level": 6,
 "out_size": 1224,
 "ratio": 0.3289,
-"compress_mbps": 8.22,
-"decompress_mbps": 43.67
+"compress_mbps": 9.75,
+"decompress_mbps": 43.61
 },
 {
 "compressor": "native",
@@ -434,8 +434,8 @@
 "level": 7,
 "out_size": 1224,
 "ratio": 0.3289,
-"compress_mbps": 3.41,
-"decompress_mbps": 43.7
+"compress_mbps": 3.61,
+"decompress_mbps": 43.76
 },
 {
 "compressor": "native",
@@ -444,8 +444,8 @@
 "level": 8,
 "out_size": 1224,
 "ratio": 0.3289,
-"compress_mbps": 3.41,
-"decompress_mbps": 43.63
+"compress_mbps": 3.61,
+"decompress_mbps": 43.53
 },
 {
 "compressor": "native",
@@ -454,8 +454,8 @@
 "level": 9,
 "out_size": 1190,
 "ratio": 0.3198,
-"compress_mbps": 1.01,
-"decompress_mbps": 43.77
+"compress_mbps": 1.14,
+"decompress_mbps": 43.3
 },
 {
 "compressor": "native",
@@ -464,8 +464,8 @@
 "level": 1,
 "out_size": 248840,
 "ratio": 0.2417,
-"compress_mbps": 36.55,
-"decompress_mbps": 129.03
+"compress_mbps": 52.92,
+"decompress_mbps": 128.08
 },
 {
 "compressor": "native",
@@ -474,8 +474,8 @@
 "level": 2,
 "out_size": 247429,
 "ratio": 0.2403,
-"compress_mbps": 30.58,
-"decompress_mbps": 149.17
+"compress_mbps": 47.08,
+"decompress_mbps": 148.22
 },
 {
 "compressor": "native",
@@ -484,8 +484,8 @@
 "level": 3,
 "out_size": 246442,
 "ratio": 0.2393,
-"compress_mbps": 27.44,
-"decompress_mbps": 155.8
+"compress_mbps": 45.5,
+"decompress_mbps": 155.05
 },
 {
 "compressor": "native",
@@ -494,8 +494,8 @@
 "level": 4,
 "out_size": 213851,
 "ratio": 0.2077,
-"compress_mbps": 12.58,
-"decompress_mbps": 160.83
+"compress_mbps": 27.65,
+"decompress_mbps": 161.61
 },
 {
 "compressor": "native",
@@ -504,8 +504,8 @@
 "level": 5,
 "out_size": 212782,
 "ratio": 0.2066,
-"compress_mbps": 10.82,
-"decompress_mbps": 130.85
+"compress_mbps": 25.32,
+"decompress_mbps": 130.39
 },
 {
 "compressor": "native",
@@ -514,8 +514,8 @@
 "level": 6,
 "out_size": 210061,
 "ratio": 0.204,
-"compress_mbps": 7.0,
-"decompress_mbps": 131.66
+"compress_mbps": 18.28,
+"decompress_mbps": 129.34
 },
 {
 "compressor": "native",
@@ -524,8 +524,8 @@
 "level": 7,
 "out_size": 201296,
 "ratio": 0.1955,
-"compress_mbps": 3.73,
-"decompress_mbps": 120.81
+"compress_mbps": 7.52,
+"decompress_mbps": 121.16
 },
 {
 "compressor": "native",
@@ -534,8 +534,8 @@
 "level": 8,
 "out_size": 201458,
 "ratio": 0.1956,
-"compress_mbps": 2.38,
-"decompress_mbps": 119.62
+"compress_mbps": 5.61,
+"decompress_mbps": 119.52
 },
 {
 "compressor": "native",
@@ -544,8 +544,8 @@
 "level": 9,
 "out_size": 178311,
 "ratio": 0.1732,
-"compress_mbps": 0.28,
-"decompress_mbps": 119.26
+"compress_mbps": 0.66,
+"decompress_mbps": 118.58
 },
 {
 "compressor": "native",
@@ -554,8 +554,8 @@
 "level": 1,
 "out_size": 158127,
 "ratio": 0.3705,
-"compress_mbps": 25.23,
-"decompress_mbps": 89.87
+"compress_mbps": 29.95,
+"decompress_mbps": 89.2
 },
 {
 "compressor": "native",
@@ -564,8 +564,8 @@
 "level": 2,
 "out_size": 153708,
 "ratio": 0.3602,
-"compress_mbps": 20.4,
-"decompress_mbps": 95.89
+"compress_mbps": 25.81,
+"decompress_mbps": 96.07
 },
 {
 "compressor": "native",
@@ -574,8 +574,8 @@
 "level": 3,
 "out_size": 150718,
 "ratio": 0.3532,
-"compress_mbps": 16.55,
-"decompress_mbps": 106.29
+"compress_mbps": 22.08,
+"decompress_mbps": 105.8
 },
 {
 "compressor": "native",
@@ -584,8 +584,8 @@
 "level": 4,
 "out_size": 147481,
 "ratio": 0.3456,
-"compress_mbps": 9.22,
-"decompress_mbps": 107.02
+"compress_mbps": 13.93,
+"decompress_mbps": 106.97
 },
 {
 "compressor": "native",
@@ -594,8 +594,8 @@
 "level": 5,
 "out_size": 146857,
 "ratio": 0.3441,
-"compress_mbps": 8.4,
-"decompress_mbps": 110.56
+"compress_mbps": 12.95,
+"decompress_mbps": 110.51
 },
 {
 "compressor": "native",
@@ -604,8 +604,8 @@
 "level": 6,
 "out_size": 146118,
 "ratio": 0.3424,
-"compress_mbps": 6.95,
-"decompress_mbps": 112.71
+"compress_mbps": 11.17,
+"decompress_mbps": 112.33
 },
 {
 "compressor": "native",
@@ -614,8 +614,8 @@
 "level": 7,
 "out_size": 145400,
 "ratio": 0.3407,
-"compress_mbps": 4.59,
-"decompress_mbps": 113.05
+"compress_mbps": 6.47,
+"decompress_mbps": 112.63
 },
 {
 "compressor": "native",
@@ -624,8 +624,8 @@
 "level": 8,
 "out_size": 145324,
 "ratio": 0.3405,
-"compress_mbps": 4.36,
-"decompress_mbps": 113.02
+"compress_mbps": 6.27,
+"decompress_mbps": 113.05
 },
 {
 "compressor": "native",
@@ -634,8 +634,8 @@
 "level": 9,
 "out_size": 138661,
 "ratio": 0.3249,
-"compress_mbps": 0.66,
-"decompress_mbps": 112.79
+"compress_mbps": 0.99,
+"decompress_mbps": 112.48
 },
 {
 "compressor": "native",
@@ -644,8 +644,8 @@
 "level": 1,
 "out_size": 212305,
 "ratio": 0.4406,
-"compress_mbps": 21.36,
-"decompress_mbps": 78.09
+"compress_mbps": 24.9,
+"decompress_mbps": 77.97
 },
 {
 "compressor": "native",
@@ -654,8 +654,8 @@
 "level": 2,
 "out_size": 207350,
 "ratio": 0.4303,
-"compress_mbps": 17.47,
-"decompress_mbps": 84.48
+"compress_mbps": 21.62,
+"decompress_mbps": 84.66
 },
 {
 "compressor": "native",
@@ -664,8 +664,8 @@
 "level": 3,
 "out_size": 203699,
 "ratio": 0.4227,
-"compress_mbps": 14.14,
-"decompress_mbps": 89.92
+"compress_mbps": 18.69,
+"decompress_mbps": 89.62
 },
 {
 "compressor": "native",
@@ -674,8 +674,8 @@
 "level": 4,
 "out_size": 200054,
 "ratio": 0.4152,
-"compress_mbps": 7.69,
-"decompress_mbps": 90.61
+"compress_mbps": 11.61,
+"decompress_mbps": 90.29
 },
 {
 "compressor": "native",
@@ -684,8 +684,8 @@
 "level": 5,
 "out_size": 199229,
 "ratio": 0.4135,
-"compress_mbps": 6.97,
-"decompress_mbps": 93.18
+"compress_mbps": 10.74,
+"decompress_mbps": 92.84
 },
 {
 "compressor": "native",
@@ -694,8 +694,8 @@
 "level": 6,
 "out_size": 198023,
 "ratio": 0.411,
-"compress_mbps": 5.69,
-"decompress_mbps": 96.49
+"compress_mbps": 9.16,
+"decompress_mbps": 95.48
 },
 {
 "compressor": "native",
@@ -704,8 +704,8 @@
 "level": 7,
 "out_size": 197186,
 "ratio": 0.4092,
-"compress_mbps": 3.73,
-"decompress_mbps": 96.52
+"compress_mbps": 5.32,
+"decompress_mbps": 96.45
 },
 {
 "compressor": "native",
@@ -714,8 +714,8 @@
 "level": 8,
 "out_size": 197001,
 "ratio": 0.4088,
-"compress_mbps": 3.39,
-"decompress_mbps": 97.17
+"compress_mbps": 4.94,
+"decompress_mbps": 96.77
 },
 {
 "compressor": "native",
@@ -724,8 +724,8 @@
 "level": 9,
 "out_size": 186472,
 "ratio": 0.387,
-"compress_mbps": 0.71,
-"decompress_mbps": 96.87
+"compress_mbps": 0.96,
+"decompress_mbps": 96.74
 },
 {
 "compressor": "native",
@@ -734,8 +734,8 @@
 "level": 1,
 "out_size": 60352,
 "ratio": 0.1176,
-"compress_mbps": 61.12,
-"decompress_mbps": 238.85
+"compress_mbps": 84.55,
+"decompress_mbps": 238.04
 },
 {
 "compressor": "native",
@@ -744,8 +744,8 @@
 "level": 2,
 "out_size": 59696,
 "ratio": 0.1163,
-"compress_mbps": 47.72,
-"decompress_mbps": 251.31
+"compress_mbps": 71.65,
+"decompress_mbps": 250.95
 },
 {
 "compressor": "native",
@@ -754,8 +754,8 @@
 "level": 3,
 "out_size": 59069,
 "ratio": 0.1151,
-"compress_mbps": 36.07,
-"decompress_mbps": 265.42
+"compress_mbps": 60.28,
+"decompress_mbps": 265.78
 },
 {
 "compressor": "native",
@@ -764,8 +764,8 @@
 "level": 4,
 "out_size": 56435,
 "ratio": 0.11,
-"compress_mbps": 18.62,
-"decompress_mbps": 238.91
+"compress_mbps": 38.5,
+"decompress_mbps": 239.04
 },
 {
 "compressor": "native",
@@ -774,8 +774,8 @@
 "level": 5,
 "out_size": 56350,
 "ratio": 0.1098,
-"compress_mbps": 15.85,
-"decompress_mbps": 251.64
+"compress_mbps": 34.74,
+"decompress_mbps": 252.85
 },
 {
 "compressor": "native",
@@ -784,8 +784,8 @@
 "level": 6,
 "out_size": 56014,
 "ratio": 0.1091,
-"compress_mbps": 10.43,
-"decompress_mbps": 267.94
+"compress_mbps": 26.78,
+"decompress_mbps": 268.03
 },
 {
 "compressor": "native",
@@ -794,8 +794,8 @@
 "level": 7,
 "out_size": 54820,
 "ratio": 0.1068,
-"compress_mbps": 5.99,
-"decompress_mbps": 278.85
+"compress_mbps": 13.6,
+"decompress_mbps": 277.59
 },
 {
 "compressor": "native",
@@ -804,8 +804,8 @@
 "level": 8,
 "out_size": 54111,
 "ratio": 0.1054,
-"compress_mbps": 4.03,
-"decompress_mbps": 290.64
+"compress_mbps": 10.93,
+"decompress_mbps": 290.35
 },
 {
 "compressor": "native",
@@ -814,8 +814,8 @@
 "level": 9,
 "out_size": 51490,
 "ratio": 0.1003,
-"compress_mbps": 0.1,
-"decompress_mbps": 294.66
+"compress_mbps": 0.4,
+"decompress_mbps": 294.91
 },
 {
 "compressor": "native",
@@ -824,8 +824,8 @@
 "level": 1,
 "out_size": 13725,
 "ratio": 0.3589,
-"compress_mbps": 19.76,
-"decompress_mbps": 65.18
+"compress_mbps": 21.42,
+"decompress_mbps": 65.02
 },
 {
 "compressor": "native",
@@ -834,8 +834,8 @@
 "level": 2,
 "out_size": 13615,
 "ratio": 0.356,
-"compress_mbps": 18.27,
-"decompress_mbps": 68.59
+"compress_mbps": 20.43,
+"decompress_mbps": 68.36
 },
 {
 "compressor": "native",
@@ -844,8 +844,8 @@
 "level": 3,
 "out_size": 13548,
 "ratio": 0.3543,
-"compress_mbps": 16.88,
-"decompress_mbps": 71.49
+"compress_mbps": 19.44,
+"decompress_mbps": 71.3
 },
 {
 "compressor": "native",
@@ -854,8 +854,8 @@
 "level": 4,
 "out_size": 13080,
 "ratio": 0.3421,
-"compress_mbps": 11.38,
-"decompress_mbps": 69.77
+"compress_mbps": 15.36,
+"decompress_mbps": 69.52
 },
 {
 "compressor": "native",
@@ -864,8 +864,8 @@
 "level": 5,
 "out_size": 13060,
 "ratio": 0.3415,
-"compress_mbps": 10.42,
-"decompress_mbps": 73.15
+"compress_mbps": 14.52,
+"decompress_mbps": 73.11
 },
 {
 "compressor": "native",
@@ -874,8 +874,8 @@
 "level": 6,
 "out_size": 13015,
 "ratio": 0.3404,
-"compress_mbps": 8.24,
-"decompress_mbps": 74.18
+"compress_mbps": 12.66,
+"decompress_mbps": 73.7
 },
 {
 "compressor": "native",
@@ -884,8 +884,8 @@
 "level": 7,
 "out_size": 12823,
 "ratio": 0.3353,
-"compress_mbps": 3.54,
-"decompress_mbps": 73.6
+"compress_mbps": 4.64,
+"decompress_mbps": 73.15
 },
 {
 "compressor": "native",
@@ -894,8 +894,8 @@
 "level": 8,
 "out_size": 12811,
 "ratio": 0.335,
-"compress_mbps": 2.84,
-"decompress_mbps": 76.84
+"compress_mbps": 4.1,
+"decompress_mbps": 76.92
 },
 {
 "compressor": "native",
@@ -904,8 +904,8 @@
 "level": 9,
 "out_size": 12278,
 "ratio": 0.3211,
-"compress_mbps": 0.54,
-"decompress_mbps": 75.66
+"compress_mbps": 0.9,
+"decompress_mbps": 74.97
 },
 {
 "compressor": "native",
@@ -914,8 +914,8 @@
 "level": 1,
 "out_size": 1781,
 "ratio": 0.4213,
-"compress_mbps": 10.86,
-"decompress_mbps": 42.07
+"compress_mbps": 11.36,
+"decompress_mbps": 41.28
 },
 {
 "compressor": "native",
@@ -924,8 +924,8 @@
 "level": 2,
 "out_size": 1764,
 "ratio": 0.4173,
-"compress_mbps": 10.72,
-"decompress_mbps": 42.94
+"compress_mbps": 11.3,
+"decompress_mbps": 42.39
 },
 {
 "compressor": "native",
@@ -934,8 +934,8 @@
 "level": 3,
 "out_size": 1765,
 "ratio": 0.4176,
-"compress_mbps": 10.66,
-"decompress_mbps": 43.12
+"compress_mbps": 11.26,
+"decompress_mbps": 42.45
 },
 {
 "compressor": "native",
@@ -944,8 +944,8 @@
 "level": 4,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 9.79,
-"decompress_mbps": 43.85
+"compress_mbps": 10.86,
+"decompress_mbps": 43.15
 },
 {
 "compressor": "native",
@@ -954,8 +954,8 @@
 "level": 5,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 9.81,
-"decompress_mbps": 43.74
+"compress_mbps": 10.88,
+"decompress_mbps": 43.11
 },
 {
 "compressor": "native",
@@ -964,8 +964,8 @@
 "level": 6,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 9.8,
-"decompress_mbps": 43.73
+"compress_mbps": 10.86,
+"decompress_mbps": 43.12
 },
 {
 "compressor": "native",
@@ -974,8 +974,8 @@
 "level": 7,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 3.7,
-"decompress_mbps": 43.16
+"compress_mbps": 3.82,
+"decompress_mbps": 43.02
 },
 {
 "compressor": "native",
@@ -984,8 +984,8 @@
 "level": 8,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 3.69,
-"decompress_mbps": 43.41
+"compress_mbps": 3.83,
+"decompress_mbps": 42.83
 },
 {
 "compressor": "native",
@@ -994,8 +994,8 @@
 "level": 9,
 "out_size": 1696,
 "ratio": 0.4012,
-"compress_mbps": 1.23,
-"decompress_mbps": 43.4
+"compress_mbps": 1.29,
+"decompress_mbps": 43.06
 },
 {
 "compressor": "zlib",
@@ -1004,8 +1004,8 @@
 "level": 1,
 "out_size": 65130,
 "ratio": 0.4282,
-"compress_mbps": 119.71,
-"decompress_mbps": 401.96
+"compress_mbps": 119.32,
+"decompress_mbps": 390.02
 },
 {
 "compressor": "zlib",
@@ -1014,8 +1014,8 @@
 "level": 2,
 "out_size": 62270,
 "ratio": 0.4094,
-"compress_mbps": 102.69,
-"decompress_mbps": 419.33
+"compress_mbps": 102.29,
+"decompress_mbps": 409.1
 },
 {
 "compressor": "zlib",
@@ -1024,8 +1024,8 @@
 "level": 3,
 "out_size": 59488,
 "ratio": 0.3911,
-"compress_mbps": 67.53,
-"decompress_mbps": 432.91
+"compress_mbps": 67.41,
+"decompress_mbps": 421.58
 },
 {
 "compressor": "zlib",
@@ -1034,8 +1034,8 @@
 "level": 4,
 "out_size": 57679,
 "ratio": 0.3792,
-"compress_mbps": 72.3,
-"decompress_mbps": 409.5
+"compress_mbps": 72.12,
+"decompress_mbps": 405.97
 },
 {
 "compressor": "zlib",
@@ -1044,8 +1044,8 @@
 "level": 5,
 "out_size": 55616,
 "ratio": 0.3657,
-"compress_mbps": 42.17,
-"decompress_mbps": 404.39
+"compress_mbps": 42.01,
+"decompress_mbps": 396.31
 },
 {
 "compressor": "zlib",
@@ -1054,8 +1054,8 @@
 "level": 6,
 "out_size": 54398,
 "ratio": 0.3577,
-"compress_mbps": 25.64,
-"decompress_mbps": 417.63
+"compress_mbps": 25.63,
+"decompress_mbps": 412.54
 },
 {
 "compressor": "zlib",
@@ -1064,8 +1064,8 @@
 "level": 7,
 "out_size": 54253,
 "ratio": 0.3567,
-"compress_mbps": 21.54,
-"decompress_mbps": 420.99
+"compress_mbps": 21.51,
+"decompress_mbps": 415.03
 },
 {
 "compressor": "zlib",
@@ -1074,8 +1074,8 @@
 "level": 8,
 "out_size": 54164,
 "ratio": 0.3561,
-"compress_mbps": 17.08,
-"decompress_mbps": 422.2
+"compress_mbps": 17.05,
+"decompress_mbps": 415.18
 },
 {
 "compressor": "zlib",
@@ -1084,8 +1084,8 @@
 "level": 9,
 "out_size": 54164,
 "ratio": 0.3561,
-"compress_mbps": 17.08,
-"decompress_mbps": 421.12
+"compress_mbps": 17.04,
+"decompress_mbps": 414.11
 },
 {
 "compressor": "zlib",
@@ -1094,8 +1094,8 @@
 "level": 1,
 "out_size": 56791,
 "ratio": 0.4537,
-"compress_mbps": 116.28,
-"decompress_mbps": 396.81
+"compress_mbps": 115.79,
+"decompress_mbps": 382.78
 },
 {
 "compressor": "zlib",
@@ -1104,8 +1104,8 @@
 "level": 2,
 "out_size": 54652,
 "ratio": 0.4366,
-"compress_mbps": 98.46,
-"decompress_mbps": 402.52
+"compress_mbps": 98.29,
+"decompress_mbps": 398.58
 },
 {
 "compressor": "zlib",
@@ -1114,8 +1114,8 @@
 "level": 3,
 "out_size": 52663,
 "ratio": 0.4207,
-"compress_mbps": 62.88,
-"decompress_mbps": 425.47
+"compress_mbps": 62.75,
+"decompress_mbps": 417.94
 },
 {
 "compressor": "zlib",
@@ -1124,8 +1124,8 @@
 "level": 4,
 "out_size": 51266,
 "ratio": 0.4095,
-"compress_mbps": 68.16,
-"decompress_mbps": 396.59
+"compress_mbps": 67.82,
+"decompress_mbps": 396.24
 },
 {
 "compressor": "zlib",
@@ -1134,8 +1134,8 @@
 "level": 5,
 "out_size": 49622,
 "ratio": 0.3964,
-"compress_mbps": 37.68,
-"decompress_mbps": 383.09
+"compress_mbps": 37.62,
+"decompress_mbps": 383.2
 },
 {
 "compressor": "zlib",
@@ -1144,8 +1144,8 @@
 "level": 6,
 "out_size": 48891,
 "ratio": 0.3906,
-"compress_mbps": 22.95,
-"decompress_mbps": 394.2
+"compress_mbps": 22.91,
+"decompress_mbps": 392.14
 },
 {
 "compressor": "zlib",
@@ -1154,8 +1154,8 @@
 "level": 7,
 "out_size": 48801,
 "ratio": 0.3898,
-"compress_mbps": 20.15,
-"decompress_mbps": 391.67
+"compress_mbps": 20.1,
+"decompress_mbps": 391.22
 },
 {
 "compressor": "zlib",
@@ -1164,8 +1164,8 @@
 "level": 8,
 "out_size": 48772,
 "ratio": 0.3896,
-"compress_mbps": 18.24,
-"decompress_mbps": 395.73
+"compress_mbps": 18.18,
+"decompress_mbps": 391.09
 },
 {
 "compressor": "zlib",
@@ -1174,8 +1174,8 @@
 "level": 9,
 "out_size": 48772,
 "ratio": 0.3896,
-"compress_mbps": 18.23,
-"decompress_mbps": 394.97
+"compress_mbps": 18.14,
+"decompress_mbps": 391.96
 },
 {
 "compressor": "zlib",
@@ -1184,8 +1184,8 @@
 "level": 1,
 "out_size": 9028,
 "ratio": 0.3669,
-"compress_mbps": 415.8,
-"decompress_mbps": 1051.6
+"compress_mbps": 412.4,
+"decompress_mbps": 1051.79
 },
 {
 "compressor": "zlib",
@@ -1194,8 +1194,8 @@
 "level": 2,
 "out_size": 8811,
 "ratio": 0.3581,
-"compress_mbps": 222.95,
-"decompress_mbps": 1078.67
+"compress_mbps": 237.96,
+"decompress_mbps": 1072.8
 },
 {
 "compressor": "zlib",
@@ -1204,8 +1204,8 @@
 "level": 3,
 "out_size": 8616,
 "ratio": 0.3502,
-"compress_mbps": 163.58,
-"decompress_mbps": 1097.23
+"compress_mbps": 159.07,
+"decompress_mbps": 1104.72
 },
 {
 "compressor": "zlib",
@@ -1214,8 +1214,8 @@
 "level": 4,
 "out_size": 8219,
 "ratio": 0.3341,
-"compress_mbps": 117.73,
-"decompress_mbps": 1115.28
+"compress_mbps": 117.08,
+"decompress_mbps": 1119.16
 },
 {
 "compressor": "zlib",
@@ -1224,8 +1224,8 @@
 "level": 5,
 "out_size": 8001,
 "ratio": 0.3252,
-"compress_mbps": 86.06,
-"decompress_mbps": 1151.57
+"compress_mbps": 85.13,
+"decompress_mbps": 1143.54
 },
 {
 "compressor": "zlib",
@@ -1234,8 +1234,8 @@
 "level": 6,
 "out_size": 7955,
 "ratio": 0.3233,
-"compress_mbps": 69.14,
-"decompress_mbps": 1158.05
+"compress_mbps": 69.08,
+"decompress_mbps": 1147.96
 },
 {
 "compressor": "zlib",
@@ -1244,8 +1244,8 @@
 "level": 7,
 "out_size": 7933,
 "ratio": 0.3224,
-"compress_mbps": 63.19,
-"decompress_mbps": 1154.57
+"compress_mbps": 63.06,
+"decompress_mbps": 1152.87
 },
 {
 "compressor": "zlib",
@@ -1254,8 +1254,8 @@
 "level": 8,
 "out_size": 7934,
 "ratio": 0.3225,
-"compress_mbps": 58.01,
-"decompress_mbps": 1154.86
+"compress_mbps": 57.89,
+"decompress_mbps": 1156.74
 },
 {
 "compressor": "zlib",
@@ -1264,8 +1264,8 @@
 "level": 9,
 "out_size": 7934,
 "ratio": 0.3225,
-"compress_mbps": 58.2,
-"decompress_mbps": 1158.22
+"compress_mbps": 57.64,
+"decompress_mbps": 1154.63
 },
 {
 "compressor": "zlib",
@@ -1274,8 +1274,8 @@
 "level": 1,
 "out_size": 3647,
 "ratio": 0.3271,
-"compress_mbps": 426.02,
-"decompress_mbps": 1071.06
+"compress_mbps": 423.31,
+"decompress_mbps": 1062.5
 },
 {
 "compressor": "zlib",
@@ -1284,8 +1284,8 @@
 "level": 2,
 "out_size": 3501,
 "ratio": 0.314,
-"compress_mbps": 410.0,
-"decompress_mbps": 1114.39
+"compress_mbps": 405.47,
+"decompress_mbps": 1105.92
 },
 {
 "compressor": "zlib",
@@ -1294,8 +1294,8 @@
 "level": 3,
 "out_size": 3393,
 "ratio": 0.3043,
-"compress_mbps": 338.93,
-"decompress_mbps": 1149.94
+"compress_mbps": 337.24,
+"decompress_mbps": 1137.27
 },
 {
 "compressor": "zlib",
@@ -1304,8 +1304,8 @@
 "level": 4,
 "out_size": 3215,
 "ratio": 0.2883,
-"compress_mbps": 275.02,
-"decompress_mbps": 1168.64
+"compress_mbps": 272.95,
+"decompress_mbps": 1165.06
 },
 {
 "compressor": "zlib",
@@ -1314,8 +1314,8 @@
 "level": 5,
 "out_size": 3140,
 "ratio": 0.2816,
-"compress_mbps": 206.79,
-"decompress_mbps": 1206.02
+"compress_mbps": 205.24,
+"decompress_mbps": 1194.24
 },
 {
 "compressor": "zlib",
@@ -1324,8 +1324,8 @@
 "level": 6,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 154.37,
-"decompress_mbps": 1220.97
+"compress_mbps": 153.89,
+"decompress_mbps": 1206.84
 },
 {
 "compressor": "zlib",
@@ -1334,8 +1334,8 @@
 "level": 7,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 132.58,
-"decompress_mbps": 1220.27
+"compress_mbps": 131.84,
+"decompress_mbps": 1209.17
 },
 {
 "compressor": "zlib",
@@ -1344,8 +1344,8 @@
 "level": 8,
 "out_size": 3109,
 "ratio": 0.2788,
-"compress_mbps": 111.68,
-"decompress_mbps": 1222.8
+"compress_mbps": 111.1,
+"decompress_mbps": 1221.82
 },
 {
 "compressor": "zlib",
@@ -1354,8 +1354,8 @@
 "level": 9,
 "out_size": 3109,
 "ratio": 0.2788,
-"compress_mbps": 111.26,
-"decompress_mbps": 1215.95
+"compress_mbps": 110.57,
+"decompress_mbps": 1214.84
 },
 {
 "compressor": "zlib",
@@ -1364,8 +1364,8 @@
 "level": 1,
 "out_size": 1326,
 "ratio": 0.3564,
-"compress_mbps": 316.76,
-"decompress_mbps": 777.18
+"compress_mbps": 314.59,
+"decompress_mbps": 780.6
 },
 {
 "compressor": "zlib",
@@ -1374,8 +1374,8 @@
 "level": 2,
 "out_size": 1306,
 "ratio": 0.351,
-"compress_mbps": 310.49,
-"decompress_mbps": 780.77
+"compress_mbps": 309.46,
+"decompress_mbps": 778.89
 },
 {
 "compressor": "zlib",
@@ -1384,8 +1384,8 @@
 "level": 3,
 "out_size": 1301,
 "ratio": 0.3496,
-"compress_mbps": 291.68,
-"decompress_mbps": 782.84
+"compress_mbps": 290.44,
+"decompress_mbps": 789.99
 },
 {
 "compressor": "zlib",
@@ -1394,8 +1394,8 @@
 "level": 4,
 "out_size": 1228,
 "ratio": 0.33,
-"compress_mbps": 234.19,
-"decompress_mbps": 823.54
+"compress_mbps": 232.65,
+"decompress_mbps": 818.41
 },
 {
 "compressor": "zlib",
@@ -1404,8 +1404,8 @@
 "level": 5,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 198.9,
-"decompress_mbps": 821.63
+"compress_mbps": 198.08,
+"decompress_mbps": 824.88
 },
 {
 "compressor": "zlib",
@@ -1414,8 +1414,8 @@
 "level": 6,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 178.37,
-"decompress_mbps": 826.41
+"compress_mbps": 177.82,
+"decompress_mbps": 826.61
 },
 {
 "compressor": "zlib",
@@ -1424,8 +1424,8 @@
 "level": 7,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 171.24,
-"decompress_mbps": 828.54
+"compress_mbps": 170.42,
+"decompress_mbps": 824.49
 },
 {
 "compressor": "zlib",
@@ -1434,8 +1434,8 @@
 "level": 8,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 167.78,
-"decompress_mbps": 827.76
+"compress_mbps": 167.47,
+"decompress_mbps": 825.26
 },
 {
 "compressor": "zlib",
@@ -1444,8 +1444,8 @@
 "level": 9,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 168.34,
-"decompress_mbps": 829.31
+"compress_mbps": 167.55,
+"decompress_mbps": 825.26
 },
 {
 "compressor": "zlib",
@@ -1454,8 +1454,8 @@
 "level": 1,
 "out_size": 242293,
 "ratio": 0.2353,
-"compress_mbps": 263.29,
-"decompress_mbps": 839.08
+"compress_mbps": 261.09,
+"decompress_mbps": 837.67
 },
 {
 "compressor": "zlib",
@@ -1464,8 +1464,8 @@
 "level": 2,
 "out_size": 233553,
 "ratio": 0.2268,
-"compress_mbps": 248.51,
-"decompress_mbps": 995.88
+"compress_mbps": 247.86,
+"decompress_mbps": 990.25
 },
 {
 "compressor": "zlib",
@@ -1474,8 +1474,8 @@
 "level": 3,
 "out_size": 228222,
 "ratio": 0.2216,
-"compress_mbps": 195.95,
-"decompress_mbps": 1055.23
+"compress_mbps": 195.83,
+"decompress_mbps": 1051.94
 },
 {
 "compressor": "zlib",
@@ -1484,8 +1484,8 @@
 "level": 4,
 "out_size": 223668,
 "ratio": 0.2172,
-"compress_mbps": 177.64,
-"decompress_mbps": 1083.37
+"compress_mbps": 176.6,
+"decompress_mbps": 1078.14
 },
 {
 "compressor": "zlib",
@@ -1494,8 +1494,8 @@
 "level": 5,
 "out_size": 205994,
 "ratio": 0.2,
-"compress_mbps": 110.68,
-"decompress_mbps": 1041.21
+"compress_mbps": 109.61,
+"decompress_mbps": 1039.6
 },
 {
 "compressor": "zlib",
@@ -1504,8 +1504,8 @@
 "level": 6,
 "out_size": 203986,
 "ratio": 0.1981,
-"compress_mbps": 49.82,
-"decompress_mbps": 1041.59
+"compress_mbps": 49.97,
+"decompress_mbps": 1037.88
 },
 {
 "compressor": "zlib",
@@ -1514,8 +1514,8 @@
 "level": 7,
 "out_size": 207681,
 "ratio": 0.2017,
-"compress_mbps": 36.85,
-"decompress_mbps": 1035.34
+"compress_mbps": 37.05,
+"decompress_mbps": 1032.63
 },
 {
 "compressor": "zlib",
@@ -1524,8 +1524,8 @@
 "level": 8,
 "out_size": 206827,
 "ratio": 0.2009,
-"compress_mbps": 7.27,
-"decompress_mbps": 1006.22
+"compress_mbps": 7.28,
+"decompress_mbps": 1006.1
 },
 {
 "compressor": "zlib",
@@ -1534,8 +1534,8 @@
 "level": 9,
 "out_size": 207023,
 "ratio": 0.201,
-"compress_mbps": 3.42,
-"decompress_mbps": 1010.03
+"compress_mbps": 3.41,
+"decompress_mbps": 1004.17
 },
 {
 "compressor": "zlib",
@@ -1544,8 +1544,8 @@
 "level": 1,
 "out_size": 174124,
 "ratio": 0.408,
-"compress_mbps": 124.45,
-"decompress_mbps": 395.34
+"compress_mbps": 123.85,
+"decompress_mbps": 392.35
 },
 {
 "compressor": "zlib",
@@ -1554,8 +1554,8 @@
 "level": 2,
 "out_size": 166150,
 "ratio": 0.3893,
-"compress_mbps": 105.49,
-"decompress_mbps": 404.08
+"compress_mbps": 105.43,
+"decompress_mbps": 403.94
 },
 {
 "compressor": "zlib",
@@ -1564,8 +1564,8 @@
 "level": 3,
 "out_size": 158784,
 "ratio": 0.3721,
-"compress_mbps": 70.49,
-"decompress_mbps": 423.1
+"compress_mbps": 70.51,
+"decompress_mbps": 419.28
 },
 {
 "compressor": "zlib",
@@ -1574,8 +1574,8 @@
 "level": 4,
 "out_size": 152782,
 "ratio": 0.358,
-"compress_mbps": 74.26,
-"decompress_mbps": 410.42
+"compress_mbps": 74.24,
+"decompress_mbps": 407.07
 },
 {
 "compressor": "zlib",
@@ -1584,8 +1584,8 @@
 "level": 5,
 "out_size": 147196,
 "ratio": 0.3449,
-"compress_mbps": 43.54,
-"decompress_mbps": 403.31
+"compress_mbps": 43.62,
+"decompress_mbps": 403.07
 },
 {
 "compressor": "zlib",
@@ -1594,8 +1594,8 @@
 "level": 6,
 "out_size": 144898,
 "ratio": 0.3395,
-"compress_mbps": 26.43,
-"decompress_mbps": 414.13
+"compress_mbps": 26.41,
+"decompress_mbps": 413.65
 },
 {
 "compressor": "zlib",
@@ -1604,8 +1604,8 @@
 "level": 7,
 "out_size": 144589,
 "ratio": 0.3388,
-"compress_mbps": 22.93,
-"decompress_mbps": 418.61
+"compress_mbps": 22.89,
+"decompress_mbps": 415.63
 },
 {
 "compressor": "zlib",
@@ -1614,8 +1614,8 @@
 "level": 8,
 "out_size": 144436,
 "ratio": 0.3385,
-"compress_mbps": 19.71,
-"decompress_mbps": 417.98
+"compress_mbps": 19.66,
+"decompress_mbps": 417.23
 },
 {
 "compressor": "zlib",
@@ -1624,8 +1624,8 @@
 "level": 9,
 "out_size": 144433,
 "ratio": 0.3384,
-"compress_mbps": 19.65,
-"decompress_mbps": 419.32
+"compress_mbps": 19.58,
+"decompress_mbps": 416.8
 },
 {
 "compressor": "zlib",
@@ -1634,8 +1634,8 @@
 "level": 1,
 "out_size": 228883,
 "ratio": 0.475,
-"compress_mbps": 108.85,
-"decompress_mbps": 370.54
+"compress_mbps": 108.55,
+"decompress_mbps": 370.7
 },
 {
 "compressor": "zlib",
@@ -1644,8 +1644,8 @@
 "level": 2,
 "out_size": 219047,
 "ratio": 0.4546,
-"compress_mbps": 91.55,
-"decompress_mbps": 385.96
+"compress_mbps": 91.19,
+"decompress_mbps": 384.69
 },
 {
 "compressor": "zlib",
@@ -1654,8 +1654,8 @@
 "level": 3,
 "out_size": 209408,
 "ratio": 0.4346,
-"compress_mbps": 55.66,
-"decompress_mbps": 400.38
+"compress_mbps": 55.63,
+"decompress_mbps": 398.48
 },
 {
 "compressor": "zlib",
@@ -1664,8 +1664,8 @@
 "level": 4,
 "out_size": 205916,
 "ratio": 0.4273,
-"compress_mbps": 62.79,
-"decompress_mbps": 374.33
+"compress_mbps": 62.54,
+"decompress_mbps": 374.43
 },
 {
 "compressor": "zlib",
@@ -1674,8 +1674,8 @@
 "level": 5,
 "out_size": 199188,
 "ratio": 0.4134,
-"compress_mbps": 33.11,
-"decompress_mbps": 358.92
+"compress_mbps": 33.15,
+"decompress_mbps": 356.87
 },
 {
 "compressor": "zlib",
@@ -1684,8 +1684,8 @@
 "level": 6,
 "out_size": 195255,
 "ratio": 0.4052,
-"compress_mbps": 19.46,
-"decompress_mbps": 366.61
+"compress_mbps": 19.42,
+"decompress_mbps": 365.73
 },
 {
 "compressor": "zlib",
@@ -1694,8 +1694,8 @@
 "level": 7,
 "out_size": 194657,
 "ratio": 0.404,
-"compress_mbps": 16.42,
-"decompress_mbps": 368.46
+"compress_mbps": 16.43,
+"decompress_mbps": 368.02
 },
 {
 "compressor": "zlib",
@@ -1704,8 +1704,8 @@
 "level": 8,
 "out_size": 194326,
 "ratio": 0.4033,
-"compress_mbps": 13.0,
-"decompress_mbps": 369.7
+"compress_mbps": 12.97,
+"decompress_mbps": 367.49
 },
 {
 "compressor": "zlib",
@@ -1714,8 +1714,8 @@
 "level": 9,
 "out_size": 194326,
 "ratio": 0.4033,
-"compress_mbps": 13.0,
-"decompress_mbps": 366.53
+"compress_mbps": 12.96,
+"decompress_mbps": 368.35
 },
 {
 "compressor": "zlib",
@@ -1724,8 +1724,8 @@
 "level": 1,
 "out_size": 65553,
 "ratio": 0.1277,
-"compress_mbps": 272.76,
-"decompress_mbps": 904.8
+"compress_mbps": 274.89,
+"decompress_mbps": 883.45
 },
 {
 "compressor": "zlib",
@@ -1734,8 +1734,8 @@
 "level": 2,
 "out_size": 63891,
 "ratio": 0.1245,
-"compress_mbps": 246.25,
-"decompress_mbps": 935.84
+"compress_mbps": 247.97,
+"decompress_mbps": 922.92
 },
 {
 "compressor": "zlib",
@@ -1744,8 +1744,8 @@
 "level": 3,
 "out_size": 62515,
 "ratio": 0.1218,
-"compress_mbps": 193.0,
-"decompress_mbps": 1003.84
+"compress_mbps": 194.77,
+"decompress_mbps": 991.64
 },
 {
 "compressor": "zlib",
@@ -1754,8 +1754,8 @@
 "level": 4,
 "out_size": 58451,
 "ratio": 0.1139,
-"compress_mbps": 168.23,
-"decompress_mbps": 702.34
+"compress_mbps": 169.93,
+"decompress_mbps": 699.01
 },
 {
 "compressor": "zlib",
@@ -1764,8 +1764,8 @@
 "level": 5,
 "out_size": 57410,
 "ratio": 0.1119,
-"compress_mbps": 129.9,
-"decompress_mbps": 735.99
+"compress_mbps": 130.72,
+"decompress_mbps": 729.68
 },
 {
 "compressor": "zlib",
@@ -1774,8 +1774,8 @@
 "level": 6,
 "out_size": 56459,
 "ratio": 0.11,
-"compress_mbps": 76.54,
-"decompress_mbps": 780.87
+"compress_mbps": 77.36,
+"decompress_mbps": 778.51
 },
 {
 "compressor": "zlib",
@@ -1784,8 +1784,8 @@
 "level": 7,
 "out_size": 55358,
 "ratio": 0.1079,
-"compress_mbps": 59.81,
-"decompress_mbps": 822.74
+"compress_mbps": 60.48,
+"decompress_mbps": 812.99
 },
 {
 "compressor": "zlib",
@@ -1794,8 +1794,8 @@
 "level": 8,
 "out_size": 52991,
 "ratio": 0.1033,
-"compress_mbps": 27.14,
-"decompress_mbps": 874.87
+"compress_mbps": 27.48,
+"decompress_mbps": 867.55
 },
 {
 "compressor": "zlib",
@@ -1804,8 +1804,8 @@
 "level": 9,
 "out_size": 52215,
 "ratio": 0.1017,
-"compress_mbps": 9.66,
-"decompress_mbps": 894.17
+"compress_mbps": 9.79,
+"decompress_mbps": 888.09
 },
 {
 "compressor": "zlib",
@@ -1814,8 +1814,8 @@
 "level": 1,
 "out_size": 14112,
 "ratio": 0.369,
-"compress_mbps": 129.22,
-"decompress_mbps": 943.75
+"compress_mbps": 129.27,
+"decompress_mbps": 921.43
 },
 {
 "compressor": "zlib",
@@ -1824,8 +1824,8 @@
 "level": 2,
 "out_size": 13815,
 "ratio": 0.3613,
-"compress_mbps": 110.17,
-"decompress_mbps": 974.47
+"compress_mbps": 109.53,
+"decompress_mbps": 972.83
 },
 {
 "compressor": "zlib",
@@ -1834,8 +1834,8 @@
 "level": 3,
 "out_size": 13795,
 "ratio": 0.3607,
-"compress_mbps": 79.62,
-"decompress_mbps": 1007.39
+"compress_mbps": 79.26,
+"decompress_mbps": 1008.45
 },
 {
 "compressor": "zlib",
@@ -1844,8 +1844,8 @@
 "level": 4,
 "out_size": 13375,
 "ratio": 0.3498,
-"compress_mbps": 81.24,
-"decompress_mbps": 1007.75
+"compress_mbps": 81.03,
+"decompress_mbps": 997.39
 },
 {
 "compressor": "zlib",
@@ -1854,8 +1854,8 @@
 "level": 5,
 "out_size": 13062,
 "ratio": 0.3416,
-"compress_mbps": 56.06,
-"decompress_mbps": 1040.47
+"compress_mbps": 55.88,
+"decompress_mbps": 1030.77
 },
 {
 "compressor": "zlib",
@@ -1864,8 +1864,8 @@
 "level": 6,
 "out_size": 12984,
 "ratio": 0.3395,
-"compress_mbps": 33.21,
-"decompress_mbps": 1058.04
+"compress_mbps": 33.17,
+"decompress_mbps": 1041.9
 },
 {
 "compressor": "zlib",
@@ -1874,8 +1874,8 @@
 "level": 7,
 "out_size": 12949,
 "ratio": 0.3386,
-"compress_mbps": 25.5,
-"decompress_mbps": 1061.61
+"compress_mbps": 25.47,
+"decompress_mbps": 1064.25
 },
 {
 "compressor": "zlib",
@@ -1884,8 +1884,8 @@
 "level": 8,
 "out_size": 12894,
 "ratio": 0.3372,
-"compress_mbps": 11.08,
-"decompress_mbps": 1076.56
+"compress_mbps": 11.06,
+"decompress_mbps": 1075.51
 },
 {
 "compressor": "zlib",
@@ -1894,8 +1894,8 @@
 "level": 9,
 "out_size": 12832,
 "ratio": 0.3356,
-"compress_mbps": 5.09,
-"decompress_mbps": 1083.08
+"compress_mbps": 5.08,
+"decompress_mbps": 1064.71
 },
 {
 "compressor": "zlib",
@@ -1904,8 +1904,8 @@
 "level": 1,
 "out_size": 1846,
 "ratio": 0.4367,
-"compress_mbps": 292.18,
-"decompress_mbps": 708.22
+"compress_mbps": 289.91,
+"decompress_mbps": 707.1
 },
 {
 "compressor": "zlib",
@@ -1914,8 +1914,8 @@
 "level": 2,
 "out_size": 1820,
 "ratio": 0.4306,
-"compress_mbps": 285.43,
-"decompress_mbps": 723.99
+"compress_mbps": 283.11,
+"decompress_mbps": 719.6
 },
 {
 "compressor": "zlib",
@@ -1924,8 +1924,8 @@
 "level": 3,
 "out_size": 1808,
 "ratio": 0.4277,
-"compress_mbps": 273.28,
-"decompress_mbps": 722.18
+"compress_mbps": 271.95,
+"decompress_mbps": 725.69
 },
 {
 "compressor": "zlib",
@@ -1934,8 +1934,8 @@
 "level": 4,
 "out_size": 1749,
 "ratio": 0.4138,
-"compress_mbps": 227.81,
-"decompress_mbps": 742.12
+"compress_mbps": 227.07,
+"decompress_mbps": 742.94
 },
 {
 "compressor": "zlib",
@@ -1944,8 +1944,8 @@
 "level": 5,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 203.36,
-"decompress_mbps": 752.23
+"compress_mbps": 202.25,
+"decompress_mbps": 746.65
 },
 {
 "compressor": "zlib",
@@ -1954,8 +1954,8 @@
 "level": 6,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 199.66,
-"decompress_mbps": 748.04
+"compress_mbps": 199.26,
+"decompress_mbps": 749.85
 },
 {
 "compressor": "zlib",
@@ -1964,8 +1964,8 @@
 "level": 7,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 198.17,
-"decompress_mbps": 744.17
+"compress_mbps": 197.02,
+"decompress_mbps": 745.55
 },
 {
 "compressor": "zlib",
@@ -1974,8 +1974,8 @@
 "level": 8,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 198.1,
-"decompress_mbps": 744.03
+"compress_mbps": 196.93,
+"decompress_mbps": 748.87
 },
 {
 "compressor": "zlib",
@@ -1984,8 +1984,8 @@
 "level": 9,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 198.03,
-"decompress_mbps": 744.45
+"compress_mbps": 197.32,
+"decompress_mbps": 747.21
 },
 {
 "compressor": "miniz_oxide",
@@ -1994,8 +1994,8 @@
 "level": 1,
 "out_size": 76470,
 "ratio": 0.5028,
-"compress_mbps": 156.4,
-"decompress_mbps": 441.81
+"compress_mbps": 152.87,
+"decompress_mbps": 440.71
 },
 {
 "compressor": "miniz_oxide",
@@ -2004,8 +2004,8 @@
 "level": 2,
 "out_size": 62765,
 "ratio": 0.4127,
-"compress_mbps": 134.45,
-"decompress_mbps": 490.73
+"compress_mbps": 132.63,
+"decompress_mbps": 491.14
 },
 {
 "compressor": "miniz_oxide",
@@ -2014,8 +2014,8 @@
 "level": 3,
 "out_size": 57162,
 "ratio": 0.3758,
-"compress_mbps": 72.66,
-"decompress_mbps": 553.35
+"compress_mbps": 72.1,
+"decompress_mbps": 547.09
 },
 {
 "compressor": "miniz_oxide",
@@ -2024,8 +2024,8 @@
 "level": 4,
 "out_size": 56826,
 "ratio": 0.3736,
-"compress_mbps": 64.87,
-"decompress_mbps": 541.5
+"compress_mbps": 63.96,
+"decompress_mbps": 536.21
 },
 {
 "compressor": "miniz_oxide",
@@ -2034,8 +2034,8 @@
 "level": 5,
 "out_size": 55696,
 "ratio": 0.3662,
-"compress_mbps": 47.15,
-"decompress_mbps": 529.66
+"compress_mbps": 46.65,
+"decompress_mbps": 524.91
 },
 {
 "compressor": "miniz_oxide",
@@ -2044,8 +2044,8 @@
 "level": 6,
 "out_size": 54440,
 "ratio": 0.3579,
-"compress_mbps": 26.64,
-"decompress_mbps": 545.13
+"compress_mbps": 26.47,
+"decompress_mbps": 538.34
 },
 {
 "compressor": "miniz_oxide",
@@ -2054,8 +2054,8 @@
 "level": 7,
 "out_size": 54283,
 "ratio": 0.3569,
-"compress_mbps": 22.46,
-"decompress_mbps": 547.49
+"compress_mbps": 22.33,
+"decompress_mbps": 540.87
 },
 {
 "compressor": "miniz_oxide",
@@ -2064,8 +2064,8 @@
 "level": 8,
 "out_size": 54221,
 "ratio": 0.3565,
-"compress_mbps": 19.79,
-"decompress_mbps": 546.76
+"compress_mbps": 19.67,
+"decompress_mbps": 540.9
 },
 {
 "compressor": "miniz_oxide",
@@ -2074,8 +2074,8 @@
 "level": 9,
 "out_size": 54217,
 "ratio": 0.3565,
-"compress_mbps": 19.55,
-"decompress_mbps": 547.03
+"compress_mbps": 19.43,
+"decompress_mbps": 540.5
 },
 {
 "compressor": "miniz_oxide",
@@ -2084,8 +2084,8 @@
 "level": 1,
 "out_size": 64926,
 "ratio": 0.5187,
-"compress_mbps": 150.37,
-"decompress_mbps": 420.76
+"compress_mbps": 148.15,
+"decompress_mbps": 416.51
 },
 {
 "compressor": "miniz_oxide",
@@ -2094,8 +2094,8 @@
 "level": 2,
 "out_size": 54985,
 "ratio": 0.4393,
-"compress_mbps": 125.76,
-"decompress_mbps": 467.18
+"compress_mbps": 124.16,
+"decompress_mbps": 465.42
 },
 {
 "compressor": "miniz_oxide",
@@ -2104,8 +2104,8 @@
 "level": 3,
 "out_size": 51148,
 "ratio": 0.4086,
-"compress_mbps": 67.53,
-"decompress_mbps": 538.84
+"compress_mbps": 67.05,
+"decompress_mbps": 532.33
 },
 {
 "compressor": "miniz_oxide",
@@ -2114,8 +2114,8 @@
 "level": 4,
 "out_size": 50599,
 "ratio": 0.4042,
-"compress_mbps": 59.54,
-"decompress_mbps": 529.42
+"compress_mbps": 58.81,
+"decompress_mbps": 521.49
 },
 {
 "compressor": "miniz_oxide",
@@ -2124,8 +2124,8 @@
 "level": 5,
 "out_size": 49775,
 "ratio": 0.3976,
-"compress_mbps": 42.92,
-"decompress_mbps": 515.15
+"compress_mbps": 42.5,
+"decompress_mbps": 505.22
 },
 {
 "compressor": "miniz_oxide",
@@ -2134,8 +2134,8 @@
 "level": 6,
 "out_size": 48967,
 "ratio": 0.3912,
-"compress_mbps": 25.08,
-"decompress_mbps": 525.18
+"compress_mbps": 24.9,
+"decompress_mbps": 520.0
 },
 {
 "compressor": "miniz_oxide",
@@ -2144,8 +2144,8 @@
 "level": 7,
 "out_size": 48870,
 "ratio": 0.3904,
-"compress_mbps": 22.24,
-"decompress_mbps": 529.2
+"compress_mbps": 22.11,
+"decompress_mbps": 521.81
 },
 {
 "compressor": "miniz_oxide",
@@ -2154,8 +2154,8 @@
 "level": 8,
 "out_size": 48845,
 "ratio": 0.3902,
-"compress_mbps": 20.95,
-"decompress_mbps": 528.02
+"compress_mbps": 20.82,
+"decompress_mbps": 522.22
 },
 {
 "compressor": "miniz_oxide",
@@ -2164,8 +2164,8 @@
 "level": 9,
 "out_size": 48845,
 "ratio": 0.3902,
-"compress_mbps": 20.95,
-"decompress_mbps": 526.74
+"compress_mbps": 20.83,
+"decompress_mbps": 522.52
 },
 {
 "compressor": "miniz_oxide",
@@ -2174,8 +2174,8 @@
 "level": 1,
 "out_size": 10024,
 "ratio": 0.4074,
-"compress_mbps": 569.59,
-"decompress_mbps": 903.58
+"compress_mbps": 558.45,
+"decompress_mbps": 901.5
 },
 {
 "compressor": "miniz_oxide",
@@ -2184,8 +2184,8 @@
 "level": 2,
 "out_size": 8577,
 "ratio": 0.3486,
-"compress_mbps": 264.04,
-"decompress_mbps": 933.3
+"compress_mbps": 252.04,
+"decompress_mbps": 922.84
 },
 {
 "compressor": "miniz_oxide",
@@ -2194,8 +2194,8 @@
 "level": 3,
 "out_size": 8168,
 "ratio": 0.332,
-"compress_mbps": 155.79,
-"decompress_mbps": 948.16
+"compress_mbps": 153.41,
+"decompress_mbps": 945.3
 },
 {
 "compressor": "miniz_oxide",
@@ -2204,8 +2204,8 @@
 "level": 4,
 "out_size": 8069,
 "ratio": 0.328,
-"compress_mbps": 115.11,
-"decompress_mbps": 965.72
+"compress_mbps": 114.91,
+"decompress_mbps": 960.03
 },
 {
 "compressor": "miniz_oxide",
@@ -2214,8 +2214,8 @@
 "level": 5,
 "out_size": 7997,
 "ratio": 0.325,
-"compress_mbps": 99.78,
-"decompress_mbps": 997.5
+"compress_mbps": 99.19,
+"decompress_mbps": 990.3
 },
 {
 "compressor": "miniz_oxide",
@@ -2224,8 +2224,8 @@
 "level": 6,
 "out_size": 7952,
 "ratio": 0.3232,
-"compress_mbps": 75.11,
-"decompress_mbps": 1004.33
+"compress_mbps": 74.62,
+"decompress_mbps": 995.3
 },
 {
 "compressor": "miniz_oxide",
@@ -2234,8 +2234,8 @@
 "level": 7,
 "out_size": 7947,
 "ratio": 0.323,
-"compress_mbps": 72.71,
-"decompress_mbps": 1005.45
+"compress_mbps": 72.01,
+"decompress_mbps": 1001.38
 },
 {
 "compressor": "miniz_oxide",
@@ -2244,8 +2244,8 @@
 "level": 8,
 "out_size": 7947,
 "ratio": 0.323,
-"compress_mbps": 71.69,
-"decompress_mbps": 1006.36
+"compress_mbps": 70.88,
+"decompress_mbps": 1000.05
 },
 {
 "compressor": "miniz_oxide",
@@ -2254,8 +2254,8 @@
 "level": 9,
 "out_size": 7947,
 "ratio": 0.323,
-"compress_mbps": 71.44,
-"decompress_mbps": 1007.18
+"compress_mbps": 70.74,
+"decompress_mbps": 999.93
 },
 {
 "compressor": "miniz_oxide",
@@ -2264,8 +2264,8 @@
 "level": 1,
 "out_size": 4061,
 "ratio": 0.3642,
-"compress_mbps": 506.24,
-"decompress_mbps": 854.09
+"compress_mbps": 496.71,
+"decompress_mbps": 850.68
 },
 {
 "compressor": "miniz_oxide",
@@ -2274,8 +2274,8 @@
 "level": 2,
 "out_size": 3446,
 "ratio": 0.3091,
-"compress_mbps": 303.65,
-"decompress_mbps": 892.14
+"compress_mbps": 300.12,
+"decompress_mbps": 886.42
 },
 {
 "compressor": "miniz_oxide",
@@ -2284,8 +2284,8 @@
 "level": 3,
 "out_size": 3201,
 "ratio": 0.2871,
-"compress_mbps": 234.21,
-"decompress_mbps": 926.74
+"compress_mbps": 232.44,
+"decompress_mbps": 916.05
 },
 {
 "compressor": "miniz_oxide",
@@ -2294,8 +2294,8 @@
 "level": 4,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 194.21,
-"decompress_mbps": 951.29
+"compress_mbps": 192.39,
+"decompress_mbps": 944.19
 },
 {
 "compressor": "miniz_oxide",
@@ -2304,8 +2304,8 @@
 "level": 5,
 "out_size": 3139,
 "ratio": 0.2815,
-"compress_mbps": 162.5,
-"decompress_mbps": 971.18
+"compress_mbps": 161.86,
+"decompress_mbps": 959.79
 },
 {
 "compressor": "miniz_oxide",
@@ -2314,8 +2314,8 @@
 "level": 6,
 "out_size": 3115,
 "ratio": 0.2794,
-"compress_mbps": 116.76,
-"decompress_mbps": 988.61
+"compress_mbps": 115.09,
+"decompress_mbps": 973.23
 },
 {
 "compressor": "miniz_oxide",
@@ -2324,8 +2324,8 @@
 "level": 7,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 106.71,
-"decompress_mbps": 987.05
+"compress_mbps": 105.62,
+"decompress_mbps": 976.35
 },
 {
 "compressor": "miniz_oxide",
@@ -2334,8 +2334,8 @@
 "level": 8,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 103.54,
-"decompress_mbps": 989.8
+"compress_mbps": 102.68,
+"decompress_mbps": 973.94
 },
 {
 "compressor": "miniz_oxide",
@@ -2344,8 +2344,8 @@
 "level": 9,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 102.91,
-"decompress_mbps": 990.08
+"compress_mbps": 102.3,
+"decompress_mbps": 975.19
 },
 {
 "compressor": "miniz_oxide",
@@ -2354,8 +2354,8 @@
 "level": 1,
 "out_size": 1410,
 "ratio": 0.3789,
-"compress_mbps": 364.45,
-"decompress_mbps": 593.81
+"compress_mbps": 365.76,
+"decompress_mbps": 582.7
 },
 {
 "compressor": "miniz_oxide",
@@ -2364,8 +2364,8 @@
 "level": 2,
 "out_size": 1262,
 "ratio": 0.3392,
-"compress_mbps": 238.34,
-"decompress_mbps": 604.02
+"compress_mbps": 238.08,
+"decompress_mbps": 589.86
 },
 {
 "compressor": "miniz_oxide",
@@ -2374,8 +2374,8 @@
 "level": 3,
 "out_size": 1238,
 "ratio": 0.3327,
-"compress_mbps": 207.1,
-"decompress_mbps": 602.69
+"compress_mbps": 206.69,
+"decompress_mbps": 591.63
 },
 {
 "compressor": "miniz_oxide",
@@ -2384,8 +2384,8 @@
 "level": 4,
 "out_size": 1219,
 "ratio": 0.3276,
-"compress_mbps": 176.98,
-"decompress_mbps": 620.82
+"compress_mbps": 177.6,
+"decompress_mbps": 609.0
 },
 {
 "compressor": "miniz_oxide",
@@ -2394,8 +2394,8 @@
 "level": 5,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 163.08,
-"decompress_mbps": 626.3
+"compress_mbps": 161.68,
+"decompress_mbps": 614.27
 },
 {
 "compressor": "miniz_oxide",
@@ -2404,8 +2404,8 @@
 "level": 6,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 147.98,
-"decompress_mbps": 630.31
+"compress_mbps": 147.07,
+"decompress_mbps": 615.55
 },
 {
 "compressor": "miniz_oxide",
@@ -2414,8 +2414,8 @@
 "level": 7,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 147.58,
-"decompress_mbps": 631.09
+"compress_mbps": 146.18,
+"decompress_mbps": 617.37
 },
 {
 "compressor": "miniz_oxide",
@@ -2424,8 +2424,8 @@
 "level": 8,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 147.06,
-"decompress_mbps": 630.87
+"compress_mbps": 146.2,
+"decompress_mbps": 617.47
 },
 {
 "compressor": "miniz_oxide",
@@ -2434,8 +2434,8 @@
 "level": 9,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 146.81,
-"decompress_mbps": 629.75
+"compress_mbps": 146.11,
+"decompress_mbps": 617.58
 },
 {
 "compressor": "miniz_oxide",
@@ -2444,8 +2444,8 @@
 "level": 1,
 "out_size": 274412,
 "ratio": 0.2665,
-"compress_mbps": 451.52,
-"decompress_mbps": 797.15
+"compress_mbps": 445.07,
+"decompress_mbps": 792.24
 },
 {
 "compressor": "miniz_oxide",
@@ -2454,8 +2454,8 @@
 "level": 2,
 "out_size": 213239,
 "ratio": 0.2071,
-"compress_mbps": 276.02,
-"decompress_mbps": 896.92
+"compress_mbps": 273.07,
+"decompress_mbps": 872.8
 },
 {
 "compressor": "miniz_oxide",
@@ -2464,8 +2464,8 @@
 "level": 3,
 "out_size": 232107,
 "ratio": 0.2254,
-"compress_mbps": 137.58,
-"decompress_mbps": 941.3
+"compress_mbps": 136.26,
+"decompress_mbps": 912.41
 },
 {
 "compressor": "miniz_oxide",
@@ -2474,8 +2474,8 @@
 "level": 4,
 "out_size": 202733,
 "ratio": 0.1969,
-"compress_mbps": 130.29,
-"decompress_mbps": 948.02
+"compress_mbps": 129.09,
+"decompress_mbps": 921.92
 },
 {
 "compressor": "miniz_oxide",
@@ -2484,8 +2484,8 @@
 "level": 5,
 "out_size": 207803,
 "ratio": 0.2018,
-"compress_mbps": 84.49,
-"decompress_mbps": 960.31
+"compress_mbps": 83.85,
+"decompress_mbps": 943.24
 },
 {
 "compressor": "miniz_oxide",
@@ -2494,8 +2494,8 @@
 "level": 6,
 "out_size": 205270,
 "ratio": 0.1993,
-"compress_mbps": 27.27,
-"decompress_mbps": 986.55
+"compress_mbps": 27.2,
+"decompress_mbps": 970.44
 },
 {
 "compressor": "miniz_oxide",
@@ -2504,8 +2504,8 @@
 "level": 7,
 "out_size": 209951,
 "ratio": 0.2039,
-"compress_mbps": 19.3,
-"decompress_mbps": 995.22
+"compress_mbps": 19.26,
+"decompress_mbps": 978.2
 },
 {
 "compressor": "miniz_oxide",
@@ -2514,8 +2514,8 @@
 "level": 8,
 "out_size": 209656,
 "ratio": 0.2036,
-"compress_mbps": 12.22,
-"decompress_mbps": 1005.87
+"compress_mbps": 12.19,
+"decompress_mbps": 992.97
 },
 {
 "compressor": "miniz_oxide",
@@ -2524,8 +2524,8 @@
 "level": 9,
 "out_size": 209189,
 "ratio": 0.2031,
-"compress_mbps": 8.94,
-"decompress_mbps": 1007.09
+"compress_mbps": 8.92,
+"decompress_mbps": 995.87
 },
 {
 "compressor": "miniz_oxide",
@@ -2534,8 +2534,8 @@
 "level": 1,
 "out_size": 208640,
 "ratio": 0.4889,
-"compress_mbps": 156.76,
-"decompress_mbps": 427.43
+"compress_mbps": 153.33,
+"decompress_mbps": 425.13
 },
 {
 "compressor": "miniz_oxide",
@@ -2544,8 +2544,8 @@
 "level": 2,
 "out_size": 167329,
 "ratio": 0.3921,
-"compress_mbps": 140.18,
-"decompress_mbps": 466.19
+"compress_mbps": 138.14,
+"decompress_mbps": 463.41
 },
 {
 "compressor": "miniz_oxide",
@@ -2554,8 +2554,8 @@
 "level": 3,
 "out_size": 151097,
 "ratio": 0.3541,
-"compress_mbps": 73.92,
-"decompress_mbps": 511.36
+"compress_mbps": 73.45,
+"decompress_mbps": 511.24
 },
 {
 "compressor": "miniz_oxide",
@@ -2564,8 +2564,8 @@
 "level": 4,
 "out_size": 150035,
 "ratio": 0.3516,
-"compress_mbps": 66.88,
-"decompress_mbps": 512.34
+"compress_mbps": 66.08,
+"decompress_mbps": 509.43
 },
 {
 "compressor": "miniz_oxide",
@@ -2574,8 +2574,8 @@
 "level": 5,
 "out_size": 147375,
 "ratio": 0.3453,
-"compress_mbps": 48.27,
-"decompress_mbps": 511.31
+"compress_mbps": 47.89,
+"decompress_mbps": 508.24
 },
 {
 "compressor": "miniz_oxide",
@@ -2584,8 +2584,8 @@
 "level": 6,
 "out_size": 144908,
 "ratio": 0.3396,
-"compress_mbps": 28.07,
-"decompress_mbps": 521.76
+"compress_mbps": 27.93,
+"decompress_mbps": 519.21
 },
 {
 "compressor": "miniz_oxide",
@@ -2594,8 +2594,8 @@
 "level": 7,
 "out_size": 144562,
 "ratio": 0.3387,
-"compress_mbps": 24.64,
-"decompress_mbps": 522.41
+"compress_mbps": 24.54,
+"decompress_mbps": 516.85
 },
 {
 "compressor": "miniz_oxide",
@@ -2604,8 +2604,8 @@
 "level": 8,
 "out_size": 144449,
 "ratio": 0.3385,
-"compress_mbps": 22.41,
-"decompress_mbps": 521.93
+"compress_mbps": 22.31,
+"decompress_mbps": 520.45
 },
 {
 "compressor": "miniz_oxide",
@@ -2614,8 +2614,8 @@
 "level": 9,
 "out_size": 144438,
 "ratio": 0.3385,
-"compress_mbps": 22.34,
-"decompress_mbps": 521.19
+"compress_mbps": 22.22,
+"decompress_mbps": 520.53
 },
 {
 "compressor": "miniz_oxide",
@@ -2624,8 +2624,8 @@
 "level": 1,
 "out_size": 264549,
 "ratio": 0.549,
-"compress_mbps": 134.68,
-"decompress_mbps": 376.2
+"compress_mbps": 132.45,
+"decompress_mbps": 374.64
 },
 {
 "compressor": "miniz_oxide",
@@ -2634,8 +2634,8 @@
 "level": 2,
 "out_size": 223724,
 "ratio": 0.4643,
-"compress_mbps": 120.05,
-"decompress_mbps": 423.09
+"compress_mbps": 118.56,
+"decompress_mbps": 420.68
 },
 {
 "compressor": "miniz_oxide",
@@ -2644,8 +2644,8 @@
 "level": 3,
 "out_size": 204825,
 "ratio": 0.4251,
-"compress_mbps": 60.86,
-"decompress_mbps": 478.31
+"compress_mbps": 60.49,
+"decompress_mbps": 474.79
 },
 {
 "compressor": "miniz_oxide",
@@ -2654,8 +2654,8 @@
 "level": 4,
 "out_size": 203945,
 "ratio": 0.4232,
-"compress_mbps": 54.29,
-"decompress_mbps": 473.4
+"compress_mbps": 53.65,
+"decompress_mbps": 471.13
 },
 {
 "compressor": "miniz_oxide",
@@ -2664,8 +2664,8 @@
 "level": 5,
 "out_size": 199780,
 "ratio": 0.4146,
-"compress_mbps": 37.97,
-"decompress_mbps": 459.2
+"compress_mbps": 37.72,
+"decompress_mbps": 456.42
 },
 {
 "compressor": "miniz_oxide",
@@ -2674,8 +2674,8 @@
 "level": 6,
 "out_size": 195417,
 "ratio": 0.4055,
-"compress_mbps": 21.17,
-"decompress_mbps": 468.36
+"compress_mbps": 21.1,
+"decompress_mbps": 467.0
 },
 {
 "compressor": "miniz_oxide",
@@ -2684,8 +2684,8 @@
 "level": 7,
 "out_size": 194796,
 "ratio": 0.4043,
-"compress_mbps": 17.89,
-"decompress_mbps": 468.8
+"compress_mbps": 17.81,
+"decompress_mbps": 465.7
 },
 {
 "compressor": "miniz_oxide",
@@ -2694,8 +2694,8 @@
 "level": 8,
 "out_size": 194543,
 "ratio": 0.4037,
-"compress_mbps": 15.71,
-"decompress_mbps": 469.33
+"compress_mbps": 15.63,
+"decompress_mbps": 467.23
 },
 {
 "compressor": "miniz_oxide",
@@ -2704,8 +2704,8 @@
 "level": 9,
 "out_size": 194460,
 "ratio": 0.4036,
-"compress_mbps": 15.04,
-"decompress_mbps": 468.74
+"compress_mbps": 14.97,
+"decompress_mbps": 466.59
 },
 {
 "compressor": "miniz_oxide",
@@ -2714,8 +2714,8 @@
 "level": 1,
 "out_size": 67436,
 "ratio": 0.1314,
-"compress_mbps": 627.81,
-"decompress_mbps": 1006.68
+"compress_mbps": 618.78,
+"decompress_mbps": 1006.9
 },
 {
 "compressor": "miniz_oxide",
@@ -2724,8 +2724,8 @@
 "level": 2,
 "out_size": 59257,
 "ratio": 0.1155,
-"compress_mbps": 281.05,
-"decompress_mbps": 1068.65
+"compress_mbps": 276.86,
+"decompress_mbps": 1061.42
 },
 {
 "compressor": "miniz_oxide",
@@ -2734,8 +2734,8 @@
 "level": 3,
 "out_size": 58316,
 "ratio": 0.1136,
-"compress_mbps": 182.31,
-"decompress_mbps": 1154.65
+"compress_mbps": 180.8,
+"decompress_mbps": 1148.4
 },
 {
 "compressor": "miniz_oxide",
@@ -2744,8 +2744,8 @@
 "level": 4,
 "out_size": 56291,
 "ratio": 0.1097,
-"compress_mbps": 185.71,
-"decompress_mbps": 1162.72
+"compress_mbps": 183.3,
+"decompress_mbps": 1152.65
 },
 {
 "compressor": "miniz_oxide",
@@ -2754,8 +2754,8 @@
 "level": 5,
 "out_size": 56220,
 "ratio": 0.1095,
-"compress_mbps": 146.65,
-"decompress_mbps": 1221.08
+"compress_mbps": 145.07,
+"decompress_mbps": 1210.99
 },
 {
 "compressor": "miniz_oxide",
@@ -2764,8 +2764,8 @@
 "level": 6,
 "out_size": 55972,
 "ratio": 0.1091,
-"compress_mbps": 74.61,
-"decompress_mbps": 1277.21
+"compress_mbps": 74.22,
+"decompress_mbps": 1271.04
 },
 {
 "compressor": "miniz_oxide",
@@ -2774,8 +2774,8 @@
 "level": 7,
 "out_size": 55121,
 "ratio": 0.1074,
-"compress_mbps": 52.15,
-"decompress_mbps": 1321.63
+"compress_mbps": 51.96,
+"decompress_mbps": 1315.79
 },
 {
 "compressor": "miniz_oxide",
@@ -2784,8 +2784,8 @@
 "level": 8,
 "out_size": 54124,
 "ratio": 0.1055,
-"compress_mbps": 36.72,
-"decompress_mbps": 1390.75
+"compress_mbps": 36.55,
+"decompress_mbps": 1376.8
 },
 {
 "compressor": "miniz_oxide",
@@ -2794,8 +2794,8 @@
 "level": 9,
 "out_size": 53699,
 "ratio": 0.1046,
-"compress_mbps": 28.66,
-"decompress_mbps": 1429.27
+"compress_mbps": 28.57,
+"decompress_mbps": 1409.51
 },
 {
 "compressor": "miniz_oxide",
@@ -2804,8 +2804,8 @@
 "level": 1,
 "out_size": 15612,
 "ratio": 0.4083,
-"compress_mbps": 512.91,
-"decompress_mbps": 852.07
+"compress_mbps": 505.31,
+"decompress_mbps": 846.57
 },
 {
 "compressor": "miniz_oxide",
@@ -2814,8 +2814,8 @@
 "level": 2,
 "out_size": 14133,
 "ratio": 0.3696,
-"compress_mbps": 146.57,
-"decompress_mbps": 876.56
+"compress_mbps": 144.56,
+"decompress_mbps": 871.76
 },
 {
 "compressor": "miniz_oxide",
@@ -2824,8 +2824,8 @@
 "level": 3,
 "out_size": 13341,
 "ratio": 0.3489,
-"compress_mbps": 89.47,
-"decompress_mbps": 908.19
+"compress_mbps": 88.14,
+"decompress_mbps": 903.8
 },
 {
 "compressor": "miniz_oxide",
@@ -2834,8 +2834,8 @@
 "level": 4,
 "out_size": 13289,
 "ratio": 0.3475,
-"compress_mbps": 83.84,
-"decompress_mbps": 935.07
+"compress_mbps": 82.56,
+"decompress_mbps": 937.73
 },
 {
 "compressor": "miniz_oxide",
@@ -2844,8 +2844,8 @@
 "level": 5,
 "out_size": 13052,
 "ratio": 0.3413,
-"compress_mbps": 67.58,
-"decompress_mbps": 978.02
+"compress_mbps": 66.32,
+"decompress_mbps": 973.12
 },
 {
 "compressor": "miniz_oxide",
@@ -2854,8 +2854,8 @@
 "level": 6,
 "out_size": 12996,
 "ratio": 0.3399,
-"compress_mbps": 37.28,
-"decompress_mbps": 992.02
+"compress_mbps": 37.0,
+"decompress_mbps": 990.59
 },
 {
 "compressor": "miniz_oxide",
@@ -2864,8 +2864,8 @@
 "level": 7,
 "out_size": 12972,
 "ratio": 0.3392,
-"compress_mbps": 27.28,
-"decompress_mbps": 993.15
+"compress_mbps": 27.13,
+"decompress_mbps": 986.81
 },
 {
 "compressor": "miniz_oxide",
@@ -2874,8 +2874,8 @@
 "level": 8,
 "out_size": 12951,
 "ratio": 0.3387,
-"compress_mbps": 19.05,
-"decompress_mbps": 996.24
+"compress_mbps": 18.96,
+"decompress_mbps": 994.64
 },
 {
 "compressor": "miniz_oxide",
@@ -2884,8 +2884,8 @@
 "level": 9,
 "out_size": 12933,
 "ratio": 0.3382,
-"compress_mbps": 14.86,
-"decompress_mbps": 1004.14
+"compress_mbps": 14.8,
+"decompress_mbps": 1004.37
 },
 {
 "compressor": "miniz_oxide",
@@ -2894,8 +2894,8 @@
 "level": 1,
 "out_size": 1988,
 "ratio": 0.4703,
-"compress_mbps": 338.47,
-"decompress_mbps": 544.31
+"compress_mbps": 342.64,
+"decompress_mbps": 536.78
 },
 {
 "compressor": "miniz_oxide",
@@ -2904,8 +2904,8 @@
 "level": 2,
 "out_size": 1802,
 "ratio": 0.4263,
-"compress_mbps": 216.7,
-"decompress_mbps": 553.35
+"compress_mbps": 216.93,
+"decompress_mbps": 541.32
 },
 {
 "compressor": "miniz_oxide",
@@ -2914,8 +2914,8 @@
 "level": 3,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 204.93,
-"decompress_mbps": 557.25
+"compress_mbps": 204.64,
+"decompress_mbps": 549.58
 },
 {
 "compressor": "miniz_oxide",
@@ -2924,8 +2924,8 @@
 "level": 4,
 "out_size": 1732,
 "ratio": 0.4097,
-"compress_mbps": 169.01,
-"decompress_mbps": 569.94
+"compress_mbps": 170.14,
+"decompress_mbps": 562.46
 },
 {
 "compressor": "miniz_oxide",
@@ -2934,8 +2934,8 @@
 "level": 5,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 167.06,
-"decompress_mbps": 579.11
+"compress_mbps": 166.51,
+"decompress_mbps": 570.26
 },
 {
 "compressor": "miniz_oxide",
@@ -2944,8 +2944,8 @@
 "level": 6,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 166.41,
-"decompress_mbps": 578.2
+"compress_mbps": 164.58,
+"decompress_mbps": 569.78
 },
 {
 "compressor": "miniz_oxide",
@@ -2954,8 +2954,8 @@
 "level": 7,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 166.31,
-"decompress_mbps": 579.11
+"compress_mbps": 165.23,
+"decompress_mbps": 566.34
 },
 {
 "compressor": "miniz_oxide",
@@ -2964,8 +2964,8 @@
 "level": 8,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 166.68,
-"decompress_mbps": 576.79
+"compress_mbps": 164.87,
+"decompress_mbps": 570.67
 },
 {
 "compressor": "miniz_oxide",
@@ -2974,8 +2974,8 @@
 "level": 9,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 166.39,
-"decompress_mbps": 576.54
+"compress_mbps": 165.35,
+"decompress_mbps": 571.72
 },
 {
 "compressor": "libdeflate",
@@ -2984,8 +2984,8 @@
 "level": 1,
 "out_size": 59790,
 "ratio": 0.3931,
-"compress_mbps": 262.49,
-"decompress_mbps": 1001.2
+"compress_mbps": 261.17,
+"decompress_mbps": 994.53
 },
 {
 "compressor": "libdeflate",
@@ -2994,8 +2994,8 @@
 "level": 2,
 "out_size": 57173,
 "ratio": 0.3759,
-"compress_mbps": 180.0,
-"decompress_mbps": 1085.03
+"compress_mbps": 179.51,
+"decompress_mbps": 1063.95
 },
 {
 "compressor": "libdeflate",
@@ -3004,8 +3004,8 @@
 "level": 3,
 "out_size": 56189,
 "ratio": 0.3694,
-"compress_mbps": 150.31,
-"decompress_mbps": 1159.83
+"compress_mbps": 149.83,
+"decompress_mbps": 1138.09
 },
 {
 "compressor": "libdeflate",
@@ -3014,8 +3014,8 @@
 "level": 4,
 "out_size": 55816,
 "ratio": 0.367,
-"compress_mbps": 137.72,
-"decompress_mbps": 1200.88
+"compress_mbps": 137.87,
+"decompress_mbps": 1176.78
 },
 {
 "compressor": "libdeflate",
@@ -3024,8 +3024,8 @@
 "level": 5,
 "out_size": 54758,
 "ratio": 0.36,
-"compress_mbps": 108.29,
-"decompress_mbps": 1260.85
+"compress_mbps": 108.49,
+"decompress_mbps": 1235.72
 },
 {
 "compressor": "libdeflate",
@@ -3034,8 +3034,8 @@
 "level": 6,
 "out_size": 54220,
 "ratio": 0.3565,
-"compress_mbps": 83.62,
-"decompress_mbps": 1284.23
+"compress_mbps": 83.91,
+"decompress_mbps": 1270.36
 },
 {
 "compressor": "libdeflate",
@@ -3044,8 +3044,8 @@
 "level": 7,
 "out_size": 53801,
 "ratio": 0.3537,
-"compress_mbps": 60.45,
-"decompress_mbps": 1298.8
+"compress_mbps": 61.12,
+"decompress_mbps": 1274.01
 },
 {
 "compressor": "libdeflate",
@@ -3054,8 +3054,8 @@
 "level": 8,
 "out_size": 53573,
 "ratio": 0.3522,
-"compress_mbps": 39.04,
-"decompress_mbps": 1300.77
+"compress_mbps": 38.87,
+"decompress_mbps": 1279.62
 },
 {
 "compressor": "libdeflate",
@@ -3064,8 +3064,8 @@
 "level": 9,
 "out_size": 53546,
 "ratio": 0.3521,
-"compress_mbps": 34.5,
-"decompress_mbps": 1298.79
+"compress_mbps": 34.42,
+"decompress_mbps": 1278.28
 },
 {
 "compressor": "libdeflate",
@@ -3074,8 +3074,8 @@
 "level": 1,
 "out_size": 52276,
 "ratio": 0.4176,
-"compress_mbps": 242.78,
-"decompress_mbps": 955.41
+"compress_mbps": 242.59,
+"decompress_mbps": 937.06
 },
 {
 "compressor": "libdeflate",
@@ -3084,8 +3084,8 @@
 "level": 2,
 "out_size": 50534,
 "ratio": 0.4037,
-"compress_mbps": 168.77,
-"decompress_mbps": 1003.96
+"compress_mbps": 168.27,
+"decompress_mbps": 982.37
 },
 {
 "compressor": "libdeflate",
@@ -3094,8 +3094,8 @@
 "level": 3,
 "out_size": 49919,
 "ratio": 0.3988,
-"compress_mbps": 141.37,
-"decompress_mbps": 1068.5
+"compress_mbps": 141.77,
+"decompress_mbps": 1050.54
 },
 {
 "compressor": "libdeflate",
@@ -3104,8 +3104,8 @@
 "level": 4,
 "out_size": 49715,
 "ratio": 0.3972,
-"compress_mbps": 131.13,
-"decompress_mbps": 1106.32
+"compress_mbps": 130.85,
+"decompress_mbps": 1083.77
 },
 {
 "compressor": "libdeflate",
@@ -3114,8 +3114,8 @@
 "level": 5,
 "out_size": 48735,
 "ratio": 0.3893,
-"compress_mbps": 100.46,
-"decompress_mbps": 1152.77
+"compress_mbps": 100.6,
+"decompress_mbps": 1133.24
 },
 {
 "compressor": "libdeflate",
@@ -3124,8 +3124,8 @@
 "level": 6,
 "out_size": 48422,
 "ratio": 0.3868,
-"compress_mbps": 79.31,
-"decompress_mbps": 1179.78
+"compress_mbps": 79.44,
+"decompress_mbps": 1158.78
 },
 {
 "compressor": "libdeflate",
@@ -3134,8 +3134,8 @@
 "level": 7,
 "out_size": 48249,
 "ratio": 0.3854,
-"compress_mbps": 61.1,
-"decompress_mbps": 1179.71
+"compress_mbps": 61.16,
+"decompress_mbps": 1158.43
 },
 {
 "compressor": "libdeflate",
@@ -3144,8 +3144,8 @@
 "level": 8,
 "out_size": 47977,
 "ratio": 0.3833,
-"compress_mbps": 42.92,
-"decompress_mbps": 1183.71
+"compress_mbps": 42.91,
+"decompress_mbps": 1158.7
 },
 {
 "compressor": "libdeflate",
@@ -3154,8 +3154,8 @@
 "level": 9,
 "out_size": 47971,
 "ratio": 0.3832,
-"compress_mbps": 40.96,
-"decompress_mbps": 1184.27
+"compress_mbps": 40.93,
+"decompress_mbps": 1161.94
 },
 {
 "compressor": "libdeflate",
@@ -3164,8 +3164,8 @@
 "level": 1,
 "out_size": 8385,
 "ratio": 0.3408,
-"compress_mbps": 690.6,
-"decompress_mbps": 931.45
+"compress_mbps": 688.7,
+"decompress_mbps": 948.24
 },
 {
 "compressor": "libdeflate",
@@ -3174,8 +3174,8 @@
 "level": 2,
 "out_size": 8380,
 "ratio": 0.3406,
-"compress_mbps": 440.41,
-"decompress_mbps": 952.13
+"compress_mbps": 438.34,
+"decompress_mbps": 970.72
 },
 {
 "compressor": "libdeflate",
@@ -3184,8 +3184,8 @@
 "level": 3,
 "out_size": 8286,
 "ratio": 0.3368,
-"compress_mbps": 405.55,
-"decompress_mbps": 986.22
+"compress_mbps": 403.66,
+"decompress_mbps": 979.8
 },
 {
 "compressor": "libdeflate",
@@ -3194,8 +3194,8 @@
 "level": 4,
 "out_size": 8163,
 "ratio": 0.3318,
-"compress_mbps": 377.17,
-"decompress_mbps": 1004.03
+"compress_mbps": 376.61,
+"decompress_mbps": 989.34
 },
 {
 "compressor": "libdeflate",
@@ -3204,8 +3204,8 @@
 "level": 5,
 "out_size": 8053,
 "ratio": 0.3273,
-"compress_mbps": 338.69,
-"decompress_mbps": 1057.71
+"compress_mbps": 338.25,
+"decompress_mbps": 1016.25
 },
 {
 "compressor": "libdeflate",
@@ -3214,8 +3214,8 @@
 "level": 6,
 "out_size": 7986,
 "ratio": 0.3246,
-"compress_mbps": 276.45,
-"decompress_mbps": 1064.77
+"compress_mbps": 276.66,
+"decompress_mbps": 1007.05
 },
 {
 "compressor": "libdeflate",
@@ -3224,8 +3224,8 @@
 "level": 7,
 "out_size": 7954,
 "ratio": 0.3233,
-"compress_mbps": 190.05,
-"decompress_mbps": 1065.4
+"compress_mbps": 191.57,
+"decompress_mbps": 1019.08
 },
 {
 "compressor": "libdeflate",
@@ -3234,8 +3234,8 @@
 "level": 8,
 "out_size": 7916,
 "ratio": 0.3217,
-"compress_mbps": 126.66,
-"decompress_mbps": 1070.4
+"compress_mbps": 129.03,
+"decompress_mbps": 1018.06
 },
 {
 "compressor": "libdeflate",
@@ -3244,8 +3244,8 @@
 "level": 9,
 "out_size": 7916,
 "ratio": 0.3217,
-"compress_mbps": 124.7,
-"decompress_mbps": 1074.18
+"compress_mbps": 122.49,
+"decompress_mbps": 1018.11
 },
 {
 "compressor": "libdeflate",
@@ -3254,8 +3254,8 @@
 "level": 1,
 "out_size": 3401,
 "ratio": 0.305,
-"compress_mbps": 589.31,
-"decompress_mbps": 811.28
+"compress_mbps": 585.7,
+"decompress_mbps": 752.76
 },
 {
 "compressor": "libdeflate",
@@ -3264,8 +3264,8 @@
 "level": 2,
 "out_size": 3307,
 "ratio": 0.2966,
-"compress_mbps": 400.52,
-"decompress_mbps": 795.92
+"compress_mbps": 397.65,
+"decompress_mbps": 781.07
 },
 {
 "compressor": "libdeflate",
@@ -3274,8 +3274,8 @@
 "level": 3,
 "out_size": 3242,
 "ratio": 0.2908,
-"compress_mbps": 372.48,
-"decompress_mbps": 854.99
+"compress_mbps": 369.13,
+"decompress_mbps": 800.47
 },
 {
 "compressor": "libdeflate",
@@ -3284,8 +3284,8 @@
 "level": 4,
 "out_size": 3205,
 "ratio": 0.2874,
-"compress_mbps": 351.19,
-"decompress_mbps": 860.1
+"compress_mbps": 348.83,
+"decompress_mbps": 805.69
 },
 {
 "compressor": "libdeflate",
@@ -3294,8 +3294,8 @@
 "level": 5,
 "out_size": 3150,
 "ratio": 0.2825,
-"compress_mbps": 314.46,
-"decompress_mbps": 877.57
+"compress_mbps": 312.41,
+"decompress_mbps": 826.54
 },
 {
 "compressor": "libdeflate",
@@ -3304,8 +3304,8 @@
 "level": 6,
 "out_size": 3126,
 "ratio": 0.2804,
-"compress_mbps": 265.98,
-"decompress_mbps": 889.31
+"compress_mbps": 265.24,
+"decompress_mbps": 832.56
 },
 {
 "compressor": "libdeflate",
@@ -3314,8 +3314,8 @@
 "level": 7,
 "out_size": 3106,
 "ratio": 0.2786,
-"compress_mbps": 207.05,
-"decompress_mbps": 900.61
+"compress_mbps": 206.29,
+"decompress_mbps": 833.47
 },
 {
 "compressor": "libdeflate",
@@ -3324,8 +3324,8 @@
 "level": 8,
 "out_size": 3102,
 "ratio": 0.2782,
-"compress_mbps": 147.6,
-"decompress_mbps": 913.92
+"compress_mbps": 147.31,
+"decompress_mbps": 832.63
 },
 {
 "compressor": "libdeflate",
@@ -3334,8 +3334,8 @@
 "level": 9,
 "out_size": 3102,
 "ratio": 0.2782,
-"compress_mbps": 140.46,
-"decompress_mbps": 899.08
+"compress_mbps": 140.03,
+"decompress_mbps": 835.11
 },
 {
 "compressor": "libdeflate",
@@ -3344,8 +3344,8 @@
 "level": 1,
 "out_size": 1251,
 "ratio": 0.3362,
-"compress_mbps": 381.86,
-"decompress_mbps": 466.56
+"compress_mbps": 379.25,
+"decompress_mbps": 553.95
 },
 {
 "compressor": "libdeflate",
@@ -3354,8 +3354,8 @@
 "level": 2,
 "out_size": 1228,
 "ratio": 0.33,
-"compress_mbps": 269.14,
-"decompress_mbps": 470.14
+"compress_mbps": 267.18,
+"decompress_mbps": 565.34
 },
 {
 "compressor": "libdeflate",
@@ -3364,8 +3364,8 @@
 "level": 3,
 "out_size": 1219,
 "ratio": 0.3276,
-"compress_mbps": 261.76,
-"decompress_mbps": 451.65
+"compress_mbps": 260.81,
+"decompress_mbps": 561.76
 },
 {
 "compressor": "libdeflate",
@@ -3374,8 +3374,8 @@
 "level": 4,
 "out_size": 1220,
 "ratio": 0.3279,
-"compress_mbps": 254.77,
-"decompress_mbps": 499.52
+"compress_mbps": 253.67,
+"decompress_mbps": 558.75
 },
 {
 "compressor": "libdeflate",
@@ -3384,8 +3384,8 @@
 "level": 5,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 239.98,
-"decompress_mbps": 486.45
+"compress_mbps": 239.32,
+"decompress_mbps": 577.29
 },
 {
 "compressor": "libdeflate",
@@ -3394,8 +3394,8 @@
 "level": 6,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 221.84,
-"decompress_mbps": 484.06
+"compress_mbps": 221.72,
+"decompress_mbps": 540.78
 },
 {
 "compressor": "libdeflate",
@@ -3404,8 +3404,8 @@
 "level": 7,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 203.28,
-"decompress_mbps": 485.85
+"compress_mbps": 202.26,
+"decompress_mbps": 576.26
 },
 {
 "compressor": "libdeflate",
@@ -3414,8 +3414,8 @@
 "level": 8,
 "out_size": 1204,
 "ratio": 0.3236,
-"compress_mbps": 168.68,
-"decompress_mbps": 504.14
+"compress_mbps": 168.42,
+"decompress_mbps": 578.33
 },
 {
 "compressor": "libdeflate",
@@ -3424,8 +3424,8 @@
 "level": 9,
 "out_size": 1204,
 "ratio": 0.3236,
-"compress_mbps": 168.83,
-"decompress_mbps": 501.15
+"compress_mbps": 168.27,
+"decompress_mbps": 576.92
 },
 {
 "compressor": "libdeflate",
@@ -3434,8 +3434,8 @@
 "level": 1,
 "out_size": 221813,
 "ratio": 0.2154,
-"compress_mbps": 585.24,
-"decompress_mbps": 1013.81
+"compress_mbps": 576.64,
+"decompress_mbps": 1008.19
 },
 {
 "compressor": "libdeflate",
@@ -3444,8 +3444,8 @@
 "level": 2,
 "out_size": 199825,
 "ratio": 0.1941,
-"compress_mbps": 407.35,
-"decompress_mbps": 1473.67
+"compress_mbps": 407.46,
+"decompress_mbps": 1449.67
 },
 {
 "compressor": "libdeflate",
@@ -3454,8 +3454,8 @@
 "level": 3,
 "out_size": 195675,
 "ratio": 0.19,
-"compress_mbps": 281.8,
-"decompress_mbps": 1540.9
+"compress_mbps": 280.26,
+"decompress_mbps": 1518.73
 },
 {
 "compressor": "libdeflate",
@@ -3464,8 +3464,8 @@
 "level": 4,
 "out_size": 195664,
 "ratio": 0.19,
-"compress_mbps": 276.98,
-"decompress_mbps": 1545.05
+"compress_mbps": 277.16,
+"decompress_mbps": 1526.06
 },
 {
 "compressor": "libdeflate",
@@ -3474,8 +3474,8 @@
 "level": 5,
 "out_size": 198900,
 "ratio": 0.1932,
-"compress_mbps": 238.88,
-"decompress_mbps": 1118.16
+"compress_mbps": 237.39,
+"decompress_mbps": 1123.39
 },
 {
 "compressor": "libdeflate",
@@ -3484,8 +3484,8 @@
 "level": 6,
 "out_size": 199347,
 "ratio": 0.1936,
-"compress_mbps": 204.52,
-"decompress_mbps": 1134.05
+"compress_mbps": 202.94,
+"decompress_mbps": 1122.55
 },
 {
 "compressor": "libdeflate",
@@ -3494,8 +3494,8 @@
 "level": 7,
 "out_size": 199777,
 "ratio": 0.194,
-"compress_mbps": 123.47,
-"decompress_mbps": 1189.09
+"compress_mbps": 122.8,
+"decompress_mbps": 1182.17
 },
 {
 "compressor": "libdeflate",
@@ -3504,8 +3504,8 @@
 "level": 8,
 "out_size": 182094,
 "ratio": 0.1768,
-"compress_mbps": 25.64,
-"decompress_mbps": 1177.2
+"compress_mbps": 25.47,
+"decompress_mbps": 1165.56
 },
 {
 "compressor": "libdeflate",
@@ -3514,8 +3514,8 @@
 "level": 9,
 "out_size": 181451,
 "ratio": 0.1762,
-"compress_mbps": 13.61,
-"decompress_mbps": 1180.48
+"compress_mbps": 13.55,
+"decompress_mbps": 1160.77
 },
 {
 "compressor": "libdeflate",
@@ -3524,8 +3524,8 @@
 "level": 1,
 "out_size": 159063,
 "ratio": 0.3727,
-"compress_mbps": 266.65,
-"decompress_mbps": 1027.21
+"compress_mbps": 264.54,
+"decompress_mbps": 1021.24
 },
 {
 "compressor": "libdeflate",
@@ -3534,8 +3534,8 @@
 "level": 2,
 "out_size": 152115,
 "ratio": 0.3564,
-"compress_mbps": 186.82,
-"decompress_mbps": 1111.89
+"compress_mbps": 186.8,
+"decompress_mbps": 1098.04
 },
 {
 "compressor": "libdeflate",
@@ -3544,8 +3544,8 @@
 "level": 3,
 "out_size": 149162,
 "ratio": 0.3495,
-"compress_mbps": 156.97,
-"decompress_mbps": 1199.4
+"compress_mbps": 155.85,
+"decompress_mbps": 1182.6
 },
 {
 "compressor": "libdeflate",
@@ -3554,8 +3554,8 @@
 "level": 4,
 "out_size": 148359,
 "ratio": 0.3476,
-"compress_mbps": 143.17,
-"decompress_mbps": 1060.01
+"compress_mbps": 142.21,
+"decompress_mbps": 1041.87
 },
 {
 "compressor": "libdeflate",
@@ -3564,8 +3564,8 @@
 "level": 5,
 "out_size": 145353,
 "ratio": 0.3406,
-"compress_mbps": 113.75,
-"decompress_mbps": 1021.2
+"compress_mbps": 112.99,
+"decompress_mbps": 1011.31
 },
 {
 "compressor": "libdeflate",
@@ -3574,8 +3574,8 @@
 "level": 6,
 "out_size": 144209,
 "ratio": 0.3379,
-"compress_mbps": 87.79,
-"decompress_mbps": 1065.52
+"compress_mbps": 86.93,
+"decompress_mbps": 1049.43
 },
 {
 "compressor": "libdeflate",
@@ -3584,8 +3584,8 @@
 "level": 7,
 "out_size": 143604,
 "ratio": 0.3365,
-"compress_mbps": 66.35,
-"decompress_mbps": 1071.25
+"compress_mbps": 66.46,
+"decompress_mbps": 1063.62
 },
 {
 "compressor": "libdeflate",
@@ -3594,8 +3594,8 @@
 "level": 8,
 "out_size": 142086,
 "ratio": 0.3329,
-"compress_mbps": 44.2,
-"decompress_mbps": 1068.73
+"compress_mbps": 44.09,
+"decompress_mbps": 1060.67
 },
 {
 "compressor": "libdeflate",
@@ -3604,8 +3604,8 @@
 "level": 9,
 "out_size": 142027,
 "ratio": 0.3328,
-"compress_mbps": 40.42,
-"decompress_mbps": 1072.96
+"compress_mbps": 40.29,
+"decompress_mbps": 1056.76
 },
 {
 "compressor": "libdeflate",
@@ -3614,8 +3614,8 @@
 "level": 1,
 "out_size": 210662,
 "ratio": 0.4372,
-"compress_mbps": 232.4,
-"decompress_mbps": 879.58
+"compress_mbps": 230.18,
+"decompress_mbps": 864.86
 },
 {
 "compressor": "libdeflate",
@@ -3624,8 +3624,8 @@
 "level": 2,
 "out_size": 202881,
 "ratio": 0.421,
-"compress_mbps": 159.36,
-"decompress_mbps": 945.11
+"compress_mbps": 158.04,
+"decompress_mbps": 933.13
 },
 {
 "compressor": "libdeflate",
@@ -3634,8 +3634,8 @@
 "level": 3,
 "out_size": 200409,
 "ratio": 0.4159,
-"compress_mbps": 133.28,
-"decompress_mbps": 1027.35
+"compress_mbps": 132.69,
+"decompress_mbps": 1014.92
 },
 {
 "compressor": "libdeflate",
@@ -3644,8 +3644,8 @@
 "level": 4,
 "out_size": 199678,
 "ratio": 0.4144,
-"compress_mbps": 122.98,
-"decompress_mbps": 861.16
+"compress_mbps": 122.81,
+"decompress_mbps": 853.48
 },
 {
 "compressor": "libdeflate",
@@ -3654,8 +3654,8 @@
 "level": 5,
 "out_size": 195798,
 "ratio": 0.4063,
-"compress_mbps": 93.51,
-"decompress_mbps": 815.07
+"compress_mbps": 93.09,
+"decompress_mbps": 807.11
 },
 {
 "compressor": "libdeflate",
@@ -3664,8 +3664,8 @@
 "level": 6,
 "out_size": 194029,
 "ratio": 0.4027,
-"compress_mbps": 71.93,
-"decompress_mbps": 839.27
+"compress_mbps": 71.72,
+"decompress_mbps": 827.42
 },
 {
 "compressor": "libdeflate",
@@ -3674,8 +3674,8 @@
 "level": 7,
 "out_size": 192773,
 "ratio": 0.4001,
-"compress_mbps": 51.46,
-"decompress_mbps": 839.27
+"compress_mbps": 51.16,
+"decompress_mbps": 833.35
 },
 {
 "compressor": "libdeflate",
@@ -3684,8 +3684,8 @@
 "level": 8,
 "out_size": 191739,
 "ratio": 0.3979,
-"compress_mbps": 33.62,
-"decompress_mbps": 843.62
+"compress_mbps": 33.53,
+"decompress_mbps": 837.14
 },
 {
 "compressor": "libdeflate",
@@ -3694,8 +3694,8 @@
 "level": 9,
 "out_size": 191676,
 "ratio": 0.3978,
-"compress_mbps": 31.04,
-"decompress_mbps": 840.75
+"compress_mbps": 30.94,
+"decompress_mbps": 838.25
 },
 {
 "compressor": "libdeflate",
@@ -3704,8 +3704,8 @@
 "level": 1,
 "out_size": 58079,
 "ratio": 0.1132,
-"compress_mbps": 372.3,
-"decompress_mbps": 1705.97
+"compress_mbps": 372.62,
+"decompress_mbps": 1684.31
 },
 {
 "compressor": "libdeflate",
@@ -3714,8 +3714,8 @@
 "level": 2,
 "out_size": 57838,
 "ratio": 0.1127,
-"compress_mbps": 414.17,
-"decompress_mbps": 1820.82
+"compress_mbps": 412.04,
+"decompress_mbps": 1784.89
 },
 {
 "compressor": "libdeflate",
@@ -3724,8 +3724,8 @@
 "level": 3,
 "out_size": 57554,
 "ratio": 0.1121,
-"compress_mbps": 393.21,
-"decompress_mbps": 1915.52
+"compress_mbps": 393.18,
+"decompress_mbps": 1896.59
 },
 {
 "compressor": "libdeflate",
@@ -3734,8 +3734,8 @@
 "level": 4,
 "out_size": 57064,
 "ratio": 0.1112,
-"compress_mbps": 373.01,
-"decompress_mbps": 1757.46
+"compress_mbps": 372.73,
+"decompress_mbps": 1727.72
 },
 {
 "compressor": "libdeflate",
@@ -3744,8 +3744,8 @@
 "level": 5,
 "out_size": 55743,
 "ratio": 0.1086,
-"compress_mbps": 343.46,
-"decompress_mbps": 1815.39
+"compress_mbps": 341.79,
+"decompress_mbps": 1781.44
 },
 {
 "compressor": "libdeflate",
@@ -3754,8 +3754,8 @@
 "level": 6,
 "out_size": 55102,
 "ratio": 0.1074,
-"compress_mbps": 285.28,
-"decompress_mbps": 1900.28
+"compress_mbps": 282.49,
+"decompress_mbps": 1880.32
 },
 {
 "compressor": "libdeflate",
@@ -3764,8 +3764,8 @@
 "level": 7,
 "out_size": 54742,
 "ratio": 0.1067,
-"compress_mbps": 193.5,
-"decompress_mbps": 1945.6
+"compress_mbps": 186.82,
+"decompress_mbps": 1929.62
 },
 {
 "compressor": "libdeflate",
@@ -3774,8 +3774,8 @@
 "level": 8,
 "out_size": 53133,
 "ratio": 0.1035,
-"compress_mbps": 102.56,
-"decompress_mbps": 2010.02
+"compress_mbps": 102.71,
+"decompress_mbps": 1956.97
 },
 {
 "compressor": "libdeflate",
@@ -3784,8 +3784,8 @@
 "level": 9,
 "out_size": 52186,
 "ratio": 0.1017,
-"compress_mbps": 72.23,
-"decompress_mbps": 2055.21
+"compress_mbps": 72.24,
+"decompress_mbps": 2014.54
 },
 {
 "compressor": "libdeflate",
@@ -3794,8 +3794,8 @@
 "level": 1,
 "out_size": 14122,
 "ratio": 0.3693,
-"compress_mbps": 650.71,
-"decompress_mbps": 832.61
+"compress_mbps": 648.55,
+"decompress_mbps": 821.07
 },
 {
 "compressor": "libdeflate",
@@ -3804,8 +3804,8 @@
 "level": 2,
 "out_size": 13374,
 "ratio": 0.3497,
-"compress_mbps": 365.52,
-"decompress_mbps": 886.62
+"compress_mbps": 365.06,
+"decompress_mbps": 875.59
 },
 {
 "compressor": "libdeflate",
@@ -3814,8 +3814,8 @@
 "level": 3,
 "out_size": 13293,
 "ratio": 0.3476,
-"compress_mbps": 295.59,
-"decompress_mbps": 979.76
+"compress_mbps": 306.06,
+"decompress_mbps": 955.02
 },
 {
 "compressor": "libdeflate",
@@ -3824,8 +3824,8 @@
 "level": 4,
 "out_size": 13259,
 "ratio": 0.3467,
-"compress_mbps": 272.32,
-"decompress_mbps": 976.14
+"compress_mbps": 276.52,
+"decompress_mbps": 953.77
 },
 {
 "compressor": "libdeflate",
@@ -3834,8 +3834,8 @@
 "level": 5,
 "out_size": 12641,
 "ratio": 0.3306,
-"compress_mbps": 187.39,
-"decompress_mbps": 1011.27
+"compress_mbps": 187.17,
+"decompress_mbps": 973.14
 },
 {
 "compressor": "libdeflate",
@@ -3844,8 +3844,8 @@
 "level": 6,
 "out_size": 12432,
 "ratio": 0.3251,
-"compress_mbps": 162.7,
-"decompress_mbps": 1035.92
+"compress_mbps": 164.66,
+"decompress_mbps": 1006.92
 },
 {
 "compressor": "libdeflate",
@@ -3854,8 +3854,8 @@
 "level": 7,
 "out_size": 12439,
 "ratio": 0.3253,
-"compress_mbps": 123.62,
-"decompress_mbps": 1048.73
+"compress_mbps": 114.94,
+"decompress_mbps": 1015.21
 },
 {
 "compressor": "libdeflate",
@@ -3864,8 +3864,8 @@
 "level": 8,
 "out_size": 12579,
 "ratio": 0.3289,
-"compress_mbps": 67.22,
-"decompress_mbps": 1054.28
+"compress_mbps": 67.44,
+"decompress_mbps": 1024.74
 },
 {
 "compressor": "libdeflate",
@@ -3874,8 +3874,8 @@
 "level": 9,
 "out_size": 12574,
 "ratio": 0.3288,
-"compress_mbps": 47.28,
-"decompress_mbps": 1067.52
+"compress_mbps": 47.24,
+"decompress_mbps": 1023.22
 },
 {
 "compressor": "libdeflate",
@@ -3884,8 +3884,8 @@
 "level": 1,
 "out_size": 1777,
 "ratio": 0.4204,
-"compress_mbps": 385.83,
-"decompress_mbps": 402.76
+"compress_mbps": 384.47,
+"decompress_mbps": 398.06
 },
 {
 "compressor": "libdeflate",
@@ -3894,8 +3894,8 @@
 "level": 2,
 "out_size": 1756,
 "ratio": 0.4154,
-"compress_mbps": 259.27,
-"decompress_mbps": 405.84
+"compress_mbps": 256.45,
+"decompress_mbps": 401.59
 },
 {
 "compressor": "libdeflate",
@@ -3904,8 +3904,8 @@
 "level": 3,
 "out_size": 1746,
 "ratio": 0.4131,
-"compress_mbps": 255.59,
-"decompress_mbps": 412.73
+"compress_mbps": 254.8,
+"decompress_mbps": 404.01
 },
 {
 "compressor": "libdeflate",
@@ -3914,8 +3914,8 @@
 "level": 4,
 "out_size": 1740,
 "ratio": 0.4116,
-"compress_mbps": 253.98,
-"decompress_mbps": 414.65
+"compress_mbps": 251.62,
+"decompress_mbps": 408.76
 },
 {
 "compressor": "libdeflate",
@@ -3924,8 +3924,8 @@
 "level": 5,
 "out_size": 1722,
 "ratio": 0.4074,
-"compress_mbps": 239.52,
-"decompress_mbps": 445.29
+"compress_mbps": 238.72,
+"decompress_mbps": 414.01
 },
 {
 "compressor": "libdeflate",
@@ -3934,8 +3934,8 @@
 "level": 6,
 "out_size": 1721,
 "ratio": 0.4071,
-"compress_mbps": 234.88,
-"decompress_mbps": 435.24
+"compress_mbps": 234.67,
+"decompress_mbps": 417.31
 },
 {
 "compressor": "libdeflate",
@@ -3944,8 +3944,8 @@
 "level": 7,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 233.31,
-"decompress_mbps": 438.89
+"compress_mbps": 232.47,
+"decompress_mbps": 419.13
 },
 {
 "compressor": "libdeflate",
@@ -3954,8 +3954,8 @@
 "level": 8,
 "out_size": 1717,
 "ratio": 0.4062,
-"compress_mbps": 216.68,
-"decompress_mbps": 441.39
+"compress_mbps": 216.79,
+"decompress_mbps": 419.13
 },
 {
 "compressor": "libdeflate",
@@ -3964,8 +3964,8 @@
 "level": 9,
 "out_size": 1717,
 "ratio": 0.4062,
-"compress_mbps": 216.27,
-"decompress_mbps": 446.67
+"compress_mbps": 216.06,
+"decompress_mbps": 419.22
 },
 {
 "compressor": "native",
@@ -3974,8 +3974,8 @@
 "level": 1,
 "out_size": 4231315,
 "ratio": 0.4151,
-"compress_mbps": 21.55,
-"decompress_mbps": 81.09
+"compress_mbps": 26.23,
+"decompress_mbps": 79.17
 },
 {
 "compressor": "native",
@@ -3984,8 +3984,8 @@
 "level": 2,
 "out_size": 4120658,
 "ratio": 0.4043,
-"compress_mbps": 17.51,
-"decompress_mbps": 86.94
+"compress_mbps": 22.46,
+"decompress_mbps": 84.35
 },
 {
 "compressor": "native",
@@ -3994,8 +3994,8 @@
 "level": 3,
 "out_size": 4037988,
 "ratio": 0.3962,
-"compress_mbps": 14.42,
-"decompress_mbps": 96.11
+"compress_mbps": 19.87,
+"decompress_mbps": 91.31
 },
 {
 "compressor": "native",
@@ -4004,8 +4004,8 @@
 "level": 4,
 "out_size": 3959738,
 "ratio": 0.3885,
-"compress_mbps": 7.78,
-"decompress_mbps": 94.28
+"compress_mbps": 12.02,
+"decompress_mbps": 91.65
 },
 {
 "compressor": "native",
@@ -4014,8 +4014,8 @@
 "level": 5,
 "out_size": 3941691,
 "ratio": 0.3867,
-"compress_mbps": 7.11,
-"decompress_mbps": 96.54
+"compress_mbps": 11.18,
+"decompress_mbps": 92.5
 },
 {
 "compressor": "native",
@@ -4024,8 +4024,8 @@
 "level": 6,
 "out_size": 3913931,
 "ratio": 0.384,
-"compress_mbps": 5.78,
-"decompress_mbps": 99.23
+"compress_mbps": 9.41,
+"decompress_mbps": 95.78
 },
 {
 "compressor": "native",
@@ -4034,8 +4034,8 @@
 "level": 7,
 "out_size": 3902484,
 "ratio": 0.3829,
-"compress_mbps": 3.85,
-"decompress_mbps": 99.25
+"compress_mbps": 5.52,
+"decompress_mbps": 98.67
 },
 {
 "compressor": "native",
@@ -4044,8 +4044,8 @@
 "level": 8,
 "out_size": 3899047,
 "ratio": 0.3825,
-"compress_mbps": 3.65,
-"decompress_mbps": 101.58
+"compress_mbps": 5.4,
+"decompress_mbps": 100.37
 },
 {
 "compressor": "native",
@@ -4054,8 +4054,8 @@
 "level": 9,
 "out_size": 3712344,
 "ratio": 0.3642,
-"compress_mbps": 0.71,
-"decompress_mbps": 101.08
+"compress_mbps": 0.97,
+"decompress_mbps": 101.66
 },
 {
 "compressor": "native",
@@ -4064,8 +4064,8 @@
 "level": 1,
 "out_size": 20729473,
 "ratio": 0.4047,
-"compress_mbps": 30.96,
-"decompress_mbps": 72.22
+"compress_mbps": 37.09,
+"decompress_mbps": 72.96
 },
 {
 "compressor": "native",
@@ -4074,8 +4074,8 @@
 "level": 2,
 "out_size": 20500337,
 "ratio": 0.4002,
-"compress_mbps": 26.5,
-"decompress_mbps": 75.01
+"compress_mbps": 33.39,
+"decompress_mbps": 74.99
 },
 {
 "compressor": "native",
@@ -4084,8 +4084,8 @@
 "level": 3,
 "out_size": 20349978,
 "ratio": 0.3973,
-"compress_mbps": 22.17,
-"decompress_mbps": 77.15
+"compress_mbps": 30.26,
+"decompress_mbps": 77.93
 },
 {
 "compressor": "native",
@@ -4094,8 +4094,8 @@
 "level": 4,
 "out_size": 19952001,
 "ratio": 0.3895,
-"compress_mbps": 11.41,
-"decompress_mbps": 78.61
+"compress_mbps": 19.24,
+"decompress_mbps": 79.34
 },
 {
 "compressor": "native",
@@ -4104,8 +4104,8 @@
 "level": 5,
 "out_size": 19925043,
 "ratio": 0.389,
-"compress_mbps": 9.97,
-"decompress_mbps": 81.88
+"compress_mbps": 17.61,
+"decompress_mbps": 82.34
 },
 {
 "compressor": "native",
@@ -4114,8 +4114,8 @@
 "level": 6,
 "out_size": 19882104,
 "ratio": 0.3882,
-"compress_mbps": 7.27,
-"decompress_mbps": 82.37
+"compress_mbps": 14.18,
+"decompress_mbps": 83.72
 },
 {
 "compressor": "native",
@@ -4124,8 +4124,8 @@
 "level": 7,
 "out_size": 18841079,
 "ratio": 0.3678,
-"compress_mbps": 3.67,
-"decompress_mbps": 84.08
+"compress_mbps": 5.8,
+"decompress_mbps": 84.39
 },
 {
 "compressor": "native",
@@ -4134,8 +4134,8 @@
 "level": 8,
 "out_size": 18833163,
 "ratio": 0.3677,
-"compress_mbps": 2.94,
-"decompress_mbps": 84.1
+"compress_mbps": 5.1,
+"decompress_mbps": 83.89
 },
 {
 "compressor": "native",
@@ -4144,8 +4144,8 @@
 "level": 9,
 "out_size": 18518350,
 "ratio": 0.3615,
-"compress_mbps": 0.41,
-"decompress_mbps": 84.15
+"compress_mbps": 0.84,
+"decompress_mbps": 84.47
 },
 {
 "compressor": "native",
@@ -4154,8 +4154,8 @@
 "level": 1,
 "out_size": 3773613,
 "ratio": 0.3785,
-"compress_mbps": 32.26,
-"decompress_mbps": 74.31
+"compress_mbps": 38.58,
+"decompress_mbps": 64.32
 },
 {
 "compressor": "native",
@@ -4164,8 +4164,8 @@
 "level": 2,
 "out_size": 3728325,
 "ratio": 0.3739,
-"compress_mbps": 26.69,
-"decompress_mbps": 76.82
+"compress_mbps": 34.1,
+"decompress_mbps": 67.89
 },
 {
 "compressor": "native",
@@ -4174,8 +4174,8 @@
 "level": 3,
 "out_size": 3701126,
 "ratio": 0.3712,
-"compress_mbps": 22.25,
-"decompress_mbps": 79.17
+"compress_mbps": 30.44,
+"decompress_mbps": 71.33
 },
 {
 "compressor": "native",
@@ -4184,8 +4184,8 @@
 "level": 4,
 "out_size": 3718920,
 "ratio": 0.373,
-"compress_mbps": 11.65,
-"decompress_mbps": 73.75
+"compress_mbps": 19.42,
+"decompress_mbps": 66.99
 },
 {
 "compressor": "native",
@@ -4194,8 +4194,8 @@
 "level": 5,
 "out_size": 3715907,
 "ratio": 0.3727,
-"compress_mbps": 10.12,
-"decompress_mbps": 75.82
+"compress_mbps": 17.58,
+"decompress_mbps": 75.52
 },
 {
 "compressor": "native",
@@ -4204,8 +4204,8 @@
 "level": 6,
 "out_size": 3715635,
 "ratio": 0.3727,
-"compress_mbps": 7.12,
-"decompress_mbps": 77.96
+"compress_mbps": 13.34,
+"decompress_mbps": 77.3
 },
 {
 "compressor": "native",
@@ -4214,8 +4214,8 @@
 "level": 7,
 "out_size": 3649251,
 "ratio": 0.366,
-"compress_mbps": 3.67,
-"decompress_mbps": 77.24
+"compress_mbps": 5.98,
+"decompress_mbps": 76.01
 },
 {
 "compressor": "native",
@@ -4224,8 +4224,8 @@
 "level": 8,
 "out_size": 3648922,
 "ratio": 0.366,
-"compress_mbps": 2.86,
-"decompress_mbps": 77.74
+"compress_mbps": 4.94,
+"decompress_mbps": 78.0
 },
 {
 "compressor": "native",
@@ -4234,8 +4234,8 @@
 "level": 9,
 "out_size": 3520112,
 "ratio": 0.3531,
-"compress_mbps": 0.09,
-"decompress_mbps": 78.22
+"compress_mbps": 0.34,
+"decompress_mbps": 78.15
 },
 {
 "compressor": "native",
@@ -4244,8 +4244,8 @@
 "level": 1,
 "out_size": 3957304,
 "ratio": 0.1179,
-"compress_mbps": 61.99,
-"decompress_mbps": 265.35
+"compress_mbps": 87.92,
+"decompress_mbps": 266.64
 },
 {
 "compressor": "native",
@@ -4254,8 +4254,8 @@
 "level": 2,
 "out_size": 3769595,
 "ratio": 0.1123,
-"compress_mbps": 50.08,
-"decompress_mbps": 295.35
+"compress_mbps": 78.16,
+"decompress_mbps": 295.8
 },
 {
 "compressor": "native",
@@ -4264,8 +4264,8 @@
 "level": 3,
 "out_size": 3594567,
 "ratio": 0.1071,
-"compress_mbps": 39.76,
-"decompress_mbps": 328.23
+"compress_mbps": 65.9,
+"decompress_mbps": 325.47
 },
 {
 "compressor": "native",
@@ -4274,8 +4274,8 @@
 "level": 4,
 "out_size": 3339928,
 "ratio": 0.0995,
-"compress_mbps": 20.44,
-"decompress_mbps": 330.19
+"compress_mbps": 42.2,
+"decompress_mbps": 323.53
 },
 {
 "compressor": "native",
@@ -4284,8 +4284,8 @@
 "level": 5,
 "out_size": 3315513,
 "ratio": 0.0988,
-"compress_mbps": 17.92,
-"decompress_mbps": 361.74
+"compress_mbps": 38.78,
+"decompress_mbps": 355.09
 },
 {
 "compressor": "native",
@@ -4294,8 +4294,8 @@
 "level": 6,
 "out_size": 3275531,
 "ratio": 0.0976,
-"compress_mbps": 13.05,
-"decompress_mbps": 384.05
+"compress_mbps": 31.07,
+"decompress_mbps": 378.85
 },
 {
 "compressor": "native",
@@ -4304,8 +4304,8 @@
 "level": 7,
 "out_size": 3249135,
 "ratio": 0.0968,
-"compress_mbps": 8.17,
-"decompress_mbps": 359.76
+"compress_mbps": 17.6,
+"decompress_mbps": 384.26
 },
 {
 "compressor": "native",
@@ -4314,8 +4314,8 @@
 "level": 8,
 "out_size": 3225205,
 "ratio": 0.0961,
-"compress_mbps": 6.01,
-"decompress_mbps": 392.29
+"compress_mbps": 14.07,
+"decompress_mbps": 386.44
 },
 {
 "compressor": "native",
@@ -4324,8 +4324,8 @@
 "level": 9,
 "out_size": 2868751,
 "ratio": 0.0855,
-"compress_mbps": 0.21,
-"decompress_mbps": 375.59
+"compress_mbps": 0.52,
+"decompress_mbps": 376.15
 },
 {
 "compressor": "native",
@@ -4334,8 +4334,8 @@
 "level": 1,
 "out_size": 3218639,
 "ratio": 0.5232,
-"compress_mbps": 22.06,
-"decompress_mbps": 49.21
+"compress_mbps": 26.01,
+"decompress_mbps": 49.1
 },
 {
 "compressor": "native",
@@ -4344,8 +4344,8 @@
 "level": 2,
 "out_size": 3192732,
 "ratio": 0.519,
-"compress_mbps": 20.23,
-"decompress_mbps": 51.1
+"compress_mbps": 24.41,
+"decompress_mbps": 50.59
 },
 {
 "compressor": "native",
@@ -4354,8 +4354,8 @@
 "level": 3,
 "out_size": 3174297,
 "ratio": 0.516,
-"compress_mbps": 18.07,
-"decompress_mbps": 54.28
+"compress_mbps": 22.4,
+"decompress_mbps": 53.48
 },
 {
 "compressor": "native",
@@ -4364,8 +4364,8 @@
 "level": 4,
 "out_size": 3121308,
 "ratio": 0.5073,
-"compress_mbps": 10.85,
-"decompress_mbps": 53.98
+"compress_mbps": 15.74,
+"decompress_mbps": 53.56
 },
 {
 "compressor": "native",
@@ -4374,8 +4374,8 @@
 "level": 5,
 "out_size": 3117864,
 "ratio": 0.5068,
-"compress_mbps": 9.96,
-"decompress_mbps": 55.93
+"compress_mbps": 14.92,
+"decompress_mbps": 54.37
 },
 {
 "compressor": "native",
@@ -4384,8 +4384,8 @@
 "level": 6,
 "out_size": 3112351,
 "ratio": 0.5059,
-"compress_mbps": 8.09,
-"decompress_mbps": 56.55
+"compress_mbps": 12.98,
+"decompress_mbps": 55.87
 },
 {
 "compressor": "native",
@@ -4394,8 +4394,8 @@
 "level": 7,
 "out_size": 3072891,
 "ratio": 0.4995,
-"compress_mbps": 3.99,
-"decompress_mbps": 56.4
+"compress_mbps": 5.27,
+"decompress_mbps": 56.86
 },
 {
 "compressor": "native",
@@ -4404,8 +4404,8 @@
 "level": 8,
 "out_size": 3071839,
 "ratio": 0.4993,
-"compress_mbps": 3.58,
-"decompress_mbps": 56.75
+"compress_mbps": 4.96,
+"decompress_mbps": 57.08
 },
 {
 "compressor": "native",
@@ -4414,8 +4414,8 @@
 "level": 9,
 "out_size": 3017696,
 "ratio": 0.4905,
-"compress_mbps": 0.81,
-"decompress_mbps": 56.63
+"compress_mbps": 1.16,
+"decompress_mbps": 57.07
 },
 {
 "compressor": "native",
@@ -4424,8 +4424,8 @@
 "level": 1,
 "out_size": 3889230,
 "ratio": 0.3856,
-"compress_mbps": 31.85,
-"decompress_mbps": 68.94
+"compress_mbps": 37.84,
+"decompress_mbps": 68.32
 },
 {
 "compressor": "native",
@@ -4434,8 +4434,8 @@
 "level": 2,
 "out_size": 3811489,
 "ratio": 0.3779,
-"compress_mbps": 28.4,
-"decompress_mbps": 71.34
+"compress_mbps": 34.61,
+"decompress_mbps": 68.46
 },
 {
 "compressor": "native",
@@ -4444,8 +4444,8 @@
 "level": 3,
 "out_size": 3789217,
 "ratio": 0.3757,
-"compress_mbps": 26.89,
-"decompress_mbps": 72.78
+"compress_mbps": 33.19,
+"decompress_mbps": 72.31
 },
 {
 "compressor": "native",
@@ -4454,8 +4454,8 @@
 "level": 4,
 "out_size": 3742155,
 "ratio": 0.371,
-"compress_mbps": 18.51,
-"decompress_mbps": 73.13
+"compress_mbps": 25.9,
+"decompress_mbps": 72.83
 },
 {
 "compressor": "native",
@@ -4464,8 +4464,8 @@
 "level": 5,
 "out_size": 3734147,
 "ratio": 0.3702,
-"compress_mbps": 17.56,
-"decompress_mbps": 72.23
+"compress_mbps": 24.95,
+"decompress_mbps": 72.35
 },
 {
 "compressor": "native",
@@ -4474,8 +4474,8 @@
 "level": 6,
 "out_size": 3723457,
 "ratio": 0.3692,
-"compress_mbps": 15.37,
-"decompress_mbps": 72.36
+"compress_mbps": 22.48,
+"decompress_mbps": 72.24
 },
 {
 "compressor": "native",
@@ -4484,8 +4484,8 @@
 "level": 7,
 "out_size": 3723087,
 "ratio": 0.3691,
-"compress_mbps": 7.1,
-"decompress_mbps": 73.43
+"compress_mbps": 9.03,
+"decompress_mbps": 71.47
 },
 {
 "compressor": "native",
@@ -4494,8 +4494,8 @@
 "level": 8,
 "out_size": 3723909,
 "ratio": 0.3692,
-"compress_mbps": 6.82,
-"decompress_mbps": 72.83
+"compress_mbps": 8.56,
+"decompress_mbps": 71.52
 },
 {
 "compressor": "native",
@@ -4504,8 +4504,8 @@
 "level": 9,
 "out_size": 3647083,
 "ratio": 0.3616,
-"compress_mbps": 1.22,
-"decompress_mbps": 73.05
+"compress_mbps": 1.5,
+"decompress_mbps": 71.54
 },
 {
 "compressor": "native",
@@ -4514,8 +4514,8 @@
 "level": 1,
 "out_size": 2146953,
 "ratio": 0.324,
-"compress_mbps": 26.2,
-"decompress_mbps": 97.42
+"compress_mbps": 33.16,
+"decompress_mbps": 96.14
 },
 {
 "compressor": "native",
@@ -4524,8 +4524,8 @@
 "level": 2,
 "out_size": 2072169,
 "ratio": 0.3127,
-"compress_mbps": 20.63,
-"decompress_mbps": 105.88
+"compress_mbps": 27.7,
+"decompress_mbps": 107.85
 },
 {
 "compressor": "native",
@@ -4534,8 +4534,8 @@
 "level": 3,
 "out_size": 2021398,
 "ratio": 0.305,
-"compress_mbps": 15.94,
-"decompress_mbps": 118.65
+"compress_mbps": 23.12,
+"decompress_mbps": 117.53
 },
 {
 "compressor": "native",
@@ -4544,8 +4544,8 @@
 "level": 4,
 "out_size": 1934888,
 "ratio": 0.292,
-"compress_mbps": 7.87,
-"decompress_mbps": 117.96
+"compress_mbps": 13.13,
+"decompress_mbps": 117.04
 },
 {
 "compressor": "native",
@@ -4554,8 +4554,8 @@
 "level": 5,
 "out_size": 1920522,
 "ratio": 0.2898,
-"compress_mbps": 6.69,
-"decompress_mbps": 123.55
+"compress_mbps": 11.42,
+"decompress_mbps": 121.22
 },
 {
 "compressor": "native",
@@ -4564,8 +4564,8 @@
 "level": 6,
 "out_size": 1893334,
 "ratio": 0.2857,
-"compress_mbps": 4.51,
-"decompress_mbps": 127.66
+"compress_mbps": 8.05,
+"decompress_mbps": 126.71
 },
 {
 "compressor": "native",
@@ -4574,8 +4574,8 @@
 "level": 7,
 "out_size": 1854694,
 "ratio": 0.2799,
-"compress_mbps": 2.86,
-"decompress_mbps": 130.61
+"compress_mbps": 4.74,
+"decompress_mbps": 130.68
 },
 {
 "compressor": "native",
@@ -4584,8 +4584,8 @@
 "level": 8,
 "out_size": 1849481,
 "ratio": 0.2791,
-"compress_mbps": 2.33,
-"decompress_mbps": 134.0
+"compress_mbps": 3.95,
+"decompress_mbps": 128.62
 },
 {
 "compressor": "native",
@@ -4594,8 +4594,8 @@
 "level": 9,
 "out_size": 1724560,
 "ratio": 0.2602,
-"compress_mbps": 0.39,
-"decompress_mbps": 132.78
+"compress_mbps": 0.63,
+"decompress_mbps": 136.96
 },
 {
 "compressor": "native",
@@ -4604,8 +4604,8 @@
 "level": 1,
 "out_size": 6185865,
 "ratio": 0.2863,
-"compress_mbps": 38.48,
-"decompress_mbps": 128.12
+"compress_mbps": 49.02,
+"decompress_mbps": 127.56
 },
 {
 "compressor": "native",
@@ -4614,8 +4614,8 @@
 "level": 2,
 "out_size": 6066146,
 "ratio": 0.2808,
-"compress_mbps": 31.95,
-"decompress_mbps": 133.49
+"compress_mbps": 43.4,
+"decompress_mbps": 133.77
 },
 {
 "compressor": "native",
@@ -4624,8 +4624,8 @@
 "level": 3,
 "out_size": 5993070,
 "ratio": 0.2774,
-"compress_mbps": 26.13,
-"decompress_mbps": 140.12
+"compress_mbps": 38.71,
+"decompress_mbps": 139.01
 },
 {
 "compressor": "native",
@@ -4634,8 +4634,8 @@
 "level": 4,
 "out_size": 5847650,
 "ratio": 0.2706,
-"compress_mbps": 14.07,
-"decompress_mbps": 142.95
+"compress_mbps": 25.19,
+"decompress_mbps": 142.12
 },
 {
 "compressor": "native",
@@ -4644,8 +4644,8 @@
 "level": 5,
 "out_size": 5837234,
 "ratio": 0.2702,
-"compress_mbps": 12.62,
-"decompress_mbps": 146.6
+"compress_mbps": 23.33,
+"decompress_mbps": 145.86
 },
 {
 "compressor": "native",
@@ -4654,8 +4654,8 @@
 "level": 6,
 "out_size": 5823141,
 "ratio": 0.2695,
-"compress_mbps": 10.13,
-"decompress_mbps": 149.22
+"compress_mbps": 20.14,
+"decompress_mbps": 148.37
 },
 {
 "compressor": "native",
@@ -4664,8 +4664,8 @@
 "level": 7,
 "out_size": 5422105,
 "ratio": 0.2509,
-"compress_mbps": 5.94,
-"decompress_mbps": 147.95
+"compress_mbps": 9.79,
+"decompress_mbps": 143.03
 },
 {
 "compressor": "native",
@@ -4674,8 +4674,8 @@
 "level": 8,
 "out_size": 5419419,
 "ratio": 0.2508,
-"compress_mbps": 5.04,
-"decompress_mbps": 147.75
+"compress_mbps": 9.11,
+"decompress_mbps": 146.0
 },
 {
 "compressor": "native",
@@ -4684,8 +4684,8 @@
 "level": 9,
 "out_size": 5169629,
 "ratio": 0.2393,
-"compress_mbps": 0.3,
-"decompress_mbps": 150.22
+"compress_mbps": 0.8,
+"decompress_mbps": 150.8
 },
 {
 "compressor": "native",
@@ -4694,8 +4694,8 @@
 "level": 1,
 "out_size": 5514155,
 "ratio": 0.7604,
-"compress_mbps": 21.29,
-"decompress_mbps": 52.52
+"compress_mbps": 23.8,
+"decompress_mbps": 51.5
 },
 {
 "compressor": "native",
@@ -4704,8 +4704,8 @@
 "level": 2,
 "out_size": 5472540,
 "ratio": 0.7546,
-"compress_mbps": 19.11,
-"decompress_mbps": 53.36
+"compress_mbps": 21.9,
+"decompress_mbps": 53.28
 },
 {
 "compressor": "native",
@@ -4714,8 +4714,8 @@
 "level": 3,
 "out_size": 5448811,
 "ratio": 0.7514,
-"compress_mbps": 16.36,
-"decompress_mbps": 54.95
+"compress_mbps": 19.72,
+"decompress_mbps": 54.5
 },
 {
 "compressor": "native",
@@ -4724,8 +4724,8 @@
 "level": 4,
 "out_size": 5375802,
 "ratio": 0.7413,
-"compress_mbps": 9.49,
-"decompress_mbps": 55.69
+"compress_mbps": 13.22,
+"decompress_mbps": 55.15
 },
 {
 "compressor": "native",
@@ -4734,8 +4734,8 @@
 "level": 5,
 "out_size": 5370794,
 "ratio": 0.7406,
-"compress_mbps": 8.63,
-"decompress_mbps": 55.53
+"compress_mbps": 12.25,
+"decompress_mbps": 55.34
 },
 {
 "compressor": "native",
@@ -4744,8 +4744,8 @@
 "level": 6,
 "out_size": 5362339,
 "ratio": 0.7394,
-"compress_mbps": 7.07,
-"decompress_mbps": 56.38
+"compress_mbps": 10.47,
+"decompress_mbps": 56.08
 },
 {
 "compressor": "native",
@@ -4754,8 +4754,8 @@
 "level": 7,
 "out_size": 5349148,
 "ratio": 0.7376,
-"compress_mbps": 3.62,
-"decompress_mbps": 55.43
+"compress_mbps": 4.49,
+"decompress_mbps": 55.46
 },
 {
 "compressor": "native",
@@ -4764,8 +4764,8 @@
 "level": 8,
 "out_size": 5348874,
 "ratio": 0.7376,
-"compress_mbps": 3.56,
-"decompress_mbps": 55.52
+"compress_mbps": 4.44,
+"decompress_mbps": 55.87
 },
 {
 "compressor": "native",
@@ -4774,8 +4774,8 @@
 "level": 9,
 "out_size": 5261135,
 "ratio": 0.7255,
-"compress_mbps": 1.02,
-"decompress_mbps": 55.8
+"compress_mbps": 1.22,
+"decompress_mbps": 55.65
 },
 {
 "compressor": "native",
@@ -4784,8 +4784,8 @@
 "level": 1,
 "out_size": 13389198,
 "ratio": 0.323,
-"compress_mbps": 28.24,
-"decompress_mbps": 101.89
+"compress_mbps": 34.63,
+"decompress_mbps": 102.73
 },
 {
 "compressor": "native",
@@ -4794,8 +4794,8 @@
 "level": 2,
 "out_size": 12991470,
 "ratio": 0.3134,
-"compress_mbps": 23.55,
-"decompress_mbps": 109.35
+"compress_mbps": 29.39,
+"decompress_mbps": 109.57
 },
 {
 "compressor": "native",
@@ -4804,8 +4804,8 @@
 "level": 3,
 "out_size": 12756198,
 "ratio": 0.3077,
-"compress_mbps": 19.51,
-"decompress_mbps": 116.59
+"compress_mbps": 26.57,
+"decompress_mbps": 117.11
 },
 {
 "compressor": "native",
@@ -4814,8 +4814,8 @@
 "level": 4,
 "out_size": 12441121,
 "ratio": 0.3001,
-"compress_mbps": 10.79,
-"decompress_mbps": 118.02
+"compress_mbps": 17.05,
+"decompress_mbps": 118.76
 },
 {
 "compressor": "native",
@@ -4824,8 +4824,8 @@
 "level": 5,
 "out_size": 12392694,
 "ratio": 0.2989,
-"compress_mbps": 9.71,
-"decompress_mbps": 120.67
+"compress_mbps": 15.73,
+"decompress_mbps": 121.9
 },
 {
 "compressor": "native",
@@ -4834,8 +4834,8 @@
 "level": 6,
 "out_size": 12309254,
 "ratio": 0.2969,
-"compress_mbps": 7.47,
-"decompress_mbps": 124.94
+"compress_mbps": 13.07,
+"decompress_mbps": 125.1
 },
 {
 "compressor": "native",
@@ -4844,8 +4844,8 @@
 "level": 7,
 "out_size": 12265937,
 "ratio": 0.2959,
-"compress_mbps": 4.88,
-"decompress_mbps": 124.36
+"compress_mbps": 7.45,
+"decompress_mbps": 125.02
 },
 {
 "compressor": "native",
@@ -4854,8 +4854,8 @@
 "level": 8,
 "out_size": 12249548,
 "ratio": 0.2955,
-"compress_mbps": 4.46,
-"decompress_mbps": 123.91
+"compress_mbps": 6.93,
+"decompress_mbps": 124.41
 },
 {
 "compressor": "native",
@@ -4864,8 +4864,8 @@
 "level": 9,
 "out_size": 11638957,
 "ratio": 0.2807,
-"compress_mbps": 0.52,
-"decompress_mbps": 126.06
+"compress_mbps": 0.82,
+"decompress_mbps": 125.82
 },
 {
 "compressor": "native",
@@ -4874,8 +4874,8 @@
 "level": 1,
 "out_size": 6018712,
 "ratio": 0.7102,
-"compress_mbps": 21.31,
-"decompress_mbps": 40.03
+"compress_mbps": 24.3,
+"decompress_mbps": 39.86
 },
 {
 "compressor": "native",
@@ -4884,8 +4884,8 @@
 "level": 2,
 "out_size": 5998688,
 "ratio": 0.7079,
-"compress_mbps": 19.01,
-"decompress_mbps": 43.23
+"compress_mbps": 22.56,
+"decompress_mbps": 42.55
 },
 {
 "compressor": "native",
@@ -4894,8 +4894,8 @@
 "level": 3,
 "out_size": 5983501,
 "ratio": 0.7061,
-"compress_mbps": 17.96,
-"decompress_mbps": 45.47
+"compress_mbps": 21.54,
+"decompress_mbps": 44.96
 },
 {
 "compressor": "native",
@@ -4904,8 +4904,8 @@
 "level": 4,
 "out_size": 5965382,
 "ratio": 0.7039,
-"compress_mbps": 13.7,
-"decompress_mbps": 42.51
+"compress_mbps": 17.66,
+"decompress_mbps": 42.54
 },
 {
 "compressor": "native",
@@ -4914,8 +4914,8 @@
 "level": 5,
 "out_size": 5964821,
 "ratio": 0.7039,
-"compress_mbps": 13.25,
-"decompress_mbps": 43.33
+"compress_mbps": 16.97,
+"decompress_mbps": 38.57
 },
 {
 "compressor": "native",
@@ -4924,8 +4924,8 @@
 "level": 6,
 "out_size": 5964654,
 "ratio": 0.7039,
-"compress_mbps": 13.04,
-"decompress_mbps": 43.2
+"compress_mbps": 16.8,
+"decompress_mbps": 39.03
 },
 {
 "compressor": "native",
@@ -4934,8 +4934,8 @@
 "level": 7,
 "out_size": 5937524,
 "ratio": 0.7007,
-"compress_mbps": 5.11,
-"decompress_mbps": 43.63
+"compress_mbps": 5.63,
+"decompress_mbps": 43.16
 },
 {
 "compressor": "native",
@@ -4944,8 +4944,8 @@
 "level": 8,
 "out_size": 5937524,
 "ratio": 0.7007,
-"compress_mbps": 5.14,
-"decompress_mbps": 44.04
+"compress_mbps": 5.47,
+"decompress_mbps": 43.72
 },
 {
 "compressor": "native",
@@ -4954,8 +4954,8 @@
 "level": 9,
 "out_size": 5825680,
 "ratio": 0.6875,
-"compress_mbps": 1.5,
-"decompress_mbps": 43.14
+"compress_mbps": 1.64,
+"decompress_mbps": 43.34
 },
 {
 "compressor": "native",
@@ -4964,8 +4964,8 @@
 "level": 1,
 "out_size": 841047,
 "ratio": 0.1573,
-"compress_mbps": 50.74,
-"decompress_mbps": 202.61
+"compress_mbps": 69.84,
+"decompress_mbps": 200.44
 },
 {
 "compressor": "native",
@@ -4974,8 +4974,8 @@
 "level": 2,
 "out_size": 796222,
 "ratio": 0.149,
-"compress_mbps": 40.93,
-"decompress_mbps": 227.22
+"compress_mbps": 59.99,
+"decompress_mbps": 226.88
 },
 {
 "compressor": "native",
@@ -4984,8 +4984,8 @@
 "level": 3,
 "out_size": 765435,
 "ratio": 0.1432,
-"compress_mbps": 33.52,
-"decompress_mbps": 247.59
+"compress_mbps": 51.09,
+"decompress_mbps": 249.46
 },
 {
 "compressor": "native",
@@ -4994,8 +4994,8 @@
 "level": 4,
 "out_size": 730001,
 "ratio": 0.1366,
-"compress_mbps": 17.43,
-"decompress_mbps": 241.49
+"compress_mbps": 31.99,
+"decompress_mbps": 241.42
 },
 {
 "compressor": "native",
@@ -5004,8 +5004,8 @@
 "level": 5,
 "out_size": 722548,
 "ratio": 0.1352,
-"compress_mbps": 15.47,
-"decompress_mbps": 263.79
+"compress_mbps": 29.6,
+"decompress_mbps": 269.76
 },
 {
 "compressor": "native",
@@ -5014,8 +5014,8 @@
 "level": 6,
 "out_size": 711223,
 "ratio": 0.1331,
-"compress_mbps": 12.07,
-"decompress_mbps": 280.17
+"compress_mbps": 24.6,
+"decompress_mbps": 281.73
 },
 {
 "compressor": "native",
@@ -5024,8 +5024,8 @@
 "level": 7,
 "out_size": 682684,
 "ratio": 0.1277,
-"compress_mbps": 8.03,
-"decompress_mbps": 276.19
+"compress_mbps": 14.38,
+"decompress_mbps": 278.79
 },
 {
 "compressor": "native",
@@ -5034,8 +5034,8 @@
 "level": 8,
 "out_size": 681103,
 "ratio": 0.1274,
-"compress_mbps": 7.04,
-"decompress_mbps": 270.67
+"compress_mbps": 13.12,
+"decompress_mbps": 279.21
 },
 {
 "compressor": "native",
@@ -5044,8 +5044,8 @@
 "level": 9,
 "out_size": 637424,
 "ratio": 0.1192,
-"compress_mbps": 0.32,
-"decompress_mbps": 287.23
+"compress_mbps": 0.66,
+"decompress_mbps": 303.45
 },
 {
 "compressor": "zlib",
@@ -5054,8 +5054,8 @@
 "level": 1,
 "out_size": 4585612,
 "ratio": 0.4499,
-"compress_mbps": 110.26,
-"decompress_mbps": 329.46
+"compress_mbps": 113.23,
+"decompress_mbps": 335.83
 },
 {
 "compressor": "zlib",
@@ -5064,8 +5064,8 @@
 "level": 2,
 "out_size": 4389474,
 "ratio": 0.4307,
-"compress_mbps": 93.06,
-"decompress_mbps": 353.43
+"compress_mbps": 95.59,
+"decompress_mbps": 351.39
 },
 {
 "compressor": "zlib",
@@ -5074,8 +5074,8 @@
 "level": 3,
 "out_size": 4192079,
 "ratio": 0.4113,
-"compress_mbps": 58.23,
-"decompress_mbps": 376.37
+"compress_mbps": 59.42,
+"decompress_mbps": 380.52
 },
 {
 "compressor": "zlib",
@@ -5084,8 +5084,8 @@
 "level": 4,
 "out_size": 4095021,
 "ratio": 0.4018,
-"compress_mbps": 64.29,
-"decompress_mbps": 364.4
+"compress_mbps": 65.91,
+"decompress_mbps": 364.75
 },
 {
 "compressor": "zlib",
@@ -5094,8 +5094,8 @@
 "level": 5,
 "out_size": 3949169,
 "ratio": 0.3875,
-"compress_mbps": 35.17,
-"decompress_mbps": 351.58
+"compress_mbps": 35.46,
+"decompress_mbps": 351.11
 },
 {
 "compressor": "zlib",
@@ -5104,8 +5104,8 @@
 "level": 6,
 "out_size": 3871628,
 "ratio": 0.3799,
-"compress_mbps": 20.95,
-"decompress_mbps": 360.31
+"compress_mbps": 21.25,
+"decompress_mbps": 362.41
 },
 {
 "compressor": "zlib",
@@ -5114,8 +5114,8 @@
 "level": 7,
 "out_size": 3858876,
 "ratio": 0.3786,
-"compress_mbps": 17.53,
-"decompress_mbps": 363.8
+"compress_mbps": 17.73,
+"decompress_mbps": 360.99
 },
 {
 "compressor": "zlib",
@@ -5124,8 +5124,8 @@
 "level": 8,
 "out_size": 3854729,
 "ratio": 0.3782,
-"compress_mbps": 14.93,
-"decompress_mbps": 362.43
+"compress_mbps": 14.97,
+"decompress_mbps": 361.22
 },
 {
 "compressor": "zlib",
@@ -5134,8 +5134,8 @@
 "level": 9,
 "out_size": 3854729,
 "ratio": 0.3782,
-"compress_mbps": 14.89,
-"decompress_mbps": 358.8
+"compress_mbps": 14.95,
+"decompress_mbps": 348.59
 },
 {
 "compressor": "zlib",
@@ -5144,8 +5144,8 @@
 "level": 1,
 "out_size": 20577220,
 "ratio": 0.4017,
-"compress_mbps": 109.44,
-"decompress_mbps": 356.42
+"compress_mbps": 111.81,
+"decompress_mbps": 357.82
 },
 {
 "compressor": "zlib",
@@ -5154,8 +5154,8 @@
 "level": 2,
 "out_size": 20247697,
 "ratio": 0.3953,
-"compress_mbps": 97.86,
-"decompress_mbps": 369.93
+"compress_mbps": 100.15,
+"decompress_mbps": 366.61
 },
 {
 "compressor": "zlib",
@@ -5164,8 +5164,8 @@
 "level": 3,
 "out_size": 19987880,
 "ratio": 0.3902,
-"compress_mbps": 74.65,
-"decompress_mbps": 387.03
+"compress_mbps": 76.7,
+"decompress_mbps": 377.43
 },
 {
 "compressor": "zlib",
@@ -5174,8 +5174,8 @@
 "level": 4,
 "out_size": 19512665,
 "ratio": 0.381,
-"compress_mbps": 76.23,
-"decompress_mbps": 377.29
+"compress_mbps": 75.92,
+"decompress_mbps": 367.79
 },
 {
 "compressor": "zlib",
@@ -5184,8 +5184,8 @@
 "level": 5,
 "out_size": 19213507,
 "ratio": 0.3751,
-"compress_mbps": 53.7,
-"decompress_mbps": 384.66
+"compress_mbps": 53.39,
+"decompress_mbps": 369.5
 },
 {
 "compressor": "zlib",
@@ -5194,8 +5194,8 @@
 "level": 6,
 "out_size": 19089118,
 "ratio": 0.3727,
-"compress_mbps": 34.54,
-"decompress_mbps": 388.8
+"compress_mbps": 34.2,
+"decompress_mbps": 379.5
 },
 {
 "compressor": "zlib",
@@ -5204,8 +5204,8 @@
 "level": 7,
 "out_size": 19061204,
 "ratio": 0.3721,
-"compress_mbps": 27.45,
-"decompress_mbps": 388.15
+"compress_mbps": 27.36,
+"decompress_mbps": 381.53
 },
 {
 "compressor": "zlib",
@@ -5214,8 +5214,8 @@
 "level": 8,
 "out_size": 19040998,
 "ratio": 0.3717,
-"compress_mbps": 15.45,
-"decompress_mbps": 387.74
+"compress_mbps": 15.4,
+"decompress_mbps": 380.59
 },
 {
 "compressor": "zlib",
@@ -5224,8 +5224,8 @@
 "level": 9,
 "out_size": 19044390,
 "ratio": 0.3718,
-"compress_mbps": 9.52,
-"decompress_mbps": 383.4
+"compress_mbps": 9.49,
+"decompress_mbps": 380.45
 },
 {
 "compressor": "zlib",
@@ -5234,8 +5234,8 @@
 "level": 1,
 "out_size": 3828360,
 "ratio": 0.384,
-"compress_mbps": 143.01,
-"decompress_mbps": 449.8
+"compress_mbps": 142.58,
+"decompress_mbps": 447.95
 },
 {
 "compressor": "zlib",
@@ -5244,8 +5244,8 @@
 "level": 2,
 "out_size": 3798539,
 "ratio": 0.381,
-"compress_mbps": 127.11,
-"decompress_mbps": 464.16
+"compress_mbps": 126.59,
+"decompress_mbps": 459.09
 },
 {
 "compressor": "zlib",
@@ -5254,8 +5254,8 @@
 "level": 3,
 "out_size": 3674568,
 "ratio": 0.3685,
-"compress_mbps": 79.49,
-"decompress_mbps": 478.98
+"compress_mbps": 79.25,
+"decompress_mbps": 476.64
 },
 {
 "compressor": "zlib",
@@ -5264,8 +5264,8 @@
 "level": 4,
 "out_size": 3680923,
 "ratio": 0.3692,
-"compress_mbps": 88.6,
-"decompress_mbps": 426.81
+"compress_mbps": 88.38,
+"decompress_mbps": 425.15
 },
 {
 "compressor": "zlib",
@@ -5274,8 +5274,8 @@
 "level": 5,
 "out_size": 3698707,
 "ratio": 0.371,
-"compress_mbps": 47.63,
-"decompress_mbps": 400.41
+"compress_mbps": 47.35,
+"decompress_mbps": 398.79
 },
 {
 "compressor": "zlib",
@@ -5284,8 +5284,8 @@
 "level": 6,
 "out_size": 3675935,
 "ratio": 0.3687,
-"compress_mbps": 26.24,
-"decompress_mbps": 414.96
+"compress_mbps": 26.19,
+"decompress_mbps": 409.42
 },
 {
 "compressor": "zlib",
@@ -5294,8 +5294,8 @@
 "level": 7,
 "out_size": 3670281,
 "ratio": 0.3681,
-"compress_mbps": 20.71,
-"decompress_mbps": 416.4
+"compress_mbps": 20.67,
+"decompress_mbps": 411.24
 },
 {
 "compressor": "zlib",
@@ -5304,8 +5304,8 @@
 "level": 8,
 "out_size": 3661103,
 "ratio": 0.3672,
-"compress_mbps": 10.95,
-"decompress_mbps": 426.18
+"compress_mbps": 10.94,
+"decompress_mbps": 421.25
 },
 {
 "compressor": "zlib",
@@ -5315,7 +5315,7 @@
 "out_size": 3660788,
 "ratio": 0.3672,
 "compress_mbps": 9.47,
-"decompress_mbps": 423.91
+"decompress_mbps": 421.34
 },
 {
 "compressor": "zlib",
@@ -5324,8 +5324,8 @@
 "level": 1,
 "out_size": 4624591,
 "ratio": 0.1378,
-"compress_mbps": 328.99,
-"decompress_mbps": 823.04
+"compress_mbps": 331.46,
+"decompress_mbps": 809.35
 },
 {
 "compressor": "zlib",
@@ -5334,8 +5334,8 @@
 "level": 2,
 "out_size": 4303176,
 "ratio": 0.1282,
-"compress_mbps": 304.48,
-"decompress_mbps": 846.96
+"compress_mbps": 307.4,
+"decompress_mbps": 834.61
 },
 {
 "compressor": "zlib",
@@ -5344,8 +5344,8 @@
 "level": 3,
 "out_size": 4010156,
 "ratio": 0.1195,
-"compress_mbps": 255.34,
-"decompress_mbps": 924.1
+"compress_mbps": 256.31,
+"decompress_mbps": 909.69
 },
 {
 "compressor": "zlib",
@@ -5354,8 +5354,8 @@
 "level": 4,
 "out_size": 3713866,
 "ratio": 0.1107,
-"compress_mbps": 211.9,
-"decompress_mbps": 898.61
+"compress_mbps": 211.34,
+"decompress_mbps": 892.52
 },
 {
 "compressor": "zlib",
@@ -5364,8 +5364,8 @@
 "level": 5,
 "out_size": 3378136,
 "ratio": 0.1007,
-"compress_mbps": 164.61,
-"decompress_mbps": 961.73
+"compress_mbps": 164.32,
+"decompress_mbps": 961.38
 },
 {
 "compressor": "zlib",
@@ -5374,8 +5374,8 @@
 "level": 6,
 "out_size": 3200182,
 "ratio": 0.0954,
-"compress_mbps": 112.65,
-"decompress_mbps": 1000.62
+"compress_mbps": 113.1,
+"decompress_mbps": 990.6
 },
 {
 "compressor": "zlib",
@@ -5384,8 +5384,8 @@
 "level": 7,
 "out_size": 3141278,
 "ratio": 0.0936,
-"compress_mbps": 89.24,
-"decompress_mbps": 1007.83
+"compress_mbps": 90.09,
+"decompress_mbps": 995.47
 },
 {
 "compressor": "zlib",
@@ -5394,8 +5394,8 @@
 "level": 8,
 "out_size": 3031199,
 "ratio": 0.0903,
-"compress_mbps": 38.77,
-"decompress_mbps": 935.68
+"compress_mbps": 39.11,
+"decompress_mbps": 1010.76
 },
 {
 "compressor": "zlib",
@@ -5404,8 +5404,8 @@
 "level": 9,
 "out_size": 2987995,
 "ratio": 0.0891,
-"compress_mbps": 21.4,
-"decompress_mbps": 1040.57
+"compress_mbps": 21.38,
+"decompress_mbps": 1019.0
 },
 {
 "compressor": "zlib",
@@ -5414,8 +5414,8 @@
 "level": 1,
 "out_size": 3290526,
 "ratio": 0.5349,
-"compress_mbps": 78.42,
-"decompress_mbps": 251.81
+"compress_mbps": 78.14,
+"decompress_mbps": 252.22
 },
 {
 "compressor": "zlib",
@@ -5424,8 +5424,8 @@
 "level": 2,
 "out_size": 3238282,
 "ratio": 0.5264,
-"compress_mbps": 71.59,
-"decompress_mbps": 256.46
+"compress_mbps": 71.3,
+"decompress_mbps": 257.39
 },
 {
 "compressor": "zlib",
@@ -5434,8 +5434,8 @@
 "level": 3,
 "out_size": 3193366,
 "ratio": 0.5191,
-"compress_mbps": 56.6,
-"decompress_mbps": 263.38
+"compress_mbps": 56.42,
+"decompress_mbps": 263.55
 },
 {
 "compressor": "zlib",
@@ -5444,8 +5444,8 @@
 "level": 4,
 "out_size": 3158012,
 "ratio": 0.5133,
-"compress_mbps": 55.1,
-"decompress_mbps": 264.47
+"compress_mbps": 54.84,
+"decompress_mbps": 264.04
 },
 {
 "compressor": "zlib",
@@ -5454,8 +5454,8 @@
 "level": 5,
 "out_size": 3115309,
 "ratio": 0.5064,
-"compress_mbps": 38.93,
-"decompress_mbps": 268.45
+"compress_mbps": 38.79,
+"decompress_mbps": 268.01
 },
 {
 "compressor": "zlib",
@@ -5464,8 +5464,8 @@
 "level": 6,
 "out_size": 3097288,
 "ratio": 0.5034,
-"compress_mbps": 26.3,
-"decompress_mbps": 271.32
+"compress_mbps": 26.25,
+"decompress_mbps": 269.7
 },
 {
 "compressor": "zlib",
@@ -5474,8 +5474,8 @@
 "level": 7,
 "out_size": 3094363,
 "ratio": 0.503,
-"compress_mbps": 21.9,
-"decompress_mbps": 269.54
+"compress_mbps": 21.86,
+"decompress_mbps": 270.92
 },
 {
 "compressor": "zlib",
@@ -5485,7 +5485,7 @@
 "out_size": 3093026,
 "ratio": 0.5028,
 "compress_mbps": 17.09,
-"decompress_mbps": 269.36
+"decompress_mbps": 269.83
 },
 {
 "compressor": "zlib",
@@ -5494,8 +5494,8 @@
 "level": 9,
 "out_size": 3092920,
 "ratio": 0.5027,
-"compress_mbps": 15.54,
-"decompress_mbps": 271.28
+"compress_mbps": 15.52,
+"decompress_mbps": 269.75
 },
 {
 "compressor": "zlib",
@@ -5504,8 +5504,8 @@
 "level": 1,
 "out_size": 4076385,
 "ratio": 0.4042,
-"compress_mbps": 126.54,
-"decompress_mbps": 445.99
+"compress_mbps": 126.22,
+"decompress_mbps": 442.08
 },
 {
 "compressor": "zlib",
@@ -5514,8 +5514,8 @@
 "level": 2,
 "out_size": 3991014,
 "ratio": 0.3957,
-"compress_mbps": 117.06,
-"decompress_mbps": 463.79
+"compress_mbps": 116.73,
+"decompress_mbps": 462.07
 },
 {
 "compressor": "zlib",
@@ -5524,8 +5524,8 @@
 "level": 3,
 "out_size": 3934055,
 "ratio": 0.3901,
-"compress_mbps": 93.54,
-"decompress_mbps": 480.01
+"compress_mbps": 93.31,
+"decompress_mbps": 475.07
 },
 {
 "compressor": "zlib",
@@ -5534,8 +5534,8 @@
 "level": 4,
 "out_size": 3825092,
 "ratio": 0.3793,
-"compress_mbps": 84.5,
-"decompress_mbps": 473.48
+"compress_mbps": 84.13,
+"decompress_mbps": 471.19
 },
 {
 "compressor": "zlib",
@@ -5544,8 +5544,8 @@
 "level": 5,
 "out_size": 3752932,
 "ratio": 0.3721,
-"compress_mbps": 64.52,
-"decompress_mbps": 460.9
+"compress_mbps": 64.3,
+"decompress_mbps": 463.51
 },
 {
 "compressor": "zlib",
@@ -5554,8 +5554,8 @@
 "level": 6,
 "out_size": 3695164,
 "ratio": 0.3664,
-"compress_mbps": 49.26,
-"decompress_mbps": 474.82
+"compress_mbps": 49.16,
+"decompress_mbps": 471.26
 },
 {
 "compressor": "zlib",
@@ -5564,8 +5564,8 @@
 "level": 7,
 "out_size": 3676881,
 "ratio": 0.3646,
-"compress_mbps": 38.06,
-"decompress_mbps": 481.85
+"compress_mbps": 38.01,
+"decompress_mbps": 478.43
 },
 {
 "compressor": "zlib",
@@ -5574,8 +5574,8 @@
 "level": 8,
 "out_size": 3673171,
 "ratio": 0.3642,
-"compress_mbps": 31.89,
-"decompress_mbps": 485.69
+"compress_mbps": 31.84,
+"decompress_mbps": 480.1
 },
 {
 "compressor": "zlib",
@@ -5584,8 +5584,8 @@
 "level": 9,
 "out_size": 3673171,
 "ratio": 0.3642,
-"compress_mbps": 31.89,
-"decompress_mbps": 487.73
+"compress_mbps": 31.69,
+"decompress_mbps": 481.45
 },
 {
 "compressor": "zlib",
@@ -5594,8 +5594,8 @@
 "level": 1,
 "out_size": 2376424,
 "ratio": 0.3586,
-"compress_mbps": 129.72,
-"decompress_mbps": 396.63
+"compress_mbps": 130.68,
+"decompress_mbps": 395.47
 },
 {
 "compressor": "zlib",
@@ -5604,8 +5604,8 @@
 "level": 2,
 "out_size": 2259060,
 "ratio": 0.3409,
-"compress_mbps": 112.08,
-"decompress_mbps": 412.76
+"compress_mbps": 112.24,
+"decompress_mbps": 405.92
 },
 {
 "compressor": "zlib",
@@ -5614,8 +5614,8 @@
 "level": 3,
 "out_size": 2135664,
 "ratio": 0.3223,
-"compress_mbps": 72.26,
-"decompress_mbps": 430.97
+"compress_mbps": 72.91,
+"decompress_mbps": 425.81
 },
 {
 "compressor": "zlib",
@@ -5624,8 +5624,8 @@
 "level": 4,
 "out_size": 2052793,
 "ratio": 0.3098,
-"compress_mbps": 81.86,
-"decompress_mbps": 427.25
+"compress_mbps": 82.22,
+"decompress_mbps": 423.64
 },
 {
 "compressor": "zlib",
@@ -5634,8 +5634,8 @@
 "level": 5,
 "out_size": 1932127,
 "ratio": 0.2915,
-"compress_mbps": 45.26,
-"decompress_mbps": 431.56
+"compress_mbps": 45.61,
+"decompress_mbps": 422.63
 },
 {
 "compressor": "zlib",
@@ -5644,8 +5644,8 @@
 "level": 6,
 "out_size": 1860865,
 "ratio": 0.2808,
-"compress_mbps": 22.74,
-"decompress_mbps": 437.39
+"compress_mbps": 22.95,
+"decompress_mbps": 434.49
 },
 {
 "compressor": "zlib",
@@ -5654,8 +5654,8 @@
 "level": 7,
 "out_size": 1838671,
 "ratio": 0.2774,
-"compress_mbps": 15.85,
-"decompress_mbps": 420.42
+"compress_mbps": 15.96,
+"decompress_mbps": 437.43
 },
 {
 "compressor": "zlib",
@@ -5664,8 +5664,8 @@
 "level": 8,
 "out_size": 1823235,
 "ratio": 0.2751,
-"compress_mbps": 8.08,
-"decompress_mbps": 429.49
+"compress_mbps": 8.13,
+"decompress_mbps": 432.62
 },
 {
 "compressor": "zlib",
@@ -5674,8 +5674,8 @@
 "level": 9,
 "out_size": 1823190,
 "ratio": 0.2751,
-"compress_mbps": 8.04,
-"decompress_mbps": 427.2
+"compress_mbps": 8.07,
+"decompress_mbps": 432.03
 },
 {
 "compressor": "zlib",
@@ -5684,8 +5684,8 @@
 "level": 1,
 "out_size": 6329449,
 "ratio": 0.2929,
-"compress_mbps": 168.59,
-"decompress_mbps": 456.99
+"compress_mbps": 169.76,
+"decompress_mbps": 487.59
 },
 {
 "compressor": "zlib",
@@ -5694,8 +5694,8 @@
 "level": 2,
 "out_size": 6128866,
 "ratio": 0.2837,
-"compress_mbps": 155.09,
-"decompress_mbps": 532.69
+"compress_mbps": 156.28,
+"decompress_mbps": 550.67
 },
 {
 "compressor": "zlib",
@@ -5704,8 +5704,8 @@
 "level": 3,
 "out_size": 5982546,
 "ratio": 0.2769,
-"compress_mbps": 124.6,
-"decompress_mbps": 570.93
+"compress_mbps": 125.47,
+"decompress_mbps": 576.15
 },
 {
 "compressor": "zlib",
@@ -5714,8 +5714,8 @@
 "level": 4,
 "out_size": 5656400,
 "ratio": 0.2618,
-"compress_mbps": 116.54,
-"decompress_mbps": 567.39
+"compress_mbps": 117.05,
+"decompress_mbps": 573.12
 },
 {
 "compressor": "zlib",
@@ -5724,8 +5724,8 @@
 "level": 5,
 "out_size": 5511352,
 "ratio": 0.2551,
-"compress_mbps": 81.93,
-"decompress_mbps": 576.1
+"compress_mbps": 82.26,
+"decompress_mbps": 579.4
 },
 {
 "compressor": "zlib",
@@ -5734,8 +5734,8 @@
 "level": 6,
 "out_size": 5451399,
 "ratio": 0.2523,
-"compress_mbps": 56.34,
-"decompress_mbps": 587.52
+"compress_mbps": 56.64,
+"decompress_mbps": 592.09
 },
 {
 "compressor": "zlib",
@@ -5744,8 +5744,8 @@
 "level": 7,
 "out_size": 5417123,
 "ratio": 0.2507,
-"compress_mbps": 46.43,
-"decompress_mbps": 590.41
+"compress_mbps": 46.72,
+"decompress_mbps": 594.93
 },
 {
 "compressor": "zlib",
@@ -5754,8 +5754,8 @@
 "level": 8,
 "out_size": 5404364,
 "ratio": 0.2501,
-"compress_mbps": 32.56,
-"decompress_mbps": 593.57
+"compress_mbps": 32.73,
+"decompress_mbps": 602.28
 },
 {
 "compressor": "zlib",
@@ -5764,8 +5764,8 @@
 "level": 9,
 "out_size": 5402704,
 "ratio": 0.2501,
-"compress_mbps": 29.69,
-"decompress_mbps": 596.78
+"compress_mbps": 29.78,
+"decompress_mbps": 601.75
 },
 {
 "compressor": "zlib",
@@ -5774,8 +5774,8 @@
 "level": 1,
 "out_size": 5567768,
 "ratio": 0.7678,
-"compress_mbps": 64.27,
-"decompress_mbps": 317.07
+"compress_mbps": 64.73,
+"decompress_mbps": 315.8
 },
 {
 "compressor": "zlib",
@@ -5784,8 +5784,8 @@
 "level": 2,
 "out_size": 5504009,
 "ratio": 0.759,
-"compress_mbps": 58.24,
-"decompress_mbps": 327.4
+"compress_mbps": 58.71,
+"decompress_mbps": 324.71
 },
 {
 "compressor": "zlib",
@@ -5794,8 +5794,8 @@
 "level": 3,
 "out_size": 5439339,
 "ratio": 0.7501,
-"compress_mbps": 46.13,
-"decompress_mbps": 334.01
+"compress_mbps": 46.64,
+"decompress_mbps": 333.28
 },
 {
 "compressor": "zlib",
@@ -5804,8 +5804,8 @@
 "level": 4,
 "out_size": 5394604,
 "ratio": 0.7439,
-"compress_mbps": 48.02,
-"decompress_mbps": 346.78
+"compress_mbps": 48.31,
+"decompress_mbps": 343.31
 },
 {
 "compressor": "zlib",
@@ -5814,8 +5814,8 @@
 "level": 5,
 "out_size": 5370116,
 "ratio": 0.7405,
-"compress_mbps": 32.93,
-"decompress_mbps": 334.71
+"compress_mbps": 33.21,
+"decompress_mbps": 336.89
 },
 {
 "compressor": "zlib",
@@ -5824,8 +5824,8 @@
 "level": 6,
 "out_size": 5331793,
 "ratio": 0.7352,
-"compress_mbps": 22.92,
-"decompress_mbps": 344.52
+"compress_mbps": 23.09,
+"decompress_mbps": 337.03
 },
 {
 "compressor": "zlib",
@@ -5834,8 +5834,8 @@
 "level": 7,
 "out_size": 5327677,
 "ratio": 0.7347,
-"compress_mbps": 21.1,
-"decompress_mbps": 347.93
+"compress_mbps": 21.17,
+"decompress_mbps": 346.36
 },
 {
 "compressor": "zlib",
@@ -5844,8 +5844,8 @@
 "level": 8,
 "out_size": 5325914,
 "ratio": 0.7344,
-"compress_mbps": 18.91,
-"decompress_mbps": 344.3
+"compress_mbps": 18.94,
+"decompress_mbps": 345.86
 },
 {
 "compressor": "zlib",
@@ -5854,8 +5854,8 @@
 "level": 9,
 "out_size": 5325914,
 "ratio": 0.7344,
-"compress_mbps": 18.83,
-"decompress_mbps": 349.48
+"compress_mbps": 18.95,
+"decompress_mbps": 345.78
 },
 {
 "compressor": "zlib",
@@ -5864,8 +5864,8 @@
 "level": 1,
 "out_size": 14991236,
 "ratio": 0.3616,
-"compress_mbps": 137.37,
-"decompress_mbps": 383.29
+"compress_mbps": 136.75,
+"decompress_mbps": 377.06
 },
 {
 "compressor": "zlib",
@@ -5874,8 +5874,8 @@
 "level": 2,
 "out_size": 14249692,
 "ratio": 0.3437,
-"compress_mbps": 120.75,
-"decompress_mbps": 404.15
+"compress_mbps": 120.65,
+"decompress_mbps": 394.34
 },
 {
 "compressor": "zlib",
@@ -5884,8 +5884,8 @@
 "level": 3,
 "out_size": 13627761,
 "ratio": 0.3287,
-"compress_mbps": 87.76,
-"decompress_mbps": 417.64
+"compress_mbps": 87.67,
+"decompress_mbps": 409.13
 },
 {
 "compressor": "zlib",
@@ -5894,8 +5894,8 @@
 "level": 4,
 "out_size": 13001990,
 "ratio": 0.3136,
-"compress_mbps": 85.32,
-"decompress_mbps": 394.2
+"compress_mbps": 85.14,
+"decompress_mbps": 392.58
 },
 {
 "compressor": "zlib",
@@ -5904,8 +5904,8 @@
 "level": 5,
 "out_size": 12445991,
 "ratio": 0.3002,
-"compress_mbps": 55.05,
-"decompress_mbps": 393.82
+"compress_mbps": 54.25,
+"decompress_mbps": 372.51
 },
 {
 "compressor": "zlib",
@@ -5914,8 +5914,8 @@
 "level": 6,
 "out_size": 12213941,
 "ratio": 0.2946,
-"compress_mbps": 36.52,
-"decompress_mbps": 398.37
+"compress_mbps": 36.46,
+"decompress_mbps": 395.28
 },
 {
 "compressor": "zlib",
@@ -5924,8 +5924,8 @@
 "level": 7,
 "out_size": 12130416,
 "ratio": 0.2926,
-"compress_mbps": 29.67,
-"decompress_mbps": 398.05
+"compress_mbps": 29.64,
+"decompress_mbps": 396.96
 },
 {
 "compressor": "zlib",
@@ -5934,8 +5934,8 @@
 "level": 8,
 "out_size": 12073697,
 "ratio": 0.2912,
-"compress_mbps": 21.47,
-"decompress_mbps": 400.52
+"compress_mbps": 21.44,
+"decompress_mbps": 398.29
 },
 {
 "compressor": "zlib",
@@ -5944,8 +5944,8 @@
 "level": 9,
 "out_size": 12073469,
 "ratio": 0.2912,
-"compress_mbps": 21.19,
-"decompress_mbps": 403.99
+"compress_mbps": 21.27,
+"decompress_mbps": 400.83
 },
 {
 "compressor": "zlib",
@@ -5954,8 +5954,8 @@
 "level": 1,
 "out_size": 6033926,
 "ratio": 0.712,
-"compress_mbps": 75.53,
-"decompress_mbps": 283.55
+"compress_mbps": 75.16,
+"decompress_mbps": 281.92
 },
 {
 "compressor": "zlib",
@@ -5964,8 +5964,8 @@
 "level": 2,
 "out_size": 5997474,
 "ratio": 0.7077,
-"compress_mbps": 68.39,
-"decompress_mbps": 292.24
+"compress_mbps": 68.12,
+"decompress_mbps": 290.48
 },
 {
 "compressor": "zlib",
@@ -5974,8 +5974,8 @@
 "level": 3,
 "out_size": 5966621,
 "ratio": 0.7041,
-"compress_mbps": 55.39,
-"decompress_mbps": 299.77
+"compress_mbps": 55.16,
+"decompress_mbps": 293.04
 },
 {
 "compressor": "zlib",
@@ -5984,8 +5984,8 @@
 "level": 4,
 "out_size": 6091108,
 "ratio": 0.7188,
-"compress_mbps": 44.65,
-"decompress_mbps": 250.26
+"compress_mbps": 45.75,
+"decompress_mbps": 255.74
 },
 {
 "compressor": "zlib",
@@ -5994,8 +5994,8 @@
 "level": 5,
 "out_size": 6053566,
 "ratio": 0.7143,
-"compress_mbps": 36.1,
-"decompress_mbps": 261.07
+"compress_mbps": 37.05,
+"decompress_mbps": 261.39
 },
 {
 "compressor": "zlib",
@@ -6004,8 +6004,8 @@
 "level": 6,
 "out_size": 6045111,
 "ratio": 0.7134,
-"compress_mbps": 33.81,
-"decompress_mbps": 265.45
+"compress_mbps": 34.84,
+"decompress_mbps": 265.98
 },
 {
 "compressor": "zlib",
@@ -6014,8 +6014,8 @@
 "level": 7,
 "out_size": 6045034,
 "ratio": 0.7133,
-"compress_mbps": 33.79,
-"decompress_mbps": 264.97
+"compress_mbps": 34.79,
+"decompress_mbps": 266.45
 },
 {
 "compressor": "zlib",
@@ -6024,8 +6024,8 @@
 "level": 8,
 "out_size": 6045032,
 "ratio": 0.7133,
-"compress_mbps": 33.87,
-"decompress_mbps": 263.49
+"compress_mbps": 34.76,
+"decompress_mbps": 266.12
 },
 {
 "compressor": "zlib",
@@ -6034,8 +6034,8 @@
 "level": 9,
 "out_size": 6045032,
 "ratio": 0.7133,
-"compress_mbps": 33.89,
-"decompress_mbps": 263.95
+"compress_mbps": 34.77,
+"decompress_mbps": 265.14
 },
 {
 "compressor": "zlib",
@@ -6044,8 +6044,8 @@
 "level": 1,
 "out_size": 965242,
 "ratio": 0.1806,
-"compress_mbps": 256.24,
-"decompress_mbps": 680.73
+"compress_mbps": 261.17,
+"decompress_mbps": 678.68
 },
 {
 "compressor": "zlib",
@@ -6054,8 +6054,8 @@
 "level": 2,
 "out_size": 887265,
 "ratio": 0.166,
-"compress_mbps": 239.61,
-"decompress_mbps": 723.67
+"compress_mbps": 245.37,
+"decompress_mbps": 733.92
 },
 {
 "compressor": "zlib",
@@ -6064,8 +6064,8 @@
 "level": 3,
 "out_size": 822167,
 "ratio": 0.1538,
-"compress_mbps": 186.66,
-"decompress_mbps": 783.72
+"compress_mbps": 190.48,
+"decompress_mbps": 788.03
 },
 {
 "compressor": "zlib",
@@ -6074,8 +6074,8 @@
 "level": 4,
 "out_size": 807518,
 "ratio": 0.1511,
-"compress_mbps": 165.21,
-"decompress_mbps": 754.89
+"compress_mbps": 168.34,
+"decompress_mbps": 753.74
 },
 {
 "compressor": "zlib",
@@ -6084,8 +6084,8 @@
 "level": 5,
 "out_size": 730574,
 "ratio": 0.1367,
-"compress_mbps": 117.71,
-"decompress_mbps": 796.94
+"compress_mbps": 121.58,
+"decompress_mbps": 811.42
 },
 {
 "compressor": "zlib",
@@ -6094,8 +6094,8 @@
 "level": 6,
 "out_size": 687991,
 "ratio": 0.1287,
-"compress_mbps": 78.16,
-"decompress_mbps": 854.12
+"compress_mbps": 79.21,
+"decompress_mbps": 859.24
 },
 {
 "compressor": "zlib",
@@ -6104,8 +6104,8 @@
 "level": 7,
 "out_size": 673933,
 "ratio": 0.1261,
-"compress_mbps": 64.01,
-"decompress_mbps": 853.88
+"compress_mbps": 64.95,
+"decompress_mbps": 873.58
 },
 {
 "compressor": "zlib",
@@ -6114,8 +6114,8 @@
 "level": 8,
 "out_size": 659518,
 "ratio": 0.1234,
-"compress_mbps": 42.93,
-"decompress_mbps": 854.35
+"compress_mbps": 43.05,
+"decompress_mbps": 901.08
 },
 {
 "compressor": "zlib",
@@ -6124,8 +6124,8 @@
 "level": 9,
 "out_size": 658899,
 "ratio": 0.1233,
-"compress_mbps": 39.77,
-"decompress_mbps": 892.48
+"compress_mbps": 39.58,
+"decompress_mbps": 894.67
 },
 {
 "compressor": "miniz_oxide",
@@ -6134,8 +6134,8 @@
 "level": 1,
 "out_size": 5363862,
 "ratio": 0.5263,
-"compress_mbps": 141.07,
-"decompress_mbps": 371.06
+"compress_mbps": 138.84,
+"decompress_mbps": 367.81
 },
 {
 "compressor": "miniz_oxide",
@@ -6144,8 +6144,8 @@
 "level": 2,
 "out_size": 4438205,
 "ratio": 0.4354,
-"compress_mbps": 129.75,
-"decompress_mbps": 430.4
+"compress_mbps": 128.37,
+"decompress_mbps": 428.06
 },
 {
 "compressor": "miniz_oxide",
@@ -6154,8 +6154,8 @@
 "level": 3,
 "out_size": 4054333,
 "ratio": 0.3978,
-"compress_mbps": 64.22,
-"decompress_mbps": 478.43
+"compress_mbps": 63.93,
+"decompress_mbps": 476.26
 },
 {
 "compressor": "miniz_oxide",
@@ -6164,8 +6164,8 @@
 "level": 4,
 "out_size": 4038550,
 "ratio": 0.3962,
-"compress_mbps": 57.95,
-"decompress_mbps": 474.3
+"compress_mbps": 57.49,
+"decompress_mbps": 470.47
 },
 {
 "compressor": "miniz_oxide",
@@ -6174,8 +6174,8 @@
 "level": 5,
 "out_size": 3954920,
 "ratio": 0.388,
-"compress_mbps": 40.42,
-"decompress_mbps": 465.22
+"compress_mbps": 40.17,
+"decompress_mbps": 457.45
 },
 {
 "compressor": "miniz_oxide",
@@ -6184,8 +6184,8 @@
 "level": 6,
 "out_size": 3872874,
 "ratio": 0.38,
-"compress_mbps": 22.63,
-"decompress_mbps": 475.18
+"compress_mbps": 22.55,
+"decompress_mbps": 469.75
 },
 {
 "compressor": "miniz_oxide",
@@ -6194,8 +6194,8 @@
 "level": 7,
 "out_size": 3859937,
 "ratio": 0.3787,
-"compress_mbps": 18.87,
-"decompress_mbps": 471.88
+"compress_mbps": 18.81,
+"decompress_mbps": 471.16
 },
 {
 "compressor": "miniz_oxide",
@@ -6204,8 +6204,8 @@
 "level": 8,
 "out_size": 3855935,
 "ratio": 0.3783,
-"compress_mbps": 17.11,
-"decompress_mbps": 474.3
+"compress_mbps": 17.06,
+"decompress_mbps": 469.53
 },
 {
 "compressor": "miniz_oxide",
@@ -6214,8 +6214,8 @@
 "level": 9,
 "out_size": 3855791,
 "ratio": 0.3783,
-"compress_mbps": 17.08,
-"decompress_mbps": 476.06
+"compress_mbps": 16.99,
+"decompress_mbps": 469.82
 },
 {
 "compressor": "miniz_oxide",
@@ -6224,8 +6224,8 @@
 "level": 1,
 "out_size": 22334882,
 "ratio": 0.4361,
-"compress_mbps": 232.41,
-"decompress_mbps": 372.28
+"compress_mbps": 230.39,
+"decompress_mbps": 363.79
 },
 {
 "compressor": "miniz_oxide",
@@ -6234,8 +6234,8 @@
 "level": 2,
 "out_size": 20150366,
 "ratio": 0.3934,
-"compress_mbps": 122.09,
-"decompress_mbps": 383.59
+"compress_mbps": 118.85,
+"decompress_mbps": 374.49
 },
 {
 "compressor": "miniz_oxide",
@@ -6244,8 +6244,8 @@
 "level": 3,
 "out_size": 19495014,
 "ratio": 0.3806,
-"compress_mbps": 70.7,
-"decompress_mbps": 387.44
+"compress_mbps": 69.8,
+"decompress_mbps": 382.14
 },
 {
 "compressor": "miniz_oxide",
@@ -6254,8 +6254,8 @@
 "level": 4,
 "out_size": 19424978,
 "ratio": 0.3792,
-"compress_mbps": 71.78,
-"decompress_mbps": 404.62
+"compress_mbps": 70.86,
+"decompress_mbps": 396.9
 },
 {
 "compressor": "miniz_oxide",
@@ -6264,8 +6264,8 @@
 "level": 5,
 "out_size": 19298736,
 "ratio": 0.3768,
-"compress_mbps": 54.42,
-"decompress_mbps": 417.0
+"compress_mbps": 53.9,
+"decompress_mbps": 410.98
 },
 {
 "compressor": "miniz_oxide",
@@ -6274,8 +6274,8 @@
 "level": 6,
 "out_size": 19179167,
 "ratio": 0.3744,
-"compress_mbps": 29.67,
-"decompress_mbps": 424.26
+"compress_mbps": 29.61,
+"decompress_mbps": 417.74
 },
 {
 "compressor": "miniz_oxide",
@@ -6284,8 +6284,8 @@
 "level": 7,
 "out_size": 19151324,
 "ratio": 0.3739,
-"compress_mbps": 21.9,
-"decompress_mbps": 423.43
+"compress_mbps": 21.88,
+"decompress_mbps": 411.94
 },
 {
 "compressor": "miniz_oxide",
@@ -6294,8 +6294,8 @@
 "level": 8,
 "out_size": 19144373,
 "ratio": 0.3738,
-"compress_mbps": 16.61,
-"decompress_mbps": 425.66
+"compress_mbps": 16.54,
+"decompress_mbps": 418.45
 },
 {
 "compressor": "miniz_oxide",
@@ -6304,8 +6304,8 @@
 "level": 9,
 "out_size": 19141383,
 "ratio": 0.3737,
-"compress_mbps": 14.19,
-"decompress_mbps": 427.28
+"compress_mbps": 14.14,
+"decompress_mbps": 417.68
 },
 {
 "compressor": "miniz_oxide",
@@ -6314,8 +6314,8 @@
 "level": 1,
 "out_size": 4249731,
 "ratio": 0.4262,
-"compress_mbps": 310.12,
-"decompress_mbps": 533.89
+"compress_mbps": 309.05,
+"decompress_mbps": 495.59
 },
 {
 "compressor": "miniz_oxide",
@@ -6324,8 +6324,8 @@
 "level": 2,
 "out_size": 3775479,
 "ratio": 0.3787,
-"compress_mbps": 160.33,
-"decompress_mbps": 558.66
+"compress_mbps": 156.4,
+"decompress_mbps": 553.56
 },
 {
 "compressor": "miniz_oxide",
@@ -6334,8 +6334,8 @@
 "level": 3,
 "out_size": 3656966,
 "ratio": 0.3668,
-"compress_mbps": 80.79,
-"decompress_mbps": 579.52
+"compress_mbps": 79.69,
+"decompress_mbps": 573.29
 },
 {
 "compressor": "miniz_oxide",
@@ -6344,8 +6344,8 @@
 "level": 4,
 "out_size": 3740378,
 "ratio": 0.3751,
-"compress_mbps": 68.31,
-"decompress_mbps": 542.64
+"compress_mbps": 67.29,
+"decompress_mbps": 532.55
 },
 {
 "compressor": "miniz_oxide",
@@ -6354,8 +6354,8 @@
 "level": 5,
 "out_size": 3713604,
 "ratio": 0.3725,
-"compress_mbps": 48.99,
-"decompress_mbps": 505.5
+"compress_mbps": 48.5,
+"decompress_mbps": 496.36
 },
 {
 "compressor": "miniz_oxide",
@@ -6364,8 +6364,8 @@
 "level": 6,
 "out_size": 3683556,
 "ratio": 0.3694,
-"compress_mbps": 25.29,
-"decompress_mbps": 525.49
+"compress_mbps": 25.11,
+"decompress_mbps": 512.39
 },
 {
 "compressor": "miniz_oxide",
@@ -6374,8 +6374,8 @@
 "level": 7,
 "out_size": 3683797,
 "ratio": 0.3695,
-"compress_mbps": 19.23,
-"decompress_mbps": 531.93
+"compress_mbps": 19.09,
+"decompress_mbps": 524.17
 },
 {
 "compressor": "miniz_oxide",
@@ -6384,8 +6384,8 @@
 "level": 8,
 "out_size": 3684477,
 "ratio": 0.3695,
-"compress_mbps": 14.5,
-"decompress_mbps": 542.85
+"compress_mbps": 14.43,
+"decompress_mbps": 535.45
 },
 {
 "compressor": "miniz_oxide",
@@ -6394,8 +6394,8 @@
 "level": 9,
 "out_size": 3679414,
 "ratio": 0.369,
-"compress_mbps": 12.43,
-"decompress_mbps": 545.52
+"compress_mbps": 12.41,
+"decompress_mbps": 536.55
 },
 {
 "compressor": "miniz_oxide",
@@ -6404,8 +6404,8 @@
 "level": 1,
 "out_size": 5594622,
 "ratio": 0.1667,
-"compress_mbps": 436.04,
-"decompress_mbps": 848.67
+"compress_mbps": 430.78,
+"decompress_mbps": 829.99
 },
 {
 "compressor": "miniz_oxide",
@@ -6414,8 +6414,8 @@
 "level": 2,
 "out_size": 4179532,
 "ratio": 0.1246,
-"compress_mbps": 331.74,
-"decompress_mbps": 939.26
+"compress_mbps": 326.57,
+"decompress_mbps": 941.63
 },
 {
 "compressor": "miniz_oxide",
@@ -6424,8 +6424,8 @@
 "level": 3,
 "out_size": 3542329,
 "ratio": 0.1056,
-"compress_mbps": 213.74,
-"decompress_mbps": 855.0
+"compress_mbps": 211.22,
+"decompress_mbps": 836.64
 },
 {
 "compressor": "miniz_oxide",
@@ -6434,8 +6434,8 @@
 "level": 4,
 "out_size": 3323363,
 "ratio": 0.099,
-"compress_mbps": 200.03,
-"decompress_mbps": 892.69
+"compress_mbps": 198.39,
+"decompress_mbps": 870.64
 },
 {
 "compressor": "miniz_oxide",
@@ -6444,8 +6444,8 @@
 "level": 5,
 "out_size": 3230343,
 "ratio": 0.0963,
-"compress_mbps": 163.74,
-"decompress_mbps": 974.59
+"compress_mbps": 161.96,
+"decompress_mbps": 952.9
 },
 {
 "compressor": "miniz_oxide",
@@ -6454,8 +6454,8 @@
 "level": 6,
 "out_size": 3123421,
 "ratio": 0.0931,
-"compress_mbps": 96.45,
-"decompress_mbps": 1031.21
+"compress_mbps": 95.56,
+"decompress_mbps": 999.0
 },
 {
 "compressor": "miniz_oxide",
@@ -6464,8 +6464,8 @@
 "level": 7,
 "out_size": 3093778,
 "ratio": 0.0922,
-"compress_mbps": 70.81,
-"decompress_mbps": 989.71
+"compress_mbps": 70.47,
+"decompress_mbps": 971.07
 },
 {
 "compressor": "miniz_oxide",
@@ -6474,8 +6474,8 @@
 "level": 8,
 "out_size": 3067318,
 "ratio": 0.0914,
-"compress_mbps": 50.12,
-"decompress_mbps": 1018.23
+"compress_mbps": 50.0,
+"decompress_mbps": 1028.45
 },
 {
 "compressor": "miniz_oxide",
@@ -6484,8 +6484,8 @@
 "level": 9,
 "out_size": 3050695,
 "ratio": 0.0909,
-"compress_mbps": 42.09,
-"decompress_mbps": 1038.43
+"compress_mbps": 41.95,
+"decompress_mbps": 1034.29
 },
 {
 "compressor": "miniz_oxide",
@@ -6494,8 +6494,8 @@
 "level": 1,
 "out_size": 3543611,
 "ratio": 0.576,
-"compress_mbps": 168.73,
-"decompress_mbps": 282.88
+"compress_mbps": 165.65,
+"decompress_mbps": 278.91
 },
 {
 "compressor": "miniz_oxide",
@@ -6504,8 +6504,8 @@
 "level": 2,
 "out_size": 3226818,
 "ratio": 0.5245,
-"compress_mbps": 87.54,
-"decompress_mbps": 289.7
+"compress_mbps": 86.5,
+"decompress_mbps": 286.55
 },
 {
 "compressor": "miniz_oxide",
@@ -6514,8 +6514,8 @@
 "level": 3,
 "out_size": 3144140,
 "ratio": 0.5111,
-"compress_mbps": 53.22,
-"decompress_mbps": 301.12
+"compress_mbps": 52.82,
+"decompress_mbps": 294.54
 },
 {
 "compressor": "miniz_oxide",
@@ -6524,8 +6524,8 @@
 "level": 4,
 "out_size": 3129833,
 "ratio": 0.5087,
-"compress_mbps": 52.07,
-"decompress_mbps": 329.72
+"compress_mbps": 51.57,
+"decompress_mbps": 323.92
 },
 {
 "compressor": "miniz_oxide",
@@ -6534,8 +6534,8 @@
 "level": 5,
 "out_size": 3114809,
 "ratio": 0.5063,
-"compress_mbps": 40.7,
-"decompress_mbps": 341.81
+"compress_mbps": 40.42,
+"decompress_mbps": 335.9
 },
 {
 "compressor": "miniz_oxide",
@@ -6544,8 +6544,8 @@
 "level": 6,
 "out_size": 3095705,
 "ratio": 0.5032,
-"compress_mbps": 25.24,
-"decompress_mbps": 348.81
+"compress_mbps": 25.14,
+"decompress_mbps": 341.7
 },
 {
 "compressor": "miniz_oxide",
@@ -6554,8 +6554,8 @@
 "level": 7,
 "out_size": 3090055,
 "ratio": 0.5023,
-"compress_mbps": 20.55,
-"decompress_mbps": 337.12
+"compress_mbps": 20.41,
+"decompress_mbps": 340.84
 },
 {
 "compressor": "miniz_oxide",
@@ -6564,8 +6564,8 @@
 "level": 8,
 "out_size": 3087665,
 "ratio": 0.5019,
-"compress_mbps": 17.46,
-"decompress_mbps": 351.13
+"compress_mbps": 17.39,
+"decompress_mbps": 346.63
 },
 {
 "compressor": "miniz_oxide",
@@ -6574,8 +6574,8 @@
 "level": 9,
 "out_size": 3087158,
 "ratio": 0.5018,
-"compress_mbps": 16.41,
-"decompress_mbps": 352.72
+"compress_mbps": 16.31,
+"decompress_mbps": 345.97
 },
 {
 "compressor": "miniz_oxide",
@@ -6584,8 +6584,8 @@
 "level": 1,
 "out_size": 5419510,
 "ratio": 0.5373,
-"compress_mbps": 241.27,
-"decompress_mbps": 514.03
+"compress_mbps": 238.52,
+"decompress_mbps": 530.68
 },
 {
 "compressor": "miniz_oxide",
@@ -6594,8 +6594,8 @@
 "level": 2,
 "out_size": 3982547,
 "ratio": 0.3949,
-"compress_mbps": 126.08,
-"decompress_mbps": 560.05
+"compress_mbps": 122.93,
+"decompress_mbps": 547.08
 },
 {
 "compressor": "miniz_oxide",
@@ -6604,8 +6604,8 @@
 "level": 3,
 "out_size": 3806102,
 "ratio": 0.3774,
-"compress_mbps": 83.09,
-"decompress_mbps": 574.93
+"compress_mbps": 81.72,
+"decompress_mbps": 561.82
 },
 {
 "compressor": "miniz_oxide",
@@ -6614,8 +6614,8 @@
 "level": 4,
 "out_size": 3761477,
 "ratio": 0.373,
-"compress_mbps": 80.09,
-"decompress_mbps": 612.34
+"compress_mbps": 78.43,
+"decompress_mbps": 597.71
 },
 {
 "compressor": "miniz_oxide",
@@ -6624,8 +6624,8 @@
 "level": 5,
 "out_size": 3740298,
 "ratio": 0.3709,
-"compress_mbps": 68.41,
-"decompress_mbps": 614.53
+"compress_mbps": 67.35,
+"decompress_mbps": 596.99
 },
 {
 "compressor": "miniz_oxide",
@@ -6634,8 +6634,8 @@
 "level": 6,
 "out_size": 3686116,
 "ratio": 0.3655,
-"compress_mbps": 49.93,
-"decompress_mbps": 651.97
+"compress_mbps": 49.33,
+"decompress_mbps": 634.77
 },
 {
 "compressor": "miniz_oxide",
@@ -6644,8 +6644,8 @@
 "level": 7,
 "out_size": 3668442,
 "ratio": 0.3637,
-"compress_mbps": 39.07,
-"decompress_mbps": 660.84
+"compress_mbps": 38.67,
+"decompress_mbps": 648.55
 },
 {
 "compressor": "miniz_oxide",
@@ -6654,8 +6654,8 @@
 "level": 8,
 "out_size": 3665072,
 "ratio": 0.3634,
-"compress_mbps": 33.38,
-"decompress_mbps": 665.89
+"compress_mbps": 33.07,
+"decompress_mbps": 641.74
 },
 {
 "compressor": "miniz_oxide",
@@ -6664,8 +6664,8 @@
 "level": 9,
 "out_size": 3665057,
 "ratio": 0.3634,
-"compress_mbps": 33.28,
-"decompress_mbps": 660.67
+"compress_mbps": 32.97,
+"decompress_mbps": 644.3
 },
 {
 "compressor": "miniz_oxide",
@@ -6674,8 +6674,8 @@
 "level": 1,
 "out_size": 2842321,
 "ratio": 0.4289,
-"compress_mbps": 190.03,
-"decompress_mbps": 479.21
+"compress_mbps": 186.85,
+"decompress_mbps": 475.6
 },
 {
 "compressor": "miniz_oxide",
@@ -6684,8 +6684,8 @@
 "level": 2,
 "out_size": 2232180,
 "ratio": 0.3368,
-"compress_mbps": 153.91,
-"decompress_mbps": 521.01
+"compress_mbps": 151.74,
+"decompress_mbps": 514.0
 },
 {
 "compressor": "miniz_oxide",
@@ -6694,8 +6694,8 @@
 "level": 3,
 "out_size": 2003056,
 "ratio": 0.3022,
-"compress_mbps": 82.58,
-"decompress_mbps": 561.49
+"compress_mbps": 81.96,
+"decompress_mbps": 551.23
 },
 {
 "compressor": "miniz_oxide",
@@ -6704,8 +6704,8 @@
 "level": 4,
 "out_size": 1985375,
 "ratio": 0.2996,
-"compress_mbps": 74.62,
-"decompress_mbps": 571.01
+"compress_mbps": 74.08,
+"decompress_mbps": 565.83
 },
 {
 "compressor": "miniz_oxide",
@@ -6714,8 +6714,8 @@
 "level": 5,
 "out_size": 1933775,
 "ratio": 0.2918,
-"compress_mbps": 52.18,
-"decompress_mbps": 545.06
+"compress_mbps": 51.9,
+"decompress_mbps": 540.96
 },
 {
 "compressor": "miniz_oxide",
@@ -6724,8 +6724,8 @@
 "level": 6,
 "out_size": 1858103,
 "ratio": 0.2804,
-"compress_mbps": 22.06,
-"decompress_mbps": 551.05
+"compress_mbps": 21.98,
+"decompress_mbps": 546.37
 },
 {
 "compressor": "miniz_oxide",
@@ -6734,8 +6734,8 @@
 "level": 7,
 "out_size": 1840414,
 "ratio": 0.2777,
-"compress_mbps": 15.14,
-"decompress_mbps": 554.29
+"compress_mbps": 15.08,
+"decompress_mbps": 541.87
 },
 {
 "compressor": "miniz_oxide",
@@ -6744,8 +6744,8 @@
 "level": 8,
 "out_size": 1831679,
 "ratio": 0.2764,
-"compress_mbps": 11.74,
-"decompress_mbps": 548.88
+"compress_mbps": 11.65,
+"decompress_mbps": 534.0
 },
 {
 "compressor": "miniz_oxide",
@@ -6754,8 +6754,8 @@
 "level": 9,
 "out_size": 1827137,
 "ratio": 0.2757,
-"compress_mbps": 10.15,
-"decompress_mbps": 550.5
+"compress_mbps": 10.13,
+"decompress_mbps": 543.76
 },
 {
 "compressor": "miniz_oxide",
@@ -6764,8 +6764,8 @@
 "level": 1,
 "out_size": 7089759,
 "ratio": 0.3281,
-"compress_mbps": 289.84,
-"decompress_mbps": 564.29
+"compress_mbps": 286.42,
+"decompress_mbps": 555.98
 },
 {
 "compressor": "miniz_oxide",
@@ -6774,8 +6774,8 @@
 "level": 2,
 "out_size": 5966231,
 "ratio": 0.2761,
-"compress_mbps": 176.67,
-"decompress_mbps": 627.58
+"compress_mbps": 173.68,
+"decompress_mbps": 620.8
 },
 {
 "compressor": "miniz_oxide",
@@ -6784,8 +6784,8 @@
 "level": 3,
 "out_size": 5611838,
 "ratio": 0.2597,
-"compress_mbps": 112.69,
-"decompress_mbps": 655.24
+"compress_mbps": 111.31,
+"decompress_mbps": 648.6
 },
 {
 "compressor": "miniz_oxide",
@@ -6794,8 +6794,8 @@
 "level": 4,
 "out_size": 5535436,
 "ratio": 0.2562,
-"compress_mbps": 106.31,
-"decompress_mbps": 679.36
+"compress_mbps": 105.34,
+"decompress_mbps": 670.88
 },
 {
 "compressor": "miniz_oxide",
@@ -6804,8 +6804,8 @@
 "level": 5,
 "out_size": 5480971,
 "ratio": 0.2537,
-"compress_mbps": 82.08,
-"decompress_mbps": 690.35
+"compress_mbps": 81.31,
+"decompress_mbps": 679.9
 },
 {
 "compressor": "miniz_oxide",
@@ -6814,8 +6814,8 @@
 "level": 6,
 "out_size": 5437556,
 "ratio": 0.2517,
-"compress_mbps": 49.64,
-"decompress_mbps": 664.08
+"compress_mbps": 49.49,
+"decompress_mbps": 695.34
 },
 {
 "compressor": "miniz_oxide",
@@ -6824,8 +6824,8 @@
 "level": 7,
 "out_size": 5432108,
 "ratio": 0.2514,
-"compress_mbps": 40.61,
-"decompress_mbps": 706.52
+"compress_mbps": 40.43,
+"decompress_mbps": 698.02
 },
 {
 "compressor": "miniz_oxide",
@@ -6834,8 +6834,8 @@
 "level": 8,
 "out_size": 5428571,
 "ratio": 0.2512,
-"compress_mbps": 33.77,
-"decompress_mbps": 709.25
+"compress_mbps": 33.63,
+"decompress_mbps": 704.91
 },
 {
 "compressor": "miniz_oxide",
@@ -6844,8 +6844,8 @@
 "level": 9,
 "out_size": 5425526,
 "ratio": 0.2511,
-"compress_mbps": 30.59,
-"decompress_mbps": 710.51
+"compress_mbps": 30.46,
+"decompress_mbps": 702.22
 },
 {
 "compressor": "miniz_oxide",
@@ -6854,8 +6854,8 @@
 "level": 1,
 "out_size": 5900800,
 "ratio": 0.8137,
-"compress_mbps": 186.06,
-"decompress_mbps": 329.79
+"compress_mbps": 185.19,
+"decompress_mbps": 325.47
 },
 {
 "compressor": "miniz_oxide",
@@ -6864,8 +6864,8 @@
 "level": 2,
 "out_size": 5523611,
 "ratio": 0.7617,
-"compress_mbps": 70.66,
-"decompress_mbps": 342.6
+"compress_mbps": 68.99,
+"decompress_mbps": 338.67
 },
 {
 "compressor": "miniz_oxide",
@@ -6874,8 +6874,8 @@
 "level": 3,
 "out_size": 5393086,
 "ratio": 0.7437,
-"compress_mbps": 40.8,
-"decompress_mbps": 354.04
+"compress_mbps": 40.2,
+"decompress_mbps": 347.87
 },
 {
 "compressor": "miniz_oxide",
@@ -6884,8 +6884,8 @@
 "level": 4,
 "out_size": 5401582,
 "ratio": 0.7448,
-"compress_mbps": 41.01,
-"decompress_mbps": 370.08
+"compress_mbps": 40.52,
+"decompress_mbps": 365.57
 },
 {
 "compressor": "miniz_oxide",
@@ -6894,8 +6894,8 @@
 "level": 5,
 "out_size": 5371274,
 "ratio": 0.7407,
-"compress_mbps": 31.55,
-"decompress_mbps": 361.79
+"compress_mbps": 31.11,
+"decompress_mbps": 356.55
 },
 {
 "compressor": "miniz_oxide",
@@ -6904,8 +6904,8 @@
 "level": 6,
 "out_size": 5330096,
 "ratio": 0.735,
-"compress_mbps": 20.92,
-"decompress_mbps": 368.37
+"compress_mbps": 20.76,
+"decompress_mbps": 363.28
 },
 {
 "compressor": "miniz_oxide",
@@ -6914,8 +6914,8 @@
 "level": 7,
 "out_size": 5325437,
 "ratio": 0.7343,
-"compress_mbps": 19.12,
-"decompress_mbps": 368.68
+"compress_mbps": 18.98,
+"decompress_mbps": 363.74
 },
 {
 "compressor": "miniz_oxide",
@@ -6924,8 +6924,8 @@
 "level": 8,
 "out_size": 5323934,
 "ratio": 0.7341,
-"compress_mbps": 18.17,
-"decompress_mbps": 362.87
+"compress_mbps": 18.03,
+"decompress_mbps": 363.6
 },
 {
 "compressor": "miniz_oxide",
@@ -6934,8 +6934,8 @@
 "level": 9,
 "out_size": 5323621,
 "ratio": 0.7341,
-"compress_mbps": 17.86,
-"decompress_mbps": 365.12
+"compress_mbps": 17.73,
+"decompress_mbps": 363.45
 },
 {
 "compressor": "miniz_oxide",
@@ -6944,8 +6944,8 @@
 "level": 1,
 "out_size": 17587173,
 "ratio": 0.4242,
-"compress_mbps": 183.29,
-"decompress_mbps": 361.5
+"compress_mbps": 180.5,
+"decompress_mbps": 373.84
 },
 {
 "compressor": "miniz_oxide",
@@ -6954,8 +6954,8 @@
 "level": 2,
 "out_size": 14171707,
 "ratio": 0.3418,
-"compress_mbps": 150.22,
-"decompress_mbps": 412.78
+"compress_mbps": 148.44,
+"decompress_mbps": 406.39
 },
 {
 "compressor": "miniz_oxide",
@@ -6964,8 +6964,8 @@
 "level": 3,
 "out_size": 12774851,
 "ratio": 0.3081,
-"compress_mbps": 86.15,
-"decompress_mbps": 443.28
+"compress_mbps": 85.79,
+"decompress_mbps": 436.74
 },
 {
 "compressor": "miniz_oxide",
@@ -6974,8 +6974,8 @@
 "level": 4,
 "out_size": 12612554,
 "ratio": 0.3042,
-"compress_mbps": 76.65,
-"decompress_mbps": 444.46
+"compress_mbps": 75.9,
+"decompress_mbps": 434.06
 },
 {
 "compressor": "miniz_oxide",
@@ -6984,8 +6984,8 @@
 "level": 5,
 "out_size": 12392339,
 "ratio": 0.2989,
-"compress_mbps": 58.33,
-"decompress_mbps": 452.8
+"compress_mbps": 57.89,
+"decompress_mbps": 442.61
 },
 {
 "compressor": "miniz_oxide",
@@ -6994,8 +6994,8 @@
 "level": 6,
 "out_size": 12158314,
 "ratio": 0.2933,
-"compress_mbps": 34.45,
-"decompress_mbps": 462.07
+"compress_mbps": 34.34,
+"decompress_mbps": 455.97
 },
 {
 "compressor": "miniz_oxide",
@@ -7004,8 +7004,8 @@
 "level": 7,
 "out_size": 12107840,
 "ratio": 0.292,
-"compress_mbps": 27.59,
-"decompress_mbps": 465.39
+"compress_mbps": 27.55,
+"decompress_mbps": 455.69
 },
 {
 "compressor": "miniz_oxide",
@@ -7014,8 +7014,8 @@
 "level": 8,
 "out_size": 12081311,
 "ratio": 0.2914,
-"compress_mbps": 22.93,
-"decompress_mbps": 467.44
+"compress_mbps": 22.79,
+"decompress_mbps": 458.8
 },
 {
 "compressor": "miniz_oxide",
@@ -7024,8 +7024,8 @@
 "level": 9,
 "out_size": 12081011,
 "ratio": 0.2914,
-"compress_mbps": 22.82,
-"decompress_mbps": 469.55
+"compress_mbps": 22.7,
+"decompress_mbps": 457.58
 },
 {
 "compressor": "miniz_oxide",
@@ -7034,8 +7034,8 @@
 "level": 1,
 "out_size": 6527324,
 "ratio": 0.7703,
-"compress_mbps": 237.3,
-"decompress_mbps": 328.1
+"compress_mbps": 236.69,
+"decompress_mbps": 324.88
 },
 {
 "compressor": "miniz_oxide",
@@ -7044,8 +7044,8 @@
 "level": 2,
 "out_size": 6051483,
 "ratio": 0.7141,
-"compress_mbps": 76.83,
-"decompress_mbps": 331.32
+"compress_mbps": 74.25,
+"decompress_mbps": 320.63
 },
 {
 "compressor": "miniz_oxide",
@@ -7054,8 +7054,8 @@
 "level": 3,
 "out_size": 6010123,
 "ratio": 0.7092,
-"compress_mbps": 52.92,
-"decompress_mbps": 334.18
+"compress_mbps": 51.61,
+"decompress_mbps": 326.32
 },
 {
 "compressor": "miniz_oxide",
@@ -7064,8 +7064,8 @@
 "level": 4,
 "out_size": 6024815,
 "ratio": 0.711,
-"compress_mbps": 45.06,
-"decompress_mbps": 286.65
+"compress_mbps": 44.14,
+"decompress_mbps": 277.6
 },
 {
 "compressor": "miniz_oxide",
@@ -7074,8 +7074,8 @@
 "level": 5,
 "out_size": 6005181,
 "ratio": 0.7086,
-"compress_mbps": 40.97,
-"decompress_mbps": 292.42
+"compress_mbps": 40.04,
+"decompress_mbps": 283.6
 },
 {
 "compressor": "miniz_oxide",
@@ -7084,8 +7084,8 @@
 "level": 6,
 "out_size": 5997508,
 "ratio": 0.7077,
-"compress_mbps": 38.41,
-"decompress_mbps": 296.27
+"compress_mbps": 37.63,
+"decompress_mbps": 289.26
 },
 {
 "compressor": "miniz_oxide",
@@ -7094,8 +7094,8 @@
 "level": 7,
 "out_size": 5997403,
 "ratio": 0.7077,
-"compress_mbps": 38.28,
-"decompress_mbps": 296.57
+"compress_mbps": 37.54,
+"decompress_mbps": 288.85
 },
 {
 "compressor": "miniz_oxide",
@@ -7104,8 +7104,8 @@
 "level": 8,
 "out_size": 5997403,
 "ratio": 0.7077,
-"compress_mbps": 38.28,
-"decompress_mbps": 296.44
+"compress_mbps": 37.53,
+"decompress_mbps": 288.55
 },
 {
 "compressor": "miniz_oxide",
@@ -7114,8 +7114,8 @@
 "level": 9,
 "out_size": 5997403,
 "ratio": 0.7077,
-"compress_mbps": 38.34,
-"decompress_mbps": 296.49
+"compress_mbps": 37.49,
+"decompress_mbps": 288.95
 },
 {
 "compressor": "miniz_oxide",
@@ -7124,8 +7124,8 @@
 "level": 1,
 "out_size": 1147652,
 "ratio": 0.2147,
-"compress_mbps": 386.02,
-"decompress_mbps": 847.06
+"compress_mbps": 385.07,
+"decompress_mbps": 825.7
 },
 {
 "compressor": "miniz_oxide",
@@ -7134,8 +7134,8 @@
 "level": 2,
 "out_size": 919639,
 "ratio": 0.172,
-"compress_mbps": 263.94,
-"decompress_mbps": 965.59
+"compress_mbps": 260.1,
+"decompress_mbps": 944.21
 },
 {
 "compressor": "miniz_oxide",
@@ -7144,8 +7144,8 @@
 "level": 3,
 "out_size": 752341,
 "ratio": 0.1407,
-"compress_mbps": 167.91,
-"decompress_mbps": 1070.54
+"compress_mbps": 166.29,
+"decompress_mbps": 1046.71
 },
 {
 "compressor": "miniz_oxide",
@@ -7154,8 +7154,8 @@
 "level": 4,
 "out_size": 735537,
 "ratio": 0.1376,
-"compress_mbps": 162.13,
-"decompress_mbps": 1050.08
+"compress_mbps": 160.33,
+"decompress_mbps": 1027.47
 },
 {
 "compressor": "miniz_oxide",
@@ -7164,8 +7164,8 @@
 "level": 5,
 "out_size": 706789,
 "ratio": 0.1322,
-"compress_mbps": 123.92,
-"decompress_mbps": 1142.07
+"compress_mbps": 122.95,
+"decompress_mbps": 1102.42
 },
 {
 "compressor": "miniz_oxide",
@@ -7174,8 +7174,8 @@
 "level": 6,
 "out_size": 676279,
 "ratio": 0.1265,
-"compress_mbps": 69.72,
-"decompress_mbps": 1226.23
+"compress_mbps": 69.28,
+"decompress_mbps": 1203.23
 },
 {
 "compressor": "miniz_oxide",
@@ -7184,8 +7184,8 @@
 "level": 7,
 "out_size": 668772,
 "ratio": 0.1251,
-"compress_mbps": 56.21,
-"decompress_mbps": 1243.36
+"compress_mbps": 55.86,
+"decompress_mbps": 1203.45
 },
 {
 "compressor": "miniz_oxide",
@@ -7194,8 +7194,8 @@
 "level": 8,
 "out_size": 665340,
 "ratio": 0.1245,
-"compress_mbps": 47.67,
-"decompress_mbps": 1216.7
+"compress_mbps": 47.32,
+"decompress_mbps": 1169.03
 },
 {
 "compressor": "miniz_oxide",
@@ -7204,8 +7204,8 @@
 "level": 9,
 "out_size": 664273,
 "ratio": 0.1243,
-"compress_mbps": 45.91,
-"decompress_mbps": 1235.34
+"compress_mbps": 45.74,
+"decompress_mbps": 1182.28
 },
 {
 "compressor": "libdeflate",
@@ -7214,8 +7214,8 @@
 "level": 1,
 "out_size": 4217525,
 "ratio": 0.4138,
-"compress_mbps": 243.54,
-"decompress_mbps": 800.78
+"compress_mbps": 238.58,
+"decompress_mbps": 774.63
 },
 {
 "compressor": "libdeflate",
@@ -7224,8 +7224,8 @@
 "level": 2,
 "out_size": 4053259,
 "ratio": 0.3977,
-"compress_mbps": 170.46,
-"decompress_mbps": 860.06
+"compress_mbps": 168.47,
+"decompress_mbps": 858.34
 },
 {
 "compressor": "libdeflate",
@@ -7234,8 +7234,8 @@
 "level": 3,
 "out_size": 3989875,
 "ratio": 0.3915,
-"compress_mbps": 139.8,
-"decompress_mbps": 925.35
+"compress_mbps": 138.74,
+"decompress_mbps": 909.13
 },
 {
 "compressor": "libdeflate",
@@ -7244,8 +7244,8 @@
 "level": 4,
 "out_size": 3972869,
 "ratio": 0.3898,
-"compress_mbps": 127.43,
-"decompress_mbps": 829.86
+"compress_mbps": 126.8,
+"decompress_mbps": 812.77
 },
 {
 "compressor": "libdeflate",
@@ -7254,8 +7254,8 @@
 "level": 5,
 "out_size": 3894026,
 "ratio": 0.3821,
-"compress_mbps": 99.5,
-"decompress_mbps": 811.78
+"compress_mbps": 98.53,
+"decompress_mbps": 765.78
 },
 {
 "compressor": "libdeflate",
@@ -7264,8 +7264,8 @@
 "level": 6,
 "out_size": 3859436,
 "ratio": 0.3787,
-"compress_mbps": 75.46,
-"decompress_mbps": 844.86
+"compress_mbps": 74.9,
+"decompress_mbps": 789.64
 },
 {
 "compressor": "libdeflate",
@@ -7274,8 +7274,8 @@
 "level": 7,
 "out_size": 3837515,
 "ratio": 0.3765,
-"compress_mbps": 55.84,
-"decompress_mbps": 842.66
+"compress_mbps": 55.3,
+"decompress_mbps": 794.86
 },
 {
 "compressor": "libdeflate",
@@ -7285,7 +7285,7 @@
 "out_size": 3811467,
 "ratio": 0.374,
 "compress_mbps": 35.91,
-"decompress_mbps": 840.46
+"decompress_mbps": 775.79
 },
 {
 "compressor": "libdeflate",
@@ -7294,8 +7294,8 @@
 "level": 9,
 "out_size": 3810354,
 "ratio": 0.3738,
-"compress_mbps": 32.74,
-"decompress_mbps": 830.81
+"compress_mbps": 32.38,
+"decompress_mbps": 808.76
 },
 {
 "compressor": "libdeflate",
@@ -7304,8 +7304,8 @@
 "level": 1,
 "out_size": 20192961,
 "ratio": 0.3942,
-"compress_mbps": 240.6,
-"decompress_mbps": 701.07
+"compress_mbps": 240.89,
+"decompress_mbps": 691.3
 },
 {
 "compressor": "libdeflate",
@@ -7314,8 +7314,8 @@
 "level": 2,
 "out_size": 19374226,
 "ratio": 0.3783,
-"compress_mbps": 186.88,
-"decompress_mbps": 733.13
+"compress_mbps": 186.23,
+"decompress_mbps": 713.89
 },
 {
 "compressor": "libdeflate",
@@ -7324,8 +7324,8 @@
 "level": 3,
 "out_size": 19234937,
 "ratio": 0.3755,
-"compress_mbps": 174.49,
-"decompress_mbps": 746.08
+"compress_mbps": 173.43,
+"decompress_mbps": 732.81
 },
 {
 "compressor": "libdeflate",
@@ -7334,8 +7334,8 @@
 "level": 4,
 "out_size": 19145385,
 "ratio": 0.3738,
-"compress_mbps": 163.58,
-"decompress_mbps": 742.18
+"compress_mbps": 162.58,
+"decompress_mbps": 727.13
 },
 {
 "compressor": "libdeflate",
@@ -7344,8 +7344,8 @@
 "level": 5,
 "out_size": 18878875,
 "ratio": 0.3686,
-"compress_mbps": 144.21,
-"decompress_mbps": 743.28
+"compress_mbps": 143.22,
+"decompress_mbps": 677.53
 },
 {
 "compressor": "libdeflate",
@@ -7354,8 +7354,8 @@
 "level": 6,
 "out_size": 18805391,
 "ratio": 0.3671,
-"compress_mbps": 118.79,
-"decompress_mbps": 767.23
+"compress_mbps": 120.24,
+"decompress_mbps": 757.33
 },
 {
 "compressor": "libdeflate",
@@ -7364,8 +7364,8 @@
 "level": 7,
 "out_size": 18749947,
 "ratio": 0.3661,
-"compress_mbps": 87.12,
-"decompress_mbps": 776.29
+"compress_mbps": 87.78,
+"decompress_mbps": 757.25
 },
 {
 "compressor": "libdeflate",
@@ -7374,8 +7374,8 @@
 "level": 8,
 "out_size": 18718540,
 "ratio": 0.3655,
-"compress_mbps": 47.54,
-"decompress_mbps": 775.04
+"compress_mbps": 47.41,
+"decompress_mbps": 758.49
 },
 {
 "compressor": "libdeflate",
@@ -7384,8 +7384,8 @@
 "level": 9,
 "out_size": 18713659,
 "ratio": 0.3654,
-"compress_mbps": 33.61,
-"decompress_mbps": 776.4
+"compress_mbps": 33.56,
+"decompress_mbps": 757.57
 },
 {
 "compressor": "libdeflate",
@@ -7394,8 +7394,8 @@
 "level": 1,
 "out_size": 3740775,
 "ratio": 0.3752,
-"compress_mbps": 292.94,
-"decompress_mbps": 852.02
+"compress_mbps": 292.24,
+"decompress_mbps": 768.0
 },
 {
 "compressor": "libdeflate",
@@ -7404,8 +7404,8 @@
 "level": 2,
 "out_size": 3707407,
 "ratio": 0.3718,
-"compress_mbps": 216.51,
-"decompress_mbps": 891.44
+"compress_mbps": 213.07,
+"decompress_mbps": 864.07
 },
 {
 "compressor": "libdeflate",
@@ -7414,8 +7414,8 @@
 "level": 3,
 "out_size": 3672389,
 "ratio": 0.3683,
-"compress_mbps": 183.35,
-"decompress_mbps": 941.59
+"compress_mbps": 182.86,
+"decompress_mbps": 916.57
 },
 {
 "compressor": "libdeflate",
@@ -7424,8 +7424,8 @@
 "level": 4,
 "out_size": 3660011,
 "ratio": 0.3671,
-"compress_mbps": 170.2,
-"decompress_mbps": 856.33
+"compress_mbps": 169.9,
+"decompress_mbps": 832.61
 },
 {
 "compressor": "libdeflate",
@@ -7434,8 +7434,8 @@
 "level": 5,
 "out_size": 3664245,
 "ratio": 0.3675,
-"compress_mbps": 140.29,
-"decompress_mbps": 808.6
+"compress_mbps": 140.03,
+"decompress_mbps": 793.62
 },
 {
 "compressor": "libdeflate",
@@ -7444,8 +7444,8 @@
 "level": 6,
 "out_size": 3648644,
 "ratio": 0.3659,
-"compress_mbps": 106.47,
-"decompress_mbps": 836.08
+"compress_mbps": 106.18,
+"decompress_mbps": 830.91
 },
 {
 "compressor": "libdeflate",
@@ -7454,8 +7454,8 @@
 "level": 7,
 "out_size": 3635323,
 "ratio": 0.3646,
-"compress_mbps": 68.66,
-"decompress_mbps": 855.46
+"compress_mbps": 68.18,
+"decompress_mbps": 828.28
 },
 {
 "compressor": "libdeflate",
@@ -7464,8 +7464,8 @@
 "level": 8,
 "out_size": 3624778,
 "ratio": 0.3635,
-"compress_mbps": 43.06,
-"decompress_mbps": 880.66
+"compress_mbps": 42.91,
+"decompress_mbps": 849.49
 },
 {
 "compressor": "libdeflate",
@@ -7474,8 +7474,8 @@
 "level": 9,
 "out_size": 3625176,
 "ratio": 0.3636,
-"compress_mbps": 38.89,
-"decompress_mbps": 881.33
+"compress_mbps": 38.73,
+"decompress_mbps": 845.04
 },
 {
 "compressor": "libdeflate",
@@ -7484,8 +7484,8 @@
 "level": 1,
 "out_size": 3837577,
 "ratio": 0.1144,
-"compress_mbps": 607.78,
-"decompress_mbps": 1511.79
+"compress_mbps": 605.41,
+"decompress_mbps": 1496.72
 },
 {
 "compressor": "libdeflate",
@@ -7494,8 +7494,8 @@
 "level": 2,
 "out_size": 3714632,
 "ratio": 0.1107,
-"compress_mbps": 464.63,
-"decompress_mbps": 1802.72
+"compress_mbps": 462.56,
+"decompress_mbps": 1680.7
 },
 {
 "compressor": "libdeflate",
@@ -7504,8 +7504,8 @@
 "level": 3,
 "out_size": 3599455,
 "ratio": 0.1073,
-"compress_mbps": 428.79,
-"decompress_mbps": 1913.27
+"compress_mbps": 424.96,
+"decompress_mbps": 1767.64
 },
 {
 "compressor": "libdeflate",
@@ -7514,8 +7514,8 @@
 "level": 4,
 "out_size": 3431843,
 "ratio": 0.1023,
-"compress_mbps": 390.0,
-"decompress_mbps": 1783.5
+"compress_mbps": 388.55,
+"decompress_mbps": 1760.65
 },
 {
 "compressor": "libdeflate",
@@ -7524,8 +7524,8 @@
 "level": 5,
 "out_size": 3268188,
 "ratio": 0.0974,
-"compress_mbps": 348.3,
-"decompress_mbps": 1827.25
+"compress_mbps": 346.98,
+"decompress_mbps": 1769.52
 },
 {
 "compressor": "libdeflate",
@@ -7534,8 +7534,8 @@
 "level": 6,
 "out_size": 3091741,
 "ratio": 0.0921,
-"compress_mbps": 265.45,
-"decompress_mbps": 1852.88
+"compress_mbps": 263.29,
+"decompress_mbps": 1828.71
 },
 {
 "compressor": "libdeflate",
@@ -7544,8 +7544,8 @@
 "level": 7,
 "out_size": 3032499,
 "ratio": 0.0904,
-"compress_mbps": 186.29,
-"decompress_mbps": 1830.86
+"compress_mbps": 185.39,
+"decompress_mbps": 1771.44
 },
 {
 "compressor": "libdeflate",
@@ -7554,8 +7554,8 @@
 "level": 8,
 "out_size": 2949097,
 "ratio": 0.0879,
-"compress_mbps": 97.33,
-"decompress_mbps": 1833.28
+"compress_mbps": 96.6,
+"decompress_mbps": 1753.7
 },
 {
 "compressor": "libdeflate",
@@ -7564,8 +7564,8 @@
 "level": 9,
 "out_size": 2925243,
 "ratio": 0.0872,
-"compress_mbps": 69.21,
-"decompress_mbps": 1748.63
+"compress_mbps": 68.93,
+"decompress_mbps": 1729.85
 },
 {
 "compressor": "libdeflate",
@@ -7574,8 +7574,8 @@
 "level": 1,
 "out_size": 3275124,
 "ratio": 0.5324,
-"compress_mbps": 165.05,
-"decompress_mbps": 485.3
+"compress_mbps": 164.9,
+"decompress_mbps": 468.52
 },
 {
 "compressor": "libdeflate",
@@ -7584,8 +7584,8 @@
 "level": 2,
 "out_size": 3150806,
 "ratio": 0.5121,
-"compress_mbps": 127.12,
-"decompress_mbps": 494.47
+"compress_mbps": 129.44,
+"decompress_mbps": 506.38
 },
 {
 "compressor": "libdeflate",
@@ -7594,8 +7594,8 @@
 "level": 3,
 "out_size": 3137061,
 "ratio": 0.5099,
-"compress_mbps": 119.28,
-"decompress_mbps": 520.69
+"compress_mbps": 121.5,
+"decompress_mbps": 531.06
 },
 {
 "compressor": "libdeflate",
@@ -7604,8 +7604,8 @@
 "level": 4,
 "out_size": 3129676,
 "ratio": 0.5087,
-"compress_mbps": 115.75,
-"decompress_mbps": 542.63
+"compress_mbps": 117.38,
+"decompress_mbps": 542.86
 },
 {
 "compressor": "libdeflate",
@@ -7614,8 +7614,8 @@
 "level": 5,
 "out_size": 3079277,
 "ratio": 0.5005,
-"compress_mbps": 98.81,
-"decompress_mbps": 547.78
+"compress_mbps": 98.94,
+"decompress_mbps": 558.82
 },
 {
 "compressor": "libdeflate",
@@ -7624,8 +7624,8 @@
 "level": 6,
 "out_size": 3072378,
 "ratio": 0.4994,
-"compress_mbps": 89.27,
-"decompress_mbps": 571.37
+"compress_mbps": 88.55,
+"decompress_mbps": 566.02
 },
 {
 "compressor": "libdeflate",
@@ -7634,8 +7634,8 @@
 "level": 7,
 "out_size": 3068123,
 "ratio": 0.4987,
-"compress_mbps": 76.15,
-"decompress_mbps": 578.73
+"compress_mbps": 75.68,
+"decompress_mbps": 563.14
 },
 {
 "compressor": "libdeflate",
@@ -7644,8 +7644,8 @@
 "level": 8,
 "out_size": 3067299,
 "ratio": 0.4986,
-"compress_mbps": 55.22,
-"decompress_mbps": 579.44
+"compress_mbps": 55.26,
+"decompress_mbps": 570.84
 },
 {
 "compressor": "libdeflate",
@@ -7654,8 +7654,8 @@
 "level": 9,
 "out_size": 3066968,
 "ratio": 0.4985,
-"compress_mbps": 49.96,
-"decompress_mbps": 580.57
+"compress_mbps": 49.89,
+"decompress_mbps": 555.16
 },
 {
 "compressor": "libdeflate",
@@ -7664,8 +7664,8 @@
 "level": 1,
 "out_size": 3868663,
 "ratio": 0.3836,
-"compress_mbps": 284.96,
-"decompress_mbps": 914.13
+"compress_mbps": 285.17,
+"decompress_mbps": 798.37
 },
 {
 "compressor": "libdeflate",
@@ -7674,8 +7674,8 @@
 "level": 2,
 "out_size": 3839158,
 "ratio": 0.3807,
-"compress_mbps": 214.3,
-"decompress_mbps": 940.22
+"compress_mbps": 210.87,
+"decompress_mbps": 896.26
 },
 {
 "compressor": "libdeflate",
@@ -7684,8 +7684,8 @@
 "level": 3,
 "out_size": 3818964,
 "ratio": 0.3787,
-"compress_mbps": 198.63,
-"decompress_mbps": 964.94
+"compress_mbps": 195.03,
+"decompress_mbps": 938.21
 },
 {
 "compressor": "libdeflate",
@@ -7694,8 +7694,8 @@
 "level": 4,
 "out_size": 3789325,
 "ratio": 0.3757,
-"compress_mbps": 180.19,
-"decompress_mbps": 966.98
+"compress_mbps": 177.54,
+"decompress_mbps": 954.54
 },
 {
 "compressor": "libdeflate",
@@ -7704,8 +7704,8 @@
 "level": 5,
 "out_size": 3666476,
 "ratio": 0.3635,
-"compress_mbps": 158.53,
-"decompress_mbps": 990.31
+"compress_mbps": 157.06,
+"decompress_mbps": 945.45
 },
 {
 "compressor": "libdeflate",
@@ -7714,8 +7714,8 @@
 "level": 6,
 "out_size": 3660266,
 "ratio": 0.3629,
-"compress_mbps": 142.71,
-"decompress_mbps": 1027.82
+"compress_mbps": 141.81,
+"decompress_mbps": 988.06
 },
 {
 "compressor": "libdeflate",
@@ -7724,8 +7724,8 @@
 "level": 7,
 "out_size": 3659491,
 "ratio": 0.3628,
-"compress_mbps": 135.25,
-"decompress_mbps": 1032.66
+"compress_mbps": 134.57,
+"decompress_mbps": 956.62
 },
 {
 "compressor": "libdeflate",
@@ -7734,8 +7734,8 @@
 "level": 8,
 "out_size": 3654863,
 "ratio": 0.3624,
-"compress_mbps": 115.14,
-"decompress_mbps": 1060.14
+"compress_mbps": 114.01,
+"decompress_mbps": 974.24
 },
 {
 "compressor": "libdeflate",
@@ -7744,8 +7744,8 @@
 "level": 9,
 "out_size": 3654860,
 "ratio": 0.3624,
-"compress_mbps": 115.1,
-"decompress_mbps": 1049.13
+"compress_mbps": 114.46,
+"decompress_mbps": 976.58
 },
 {
 "compressor": "libdeflate",
@@ -7754,8 +7754,8 @@
 "level": 1,
 "out_size": 2197055,
 "ratio": 0.3315,
-"compress_mbps": 301.27,
-"decompress_mbps": 999.43
+"compress_mbps": 299.67,
+"decompress_mbps": 998.3
 },
 {
 "compressor": "libdeflate",
@@ -7764,8 +7764,8 @@
 "level": 2,
 "out_size": 2082309,
 "ratio": 0.3142,
-"compress_mbps": 214.89,
-"decompress_mbps": 1125.67
+"compress_mbps": 212.41,
+"decompress_mbps": 1074.09
 },
 {
 "compressor": "libdeflate",
@@ -7774,8 +7774,8 @@
 "level": 3,
 "out_size": 2021047,
 "ratio": 0.305,
-"compress_mbps": 178.31,
-"decompress_mbps": 1242.85
+"compress_mbps": 177.45,
+"decompress_mbps": 1202.29
 },
 {
 "compressor": "libdeflate",
@@ -7784,8 +7784,8 @@
 "level": 4,
 "out_size": 1990952,
 "ratio": 0.3004,
-"compress_mbps": 158.38,
-"decompress_mbps": 1155.2
+"compress_mbps": 157.71,
+"decompress_mbps": 1103.11
 },
 {
 "compressor": "libdeflate",
@@ -7794,8 +7794,8 @@
 "level": 5,
 "out_size": 1921113,
 "ratio": 0.2899,
-"compress_mbps": 127.7,
-"decompress_mbps": 1085.1
+"compress_mbps": 126.82,
+"decompress_mbps": 1027.98
 },
 {
 "compressor": "libdeflate",
@@ -7804,8 +7804,8 @@
 "level": 6,
 "out_size": 1876257,
 "ratio": 0.2831,
-"compress_mbps": 87.12,
-"decompress_mbps": 1116.4
+"compress_mbps": 86.63,
+"decompress_mbps": 1056.64
 },
 {
 "compressor": "libdeflate",
@@ -7814,8 +7814,8 @@
 "level": 7,
 "out_size": 1832695,
 "ratio": 0.2765,
-"compress_mbps": 46.66,
-"decompress_mbps": 1121.59
+"compress_mbps": 46.52,
+"decompress_mbps": 1064.64
 },
 {
 "compressor": "libdeflate",
@@ -7824,8 +7824,8 @@
 "level": 8,
 "out_size": 1809967,
 "ratio": 0.2731,
-"compress_mbps": 24.3,
-"decompress_mbps": 1108.04
+"compress_mbps": 24.23,
+"decompress_mbps": 1054.03
 },
 {
 "compressor": "libdeflate",
@@ -7834,8 +7834,8 @@
 "level": 9,
 "out_size": 1806374,
 "ratio": 0.2726,
-"compress_mbps": 19.7,
-"decompress_mbps": 979.49
+"compress_mbps": 19.85,
+"decompress_mbps": 1027.55
 },
 {
 "compressor": "libdeflate",
@@ -7844,8 +7844,8 @@
 "level": 1,
 "out_size": 5866517,
 "ratio": 0.2715,
-"compress_mbps": 339.9,
-"decompress_mbps": 921.94
+"compress_mbps": 337.5,
+"decompress_mbps": 987.53
 },
 {
 "compressor": "libdeflate",
@@ -7854,8 +7854,8 @@
 "level": 2,
 "out_size": 5695942,
 "ratio": 0.2636,
-"compress_mbps": 258.5,
-"decompress_mbps": 1059.87
+"compress_mbps": 256.94,
+"decompress_mbps": 1071.13
 },
 {
 "compressor": "libdeflate",
@@ -7864,8 +7864,8 @@
 "level": 3,
 "out_size": 5605878,
 "ratio": 0.2595,
-"compress_mbps": 235.53,
-"decompress_mbps": 1094.01
+"compress_mbps": 234.56,
+"decompress_mbps": 1101.26
 },
 {
 "compressor": "libdeflate",
@@ -7874,8 +7874,8 @@
 "level": 4,
 "out_size": 5553432,
 "ratio": 0.257,
-"compress_mbps": 218.07,
-"decompress_mbps": 1076.97
+"compress_mbps": 217.52,
+"decompress_mbps": 1087.45
 },
 {
 "compressor": "libdeflate",
@@ -7884,8 +7884,8 @@
 "level": 5,
 "out_size": 5416713,
 "ratio": 0.2507,
-"compress_mbps": 189.09,
-"decompress_mbps": 1090.89
+"compress_mbps": 187.45,
+"decompress_mbps": 1085.0
 },
 {
 "compressor": "libdeflate",
@@ -7894,8 +7894,8 @@
 "level": 6,
 "out_size": 5337149,
 "ratio": 0.247,
-"compress_mbps": 144.0,
-"decompress_mbps": 1119.86
+"compress_mbps": 144.12,
+"decompress_mbps": 1092.33
 },
 {
 "compressor": "libdeflate",
@@ -7904,8 +7904,8 @@
 "level": 7,
 "out_size": 5310181,
 "ratio": 0.2458,
-"compress_mbps": 100.72,
-"decompress_mbps": 1110.17
+"compress_mbps": 100.2,
+"decompress_mbps": 1043.71
 },
 {
 "compressor": "libdeflate",
@@ -7914,8 +7914,8 @@
 "level": 8,
 "out_size": 5272761,
 "ratio": 0.244,
-"compress_mbps": 62.5,
-"decompress_mbps": 1106.6
+"compress_mbps": 62.12,
+"decompress_mbps": 1077.99
 },
 {
 "compressor": "libdeflate",
@@ -7924,8 +7924,8 @@
 "level": 9,
 "out_size": 5270405,
 "ratio": 0.2439,
-"compress_mbps": 49.85,
-"decompress_mbps": 1105.05
+"compress_mbps": 50.08,
+"decompress_mbps": 634.63
 },
 {
 "compressor": "libdeflate",
@@ -7934,8 +7934,8 @@
 "level": 1,
 "out_size": 5575128,
 "ratio": 0.7688,
-"compress_mbps": 161.9,
-"decompress_mbps": 490.84
+"compress_mbps": 161.1,
+"decompress_mbps": 419.63
 },
 {
 "compressor": "libdeflate",
@@ -7944,8 +7944,8 @@
 "level": 2,
 "out_size": 5417142,
 "ratio": 0.747,
-"compress_mbps": 116.25,
-"decompress_mbps": 522.92
+"compress_mbps": 116.31,
+"decompress_mbps": 390.97
 },
 {
 "compressor": "libdeflate",
@@ -7954,8 +7954,8 @@
 "level": 3,
 "out_size": 5397999,
 "ratio": 0.7444,
-"compress_mbps": 105.43,
-"decompress_mbps": 534.91
+"compress_mbps": 105.09,
+"decompress_mbps": 278.73
 },
 {
 "compressor": "libdeflate",
@@ -7964,8 +7964,8 @@
 "level": 4,
 "out_size": 5391125,
 "ratio": 0.7434,
-"compress_mbps": 99.43,
-"decompress_mbps": 545.67
+"compress_mbps": 99.15,
+"decompress_mbps": 400.63
 },
 {
 "compressor": "libdeflate",
@@ -7974,8 +7974,8 @@
 "level": 5,
 "out_size": 5352212,
 "ratio": 0.738,
-"compress_mbps": 88.12,
-"decompress_mbps": 525.04
+"compress_mbps": 83.53,
+"decompress_mbps": 497.88
 },
 {
 "compressor": "libdeflate",
@@ -7984,8 +7984,8 @@
 "level": 6,
 "out_size": 5335405,
 "ratio": 0.7357,
-"compress_mbps": 74.04,
-"decompress_mbps": 537.34
+"compress_mbps": 72.15,
+"decompress_mbps": 517.65
 },
 {
 "compressor": "libdeflate",
@@ -7994,8 +7994,8 @@
 "level": 7,
 "out_size": 5325697,
 "ratio": 0.7344,
-"compress_mbps": 63.76,
-"decompress_mbps": 538.25
+"compress_mbps": 61.33,
+"decompress_mbps": 462.7
 },
 {
 "compressor": "libdeflate",
@@ -8004,8 +8004,8 @@
 "level": 8,
 "out_size": 5324004,
 "ratio": 0.7341,
-"compress_mbps": 52.76,
-"decompress_mbps": 534.4
+"compress_mbps": 51.85,
+"decompress_mbps": 519.59
 },
 {
 "compressor": "libdeflate",
@@ -8014,8 +8014,8 @@
 "level": 9,
 "out_size": 5323197,
 "ratio": 0.734,
-"compress_mbps": 51.0,
-"decompress_mbps": 537.49
+"compress_mbps": 50.8,
+"decompress_mbps": 519.09
 },
 {
 "compressor": "libdeflate",
@@ -8024,8 +8024,8 @@
 "level": 1,
 "out_size": 13550569,
 "ratio": 0.3268,
-"compress_mbps": 266.55,
-"decompress_mbps": 826.44
+"compress_mbps": 265.58,
+"decompress_mbps": 859.69
 },
 {
 "compressor": "libdeflate",
@@ -8034,8 +8034,8 @@
 "level": 2,
 "out_size": 13130705,
 "ratio": 0.3167,
-"compress_mbps": 201.55,
-"decompress_mbps": 974.67
+"compress_mbps": 198.44,
+"decompress_mbps": 951.75
 },
 {
 "compressor": "libdeflate",
@@ -8044,8 +8044,8 @@
 "level": 3,
 "out_size": 12839361,
 "ratio": 0.3097,
-"compress_mbps": 178.9,
-"decompress_mbps": 1036.93
+"compress_mbps": 176.28,
+"decompress_mbps": 880.28
 },
 {
 "compressor": "libdeflate",
@@ -8054,8 +8054,8 @@
 "level": 4,
 "out_size": 12601933,
 "ratio": 0.304,
-"compress_mbps": 163.55,
-"decompress_mbps": 919.26
+"compress_mbps": 161.52,
+"decompress_mbps": 884.3
 },
 {
 "compressor": "libdeflate",
@@ -8064,8 +8064,8 @@
 "level": 5,
 "out_size": 12310776,
 "ratio": 0.2969,
-"compress_mbps": 133.0,
-"decompress_mbps": 903.81
+"compress_mbps": 131.44,
+"decompress_mbps": 870.48
 },
 {
 "compressor": "libdeflate",
@@ -8074,8 +8074,8 @@
 "level": 6,
 "out_size": 12140474,
 "ratio": 0.2928,
-"compress_mbps": 105.17,
-"decompress_mbps": 912.74
+"compress_mbps": 104.64,
+"decompress_mbps": 879.58
 },
 {
 "compressor": "libdeflate",
@@ -8084,8 +8084,8 @@
 "level": 7,
 "out_size": 12025296,
 "ratio": 0.2901,
-"compress_mbps": 73.54,
-"decompress_mbps": 877.08
+"compress_mbps": 75.02,
+"decompress_mbps": 862.76
 },
 {
 "compressor": "libdeflate",
@@ -8094,8 +8094,8 @@
 "level": 8,
 "out_size": 11893824,
 "ratio": 0.2869,
-"compress_mbps": 46.02,
-"decompress_mbps": 882.51
+"compress_mbps": 46.04,
+"decompress_mbps": 889.34
 },
 {
 "compressor": "libdeflate",
@@ -8104,8 +8104,8 @@
 "level": 9,
 "out_size": 11882496,
 "ratio": 0.2866,
-"compress_mbps": 39.57,
-"decompress_mbps": 874.36
+"compress_mbps": 39.54,
+"decompress_mbps": 895.98
 },
 {
 "compressor": "libdeflate",
@@ -8114,8 +8114,8 @@
 "level": 1,
 "out_size": 6293390,
 "ratio": 0.7426,
-"compress_mbps": 148.57,
-"decompress_mbps": 505.8
+"compress_mbps": 144.69,
+"decompress_mbps": 508.14
 },
 {
 "compressor": "libdeflate",
@@ -8124,8 +8124,8 @@
 "level": 2,
 "out_size": 6058412,
 "ratio": 0.7149,
-"compress_mbps": 120.07,
-"decompress_mbps": 532.7
+"compress_mbps": 120.48,
+"decompress_mbps": 534.42
 },
 {
 "compressor": "libdeflate",
@@ -8134,8 +8134,8 @@
 "level": 3,
 "out_size": 6058381,
 "ratio": 0.7149,
-"compress_mbps": 119.9,
-"decompress_mbps": 537.9
+"compress_mbps": 120.15,
+"decompress_mbps": 541.13
 },
 {
 "compressor": "libdeflate",
@@ -8144,8 +8144,8 @@
 "level": 4,
 "out_size": 6058363,
 "ratio": 0.7149,
-"compress_mbps": 119.97,
-"decompress_mbps": 428.23
+"compress_mbps": 120.27,
+"decompress_mbps": 432.5
 },
 {
 "compressor": "libdeflate",
@@ -8154,8 +8154,8 @@
 "level": 5,
 "out_size": 5998400,
 "ratio": 0.7078,
-"compress_mbps": 106.93,
-"decompress_mbps": 447.34
+"compress_mbps": 107.62,
+"decompress_mbps": 455.93
 },
 {
 "compressor": "libdeflate",
@@ -8164,8 +8164,8 @@
 "level": 6,
 "out_size": 5998438,
 "ratio": 0.7078,
-"compress_mbps": 106.86,
-"decompress_mbps": 457.87
+"compress_mbps": 107.71,
+"decompress_mbps": 451.42
 },
 {
 "compressor": "libdeflate",
@@ -8174,8 +8174,8 @@
 "level": 7,
 "out_size": 5998439,
 "ratio": 0.7078,
-"compress_mbps": 106.9,
-"decompress_mbps": 458.26
+"compress_mbps": 107.99,
+"decompress_mbps": 461.39
 },
 {
 "compressor": "libdeflate",
@@ -8184,8 +8184,8 @@
 "level": 8,
 "out_size": 5986859,
 "ratio": 0.7065,
-"compress_mbps": 89.16,
-"decompress_mbps": 453.75
+"compress_mbps": 90.1,
+"decompress_mbps": 456.45
 },
 {
 "compressor": "libdeflate",
@@ -8194,8 +8194,8 @@
 "level": 9,
 "out_size": 5986859,
 "ratio": 0.7065,
-"compress_mbps": 89.34,
-"decompress_mbps": 458.03
+"compress_mbps": 89.87,
+"decompress_mbps": 458.45
 },
 {
 "compressor": "libdeflate",
@@ -8204,8 +8204,8 @@
 "level": 1,
 "out_size": 887708,
 "ratio": 0.1661,
-"compress_mbps": 488.58,
-"decompress_mbps": 1331.05
+"compress_mbps": 488.6,
+"decompress_mbps": 1315.83
 },
 {
 "compressor": "libdeflate",
@@ -8214,8 +8214,8 @@
 "level": 2,
 "out_size": 843475,
 "ratio": 0.1578,
-"compress_mbps": 362.33,
-"decompress_mbps": 1455.68
+"compress_mbps": 363.67,
+"decompress_mbps": 1445.93
 },
 {
 "compressor": "libdeflate",
@@ -8224,8 +8224,8 @@
 "level": 3,
 "out_size": 793388,
 "ratio": 0.1484,
-"compress_mbps": 335.01,
-"decompress_mbps": 1562.95
+"compress_mbps": 336.94,
+"decompress_mbps": 1567.54
 },
 {
 "compressor": "libdeflate",
@@ -8234,8 +8234,8 @@
 "level": 4,
 "out_size": 747602,
 "ratio": 0.1399,
-"compress_mbps": 304.02,
-"decompress_mbps": 1524.94
+"compress_mbps": 302.89,
+"decompress_mbps": 1487.72
 },
 {
 "compressor": "libdeflate",
@@ -8244,8 +8244,8 @@
 "level": 5,
 "out_size": 718615,
 "ratio": 0.1344,
-"compress_mbps": 261.57,
-"decompress_mbps": 1537.59
+"compress_mbps": 261.62,
+"decompress_mbps": 1521.98
 },
 {
 "compressor": "libdeflate",
@@ -8254,8 +8254,8 @@
 "level": 6,
 "out_size": 684405,
 "ratio": 0.128,
-"compress_mbps": 205.1,
-"decompress_mbps": 1551.32
+"compress_mbps": 205.52,
+"decompress_mbps": 1584.25
 },
 {
 "compressor": "libdeflate",
@@ -8264,8 +8264,8 @@
 "level": 7,
 "out_size": 664859,
 "ratio": 0.1244,
-"compress_mbps": 142.08,
-"decompress_mbps": 1578.9
+"compress_mbps": 142.64,
+"decompress_mbps": 1541.27
 },
 {
 "compressor": "libdeflate",
@@ -8274,8 +8274,8 @@
 "level": 8,
 "out_size": 650835,
 "ratio": 0.1218,
-"compress_mbps": 84.34,
-"decompress_mbps": 1571.97
+"compress_mbps": 84.4,
+"decompress_mbps": 1506.86
 },
 {
 "compressor": "libdeflate",
@@ -8284,8 +8284,8 @@
 "level": 9,
 "out_size": 649494,
 "ratio": 0.1215,
-"compress_mbps": 68.33,
-"decompress_mbps": 1591.71
+"compress_mbps": 68.24,
+"decompress_mbps": 1540.82
 },
 {
 "compressor": "go",
@@ -8294,8 +8294,8 @@
 "level": 1,
 "out_size": 65708,
 "ratio": 0.432,
-"compress_mbps": 91.69,
-"decompress_mbps": 167.68
+"compress_mbps": 33.78,
+"decompress_mbps": 60.3
 },
 {
 "compressor": "go",
@@ -8304,8 +8304,8 @@
 "level": 2,
 "out_size": 60259,
 "ratio": 0.3962,
-"compress_mbps": 67.86,
-"decompress_mbps": 188.09
+"compress_mbps": 25.56,
+"decompress_mbps": 67.24
 },
 {
 "compressor": "go",
@@ -8314,8 +8314,8 @@
 "level": 3,
 "out_size": 58544,
 "ratio": 0.3849,
-"compress_mbps": 58.27,
-"decompress_mbps": 193.47
+"compress_mbps": 21.29,
+"decompress_mbps": 69.5
 },
 {
 "compressor": "go",
@@ -8324,8 +8324,8 @@
 "level": 4,
 "out_size": 56238,
 "ratio": 0.3698,
-"compress_mbps": 56.88,
-"decompress_mbps": 194.97
+"compress_mbps": 26.49,
+"decompress_mbps": 70.65
 },
 {
 "compressor": "go",
@@ -8334,8 +8334,8 @@
 "level": 5,
 "out_size": 54764,
 "ratio": 0.3601,
-"compress_mbps": 35.95,
-"decompress_mbps": 198.4
+"compress_mbps": 16.09,
+"decompress_mbps": 75.58
 },
 {
 "compressor": "go",
@@ -8344,8 +8344,8 @@
 "level": 6,
 "out_size": 54311,
 "ratio": 0.3571,
-"compress_mbps": 27.99,
-"decompress_mbps": 197.23
+"compress_mbps": 11.03,
+"decompress_mbps": 71.03
 },
 {
 "compressor": "go",
@@ -8354,8 +8354,8 @@
 "level": 7,
 "out_size": 54262,
 "ratio": 0.3568,
-"compress_mbps": 25.23,
-"decompress_mbps": 199.8
+"compress_mbps": 11.66,
+"decompress_mbps": 74.11
 },
 {
 "compressor": "go",
@@ -8364,8 +8364,8 @@
 "level": 8,
 "out_size": 54247,
 "ratio": 0.3567,
-"compress_mbps": 24.13,
-"decompress_mbps": 193.92
+"compress_mbps": 10.06,
+"decompress_mbps": 73.17
 },
 {
 "compressor": "go",
@@ -8374,8 +8374,8 @@
 "level": 9,
 "out_size": 54247,
 "ratio": 0.3567,
-"compress_mbps": 24.22,
-"decompress_mbps": 204.12
+"compress_mbps": 11.15,
+"decompress_mbps": 85.04
 },
 {
 "compressor": "go",
@@ -8384,8 +8384,8 @@
 "level": 1,
 "out_size": 56882,
 "ratio": 0.4544,
-"compress_mbps": 86.48,
-"decompress_mbps": 159.26
+"compress_mbps": 35.95,
+"decompress_mbps": 59.11
 },
 {
 "compressor": "go",
@@ -8394,8 +8394,8 @@
 "level": 2,
 "out_size": 52826,
 "ratio": 0.422,
-"compress_mbps": 61.32,
-"decompress_mbps": 176
+"compress_mbps": 29.02,
+"decompress_mbps": 77.03
 },
 {
 "compressor": "go",
@@ -8404,8 +8404,8 @@
 "level": 3,
 "out_size": 51625,
 "ratio": 0.4124,
-"compress_mbps": 53.4,
-"decompress_mbps": 177.56
+"compress_mbps": 23.6,
+"decompress_mbps": 72.79
 },
 {
 "compressor": "go",
@@ -8414,8 +8414,8 @@
 "level": 4,
 "out_size": 50034,
 "ratio": 0.3997,
-"compress_mbps": 52.75,
-"decompress_mbps": 181.24
+"compress_mbps": 24.26,
+"decompress_mbps": 68.2
 },
 {
 "compressor": "go",
@@ -8424,8 +8424,8 @@
 "level": 5,
 "out_size": 48912,
 "ratio": 0.3907,
-"compress_mbps": 33.84,
-"decompress_mbps": 185.93
+"compress_mbps": 17.45,
+"decompress_mbps": 65.87
 },
 {
 "compressor": "go",
@@ -8434,8 +8434,8 @@
 "level": 6,
 "out_size": 48738,
 "ratio": 0.3893,
-"compress_mbps": 28.97,
-"decompress_mbps": 181.77
+"compress_mbps": 10.22,
+"decompress_mbps": 67.48
 },
 {
 "compressor": "go",
@@ -8444,8 +8444,8 @@
 "level": 7,
 "out_size": 48719,
 "ratio": 0.3892,
-"compress_mbps": 27.67,
-"decompress_mbps": 184.24
+"compress_mbps": 9.98,
+"decompress_mbps": 66.6
 },
 {
 "compressor": "go",
@@ -8454,8 +8454,8 @@
 "level": 8,
 "out_size": 48716,
 "ratio": 0.3892,
-"compress_mbps": 27.28,
-"decompress_mbps": 183.45
+"compress_mbps": 9.88,
+"decompress_mbps": 66.81
 },
 {
 "compressor": "go",
@@ -8464,8 +8464,8 @@
 "level": 9,
 "out_size": 48716,
 "ratio": 0.3892,
-"compress_mbps": 27.2,
-"decompress_mbps": 184.09
+"compress_mbps": 10.01,
+"decompress_mbps": 65.66
 },
 {
 "compressor": "go",
@@ -8474,8 +8474,8 @@
 "level": 1,
 "out_size": 8988,
 "ratio": 0.3653,
-"compress_mbps": 56.4,
-"decompress_mbps": 243.45
+"compress_mbps": 34.84,
+"decompress_mbps": 97.77
 },
 {
 "compressor": "go",
@@ -8484,8 +8484,8 @@
 "level": 2,
 "out_size": 8564,
 "ratio": 0.3481,
-"compress_mbps": 60.58,
-"decompress_mbps": 272.51
+"compress_mbps": 36.37,
+"decompress_mbps": 107.73
 },
 {
 "compressor": "go",
@@ -8494,8 +8494,8 @@
 "level": 3,
 "out_size": 8390,
 "ratio": 0.341,
-"compress_mbps": 59.23,
-"decompress_mbps": 264.78
+"compress_mbps": 30.51,
+"decompress_mbps": 101.68
 },
 {
 "compressor": "go",
@@ -8504,8 +8504,8 @@
 "level": 4,
 "out_size": 8167,
 "ratio": 0.332,
-"compress_mbps": 57.65,
-"decompress_mbps": 264.33
+"compress_mbps": 39.31,
+"decompress_mbps": 150.64
 },
 {
 "compressor": "go",
@@ -8514,8 +8514,8 @@
 "level": 5,
 "out_size": 7965,
 "ratio": 0.3237,
-"compress_mbps": 45.07,
-"decompress_mbps": 195.7
+"compress_mbps": 27.65,
+"decompress_mbps": 116.16
 },
 {
 "compressor": "go",
@@ -8524,8 +8524,8 @@
 "level": 6,
 "out_size": 7916,
 "ratio": 0.3217,
-"compress_mbps": 39.42,
-"decompress_mbps": 296.12
+"compress_mbps": 29.01,
+"decompress_mbps": 158.88
 },
 {
 "compressor": "go",
@@ -8534,8 +8534,8 @@
 "level": 7,
 "out_size": 7900,
 "ratio": 0.3211,
-"compress_mbps": 38.14,
-"decompress_mbps": 298.4
+"compress_mbps": 18.21,
+"decompress_mbps": 82.57
 },
 {
 "compressor": "go",
@@ -8544,8 +8544,8 @@
 "level": 8,
 "out_size": 7900,
 "ratio": 0.3211,
-"compress_mbps": 38.4,
-"decompress_mbps": 214.97
+"compress_mbps": 20.44,
+"decompress_mbps": 105.04
 },
 {
 "compressor": "go",
@@ -8554,8 +8554,8 @@
 "level": 9,
 "out_size": 7900,
 "ratio": 0.3211,
-"compress_mbps": 37.42,
-"decompress_mbps": 308.68
+"compress_mbps": 20.64,
+"decompress_mbps": 101.22
 },
 {
 "compressor": "go",
@@ -8564,8 +8564,8 @@
 "level": 1,
 "out_size": 3731,
 "ratio": 0.3346,
-"compress_mbps": 38.08,
-"decompress_mbps": 197.18
+"compress_mbps": 19.2,
+"decompress_mbps": 78.63
 },
 {
 "compressor": "go",
@@ -8574,8 +8574,8 @@
 "level": 2,
 "out_size": 3491,
 "ratio": 0.3131,
-"compress_mbps": 48.46,
-"decompress_mbps": 218.06
+"compress_mbps": 24.58,
+"decompress_mbps": 91.07
 },
 {
 "compressor": "go",
@@ -8584,8 +8584,8 @@
 "level": 3,
 "out_size": 3384,
 "ratio": 0.3035,
-"compress_mbps": 47.6,
-"decompress_mbps": 221.1
+"compress_mbps": 23.1,
+"decompress_mbps": 88.61
 },
 {
 "compressor": "go",
@@ -8594,8 +8594,8 @@
 "level": 4,
 "out_size": 3220,
 "ratio": 0.2888,
-"compress_mbps": 43.48,
-"decompress_mbps": 221.7
+"compress_mbps": 21.98,
+"decompress_mbps": 95.14
 },
 {
 "compressor": "go",
@@ -8604,8 +8604,8 @@
 "level": 5,
 "out_size": 3138,
 "ratio": 0.2814,
-"compress_mbps": 36.26,
-"decompress_mbps": 230.04
+"compress_mbps": 16.82,
+"decompress_mbps": 97.05
 },
 {
 "compressor": "go",
@@ -8614,8 +8614,8 @@
 "level": 6,
 "out_size": 3118,
 "ratio": 0.2796,
-"compress_mbps": 35.59,
-"decompress_mbps": 232.99
+"compress_mbps": 14.9,
+"decompress_mbps": 96.4
 },
 {
 "compressor": "go",
@@ -8624,8 +8624,8 @@
 "level": 7,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 32.12,
-"decompress_mbps": 230.11
+"compress_mbps": 14.42,
+"decompress_mbps": 95.72
 },
 {
 "compressor": "go",
@@ -8634,8 +8634,8 @@
 "level": 8,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 32.57,
-"decompress_mbps": 228.83
+"compress_mbps": 14.06,
+"decompress_mbps": 95.76
 },
 {
 "compressor": "go",
@@ -8644,8 +8644,8 @@
 "level": 9,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 32.07,
-"decompress_mbps": 230.9
+"compress_mbps": 13.88,
+"decompress_mbps": 99.01
 },
 {
 "compressor": "go",
@@ -8654,8 +8654,8 @@
 "level": 1,
 "out_size": 1352,
 "ratio": 0.3633,
-"compress_mbps": 14.55,
-"decompress_mbps": 143.09
+"compress_mbps": 9.25,
+"decompress_mbps": 85.2
 },
 {
 "compressor": "go",
@@ -8664,8 +8664,8 @@
 "level": 2,
 "out_size": 1287,
 "ratio": 0.3459,
-"compress_mbps": 18.83,
-"decompress_mbps": 148.22
+"compress_mbps": 12.52,
+"decompress_mbps": 71.36
 },
 {
 "compressor": "go",
@@ -8674,8 +8674,8 @@
 "level": 3,
 "out_size": 1284,
 "ratio": 0.3451,
-"compress_mbps": 18.92,
-"decompress_mbps": 136.07
+"compress_mbps": 12.42,
+"decompress_mbps": 67.11
 },
 {
 "compressor": "go",
@@ -8684,8 +8684,8 @@
 "level": 4,
 "out_size": 1226,
 "ratio": 0.3295,
-"compress_mbps": 19.16,
-"decompress_mbps": 168.42
+"compress_mbps": 10.2,
+"decompress_mbps": 69.98
 },
 {
 "compressor": "go",
@@ -8694,8 +8694,8 @@
 "level": 5,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 18.41,
-"decompress_mbps": 151.35
+"compress_mbps": 9.19,
+"decompress_mbps": 72.4
 },
 {
 "compressor": "go",
@@ -8704,8 +8704,8 @@
 "level": 6,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 16.84,
-"decompress_mbps": 130.54
+"compress_mbps": 10.05,
+"decompress_mbps": 66.29
 },
 {
 "compressor": "go",
@@ -8714,8 +8714,8 @@
 "level": 7,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 18.87,
-"decompress_mbps": 181.18
+"compress_mbps": 8.89,
+"decompress_mbps": 72.27
 },
 {
 "compressor": "go",
@@ -8724,8 +8724,8 @@
 "level": 8,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 18.94,
-"decompress_mbps": 143.21
+"compress_mbps": 9.38,
+"decompress_mbps": 54.85
 },
 {
 "compressor": "go",
@@ -8734,8 +8734,8 @@
 "level": 9,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 18.38,
-"decompress_mbps": 152.05
+"compress_mbps": 10.73,
+"decompress_mbps": 66.9
 },
 {
 "compressor": "go",
@@ -8744,8 +8744,8 @@
 "level": 1,
 "out_size": 245423,
 "ratio": 0.2383,
-"compress_mbps": 233.11,
-"decompress_mbps": 374.93
+"compress_mbps": 91.51,
+"decompress_mbps": 133.02
 },
 {
 "compressor": "go",
@@ -8754,8 +8754,8 @@
 "level": 2,
 "out_size": 229642,
 "ratio": 0.223,
-"compress_mbps": 199.08,
-"decompress_mbps": 415.93
+"compress_mbps": 91,
+"decompress_mbps": 151.64
 },
 {
 "compressor": "go",
@@ -8764,8 +8764,8 @@
 "level": 3,
 "out_size": 225678,
 "ratio": 0.2192,
-"compress_mbps": 174.53,
-"decompress_mbps": 444.52
+"compress_mbps": 90.31,
+"decompress_mbps": 154.77
 },
 {
 "compressor": "go",
@@ -8774,8 +8774,8 @@
 "level": 4,
 "out_size": 218218,
 "ratio": 0.2119,
-"compress_mbps": 166.52,
-"decompress_mbps": 448.29
+"compress_mbps": 85.09,
+"decompress_mbps": 162.27
 },
 {
 "compressor": "go",
@@ -8784,8 +8784,8 @@
 "level": 5,
 "out_size": 210550,
 "ratio": 0.2045,
-"compress_mbps": 94.99,
-"decompress_mbps": 428.06
+"compress_mbps": 59.62,
+"decompress_mbps": 148.86
 },
 {
 "compressor": "go",
@@ -8794,8 +8794,8 @@
 "level": 6,
 "out_size": 207949,
 "ratio": 0.2019,
-"compress_mbps": 41.36,
-"decompress_mbps": 439.96
+"compress_mbps": 27.96,
+"decompress_mbps": 432.34
 },
 {
 "compressor": "go",
@@ -8804,8 +8804,8 @@
 "level": 7,
 "out_size": 207413,
 "ratio": 0.2014,
-"compress_mbps": 24.24,
-"decompress_mbps": 386.02
+"compress_mbps": 18.94,
+"decompress_mbps": 162.58
 },
 {
 "compressor": "go",
@@ -8814,8 +8814,8 @@
 "level": 8,
 "out_size": 207478,
 "ratio": 0.2015,
-"compress_mbps": 7.4,
-"decompress_mbps": 433.05
+"compress_mbps": 6.77,
+"decompress_mbps": 162.78
 },
 {
 "compressor": "go",
@@ -8824,8 +8824,8 @@
 "level": 9,
 "out_size": 207482,
 "ratio": 0.2015,
-"compress_mbps": 3.71,
-"decompress_mbps": 397.32
+"compress_mbps": 3.58,
+"decompress_mbps": 160.96
 },
 {
 "compressor": "go",
@@ -8834,8 +8834,8 @@
 "level": 1,
 "out_size": 175980,
 "ratio": 0.4124,
-"compress_mbps": 104.25,
-"decompress_mbps": 179.32
+"compress_mbps": 41.39,
+"decompress_mbps": 62.26
 },
 {
 "compressor": "go",
@@ -8844,8 +8844,8 @@
 "level": 2,
 "out_size": 160455,
 "ratio": 0.376,
-"compress_mbps": 76.6,
-"decompress_mbps": 202.4
+"compress_mbps": 40.48,
+"decompress_mbps": 73.31
 },
 {
 "compressor": "go",
@@ -8854,8 +8854,8 @@
 "level": 3,
 "out_size": 156690,
 "ratio": 0.3672,
-"compress_mbps": 65.31,
-"decompress_mbps": 204.83
+"compress_mbps": 28.23,
+"decompress_mbps": 73.71
 },
 {
 "compressor": "go",
@@ -8864,8 +8864,8 @@
 "level": 4,
 "out_size": 149064,
 "ratio": 0.3493,
-"compress_mbps": 63.55,
-"decompress_mbps": 212.84
+"compress_mbps": 26.29,
+"decompress_mbps": 75.84
 },
 {
 "compressor": "go",
@@ -8874,8 +8874,8 @@
 "level": 5,
 "out_size": 145616,
 "ratio": 0.3412,
-"compress_mbps": 39.82,
-"decompress_mbps": 212.53
+"compress_mbps": 23.45,
+"decompress_mbps": 78.53
 },
 {
 "compressor": "go",
@@ -8884,8 +8884,8 @@
 "level": 6,
 "out_size": 144773,
 "ratio": 0.3392,
-"compress_mbps": 31.88,
-"decompress_mbps": 212.08
+"compress_mbps": 17.24,
+"decompress_mbps": 77.08
 },
 {
 "compressor": "go",
@@ -8894,8 +8894,8 @@
 "level": 7,
 "out_size": 144603,
 "ratio": 0.3388,
-"compress_mbps": 28.86,
-"decompress_mbps": 215.61
+"compress_mbps": 16.31,
+"decompress_mbps": 76.52
 },
 {
 "compressor": "go",
@@ -8904,8 +8904,8 @@
 "level": 8,
 "out_size": 144573,
 "ratio": 0.3388,
-"compress_mbps": 28.03,
-"decompress_mbps": 212.44
+"compress_mbps": 20.34,
+"decompress_mbps": 75.62
 },
 {
 "compressor": "go",
@@ -8914,8 +8914,8 @@
 "level": 9,
 "out_size": 144570,
 "ratio": 0.3388,
-"compress_mbps": 28.3,
-"decompress_mbps": 217.26
+"compress_mbps": 16.14,
+"decompress_mbps": 75.77
 },
 {
 "compressor": "go",
@@ -8924,8 +8924,8 @@
 "level": 1,
 "out_size": 228837,
 "ratio": 0.4749,
-"compress_mbps": 95.25,
-"decompress_mbps": 153.04
+"compress_mbps": 38.29,
+"decompress_mbps": 55.94
 },
 {
 "compressor": "go",
@@ -8934,8 +8934,8 @@
 "level": 2,
 "out_size": 211248,
 "ratio": 0.4384,
-"compress_mbps": 64.95,
-"decompress_mbps": 178.34
+"compress_mbps": 42.49,
+"decompress_mbps": 62.83
 },
 {
 "compressor": "go",
@@ -8944,8 +8944,8 @@
 "level": 3,
 "out_size": 205619,
 "ratio": 0.4267,
-"compress_mbps": 53.31,
-"decompress_mbps": 184.65
+"compress_mbps": 42.45,
+"decompress_mbps": 66.52
 },
 {
 "compressor": "go",
@@ -8954,8 +8954,8 @@
 "level": 4,
 "out_size": 200595,
 "ratio": 0.4163,
-"compress_mbps": 53.24,
-"decompress_mbps": 186.17
+"compress_mbps": 23.72,
+"decompress_mbps": 65.74
 },
 {
 "compressor": "go",
@@ -8964,8 +8964,8 @@
 "level": 5,
 "out_size": 195418,
 "ratio": 0.4055,
-"compress_mbps": 32.16,
-"decompress_mbps": 183.78
+"compress_mbps": 22.13,
+"decompress_mbps": 65.81
 },
 {
 "compressor": "go",
@@ -8974,8 +8974,8 @@
 "level": 6,
 "out_size": 194148,
 "ratio": 0.4029,
-"compress_mbps": 24.7,
-"decompress_mbps": 186.18
+"compress_mbps": 15.66,
+"decompress_mbps": 66.02
 },
 {
 "compressor": "go",
@@ -8984,8 +8984,8 @@
 "level": 7,
 "out_size": 193994,
 "ratio": 0.4026,
-"compress_mbps": 22.87,
-"decompress_mbps": 185.29
+"compress_mbps": 14.95,
+"decompress_mbps": 105.66
 },
 {
 "compressor": "go",
@@ -8994,8 +8994,8 @@
 "level": 8,
 "out_size": 193991,
 "ratio": 0.4026,
-"compress_mbps": 23.27,
-"decompress_mbps": 188.41
+"compress_mbps": 14.67,
+"decompress_mbps": 92.53
 },
 {
 "compressor": "go",
@@ -9004,8 +9004,8 @@
 "level": 9,
 "out_size": 193991,
 "ratio": 0.4026,
-"compress_mbps": 22.94,
-"decompress_mbps": 187.08
+"compress_mbps": 15,
+"decompress_mbps": 68.77
 },
 {
 "compressor": "go",
@@ -9014,8 +9014,8 @@
 "level": 1,
 "out_size": 60990,
 "ratio": 0.1188,
-"compress_mbps": 276.08,
-"decompress_mbps": 478.56
+"compress_mbps": 122.72,
+"decompress_mbps": 180.34
 },
 {
 "compressor": "go",
@@ -9024,8 +9024,8 @@
 "level": 2,
 "out_size": 61650,
 "ratio": 0.1201,
-"compress_mbps": 255.87,
-"decompress_mbps": 493.77
+"compress_mbps": 151.36,
+"decompress_mbps": 194.34
 },
 {
 "compressor": "go",
@@ -9034,8 +9034,8 @@
 "level": 3,
 "out_size": 60035,
 "ratio": 0.117,
-"compress_mbps": 226.11,
-"decompress_mbps": 505.86
+"compress_mbps": 137.26,
+"decompress_mbps": 209.01
 },
 {
 "compressor": "go",
@@ -9044,8 +9044,8 @@
 "level": 4,
 "out_size": 57005,
 "ratio": 0.1111,
-"compress_mbps": 202.3,
-"decompress_mbps": 509.85
+"compress_mbps": 113.11,
+"decompress_mbps": 208.57
 },
 {
 "compressor": "go",
@@ -9054,8 +9054,8 @@
 "level": 5,
 "out_size": 55779,
 "ratio": 0.1087,
-"compress_mbps": 156.17,
-"decompress_mbps": 541.13
+"compress_mbps": 149.82,
+"decompress_mbps": 207.87
 },
 {
 "compressor": "go",
@@ -9064,8 +9064,8 @@
 "level": 6,
 "out_size": 54970,
 "ratio": 0.1071,
-"compress_mbps": 105.2,
-"decompress_mbps": 565.8
+"compress_mbps": 42.88,
+"decompress_mbps": 206.16
 },
 {
 "compressor": "go",
@@ -9074,8 +9074,8 @@
 "level": 7,
 "out_size": 53922,
 "ratio": 0.1051,
-"compress_mbps": 78.71,
-"decompress_mbps": 562.13
+"compress_mbps": 48.7,
+"decompress_mbps": 229.16
 },
 {
 "compressor": "go",
@@ -9084,8 +9084,8 @@
 "level": 8,
 "out_size": 51977,
 "ratio": 0.1013,
-"compress_mbps": 28.54,
-"decompress_mbps": 563.52
+"compress_mbps": 20.46,
+"decompress_mbps": 242.39
 },
 {
 "compressor": "go",
@@ -9094,8 +9094,8 @@
 "level": 9,
 "out_size": 51474,
 "ratio": 0.1003,
-"compress_mbps": 7.43,
-"decompress_mbps": 563.65
+"compress_mbps": 6.35,
+"decompress_mbps": 228.79
 },
 {
 "compressor": "go",
@@ -9104,8 +9104,8 @@
 "level": 1,
 "out_size": 14783,
 "ratio": 0.3866,
-"compress_mbps": 62.15,
-"decompress_mbps": 183.68
+"compress_mbps": 40.03,
+"decompress_mbps": 80.88
 },
 {
 "compressor": "go",
@@ -9114,8 +9114,8 @@
 "level": 2,
 "out_size": 14101,
 "ratio": 0.3688,
-"compress_mbps": 63.1,
-"decompress_mbps": 210.86
+"compress_mbps": 37.23,
+"decompress_mbps": 90.07
 },
 {
 "compressor": "go",
@@ -9124,8 +9124,8 @@
 "level": 3,
 "out_size": 13975,
 "ratio": 0.3655,
-"compress_mbps": 63.33,
-"decompress_mbps": 211.48
+"compress_mbps": 39.34,
+"decompress_mbps": 104.76
 },
 {
 "compressor": "go",
@@ -9134,8 +9134,8 @@
 "level": 4,
 "out_size": 13632,
 "ratio": 0.3565,
-"compress_mbps": 59.08,
-"decompress_mbps": 204.24
+"compress_mbps": 26.53,
+"decompress_mbps": 80.69
 },
 {
 "compressor": "go",
@@ -9144,8 +9144,8 @@
 "level": 5,
 "out_size": 13302,
 "ratio": 0.3479,
-"compress_mbps": 46.95,
-"decompress_mbps": 212.87
+"compress_mbps": 21.13,
+"decompress_mbps": 86.28
 },
 {
 "compressor": "go",
@@ -9154,8 +9154,8 @@
 "level": 6,
 "out_size": 13279,
 "ratio": 0.3473,
-"compress_mbps": 38.93,
-"decompress_mbps": 211.84
+"compress_mbps": 17.14,
+"decompress_mbps": 79.33
 },
 {
 "compressor": "go",
@@ -9164,8 +9164,8 @@
 "level": 7,
 "out_size": 13274,
 "ratio": 0.3471,
-"compress_mbps": 33.41,
-"decompress_mbps": 212.77
+"compress_mbps": 15.32,
+"decompress_mbps": 83.88
 },
 {
 "compressor": "go",
@@ -9174,8 +9174,8 @@
 "level": 8,
 "out_size": 13260,
 "ratio": 0.3468,
-"compress_mbps": 20.24,
-"decompress_mbps": 218.96
+"compress_mbps": 7.1,
+"decompress_mbps": 87.92
 },
 {
 "compressor": "go",
@@ -9184,8 +9184,8 @@
 "level": 9,
 "out_size": 13260,
 "ratio": 0.3468,
-"compress_mbps": 13.03,
-"decompress_mbps": 239.06
+"compress_mbps": 4.88,
+"decompress_mbps": 79.05
 },
 {
 "compressor": "go",
@@ -9194,8 +9194,8 @@
 "level": 1,
 "out_size": 1862,
 "ratio": 0.4405,
-"compress_mbps": 16.72,
-"decompress_mbps": 122.68
+"compress_mbps": 7.78,
+"decompress_mbps": 56.77
 },
 {
 "compressor": "go",
@@ -9204,8 +9204,8 @@
 "level": 2,
 "out_size": 1803,
 "ratio": 0.4265,
-"compress_mbps": 19.44,
-"decompress_mbps": 138.88
+"compress_mbps": 13.51,
+"decompress_mbps": 70.27
 },
 {
 "compressor": "go",
@@ -9214,8 +9214,8 @@
 "level": 3,
 "out_size": 1791,
 "ratio": 0.4237,
-"compress_mbps": 20.23,
-"decompress_mbps": 147.38
+"compress_mbps": 9.89,
+"decompress_mbps": 60.57
 },
 {
 "compressor": "go",
@@ -9224,8 +9224,8 @@
 "level": 4,
 "out_size": 1746,
 "ratio": 0.4131,
-"compress_mbps": 21.45,
-"decompress_mbps": 148.33
+"compress_mbps": 9.69,
+"decompress_mbps": 63.5
 },
 {
 "compressor": "go",
@@ -9234,8 +9234,8 @@
 "level": 5,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 19.41,
-"decompress_mbps": 142.31
+"compress_mbps": 10.1,
+"decompress_mbps": 61.29
 },
 {
 "compressor": "go",
@@ -9244,8 +9244,8 @@
 "level": 6,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 20.95,
-"decompress_mbps": 161.18
+"compress_mbps": 9.3,
+"decompress_mbps": 56.29
 },
 {
 "compressor": "go",
@@ -9254,8 +9254,8 @@
 "level": 7,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 19.99,
-"decompress_mbps": 160.15
+"compress_mbps": 9.67,
+"decompress_mbps": 60.03
 },
 {
 "compressor": "go",
@@ -9264,8 +9264,8 @@
 "level": 8,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 20.84,
-"decompress_mbps": 153.6
+"compress_mbps": 11.17,
+"decompress_mbps": 52.92
 },
 {
 "compressor": "go",
@@ -9274,8 +9274,8 @@
 "level": 9,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 18.94,
-"decompress_mbps": 136.52
+"compress_mbps": 11,
+"decompress_mbps": 64.2
 },
 {
 "compressor": "go",
@@ -9284,8 +9284,8 @@
 "level": 1,
 "out_size": 4623589,
 "ratio": 0.4536,
-"compress_mbps": 104.54,
-"decompress_mbps": 171.53
+"compress_mbps": 77.1,
+"decompress_mbps": 122.1
 },
 {
 "compressor": "go",
@@ -9294,8 +9294,8 @@
 "level": 2,
 "out_size": 4241525,
 "ratio": 0.4161,
-"compress_mbps": 72.15,
-"decompress_mbps": 192.75
+"compress_mbps": 61.57,
+"decompress_mbps": 183.36
 },
 {
 "compressor": "go",
@@ -9304,8 +9304,8 @@
 "level": 3,
 "out_size": 4123202,
 "ratio": 0.4045,
-"compress_mbps": 60.67,
-"decompress_mbps": 200.64
+"compress_mbps": 54.72,
+"decompress_mbps": 117.47
 },
 {
 "compressor": "go",
@@ -9314,8 +9314,8 @@
 "level": 4,
 "out_size": 3985937,
 "ratio": 0.3911,
-"compress_mbps": 59.19,
-"decompress_mbps": 209.56
+"compress_mbps": 56.6,
+"decompress_mbps": 154.99
 },
 {
 "compressor": "go",
@@ -9324,8 +9324,8 @@
 "level": 5,
 "out_size": 3883839,
 "ratio": 0.3811,
-"compress_mbps": 34.67,
-"decompress_mbps": 206.51
+"compress_mbps": 34.87,
+"decompress_mbps": 114.82
 },
 {
 "compressor": "go",
@@ -9334,8 +9334,8 @@
 "level": 6,
 "out_size": 3860437,
 "ratio": 0.3788,
-"compress_mbps": 27.08,
-"decompress_mbps": 201.56
+"compress_mbps": 27.55,
+"decompress_mbps": 196.4
 },
 {
 "compressor": "go",
@@ -9344,8 +9344,8 @@
 "level": 7,
 "out_size": 3857076,
 "ratio": 0.3784,
-"compress_mbps": 24.78,
-"decompress_mbps": 206.59
+"compress_mbps": 25.11,
+"decompress_mbps": 193.13
 },
 {
 "compressor": "go",
@@ -9354,8 +9354,8 @@
 "level": 8,
 "out_size": 3856651,
 "ratio": 0.3784,
-"compress_mbps": 24.08,
-"decompress_mbps": 203.55
+"compress_mbps": 24.8,
+"decompress_mbps": 114.82
 },
 {
 "compressor": "go",
@@ -9364,8 +9364,8 @@
 "level": 9,
 "out_size": 3856651,
 "ratio": 0.3784,
-"compress_mbps": 24.14,
-"decompress_mbps": 200.48
+"compress_mbps": 24.78,
+"decompress_mbps": 123.12
 },
 {
 "compressor": "go",
@@ -9374,8 +9374,8 @@
 "level": 1,
 "out_size": 21508211,
 "ratio": 0.4199,
-"compress_mbps": 140.29,
-"decompress_mbps": 235.88
+"compress_mbps": 142.41,
+"decompress_mbps": 235.64
 },
 {
 "compressor": "go",
@@ -9384,8 +9384,8 @@
 "level": 2,
 "out_size": 20538783,
 "ratio": 0.401,
-"compress_mbps": 98.4,
-"decompress_mbps": 233.91
+"compress_mbps": 101.38,
+"decompress_mbps": 212.37
 },
 {
 "compressor": "go",
@@ -9394,8 +9394,8 @@
 "level": 3,
 "out_size": 20334352,
 "ratio": 0.397,
-"compress_mbps": 92.43,
-"decompress_mbps": 219.29
+"compress_mbps": 95.16,
+"decompress_mbps": 231.59
 },
 {
 "compressor": "go",
@@ -9404,8 +9404,8 @@
 "level": 4,
 "out_size": 19886937,
 "ratio": 0.3883,
-"compress_mbps": 90.68,
-"decompress_mbps": 236.85
+"compress_mbps": 89.25,
+"decompress_mbps": 205.76
 },
 {
 "compressor": "go",
@@ -9414,8 +9414,8 @@
 "level": 5,
 "out_size": 19582363,
 "ratio": 0.3823,
-"compress_mbps": 64.11,
-"decompress_mbps": 243.57
+"compress_mbps": 64.33,
+"decompress_mbps": 231.41
 },
 {
 "compressor": "go",
@@ -9424,8 +9424,8 @@
 "level": 6,
 "out_size": 19512479,
 "ratio": 0.381,
-"compress_mbps": 43.78,
-"decompress_mbps": 243.65
+"compress_mbps": 43.83,
+"decompress_mbps": 252.53
 },
 {
 "compressor": "go",
@@ -9434,8 +9434,8 @@
 "level": 7,
 "out_size": 19489160,
 "ratio": 0.3805,
-"compress_mbps": 32.04,
-"decompress_mbps": 245.89
+"compress_mbps": 32.14,
+"decompress_mbps": 255.54
 },
 {
 "compressor": "go",
@@ -9444,8 +9444,8 @@
 "level": 8,
 "out_size": 19475109,
 "ratio": 0.3802,
-"compress_mbps": 18.55,
-"decompress_mbps": 251.69
+"compress_mbps": 18.3,
+"decompress_mbps": 224.66
 },
 {
 "compressor": "go",
@@ -9454,8 +9454,8 @@
 "level": 9,
 "out_size": 19476276,
 "ratio": 0.3802,
-"compress_mbps": 10.44,
-"decompress_mbps": 250.33
+"compress_mbps": 10.45,
+"decompress_mbps": 248.46
 },
 {
 "compressor": "go",
@@ -9464,8 +9464,8 @@
 "level": 1,
 "out_size": 3967718,
 "ratio": 0.3979,
-"compress_mbps": 146.94,
-"decompress_mbps": 229.99
+"compress_mbps": 150.31,
+"decompress_mbps": 122.19
 },
 {
 "compressor": "go",
@@ -9474,8 +9474,8 @@
 "level": 2,
 "out_size": 3773274,
 "ratio": 0.3784,
-"compress_mbps": 103.74,
-"decompress_mbps": 230.63
+"compress_mbps": 105.87,
+"decompress_mbps": 106.97
 },
 {
 "compressor": "go",
@@ -9484,8 +9484,8 @@
 "level": 3,
 "out_size": 3670460,
 "ratio": 0.3681,
-"compress_mbps": 76.73,
-"decompress_mbps": 239.13
+"compress_mbps": 77.56,
+"decompress_mbps": 128.99
 },
 {
 "compressor": "go",
@@ -9494,8 +9494,8 @@
 "level": 4,
 "out_size": 3655100,
 "ratio": 0.3666,
-"compress_mbps": 85.76,
-"decompress_mbps": 234.93
+"compress_mbps": 87.09,
+"decompress_mbps": 115.3
 },
 {
 "compressor": "go",
@@ -9504,8 +9504,8 @@
 "level": 5,
 "out_size": 3620881,
 "ratio": 0.3632,
-"compress_mbps": 50.14,
-"decompress_mbps": 247.21
+"compress_mbps": 50.36,
+"decompress_mbps": 142.9
 },
 {
 "compressor": "go",
@@ -9514,8 +9514,8 @@
 "level": 6,
 "out_size": 3606626,
 "ratio": 0.3617,
-"compress_mbps": 33.75,
-"decompress_mbps": 241.89
+"compress_mbps": 33.56,
+"decompress_mbps": 114.22
 },
 {
 "compressor": "go",
@@ -9524,8 +9524,8 @@
 "level": 7,
 "out_size": 3605405,
 "ratio": 0.3616,
-"compress_mbps": 30.4,
-"decompress_mbps": 246.44
+"compress_mbps": 30.14,
+"decompress_mbps": 153.09
 },
 {
 "compressor": "go",
@@ -9534,8 +9534,8 @@
 "level": 8,
 "out_size": 3601635,
 "ratio": 0.3612,
-"compress_mbps": 25.54,
-"decompress_mbps": 242.36
+"compress_mbps": 26.03,
+"decompress_mbps": 200.1
 },
 {
 "compressor": "go",
@@ -9544,8 +9544,8 @@
 "level": 9,
 "out_size": 3601151,
 "ratio": 0.3612,
-"compress_mbps": 19.23,
-"decompress_mbps": 244.02
+"compress_mbps": 19.32,
+"decompress_mbps": 136.51
 },
 {
 "compressor": "go",
@@ -9554,8 +9554,8 @@
 "level": 1,
 "out_size": 4501482,
 "ratio": 0.1342,
-"compress_mbps": 334.08,
-"decompress_mbps": 494.49
+"compress_mbps": 292.23,
+"decompress_mbps": 256.55
 },
 {
 "compressor": "go",
@@ -9564,8 +9564,8 @@
 "level": 2,
 "out_size": 3875891,
 "ratio": 0.1155,
-"compress_mbps": 313.82,
-"decompress_mbps": 608.4
+"compress_mbps": 313.24,
+"decompress_mbps": 407.87
 },
 {
 "compressor": "go",
@@ -9574,8 +9574,8 @@
 "level": 3,
 "out_size": 3731525,
 "ratio": 0.1112,
-"compress_mbps": 288.93,
-"decompress_mbps": 638.33
+"compress_mbps": 287.16,
+"decompress_mbps": 372.8
 },
 {
 "compressor": "go",
@@ -9584,8 +9584,8 @@
 "level": 4,
 "out_size": 3542242,
 "ratio": 0.1056,
-"compress_mbps": 231.3,
-"decompress_mbps": 652.66
+"compress_mbps": 237.61,
+"decompress_mbps": 483.22
 },
 {
 "compressor": "go",
@@ -9594,8 +9594,8 @@
 "level": 5,
 "out_size": 3239184,
 "ratio": 0.0965,
-"compress_mbps": 168.14,
-"decompress_mbps": 704.78
+"compress_mbps": 173.52,
+"decompress_mbps": 397.95
 },
 {
 "compressor": "go",
@@ -9604,8 +9604,8 @@
 "level": 6,
 "out_size": 3113927,
 "ratio": 0.0928,
-"compress_mbps": 123.7,
-"decompress_mbps": 736.44
+"compress_mbps": 123.11,
+"decompress_mbps": 410.03
 },
 {
 "compressor": "go",
@@ -9614,8 +9614,8 @@
 "level": 7,
 "out_size": 3063520,
 "ratio": 0.0913,
-"compress_mbps": 82.58,
-"decompress_mbps": 731.78
+"compress_mbps": 83.5,
+"decompress_mbps": 466.13
 },
 {
 "compressor": "go",
@@ -9624,8 +9624,8 @@
 "level": 8,
 "out_size": 2961320,
 "ratio": 0.0883,
-"compress_mbps": 29.25,
-"decompress_mbps": 748.18
+"compress_mbps": 29.16,
+"decompress_mbps": 385.99
 },
 {
 "compressor": "go",
@@ -9635,7 +9635,7 @@
 "out_size": 2940087,
 "ratio": 0.0876,
 "compress_mbps": 20.42,
-"decompress_mbps": 649.48
+"decompress_mbps": 619.74
 },
 {
 "compressor": "go",
@@ -9644,8 +9644,8 @@
 "level": 1,
 "out_size": 3462708,
 "ratio": 0.5628,
-"compress_mbps": 98.98,
-"decompress_mbps": 164.7
+"compress_mbps": 62.01,
+"decompress_mbps": 87.53
 },
 {
 "compressor": "go",
@@ -9654,8 +9654,8 @@
 "level": 2,
 "out_size": 3327399,
 "ratio": 0.5408,
-"compress_mbps": 70.17,
-"decompress_mbps": 169.12
+"compress_mbps": 72.35,
+"decompress_mbps": 125.5
 },
 {
 "compressor": "go",
@@ -9664,8 +9664,8 @@
 "level": 3,
 "out_size": 3297422,
 "ratio": 0.536,
-"compress_mbps": 66.8,
-"decompress_mbps": 169.83
+"compress_mbps": 66.76,
+"decompress_mbps": 89.09
 },
 {
 "compressor": "go",
@@ -9674,8 +9674,8 @@
 "level": 4,
 "out_size": 3249485,
 "ratio": 0.5282,
-"compress_mbps": 61.84,
-"decompress_mbps": 172.16
+"compress_mbps": 63.73,
+"decompress_mbps": 91.87
 },
 {
 "compressor": "go",
@@ -9684,8 +9684,8 @@
 "level": 5,
 "out_size": 3220046,
 "ratio": 0.5234,
-"compress_mbps": 47.68,
-"decompress_mbps": 177.28
+"compress_mbps": 48.89,
+"decompress_mbps": 91.37
 },
 {
 "compressor": "go",
@@ -9694,8 +9694,8 @@
 "level": 6,
 "out_size": 3213239,
 "ratio": 0.5223,
-"compress_mbps": 43.07,
-"decompress_mbps": 175.97
+"compress_mbps": 42.97,
+"decompress_mbps": 93.73
 },
 {
 "compressor": "go",
@@ -9704,8 +9704,8 @@
 "level": 7,
 "out_size": 3212009,
 "ratio": 0.5221,
-"compress_mbps": 39.63,
-"decompress_mbps": 175.93
+"compress_mbps": 38.55,
+"decompress_mbps": 113.57
 },
 {
 "compressor": "go",
@@ -9714,8 +9714,8 @@
 "level": 8,
 "out_size": 3211575,
 "ratio": 0.522,
-"compress_mbps": 32.82,
-"decompress_mbps": 174.56
+"compress_mbps": 28.29,
+"decompress_mbps": 92.89
 },
 {
 "compressor": "go",
@@ -9724,8 +9724,8 @@
 "level": 9,
 "out_size": 3211561,
 "ratio": 0.522,
-"compress_mbps": 29.75,
-"decompress_mbps": 173.58
+"compress_mbps": 29.81,
+"decompress_mbps": 84.49
 },
 {
 "compressor": "go",
@@ -9734,8 +9734,8 @@
 "level": 1,
 "out_size": 4334497,
 "ratio": 0.4298,
-"compress_mbps": 138.51,
-"decompress_mbps": 235.68
+"compress_mbps": 131.83,
+"decompress_mbps": 228.82
 },
 {
 "compressor": "go",
@@ -9744,8 +9744,8 @@
 "level": 2,
 "out_size": 3900156,
 "ratio": 0.3867,
-"compress_mbps": 127.96,
-"decompress_mbps": 247.2
+"compress_mbps": 131.13,
+"decompress_mbps": 116.94
 },
 {
 "compressor": "go",
@@ -9754,8 +9754,8 @@
 "level": 3,
 "out_size": 3876099,
 "ratio": 0.3843,
-"compress_mbps": 121.59,
-"decompress_mbps": 255.71
+"compress_mbps": 121.23,
+"decompress_mbps": 257.07
 },
 {
 "compressor": "go",
@@ -9764,8 +9764,8 @@
 "level": 4,
 "out_size": 3782364,
 "ratio": 0.375,
-"compress_mbps": 108.89,
-"decompress_mbps": 253.67
+"compress_mbps": 107.18,
+"decompress_mbps": 149.32
 },
 {
 "compressor": "go",
@@ -9774,8 +9774,8 @@
 "level": 5,
 "out_size": 3679310,
 "ratio": 0.3648,
-"compress_mbps": 88.53,
-"decompress_mbps": 265.84
+"compress_mbps": 88.54,
+"decompress_mbps": 157.7
 },
 {
 "compressor": "go",
@@ -9784,8 +9784,8 @@
 "level": 6,
 "out_size": 3679424,
 "ratio": 0.3648,
-"compress_mbps": 86.09,
-"decompress_mbps": 260.67
+"compress_mbps": 85.7,
+"decompress_mbps": 134.04
 },
 {
 "compressor": "go",
@@ -9794,8 +9794,8 @@
 "level": 7,
 "out_size": 3679163,
 "ratio": 0.3648,
-"compress_mbps": 79.85,
-"decompress_mbps": 273.86
+"compress_mbps": 81.34,
+"decompress_mbps": 154.86
 },
 {
 "compressor": "go",
@@ -9804,8 +9804,8 @@
 "level": 8,
 "out_size": 3679169,
 "ratio": 0.3648,
-"compress_mbps": 79.48,
-"decompress_mbps": 264.02
+"compress_mbps": 81.36,
+"decompress_mbps": 132.98
 },
 {
 "compressor": "go",
@@ -9814,8 +9814,8 @@
 "level": 9,
 "out_size": 3679169,
 "ratio": 0.3648,
-"compress_mbps": 80.01,
-"decompress_mbps": 260.73
+"compress_mbps": 81.21,
+"decompress_mbps": 133.94
 },
 {
 "compressor": "go",
@@ -9824,8 +9824,8 @@
 "level": 1,
 "out_size": 2496363,
 "ratio": 0.3767,
-"compress_mbps": 129.75,
-"decompress_mbps": 200.14
+"compress_mbps": 127.67,
+"decompress_mbps": 96.47
 },
 {
 "compressor": "go",
@@ -9834,8 +9834,8 @@
 "level": 2,
 "out_size": 2202601,
 "ratio": 0.3324,
-"compress_mbps": 91.17,
-"decompress_mbps": 238.62
+"compress_mbps": 85.16,
+"decompress_mbps": 101.69
 },
 {
 "compressor": "go",
@@ -9844,8 +9844,8 @@
 "level": 3,
 "out_size": 2103089,
 "ratio": 0.3173,
-"compress_mbps": 64.67,
-"decompress_mbps": 244.57
+"compress_mbps": 65.11,
+"decompress_mbps": 112.99
 },
 {
 "compressor": "go",
@@ -9854,8 +9854,8 @@
 "level": 4,
 "out_size": 1999697,
 "ratio": 0.3017,
-"compress_mbps": 72.35,
-"decompress_mbps": 244.52
+"compress_mbps": 75.64,
+"decompress_mbps": 135.01
 },
 {
 "compressor": "go",
@@ -9864,8 +9864,8 @@
 "level": 5,
 "out_size": 1892143,
 "ratio": 0.2855,
-"compress_mbps": 36.16,
-"decompress_mbps": 247.24
+"compress_mbps": 37.13,
+"decompress_mbps": 120.58
 },
 {
 "compressor": "go",
@@ -9874,8 +9874,8 @@
 "level": 6,
 "out_size": 1838372,
 "ratio": 0.2774,
-"compress_mbps": 20.39,
-"decompress_mbps": 246.73
+"compress_mbps": 20.25,
+"decompress_mbps": 103.98
 },
 {
 "compressor": "go",
@@ -9884,8 +9884,8 @@
 "level": 7,
 "out_size": 1828850,
 "ratio": 0.276,
-"compress_mbps": 15.93,
-"decompress_mbps": 263.66
+"compress_mbps": 15.63,
+"decompress_mbps": 104.59
 },
 {
 "compressor": "go",
@@ -9894,8 +9894,8 @@
 "level": 8,
 "out_size": 1823159,
 "ratio": 0.2751,
-"compress_mbps": 12.29,
-"decompress_mbps": 243.97
+"compress_mbps": 12.46,
+"decompress_mbps": 108.27
 },
 {
 "compressor": "go",
@@ -9904,8 +9904,8 @@
 "level": 9,
 "out_size": 1823159,
 "ratio": 0.2751,
-"compress_mbps": 12.3,
-"decompress_mbps": 253.95
+"compress_mbps": 12.45,
+"decompress_mbps": 123.31
 },
 {
 "compressor": "go",
@@ -9914,8 +9914,8 @@
 "level": 1,
 "out_size": 6447290,
 "ratio": 0.2984,
-"compress_mbps": 190.6,
-"decompress_mbps": 293.2
+"compress_mbps": 189.76,
+"decompress_mbps": 197.73
 },
 {
 "compressor": "go",
@@ -9924,8 +9924,8 @@
 "level": 2,
 "out_size": 6030257,
 "ratio": 0.2791,
-"compress_mbps": 143.44,
-"decompress_mbps": 316.06
+"compress_mbps": 134.11,
+"decompress_mbps": 316.04
 },
 {
 "compressor": "go",
@@ -9934,8 +9934,8 @@
 "level": 3,
 "out_size": 5928121,
 "ratio": 0.2744,
-"compress_mbps": 127.82,
-"decompress_mbps": 325.46
+"compress_mbps": 128.48,
+"decompress_mbps": 217.44
 },
 {
 "compressor": "go",
@@ -9944,8 +9944,8 @@
 "level": 4,
 "out_size": 5615804,
 "ratio": 0.2599,
-"compress_mbps": 122.31,
-"decompress_mbps": 341.69
+"compress_mbps": 122.08,
+"decompress_mbps": 207.66
 },
 {
 "compressor": "go",
@@ -9954,8 +9954,8 @@
 "level": 5,
 "out_size": 5496738,
 "ratio": 0.2544,
-"compress_mbps": 78.34,
-"decompress_mbps": 338.67
+"compress_mbps": 79.36,
+"decompress_mbps": 337.82
 },
 {
 "compressor": "go",
@@ -9964,8 +9964,8 @@
 "level": 6,
 "out_size": 5464184,
 "ratio": 0.2529,
-"compress_mbps": 62.04,
-"decompress_mbps": 348.43
+"compress_mbps": 61.56,
+"decompress_mbps": 190
 },
 {
 "compressor": "go",
@@ -9974,8 +9974,8 @@
 "level": 7,
 "out_size": 5429645,
 "ratio": 0.2513,
-"compress_mbps": 47.97,
-"decompress_mbps": 346.07
+"compress_mbps": 49.03,
+"decompress_mbps": 196.3
 },
 {
 "compressor": "go",
@@ -9984,8 +9984,8 @@
 "level": 8,
 "out_size": 5418135,
 "ratio": 0.2508,
-"compress_mbps": 37.08,
-"decompress_mbps": 350.53
+"compress_mbps": 37.39,
+"decompress_mbps": 338.75
 },
 {
 "compressor": "go",
@@ -9994,8 +9994,8 @@
 "level": 9,
 "out_size": 5416628,
 "ratio": 0.2507,
-"compress_mbps": 33.19,
-"decompress_mbps": 351.24
+"compress_mbps": 33.91,
+"decompress_mbps": 289.29
 },
 {
 "compressor": "go",
@@ -10004,8 +10004,8 @@
 "level": 1,
 "out_size": 5759187,
 "ratio": 0.7942,
-"compress_mbps": 97.22,
-"decompress_mbps": 174.65
+"compress_mbps": 95.17,
+"decompress_mbps": 114.01
 },
 {
 "compressor": "go",
@@ -10014,8 +10014,8 @@
 "level": 2,
 "out_size": 5619390,
 "ratio": 0.7749,
-"compress_mbps": 66.43,
-"decompress_mbps": 176.24
+"compress_mbps": 49.5,
+"decompress_mbps": 93.51
 },
 {
 "compressor": "go",
@@ -10024,8 +10024,8 @@
 "level": 3,
 "out_size": 5560914,
 "ratio": 0.7668,
-"compress_mbps": 55,
-"decompress_mbps": 172.47
+"compress_mbps": 44.13,
+"decompress_mbps": 93.77
 },
 {
 "compressor": "go",
@@ -10034,8 +10034,8 @@
 "level": 4,
 "out_size": 5544069,
 "ratio": 0.7645,
-"compress_mbps": 57.44,
-"decompress_mbps": 178.67
+"compress_mbps": 50.73,
+"decompress_mbps": 93.55
 },
 {
 "compressor": "go",
@@ -10044,8 +10044,8 @@
 "level": 5,
 "out_size": 5518257,
 "ratio": 0.7609,
-"compress_mbps": 43.91,
-"decompress_mbps": 180.34
+"compress_mbps": 36.4,
+"decompress_mbps": 93.75
 },
 {
 "compressor": "go",
@@ -10054,8 +10054,8 @@
 "level": 6,
 "out_size": 5508662,
 "ratio": 0.7596,
-"compress_mbps": 38.99,
-"decompress_mbps": 178.89
+"compress_mbps": 33.21,
+"decompress_mbps": 96.67
 },
 {
 "compressor": "go",
@@ -10064,8 +10064,8 @@
 "level": 7,
 "out_size": 5507534,
 "ratio": 0.7595,
-"compress_mbps": 38.27,
-"decompress_mbps": 176.97
+"compress_mbps": 32.93,
+"decompress_mbps": 95.78
 },
 {
 "compressor": "go",
@@ -10074,8 +10074,8 @@
 "level": 8,
 "out_size": 5507183,
 "ratio": 0.7594,
-"compress_mbps": 37.73,
-"decompress_mbps": 180.22
+"compress_mbps": 32.29,
+"decompress_mbps": 97.4
 },
 {
 "compressor": "go",
@@ -10084,8 +10084,8 @@
 "level": 9,
 "out_size": 5507183,
 "ratio": 0.7594,
-"compress_mbps": 37.83,
-"decompress_mbps": 180.71
+"compress_mbps": 35.31,
+"decompress_mbps": 96.83
 },
 {
 "compressor": "go",
@@ -10094,8 +10094,8 @@
 "level": 1,
 "out_size": 15230651,
 "ratio": 0.3674,
-"compress_mbps": 124.36,
-"decompress_mbps": 200.63
+"compress_mbps": 122.11,
+"decompress_mbps": 204.99
 },
 {
 "compressor": "go",
@@ -10104,8 +10104,8 @@
 "level": 2,
 "out_size": 13822040,
 "ratio": 0.3334,
-"compress_mbps": 93.72,
-"decompress_mbps": 234.53
+"compress_mbps": 96.92,
+"decompress_mbps": 188.65
 },
 {
 "compressor": "go",
@@ -10114,8 +10114,8 @@
 "level": 3,
 "out_size": 13397592,
 "ratio": 0.3232,
-"compress_mbps": 83.81,
-"decompress_mbps": 233.94
+"compress_mbps": 82.59,
+"decompress_mbps": 197.78
 },
 {
 "compressor": "go",
@@ -10124,8 +10124,8 @@
 "level": 4,
 "out_size": 12759940,
 "ratio": 0.3078,
-"compress_mbps": 78.42,
-"decompress_mbps": 247.58
+"compress_mbps": 80.83,
+"decompress_mbps": 212.94
 },
 {
 "compressor": "go",
@@ -10134,8 +10134,8 @@
 "level": 5,
 "out_size": 12274278,
 "ratio": 0.2961,
-"compress_mbps": 51.99,
-"decompress_mbps": 242.11
+"compress_mbps": 53.88,
+"decompress_mbps": 237.3
 },
 {
 "compressor": "go",
@@ -10144,8 +10144,8 @@
 "level": 6,
 "out_size": 12131738,
 "ratio": 0.2926,
-"compress_mbps": 39.23,
-"decompress_mbps": 248.46
+"compress_mbps": 40.69,
+"decompress_mbps": 208.37
 },
 {
 "compressor": "go",
@@ -10154,8 +10154,8 @@
 "level": 7,
 "out_size": 12060450,
 "ratio": 0.2909,
-"compress_mbps": 33.24,
-"decompress_mbps": 248.95
+"compress_mbps": 33.2,
+"decompress_mbps": 208.57
 },
 {
 "compressor": "go",
@@ -10164,8 +10164,8 @@
 "level": 8,
 "out_size": 12036900,
 "ratio": 0.2903,
-"compress_mbps": 29.25,
-"decompress_mbps": 249.14
+"compress_mbps": 30.02,
+"decompress_mbps": 223.92
 },
 {
 "compressor": "go",
@@ -10174,8 +10174,8 @@
 "level": 9,
 "out_size": 12036900,
 "ratio": 0.2903,
-"compress_mbps": 30.01,
-"decompress_mbps": 237.62
+"compress_mbps": 29.8,
+"decompress_mbps": 223.72
 },
 {
 "compressor": "go",
@@ -10184,8 +10184,8 @@
 "level": 1,
 "out_size": 6653052,
 "ratio": 0.7851,
-"compress_mbps": 172.1,
-"decompress_mbps": 180.77
+"compress_mbps": 101.23,
+"decompress_mbps": 168.68
 },
 {
 "compressor": "go",
@@ -10194,8 +10194,8 @@
 "level": 2,
 "out_size": 6305035,
 "ratio": 0.744,
-"compress_mbps": 68.67,
-"decompress_mbps": 164.16
+"compress_mbps": 68.39,
+"decompress_mbps": 99.08
 },
 {
 "compressor": "go",
@@ -10204,8 +10204,8 @@
 "level": 3,
 "out_size": 6302730,
 "ratio": 0.7438,
-"compress_mbps": 67.35,
-"decompress_mbps": 164.63
+"compress_mbps": 68.76,
+"decompress_mbps": 159.09
 },
 {
 "compressor": "go",
@@ -10214,8 +10214,8 @@
 "level": 4,
 "out_size": 6299134,
 "ratio": 0.7433,
-"compress_mbps": 66.48,
-"decompress_mbps": 161.51
+"compress_mbps": 55.23,
+"decompress_mbps": 98.32
 },
 {
 "compressor": "go",
@@ -10224,8 +10224,8 @@
 "level": 5,
 "out_size": 6289022,
 "ratio": 0.7421,
-"compress_mbps": 63.48,
-"decompress_mbps": 164.92
+"compress_mbps": 61.6,
+"decompress_mbps": 100.51
 },
 {
 "compressor": "go",
@@ -10234,8 +10234,8 @@
 "level": 6,
 "out_size": 6289013,
 "ratio": 0.7421,
-"compress_mbps": 63.74,
-"decompress_mbps": 162.98
+"compress_mbps": 64.84,
+"decompress_mbps": 162.54
 },
 {
 "compressor": "go",
@@ -10244,8 +10244,8 @@
 "level": 7,
 "out_size": 6289013,
 "ratio": 0.7421,
-"compress_mbps": 63.8,
-"decompress_mbps": 165.35
+"compress_mbps": 50.62,
+"decompress_mbps": 162.09
 },
 {
 "compressor": "go",
@@ -10254,8 +10254,8 @@
 "level": 8,
 "out_size": 6289012,
 "ratio": 0.7421,
-"compress_mbps": 63.54,
-"decompress_mbps": 167.03
+"compress_mbps": 50.26,
+"decompress_mbps": 167.1
 },
 {
 "compressor": "go",
@@ -10264,8 +10264,8 @@
 "level": 9,
 "out_size": 6289012,
 "ratio": 0.7421,
-"compress_mbps": 63.5,
-"decompress_mbps": 163.91
+"compress_mbps": 50.61,
+"decompress_mbps": 102.92
 },
 {
 "compressor": "go",
@@ -10274,8 +10274,8 @@
 "level": 1,
 "out_size": 989456,
 "ratio": 0.1851,
-"compress_mbps": 250.57,
-"decompress_mbps": 375.57
+"compress_mbps": 165.95,
+"decompress_mbps": 297.54
 },
 {
 "compressor": "go",
@@ -10284,8 +10284,8 @@
 "level": 2,
 "out_size": 839766,
 "ratio": 0.1571,
-"compress_mbps": 221.64,
-"decompress_mbps": 475.43
+"compress_mbps": 185.49,
+"decompress_mbps": 169.06
 },
 {
 "compressor": "go",
@@ -10294,8 +10294,8 @@
 "level": 3,
 "out_size": 800619,
 "ratio": 0.1498,
-"compress_mbps": 195.87,
-"decompress_mbps": 472.3
+"compress_mbps": 161.42,
+"decompress_mbps": 183.63
 },
 {
 "compressor": "go",
@@ -10304,8 +10304,8 @@
 "level": 4,
 "out_size": 776397,
 "ratio": 0.1452,
-"compress_mbps": 172.07,
-"decompress_mbps": 477.79
+"compress_mbps": 122.26,
+"decompress_mbps": 189.6
 },
 {
 "compressor": "go",
@@ -10314,8 +10314,8 @@
 "level": 5,
 "out_size": 712679,
 "ratio": 0.1333,
-"compress_mbps": 125.92,
-"decompress_mbps": 531.18
+"compress_mbps": 102.21,
+"decompress_mbps": 310.05
 },
 {
 "compressor": "go",
@@ -10324,8 +10324,8 @@
 "level": 6,
 "out_size": 683707,
 "ratio": 0.1279,
-"compress_mbps": 92.58,
-"decompress_mbps": 504.65
+"compress_mbps": 95.34,
+"decompress_mbps": 262.26
 },
 {
 "compressor": "go",
@@ -10334,8 +10334,8 @@
 "level": 7,
 "out_size": 668601,
 "ratio": 0.1251,
-"compress_mbps": 70.72,
-"decompress_mbps": 547.08
+"compress_mbps": 71.48,
+"decompress_mbps": 289.05
 },
 {
 "compressor": "go",
@@ -10344,8 +10344,8 @@
 "level": 8,
 "out_size": 659106,
 "ratio": 0.1233,
-"compress_mbps": 47.86,
-"decompress_mbps": 567.09
+"compress_mbps": 48.35,
+"decompress_mbps": 206.6
 },
 {
 "compressor": "go",
@@ -10354,8 +10354,8 @@
 "level": 9,
 "out_size": 658920,
 "ratio": 0.1233,
-"compress_mbps": 46,
-"decompress_mbps": 545.48
+"compress_mbps": 41.59,
+"decompress_mbps": 291.53
 },
 {
 "compressor": "js",
@@ -10364,8 +10364,8 @@
 "level": 1,
 "out_size": 62797,
 "ratio": 0.4129,
-"compress_mbps": 74.23,
-"decompress_mbps": 163.41
+"compress_mbps": 76.05,
+"decompress_mbps": 141.06
 },
 {
 "compressor": "js",
@@ -10374,8 +10374,8 @@
 "level": 2,
 "out_size": 59605,
 "ratio": 0.3919,
-"compress_mbps": 59.84,
-"decompress_mbps": 201.19
+"compress_mbps": 63.18,
+"decompress_mbps": 133.39
 },
 {
 "compressor": "js",
@@ -10384,8 +10384,8 @@
 "level": 3,
 "out_size": 57675,
 "ratio": 0.3792,
-"compress_mbps": 44.62,
-"decompress_mbps": 179.52
+"compress_mbps": 45.32,
+"decompress_mbps": 126.55
 },
 {
 "compressor": "js",
@@ -10394,8 +10394,8 @@
 "level": 4,
 "out_size": 56500,
 "ratio": 0.3715,
-"compress_mbps": 38.1,
-"decompress_mbps": 196.07
+"compress_mbps": 45.86,
+"decompress_mbps": 133.66
 },
 {
 "compressor": "js",
@@ -10404,8 +10404,8 @@
 "level": 5,
 "out_size": 56440,
 "ratio": 0.3711,
-"compress_mbps": 37.86,
-"decompress_mbps": 196.69
+"compress_mbps": 38.8,
+"decompress_mbps": 132.26
 },
 {
 "compressor": "js",
@@ -10414,8 +10414,8 @@
 "level": 6,
 "out_size": 55443,
 "ratio": 0.3645,
-"compress_mbps": 31.72,
-"decompress_mbps": 217.75
+"compress_mbps": 32.65,
+"decompress_mbps": 146.2
 },
 {
 "compressor": "js",
@@ -10424,8 +10424,8 @@
 "level": 7,
 "out_size": 55373,
 "ratio": 0.3641,
-"compress_mbps": 30.99,
-"decompress_mbps": 194.94
+"compress_mbps": 31.53,
+"decompress_mbps": 134.56
 },
 {
 "compressor": "js",
@@ -10434,8 +10434,8 @@
 "level": 8,
 "out_size": 55352,
 "ratio": 0.3639,
-"compress_mbps": 30.77,
-"decompress_mbps": 200.58
+"compress_mbps": 35.49,
+"decompress_mbps": 135.96
 },
 {
 "compressor": "js",
@@ -10444,8 +10444,8 @@
 "level": 9,
 "out_size": 55352,
 "ratio": 0.3639,
-"compress_mbps": 30.55,
-"decompress_mbps": 202.33
+"compress_mbps": 31.2,
+"decompress_mbps": 133.03
 },
 {
 "compressor": "js",
@@ -10454,8 +10454,8 @@
 "level": 1,
 "out_size": 55063,
 "ratio": 0.4399,
-"compress_mbps": 73.76,
-"decompress_mbps": 175.23
+"compress_mbps": 74.96,
+"decompress_mbps": 114.52
 },
 {
 "compressor": "js",
@@ -10464,8 +10464,8 @@
 "level": 2,
 "out_size": 52932,
 "ratio": 0.4229,
-"compress_mbps": 59.64,
-"decompress_mbps": 165.44
+"compress_mbps": 60.84,
+"decompress_mbps": 112.42
 },
 {
 "compressor": "js",
@@ -10474,8 +10474,8 @@
 "level": 3,
 "out_size": 51597,
 "ratio": 0.4122,
-"compress_mbps": 43.3,
-"decompress_mbps": 162.06
+"compress_mbps": 51.25,
+"decompress_mbps": 118.62
 },
 {
 "compressor": "js",
@@ -10484,8 +10484,8 @@
 "level": 4,
 "out_size": 50780,
 "ratio": 0.4057,
-"compress_mbps": 37.67,
-"decompress_mbps": 170.14
+"compress_mbps": 38.15,
+"decompress_mbps": 123.69
 },
 {
 "compressor": "js",
@@ -10494,8 +10494,8 @@
 "level": 5,
 "out_size": 50767,
 "ratio": 0.4056,
-"compress_mbps": 37.25,
-"decompress_mbps": 167.11
+"compress_mbps": 42.83,
+"decompress_mbps": 121.44
 },
 {
 "compressor": "js",
@@ -10504,8 +10504,8 @@
 "level": 6,
 "out_size": 50160,
 "ratio": 0.4007,
-"compress_mbps": 32.37,
-"decompress_mbps": 193.25
+"compress_mbps": 32.88,
+"decompress_mbps": 127.67
 },
 {
 "compressor": "js",
@@ -10514,8 +10514,8 @@
 "level": 7,
 "out_size": 50138,
 "ratio": 0.4005,
-"compress_mbps": 31.72,
-"decompress_mbps": 191.35
+"compress_mbps": 32.53,
+"decompress_mbps": 124.75
 },
 {
 "compressor": "js",
@@ -10524,8 +10524,8 @@
 "level": 8,
 "out_size": 50138,
 "ratio": 0.4005,
-"compress_mbps": 31.72,
-"decompress_mbps": 170.37
+"compress_mbps": 32.23,
+"decompress_mbps": 122.69
 },
 {
 "compressor": "js",
@@ -10534,8 +10534,8 @@
 "level": 9,
 "out_size": 50138,
 "ratio": 0.4005,
-"compress_mbps": 31.76,
-"decompress_mbps": 194.28
+"compress_mbps": 32.33,
+"decompress_mbps": 124.47
 },
 {
 "compressor": "js",
@@ -10544,8 +10544,8 @@
 "level": 1,
 "out_size": 8730,
 "ratio": 0.3548,
-"compress_mbps": 77.53,
-"decompress_mbps": 118.42
+"compress_mbps": 50.41,
+"decompress_mbps": 131.15
 },
 {
 "compressor": "js",
@@ -10554,8 +10554,8 @@
 "level": 2,
 "out_size": 8457,
 "ratio": 0.3437,
-"compress_mbps": 55.47,
-"decompress_mbps": 136.64
+"compress_mbps": 45.45,
+"decompress_mbps": 130.16
 },
 {
 "compressor": "js",
@@ -10564,8 +10564,8 @@
 "level": 3,
 "out_size": 8353,
 "ratio": 0.3395,
-"compress_mbps": 63.64,
-"decompress_mbps": 102.59
+"compress_mbps": 42.76,
+"decompress_mbps": 112.19
 },
 {
 "compressor": "js",
@@ -10574,8 +10574,8 @@
 "level": 4,
 "out_size": 8301,
 "ratio": 0.3374,
-"compress_mbps": 63.88,
-"decompress_mbps": 126.06
+"compress_mbps": 63.24,
+"decompress_mbps": 136.7
 },
 {
 "compressor": "js",
@@ -10584,8 +10584,8 @@
 "level": 5,
 "out_size": 8212,
 "ratio": 0.3338,
-"compress_mbps": 58.37,
-"decompress_mbps": 103.52
+"compress_mbps": 50.56,
+"decompress_mbps": 112.06
 },
 {
 "compressor": "js",
@@ -10594,8 +10594,8 @@
 "level": 6,
 "out_size": 8172,
 "ratio": 0.3322,
-"compress_mbps": 55.19,
-"decompress_mbps": 112.93
+"compress_mbps": 45.37,
+"decompress_mbps": 107.58
 },
 {
 "compressor": "js",
@@ -10604,8 +10604,8 @@
 "level": 7,
 "out_size": 8171,
 "ratio": 0.3321,
-"compress_mbps": 54.86,
-"decompress_mbps": 108.45
+"compress_mbps": 48.54,
+"decompress_mbps": 109.8
 },
 {
 "compressor": "js",
@@ -10614,8 +10614,8 @@
 "level": 8,
 "out_size": 8171,
 "ratio": 0.3321,
-"compress_mbps": 52.02,
-"decompress_mbps": 104.26
+"compress_mbps": 52.95,
+"decompress_mbps": 102.83
 },
 {
 "compressor": "js",
@@ -10624,8 +10624,8 @@
 "level": 9,
 "out_size": 8171,
 "ratio": 0.3321,
-"compress_mbps": 53.91,
-"decompress_mbps": 110.74
+"compress_mbps": 55.39,
+"decompress_mbps": 105.1
 },
 {
 "compressor": "js",
@@ -10634,8 +10634,8 @@
 "level": 1,
 "out_size": 3475,
 "ratio": 0.3117,
-"compress_mbps": 109.57,
-"decompress_mbps": 96.22
+"compress_mbps": 111.63,
+"decompress_mbps": 83.66
 },
 {
 "compressor": "js",
@@ -10644,8 +10644,8 @@
 "level": 2,
 "out_size": 3305,
 "ratio": 0.2964,
-"compress_mbps": 106.79,
-"decompress_mbps": 100.32
+"compress_mbps": 91.35,
+"decompress_mbps": 98.21
 },
 {
 "compressor": "js",
@@ -10654,8 +10654,8 @@
 "level": 3,
 "out_size": 3225,
 "ratio": 0.2892,
-"compress_mbps": 102.47,
-"decompress_mbps": 100.71
+"compress_mbps": 99.89,
+"decompress_mbps": 95.55
 },
 {
 "compressor": "js",
@@ -10664,8 +10664,8 @@
 "level": 4,
 "out_size": 3192,
 "ratio": 0.2863,
-"compress_mbps": 95.85,
-"decompress_mbps": 112.12
+"compress_mbps": 94.13,
+"decompress_mbps": 106.24
 },
 {
 "compressor": "js",
@@ -10674,8 +10674,8 @@
 "level": 5,
 "out_size": 3180,
 "ratio": 0.2852,
-"compress_mbps": 100.31,
-"decompress_mbps": 117.96
+"compress_mbps": 89.38,
+"decompress_mbps": 94.53
 },
 {
 "compressor": "js",
@@ -10684,8 +10684,8 @@
 "level": 6,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 96.86,
-"decompress_mbps": 101.88
+"compress_mbps": 95.12,
+"decompress_mbps": 91.55
 },
 {
 "compressor": "js",
@@ -10694,8 +10694,8 @@
 "level": 7,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 91.48,
-"decompress_mbps": 121.78
+"compress_mbps": 85.6,
+"decompress_mbps": 134.73
 },
 {
 "compressor": "js",
@@ -10704,8 +10704,8 @@
 "level": 8,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 96.59,
-"decompress_mbps": 120.66
+"compress_mbps": 95.9,
+"decompress_mbps": 126.42
 },
 {
 "compressor": "js",
@@ -10714,8 +10714,8 @@
 "level": 9,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 96.98,
-"decompress_mbps": 119.72
+"compress_mbps": 93.09,
+"decompress_mbps": 96.3
 },
 {
 "compressor": "js",
@@ -10724,8 +10724,8 @@
 "level": 1,
 "out_size": 1275,
 "ratio": 0.3426,
-"compress_mbps": 59.29,
-"decompress_mbps": 49.54
+"compress_mbps": 60.59,
+"decompress_mbps": 44.76
 },
 {
 "compressor": "js",
@@ -10734,8 +10734,8 @@
 "level": 2,
 "out_size": 1247,
 "ratio": 0.3351,
-"compress_mbps": 61.26,
-"decompress_mbps": 45.6
+"compress_mbps": 58.36,
+"decompress_mbps": 52.27
 },
 {
 "compressor": "js",
@@ -10744,8 +10744,8 @@
 "level": 3,
 "out_size": 1239,
 "ratio": 0.333,
-"compress_mbps": 59.07,
-"decompress_mbps": 49.4
+"compress_mbps": 58.29,
+"decompress_mbps": 50.66
 },
 {
 "compressor": "js",
@@ -10754,8 +10754,8 @@
 "level": 4,
 "out_size": 1238,
 "ratio": 0.3327,
-"compress_mbps": 58.48,
-"decompress_mbps": 45.96
+"compress_mbps": 56.23,
+"decompress_mbps": 49.05
 },
 {
 "compressor": "js",
@@ -10764,8 +10764,8 @@
 "level": 5,
 "out_size": 1239,
 "ratio": 0.333,
-"compress_mbps": 57.99,
-"decompress_mbps": 48.71
+"compress_mbps": 55.93,
+"decompress_mbps": 48.37
 },
 {
 "compressor": "js",
@@ -10774,8 +10774,8 @@
 "level": 6,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 58.4,
-"decompress_mbps": 48.33
+"compress_mbps": 57.62,
+"decompress_mbps": 47.88
 },
 {
 "compressor": "js",
@@ -10784,8 +10784,8 @@
 "level": 7,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 57.83,
-"decompress_mbps": 48.18
+"compress_mbps": 55.63,
+"decompress_mbps": 48.4
 },
 {
 "compressor": "js",
@@ -10794,8 +10794,8 @@
 "level": 8,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 57.64,
-"decompress_mbps": 47.73
+"compress_mbps": 52.3,
+"decompress_mbps": 46.23
 },
 {
 "compressor": "js",
@@ -10804,8 +10804,8 @@
 "level": 9,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 57.96,
-"decompress_mbps": 45.38
+"compress_mbps": 50.81,
+"decompress_mbps": 45.99
 },
 {
 "compressor": "js",
@@ -10814,8 +10814,8 @@
 "level": 1,
 "out_size": 226284,
 "ratio": 0.2197,
-"compress_mbps": 111.26,
-"decompress_mbps": 292.63
+"compress_mbps": 112.74,
+"decompress_mbps": 178.22
 },
 {
 "compressor": "js",
@@ -10824,8 +10824,8 @@
 "level": 2,
 "out_size": 221369,
 "ratio": 0.215,
-"compress_mbps": 91.21,
-"decompress_mbps": 296.62
+"compress_mbps": 90.86,
+"decompress_mbps": 190.73
 },
 {
 "compressor": "js",
@@ -10834,8 +10834,8 @@
 "level": 3,
 "out_size": 218607,
 "ratio": 0.2123,
-"compress_mbps": 79.73,
-"decompress_mbps": 306.9
+"compress_mbps": 78.8,
+"decompress_mbps": 190.72
 },
 {
 "compressor": "js",
@@ -10844,8 +10844,8 @@
 "level": 4,
 "out_size": 217919,
 "ratio": 0.2116,
-"compress_mbps": 70.47,
-"decompress_mbps": 317.16
+"compress_mbps": 70.99,
+"decompress_mbps": 191.79
 },
 {
 "compressor": "js",
@@ -10854,8 +10854,8 @@
 "level": 5,
 "out_size": 217919,
 "ratio": 0.2116,
-"compress_mbps": 70.8,
-"decompress_mbps": 315.85
+"compress_mbps": 70.12,
+"decompress_mbps": 196.23
 },
 {
 "compressor": "js",
@@ -10864,8 +10864,8 @@
 "level": 6,
 "out_size": 217312,
 "ratio": 0.211,
-"compress_mbps": 43.87,
-"decompress_mbps": 306.99
+"compress_mbps": 43.89,
+"decompress_mbps": 193.38
 },
 {
 "compressor": "js",
@@ -10874,8 +10874,8 @@
 "level": 7,
 "out_size": 215966,
 "ratio": 0.2097,
-"compress_mbps": 31.11,
-"decompress_mbps": 303.57
+"compress_mbps": 31.02,
+"decompress_mbps": 191.16
 },
 {
 "compressor": "js",
@@ -10884,8 +10884,8 @@
 "level": 8,
 "out_size": 215930,
 "ratio": 0.2097,
-"compress_mbps": 14.29,
-"decompress_mbps": 304.52
+"compress_mbps": 14.32,
+"decompress_mbps": 194.39
 },
 {
 "compressor": "js",
@@ -10895,7 +10895,7 @@
 "out_size": 215912,
 "ratio": 0.2097,
 "compress_mbps": 11.24,
-"decompress_mbps": 353.37
+"decompress_mbps": 209.84
 },
 {
 "compressor": "js",
@@ -10904,8 +10904,8 @@
 "level": 1,
 "out_size": 167622,
 "ratio": 0.3928,
-"compress_mbps": 64.61,
-"decompress_mbps": 173.93
+"compress_mbps": 64.98,
+"decompress_mbps": 118.12
 },
 {
 "compressor": "js",
@@ -10914,8 +10914,8 @@
 "level": 2,
 "out_size": 158003,
 "ratio": 0.3702,
-"compress_mbps": 52.78,
-"decompress_mbps": 180.81
+"compress_mbps": 54.15,
+"decompress_mbps": 139.99
 },
 {
 "compressor": "js",
@@ -10924,8 +10924,8 @@
 "level": 3,
 "out_size": 152928,
 "ratio": 0.3584,
-"compress_mbps": 45.25,
-"decompress_mbps": 187.7
+"compress_mbps": 46.69,
+"decompress_mbps": 143.87
 },
 {
 "compressor": "js",
@@ -10934,8 +10934,8 @@
 "level": 4,
 "out_size": 149886,
 "ratio": 0.3512,
-"compress_mbps": 39.8,
-"decompress_mbps": 154.42
+"compress_mbps": 40.39,
+"decompress_mbps": 136.81
 },
 {
 "compressor": "js",
@@ -10944,8 +10944,8 @@
 "level": 5,
 "out_size": 149767,
 "ratio": 0.3509,
-"compress_mbps": 39.37,
-"decompress_mbps": 174.23
+"compress_mbps": 38.7,
+"decompress_mbps": 136.38
 },
 {
 "compressor": "js",
@@ -10954,8 +10954,8 @@
 "level": 6,
 "out_size": 147818,
 "ratio": 0.3464,
-"compress_mbps": 32.84,
-"decompress_mbps": 183.87
+"compress_mbps": 28.52,
+"decompress_mbps": 151.53
 },
 {
 "compressor": "js",
@@ -10964,8 +10964,8 @@
 "level": 7,
 "out_size": 147733,
 "ratio": 0.3462,
-"compress_mbps": 32.66,
-"decompress_mbps": 175.76
+"compress_mbps": 32.91,
+"decompress_mbps": 152.45
 },
 {
 "compressor": "js",
@@ -10974,8 +10974,8 @@
 "level": 8,
 "out_size": 147709,
 "ratio": 0.3461,
-"compress_mbps": 31.37,
-"decompress_mbps": 170.1
+"compress_mbps": 31.92,
+"decompress_mbps": 149.4
 },
 {
 "compressor": "js",
@@ -10984,8 +10984,8 @@
 "level": 9,
 "out_size": 147705,
 "ratio": 0.3461,
-"compress_mbps": 33.05,
-"decompress_mbps": 164.41
+"compress_mbps": 28.26,
+"decompress_mbps": 136.77
 },
 {
 "compressor": "js",
@@ -10994,8 +10994,8 @@
 "level": 1,
 "out_size": 222866,
 "ratio": 0.4625,
-"compress_mbps": 58.89,
-"decompress_mbps": 156.12
+"compress_mbps": 57.48,
+"decompress_mbps": 101.55
 },
 {
 "compressor": "js",
@@ -11004,8 +11004,8 @@
 "level": 2,
 "out_size": 212925,
 "ratio": 0.4419,
-"compress_mbps": 48.34,
-"decompress_mbps": 185.83
+"compress_mbps": 49.36,
+"decompress_mbps": 118.79
 },
 {
 "compressor": "js",
@@ -11014,8 +11014,8 @@
 "level": 3,
 "out_size": 206913,
 "ratio": 0.4294,
-"compress_mbps": 39.34,
-"decompress_mbps": 177.1
+"compress_mbps": 40.36,
+"decompress_mbps": 118.27
 },
 {
 "compressor": "js",
@@ -11024,8 +11024,8 @@
 "level": 4,
 "out_size": 202875,
 "ratio": 0.421,
-"compress_mbps": 34.5,
-"decompress_mbps": 176.6
+"compress_mbps": 34.31,
+"decompress_mbps": 116.61
 },
 {
 "compressor": "js",
@@ -11034,8 +11034,8 @@
 "level": 5,
 "out_size": 202867,
 "ratio": 0.421,
-"compress_mbps": 33.48,
-"decompress_mbps": 196.89
+"compress_mbps": 34.04,
+"decompress_mbps": 127.97
 },
 {
 "compressor": "js",
@@ -11044,8 +11044,8 @@
 "level": 6,
 "out_size": 199818,
 "ratio": 0.4147,
-"compress_mbps": 28.71,
-"decompress_mbps": 202.16
+"compress_mbps": 28.49,
+"decompress_mbps": 129.39
 },
 {
 "compressor": "js",
@@ -11054,8 +11054,8 @@
 "level": 7,
 "out_size": 199664,
 "ratio": 0.4144,
-"compress_mbps": 28.19,
-"decompress_mbps": 180.45
+"compress_mbps": 27.82,
+"decompress_mbps": 119.82
 },
 {
 "compressor": "js",
@@ -11064,8 +11064,8 @@
 "level": 8,
 "out_size": 199634,
 "ratio": 0.4143,
-"compress_mbps": 27.57,
-"decompress_mbps": 174.55
+"compress_mbps": 28,
+"decompress_mbps": 119.17
 },
 {
 "compressor": "js",
@@ -11074,8 +11074,8 @@
 "level": 9,
 "out_size": 199634,
 "ratio": 0.4143,
-"compress_mbps": 27.74,
-"decompress_mbps": 177.19
+"compress_mbps": 28,
+"decompress_mbps": 161.01
 },
 {
 "compressor": "js",
@@ -11084,8 +11084,8 @@
 "level": 1,
 "out_size": 60580,
 "ratio": 0.118,
-"compress_mbps": 117.93,
-"decompress_mbps": 273.99
+"compress_mbps": 116.16,
+"decompress_mbps": 253.54
 },
 {
 "compressor": "js",
@@ -11094,8 +11094,8 @@
 "level": 2,
 "out_size": 59663,
 "ratio": 0.1163,
-"compress_mbps": 107.66,
-"decompress_mbps": 313.28
+"compress_mbps": 106.69,
+"decompress_mbps": 292.51
 },
 {
 "compressor": "js",
@@ -11104,8 +11104,8 @@
 "level": 3,
 "out_size": 59465,
 "ratio": 0.1159,
-"compress_mbps": 102.51,
-"decompress_mbps": 319.13
+"compress_mbps": 126.73,
+"decompress_mbps": 280.23
 },
 {
 "compressor": "js",
@@ -11114,8 +11114,8 @@
 "level": 4,
 "out_size": 59353,
 "ratio": 0.1156,
-"compress_mbps": 93.84,
-"decompress_mbps": 279.41
+"compress_mbps": 95.04,
+"decompress_mbps": 292.15
 },
 {
 "compressor": "js",
@@ -11124,8 +11124,8 @@
 "level": 5,
 "out_size": 58830,
 "ratio": 0.1146,
-"compress_mbps": 90.81,
-"decompress_mbps": 289.81
+"compress_mbps": 89.4,
+"decompress_mbps": 277.16
 },
 {
 "compressor": "js",
@@ -11134,8 +11134,8 @@
 "level": 6,
 "out_size": 57884,
 "ratio": 0.1128,
-"compress_mbps": 57.52,
-"decompress_mbps": 292.95
+"compress_mbps": 58.51,
+"decompress_mbps": 292.89
 },
 {
 "compressor": "js",
@@ -11144,8 +11144,8 @@
 "level": 7,
 "out_size": 57206,
 "ratio": 0.1115,
-"compress_mbps": 46.23,
-"decompress_mbps": 293.85
+"compress_mbps": 45.45,
+"decompress_mbps": 315.94
 },
 {
 "compressor": "js",
@@ -11154,8 +11154,8 @@
 "level": 8,
 "out_size": 56545,
 "ratio": 0.1102,
-"compress_mbps": 23.06,
-"decompress_mbps": 287.96
+"compress_mbps": 23.11,
+"decompress_mbps": 281.11
 },
 {
 "compressor": "js",
@@ -11164,8 +11164,8 @@
 "level": 9,
 "out_size": 56454,
 "ratio": 0.11,
-"compress_mbps": 9.16,
-"decompress_mbps": 312.37
+"compress_mbps": 9.14,
+"decompress_mbps": 288.48
 },
 {
 "compressor": "js",
@@ -11174,8 +11174,8 @@
 "level": 1,
 "out_size": 14194,
 "ratio": 0.3712,
-"compress_mbps": 80.51,
-"decompress_mbps": 134.84
+"compress_mbps": 69.06,
+"decompress_mbps": 136.08
 },
 {
 "compressor": "js",
@@ -11184,8 +11184,8 @@
 "level": 2,
 "out_size": 13770,
 "ratio": 0.3601,
-"compress_mbps": 72.84,
-"decompress_mbps": 120.14
+"compress_mbps": 69.84,
+"decompress_mbps": 117.52
 },
 {
 "compressor": "js",
@@ -11194,8 +11194,8 @@
 "level": 3,
 "out_size": 13611,
 "ratio": 0.3559,
-"compress_mbps": 67.41,
-"decompress_mbps": 122.19
+"compress_mbps": 66.55,
+"decompress_mbps": 114.95
 },
 {
 "compressor": "js",
@@ -11204,8 +11204,8 @@
 "level": 4,
 "out_size": 13534,
 "ratio": 0.3539,
-"compress_mbps": 59.72,
-"decompress_mbps": 120.88
+"compress_mbps": 62.69,
+"decompress_mbps": 120.61
 },
 {
 "compressor": "js",
@@ -11214,8 +11214,8 @@
 "level": 5,
 "out_size": 13527,
 "ratio": 0.3537,
-"compress_mbps": 59.8,
-"decompress_mbps": 146.48
+"compress_mbps": 63.23,
+"decompress_mbps": 138.62
 },
 {
 "compressor": "js",
@@ -11224,8 +11224,8 @@
 "level": 6,
 "out_size": 13438,
 "ratio": 0.3514,
-"compress_mbps": 51.42,
-"decompress_mbps": 146.92
+"compress_mbps": 51.86,
+"decompress_mbps": 144.66
 },
 {
 "compressor": "js",
@@ -11234,8 +11234,8 @@
 "level": 7,
 "out_size": 13419,
 "ratio": 0.3509,
-"compress_mbps": 47.67,
-"decompress_mbps": 128.04
+"compress_mbps": 46.83,
+"decompress_mbps": 117.01
 },
 {
 "compressor": "js",
@@ -11244,8 +11244,8 @@
 "level": 8,
 "out_size": 13404,
 "ratio": 0.3505,
-"compress_mbps": 41.52,
-"decompress_mbps": 134.62
+"compress_mbps": 40.59,
+"decompress_mbps": 118.55
 },
 {
 "compressor": "js",
@@ -11254,8 +11254,8 @@
 "level": 9,
 "out_size": 13390,
 "ratio": 0.3502,
-"compress_mbps": 36.21,
-"decompress_mbps": 129.12
+"compress_mbps": 36.42,
+"decompress_mbps": 124.76
 },
 {
 "compressor": "js",
@@ -11264,8 +11264,8 @@
 "level": 1,
 "out_size": 1832,
 "ratio": 0.4334,
-"compress_mbps": 61.16,
-"decompress_mbps": 60.49
+"compress_mbps": 58.16,
+"decompress_mbps": 49.55
 },
 {
 "compressor": "js",
@@ -11274,8 +11274,8 @@
 "level": 2,
 "out_size": 1776,
 "ratio": 0.4202,
-"compress_mbps": 59.7,
-"decompress_mbps": 59.86
+"compress_mbps": 55.77,
+"decompress_mbps": 57.76
 },
 {
 "compressor": "js",
@@ -11284,8 +11284,8 @@
 "level": 3,
 "out_size": 1764,
 "ratio": 0.4173,
-"compress_mbps": 60.74,
-"decompress_mbps": 61.79
+"compress_mbps": 59.44,
+"decompress_mbps": 54.77
 },
 {
 "compressor": "js",
@@ -11294,8 +11294,8 @@
 "level": 4,
 "out_size": 1763,
 "ratio": 0.4171,
-"compress_mbps": 59.24,
-"decompress_mbps": 62.58
+"compress_mbps": 59.15,
+"decompress_mbps": 56.14
 },
 {
 "compressor": "js",
@@ -11304,8 +11304,8 @@
 "level": 5,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 60.56,
-"decompress_mbps": 62.54
+"compress_mbps": 57.65,
+"decompress_mbps": 50.9
 },
 {
 "compressor": "js",
@@ -11314,8 +11314,8 @@
 "level": 6,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 63.39,
-"decompress_mbps": 62.6
+"compress_mbps": 57.84,
+"decompress_mbps": 49.69
 },
 {
 "compressor": "js",
@@ -11324,8 +11324,8 @@
 "level": 7,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 59.82,
-"decompress_mbps": 62.62
+"compress_mbps": 59.49,
+"decompress_mbps": 50.96
 },
 {
 "compressor": "js",
@@ -11334,8 +11334,8 @@
 "level": 8,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 60.48,
-"decompress_mbps": 58.28
+"compress_mbps": 39.79,
+"decompress_mbps": 61.84
 },
 {
 "compressor": "js",
@@ -11344,8 +11344,8 @@
 "level": 9,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 60.86,
-"decompress_mbps": 64.74
+"compress_mbps": 37.74,
+"decompress_mbps": 48.52
 },
 {
 "compressor": "js",
@@ -11354,8 +11354,8 @@
 "level": 1,
 "out_size": 4462632,
 "ratio": 0.4378,
-"compress_mbps": 61.81,
-"decompress_mbps": 165.14
+"compress_mbps": 62.3,
+"decompress_mbps": 135.54
 },
 {
 "compressor": "js",
@@ -11364,8 +11364,8 @@
 "level": 2,
 "out_size": 4244833,
 "ratio": 0.4165,
-"compress_mbps": 50.4,
-"decompress_mbps": 197.68
+"compress_mbps": 50.68,
+"decompress_mbps": 204.52
 },
 {
 "compressor": "js",
@@ -11374,8 +11374,8 @@
 "level": 3,
 "out_size": 4112285,
 "ratio": 0.4035,
-"compress_mbps": 41.58,
-"decompress_mbps": 181.3
+"compress_mbps": 41.76,
+"decompress_mbps": 136.18
 },
 {
 "compressor": "js",
@@ -11384,8 +11384,8 @@
 "level": 4,
 "out_size": 4020435,
 "ratio": 0.3945,
-"compress_mbps": 34.79,
-"decompress_mbps": 175.72
+"compress_mbps": 35.63,
+"decompress_mbps": 143
 },
 {
 "compressor": "js",
@@ -11394,8 +11394,8 @@
 "level": 5,
 "out_size": 4019177,
 "ratio": 0.3943,
-"compress_mbps": 34.74,
-"decompress_mbps": 176.12
+"compress_mbps": 35.03,
+"decompress_mbps": 141.23
 },
 {
 "compressor": "js",
@@ -11404,8 +11404,8 @@
 "level": 6,
 "out_size": 3956464,
 "ratio": 0.3882,
-"compress_mbps": 29.23,
-"decompress_mbps": 220.29
+"compress_mbps": 29.27,
+"decompress_mbps": 156.61
 },
 {
 "compressor": "js",
@@ -11414,8 +11414,8 @@
 "level": 7,
 "out_size": 3953310,
 "ratio": 0.3879,
-"compress_mbps": 28.06,
-"decompress_mbps": 195.23
+"compress_mbps": 28.42,
+"decompress_mbps": 201.57
 },
 {
 "compressor": "js",
@@ -11424,8 +11424,8 @@
 "level": 8,
 "out_size": 3952872,
 "ratio": 0.3878,
-"compress_mbps": 29.23,
-"decompress_mbps": 222.08
+"compress_mbps": 29.33,
+"decompress_mbps": 224.21
 },
 {
 "compressor": "js",
@@ -11434,8 +11434,8 @@
 "level": 9,
 "out_size": 3952872,
 "ratio": 0.3878,
-"compress_mbps": 29.32,
-"decompress_mbps": 220.9
+"compress_mbps": 29.3,
+"decompress_mbps": 224.69
 },
 {
 "compressor": "js",
@@ -11444,8 +11444,8 @@
 "level": 1,
 "out_size": 20177423,
 "ratio": 0.3939,
-"compress_mbps": 72.33,
-"decompress_mbps": 213
+"compress_mbps": 72.21,
+"decompress_mbps": 215.81
 },
 {
 "compressor": "js",
@@ -11454,8 +11454,8 @@
 "level": 2,
 "out_size": 19759467,
 "ratio": 0.3858,
-"compress_mbps": 62.96,
-"decompress_mbps": 196.71
+"compress_mbps": 63.43,
+"decompress_mbps": 196.73
 },
 {
 "compressor": "js",
@@ -11464,8 +11464,8 @@
 "level": 3,
 "out_size": 19583171,
 "ratio": 0.3823,
-"compress_mbps": 56.71,
-"decompress_mbps": 209.57
+"compress_mbps": 57.71,
+"decompress_mbps": 220.64
 },
 {
 "compressor": "js",
@@ -11474,8 +11474,8 @@
 "level": 4,
 "out_size": 19479125,
 "ratio": 0.3803,
-"compress_mbps": 51.13,
-"decompress_mbps": 217.1
+"compress_mbps": 50.61,
+"decompress_mbps": 219.56
 },
 {
 "compressor": "js",
@@ -11484,8 +11484,8 @@
 "level": 5,
 "out_size": 19423693,
 "ratio": 0.3792,
-"compress_mbps": 48.9,
-"decompress_mbps": 200.31
+"compress_mbps": 49.4,
+"decompress_mbps": 202.99
 },
 {
 "compressor": "js",
@@ -11494,8 +11494,8 @@
 "level": 6,
 "out_size": 19337683,
 "ratio": 0.3775,
-"compress_mbps": 35.84,
-"decompress_mbps": 202.93
+"compress_mbps": 36.36,
+"decompress_mbps": 201.74
 },
 {
 "compressor": "js",
@@ -11504,8 +11504,8 @@
 "level": 7,
 "out_size": 19323922,
 "ratio": 0.3773,
-"compress_mbps": 30.1,
-"decompress_mbps": 199.63
+"compress_mbps": 30.39,
+"decompress_mbps": 192.6
 },
 {
 "compressor": "js",
@@ -11514,8 +11514,8 @@
 "level": 8,
 "out_size": 19314797,
 "ratio": 0.3771,
-"compress_mbps": 19.56,
-"decompress_mbps": 219.1
+"compress_mbps": 19.5,
+"decompress_mbps": 205.3
 },
 {
 "compressor": "js",
@@ -11524,8 +11524,8 @@
 "level": 9,
 "out_size": 19312663,
 "ratio": 0.377,
-"compress_mbps": 11,
-"decompress_mbps": 213.54
+"compress_mbps": 11.1,
+"decompress_mbps": 227.07
 },
 {
 "compressor": "js",
@@ -11534,8 +11534,8 @@
 "level": 1,
 "out_size": 3762978,
 "ratio": 0.3774,
-"compress_mbps": 78.25,
-"decompress_mbps": 175.83
+"compress_mbps": 78.61,
+"decompress_mbps": 158.12
 },
 {
 "compressor": "js",
@@ -11544,8 +11544,8 @@
 "level": 2,
 "out_size": 3711615,
 "ratio": 0.3723,
-"compress_mbps": 68.43,
-"decompress_mbps": 210.69
+"compress_mbps": 68.12,
+"decompress_mbps": 202.97
 },
 {
 "compressor": "js",
@@ -11554,8 +11554,8 @@
 "level": 3,
 "out_size": 3663131,
 "ratio": 0.3674,
-"compress_mbps": 56.94,
-"decompress_mbps": 243.75
+"compress_mbps": 57.42,
+"decompress_mbps": 181.04
 },
 {
 "compressor": "js",
@@ -11564,8 +11564,8 @@
 "level": 4,
 "out_size": 3631512,
 "ratio": 0.3642,
-"compress_mbps": 49.58,
-"decompress_mbps": 193.55
+"compress_mbps": 50.24,
+"decompress_mbps": 222.02
 },
 {
 "compressor": "js",
@@ -11574,8 +11574,8 @@
 "level": 5,
 "out_size": 3630867,
 "ratio": 0.3642,
-"compress_mbps": 49.37,
-"decompress_mbps": 201.21
+"compress_mbps": 48.7,
+"decompress_mbps": 223.69
 },
 {
 "compressor": "js",
@@ -11584,8 +11584,8 @@
 "level": 6,
 "out_size": 3615953,
 "ratio": 0.3627,
-"compress_mbps": 37.75,
-"decompress_mbps": 228.72
+"compress_mbps": 37.66,
+"decompress_mbps": 249.33
 },
 {
 "compressor": "js",
@@ -11594,8 +11594,8 @@
 "level": 7,
 "out_size": 3615518,
 "ratio": 0.3626,
-"compress_mbps": 36.37,
-"decompress_mbps": 206.12
+"compress_mbps": 35.64,
+"decompress_mbps": 221.77
 },
 {
 "compressor": "js",
@@ -11604,8 +11604,8 @@
 "level": 8,
 "out_size": 3613845,
 "ratio": 0.3625,
-"compress_mbps": 30.29,
-"decompress_mbps": 224.43
+"compress_mbps": 30.23,
+"decompress_mbps": 213.61
 },
 {
 "compressor": "js",
@@ -11614,8 +11614,8 @@
 "level": 9,
 "out_size": 3614283,
 "ratio": 0.3625,
-"compress_mbps": 26.44,
-"decompress_mbps": 227.73
+"compress_mbps": 26.82,
+"decompress_mbps": 162.6
 },
 {
 "compressor": "js",
@@ -11624,8 +11624,8 @@
 "level": 1,
 "out_size": 4418800,
 "ratio": 0.1317,
-"compress_mbps": 132.21,
-"decompress_mbps": 379.83
+"compress_mbps": 133.39,
+"decompress_mbps": 341.59
 },
 {
 "compressor": "js",
@@ -11634,8 +11634,8 @@
 "level": 2,
 "out_size": 4026774,
 "ratio": 0.12,
-"compress_mbps": 121.47,
-"decompress_mbps": 370.83
+"compress_mbps": 124.09,
+"decompress_mbps": 340.36
 },
 {
 "compressor": "js",
@@ -11644,8 +11644,8 @@
 "level": 3,
 "out_size": 3837798,
 "ratio": 0.1144,
-"compress_mbps": 114.77,
-"decompress_mbps": 428.74
+"compress_mbps": 115.23,
+"decompress_mbps": 469.72
 },
 {
 "compressor": "js",
@@ -11654,8 +11654,8 @@
 "level": 4,
 "out_size": 3751023,
 "ratio": 0.1118,
-"compress_mbps": 111.24,
-"decompress_mbps": 404.66
+"compress_mbps": 110.56,
+"decompress_mbps": 370.32
 },
 {
 "compressor": "js",
@@ -11664,8 +11664,8 @@
 "level": 5,
 "out_size": 3643468,
 "ratio": 0.1086,
-"compress_mbps": 100.04,
-"decompress_mbps": 400.42
+"compress_mbps": 99.67,
+"decompress_mbps": 356.18
 },
 {
 "compressor": "js",
@@ -11674,8 +11674,8 @@
 "level": 6,
 "out_size": 3379481,
 "ratio": 0.1007,
-"compress_mbps": 67.76,
-"decompress_mbps": 418.97
+"compress_mbps": 68.43,
+"decompress_mbps": 366.08
 },
 {
 "compressor": "js",
@@ -11684,8 +11684,8 @@
 "level": 7,
 "out_size": 3354082,
 "ratio": 0.1,
-"compress_mbps": 60.49,
-"decompress_mbps": 412.41
+"compress_mbps": 60.97,
+"decompress_mbps": 369.9
 },
 {
 "compressor": "js",
@@ -11694,8 +11694,8 @@
 "level": 8,
 "out_size": 3330028,
 "ratio": 0.0992,
-"compress_mbps": 47.38,
-"decompress_mbps": 427.83
+"compress_mbps": 48.02,
+"decompress_mbps": 386.87
 },
 {
 "compressor": "js",
@@ -11704,8 +11704,8 @@
 "level": 9,
 "out_size": 3327482,
 "ratio": 0.0992,
-"compress_mbps": 37.31,
-"decompress_mbps": 405.67
+"compress_mbps": 37.78,
+"decompress_mbps": 371.65
 },
 {
 "compressor": "js",
@@ -11714,8 +11714,8 @@
 "level": 1,
 "out_size": 3233790,
 "ratio": 0.5256,
-"compress_mbps": 53.08,
-"decompress_mbps": 126.44
+"compress_mbps": 53.3,
+"decompress_mbps": 141.8
 },
 {
 "compressor": "js",
@@ -11724,8 +11724,8 @@
 "level": 2,
 "out_size": 3184644,
 "ratio": 0.5176,
-"compress_mbps": 47.84,
-"decompress_mbps": 128.59
+"compress_mbps": 48.44,
+"decompress_mbps": 142.37
 },
 {
 "compressor": "js",
@@ -11734,8 +11734,8 @@
 "level": 3,
 "out_size": 3160521,
 "ratio": 0.5137,
-"compress_mbps": 43.04,
-"decompress_mbps": 137.68
+"compress_mbps": 43.93,
+"decompress_mbps": 146.37
 },
 {
 "compressor": "js",
@@ -11744,8 +11744,8 @@
 "level": 4,
 "out_size": 3141929,
 "ratio": 0.5107,
-"compress_mbps": 40.02,
-"decompress_mbps": 150.26
+"compress_mbps": 39.81,
+"decompress_mbps": 153.04
 },
 {
 "compressor": "js",
@@ -11754,8 +11754,8 @@
 "level": 5,
 "out_size": 3138514,
 "ratio": 0.5101,
-"compress_mbps": 39.04,
-"decompress_mbps": 144.33
+"compress_mbps": 38.94,
+"decompress_mbps": 143.83
 },
 {
 "compressor": "js",
@@ -11764,8 +11764,8 @@
 "level": 6,
 "out_size": 3126843,
 "ratio": 0.5082,
-"compress_mbps": 33.03,
-"decompress_mbps": 142.93
+"compress_mbps": 32.97,
+"decompress_mbps": 110.54
 },
 {
 "compressor": "js",
@@ -11774,8 +11774,8 @@
 "level": 7,
 "out_size": 3126796,
 "ratio": 0.5082,
-"compress_mbps": 30.35,
-"decompress_mbps": 149.74
+"compress_mbps": 29.89,
+"decompress_mbps": 147.75
 },
 {
 "compressor": "js",
@@ -11784,8 +11784,8 @@
 "level": 8,
 "out_size": 3126322,
 "ratio": 0.5082,
-"compress_mbps": 26.91,
-"decompress_mbps": 139.64
+"compress_mbps": 26.77,
+"decompress_mbps": 145.02
 },
 {
 "compressor": "js",
@@ -11794,8 +11794,8 @@
 "level": 9,
 "out_size": 3126286,
 "ratio": 0.5082,
-"compress_mbps": 23.23,
-"decompress_mbps": 135.89
+"compress_mbps": 23.08,
+"decompress_mbps": 108.68
 },
 {
 "compressor": "js",
@@ -11804,8 +11804,8 @@
 "level": 1,
 "out_size": 4076349,
 "ratio": 0.4042,
-"compress_mbps": 78.22,
-"decompress_mbps": 206.35
+"compress_mbps": 78.41,
+"decompress_mbps": 204.75
 },
 {
 "compressor": "js",
@@ -11814,8 +11814,8 @@
 "level": 2,
 "out_size": 3914739,
 "ratio": 0.3881,
-"compress_mbps": 71.01,
-"decompress_mbps": 237.17
+"compress_mbps": 72.23,
+"decompress_mbps": 236.11
 },
 {
 "compressor": "js",
@@ -11824,8 +11824,8 @@
 "level": 3,
 "out_size": 3845160,
 "ratio": 0.3812,
-"compress_mbps": 67.41,
-"decompress_mbps": 241.77
+"compress_mbps": 68.12,
+"decompress_mbps": 271.44
 },
 {
 "compressor": "js",
@@ -11834,8 +11834,8 @@
 "level": 4,
 "out_size": 3822047,
 "ratio": 0.379,
-"compress_mbps": 65.46,
-"decompress_mbps": 253.64
+"compress_mbps": 64.41,
+"decompress_mbps": 241.99
 },
 {
 "compressor": "js",
@@ -11844,8 +11844,8 @@
 "level": 5,
 "out_size": 3799472,
 "ratio": 0.3767,
-"compress_mbps": 59.91,
-"decompress_mbps": 281.83
+"compress_mbps": 59.9,
+"decompress_mbps": 192.04
 },
 {
 "compressor": "js",
@@ -11854,8 +11854,8 @@
 "level": 6,
 "out_size": 3783861,
 "ratio": 0.3752,
-"compress_mbps": 57.83,
-"decompress_mbps": 282.08
+"compress_mbps": 58.33,
+"decompress_mbps": 199
 },
 {
 "compressor": "js",
@@ -11864,8 +11864,8 @@
 "level": 7,
 "out_size": 3783432,
 "ratio": 0.3751,
-"compress_mbps": 56.68,
-"decompress_mbps": 282.24
+"compress_mbps": 57.77,
+"decompress_mbps": 277.51
 },
 {
 "compressor": "js",
@@ -11874,8 +11874,8 @@
 "level": 8,
 "out_size": 3783342,
 "ratio": 0.3751,
-"compress_mbps": 56.69,
-"decompress_mbps": 257.46
+"compress_mbps": 58.02,
+"decompress_mbps": 278.74
 },
 {
 "compressor": "js",
@@ -11884,8 +11884,8 @@
 "level": 9,
 "out_size": 3783342,
 "ratio": 0.3751,
-"compress_mbps": 57.6,
-"decompress_mbps": 282.42
+"compress_mbps": 58.55,
+"decompress_mbps": 201.28
 },
 {
 "compressor": "js",
@@ -11894,8 +11894,8 @@
 "level": 1,
 "out_size": 2261112,
 "ratio": 0.3412,
-"compress_mbps": 71.58,
-"decompress_mbps": 229.34
+"compress_mbps": 70.59,
+"decompress_mbps": 202.5
 },
 {
 "compressor": "js",
@@ -11904,8 +11904,8 @@
 "level": 2,
 "out_size": 2128691,
 "ratio": 0.3212,
-"compress_mbps": 57.59,
-"decompress_mbps": 172.51
+"compress_mbps": 58.76,
+"decompress_mbps": 206.2
 },
 {
 "compressor": "js",
@@ -11914,8 +11914,8 @@
 "level": 3,
 "out_size": 2049023,
 "ratio": 0.3092,
-"compress_mbps": 47.7,
-"decompress_mbps": 219.63
+"compress_mbps": 48.36,
+"decompress_mbps": 212.84
 },
 {
 "compressor": "js",
@@ -11924,8 +11924,8 @@
 "level": 4,
 "out_size": 1990249,
 "ratio": 0.3003,
-"compress_mbps": 40.84,
-"decompress_mbps": 217.37
+"compress_mbps": 40.57,
+"decompress_mbps": 208.73
 },
 {
 "compressor": "js",
@@ -11934,8 +11934,8 @@
 "level": 5,
 "out_size": 1975224,
 "ratio": 0.298,
-"compress_mbps": 38.28,
-"decompress_mbps": 190.42
+"compress_mbps": 39.48,
+"decompress_mbps": 224.74
 },
 {
 "compressor": "js",
@@ -11944,8 +11944,8 @@
 "level": 6,
 "out_size": 1910262,
 "ratio": 0.2882,
-"compress_mbps": 27.01,
-"decompress_mbps": 229.32
+"compress_mbps": 27.24,
+"decompress_mbps": 229.35
 },
 {
 "compressor": "js",
@@ -11954,8 +11954,8 @@
 "level": 7,
 "out_size": 1902923,
 "ratio": 0.2871,
-"compress_mbps": 24.52,
-"decompress_mbps": 192.04
+"compress_mbps": 25.22,
+"decompress_mbps": 226.88
 },
 {
 "compressor": "js",
@@ -11964,8 +11964,8 @@
 "level": 8,
 "out_size": 1900964,
 "ratio": 0.2868,
-"compress_mbps": 23.58,
-"decompress_mbps": 228.26
+"compress_mbps": 23.32,
+"decompress_mbps": 226.28
 },
 {
 "compressor": "js",
@@ -11974,8 +11974,8 @@
 "level": 9,
 "out_size": 1900958,
 "ratio": 0.2868,
-"compress_mbps": 23.93,
-"decompress_mbps": 228.24
+"compress_mbps": 24.68,
+"decompress_mbps": 163.44
 },
 {
 "compressor": "js",
@@ -11984,8 +11984,8 @@
 "level": 1,
 "out_size": 6016919,
 "ratio": 0.2785,
-"compress_mbps": 88.77,
-"decompress_mbps": 243.55
+"compress_mbps": 90.05,
+"decompress_mbps": 253.09
 },
 {
 "compressor": "js",
@@ -11994,8 +11994,8 @@
 "level": 2,
 "out_size": 5767272,
 "ratio": 0.2669,
-"compress_mbps": 81.51,
-"decompress_mbps": 253.9
+"compress_mbps": 82.21,
+"decompress_mbps": 286.5
 },
 {
 "compressor": "js",
@@ -12004,8 +12004,8 @@
 "level": 3,
 "out_size": 5669548,
 "ratio": 0.2624,
-"compress_mbps": 76.22,
-"decompress_mbps": 242.45
+"compress_mbps": 75.74,
+"decompress_mbps": 269.87
 },
 {
 "compressor": "js",
@@ -12014,8 +12014,8 @@
 "level": 4,
 "out_size": 5619947,
 "ratio": 0.2601,
-"compress_mbps": 68.07,
-"decompress_mbps": 269.58
+"compress_mbps": 69.65,
+"decompress_mbps": 221.32
 },
 {
 "compressor": "js",
@@ -12024,8 +12024,8 @@
 "level": 5,
 "out_size": 5586034,
 "ratio": 0.2585,
-"compress_mbps": 63.44,
-"decompress_mbps": 260.48
+"compress_mbps": 64.6,
+"decompress_mbps": 225.88
 },
 {
 "compressor": "js",
@@ -12034,8 +12034,8 @@
 "level": 6,
 "out_size": 5540130,
 "ratio": 0.2564,
-"compress_mbps": 48.4,
-"decompress_mbps": 259.76
+"compress_mbps": 50.88,
+"decompress_mbps": 277.05
 },
 {
 "compressor": "js",
@@ -12044,8 +12044,8 @@
 "level": 7,
 "out_size": 5537271,
 "ratio": 0.2563,
-"compress_mbps": 47.26,
-"decompress_mbps": 274.35
+"compress_mbps": 46.44,
+"decompress_mbps": 279.81
 },
 {
 "compressor": "js",
@@ -12054,8 +12054,8 @@
 "level": 8,
 "out_size": 5530686,
 "ratio": 0.256,
-"compress_mbps": 36.98,
-"decompress_mbps": 304.18
+"compress_mbps": 39.66,
+"decompress_mbps": 304
 },
 {
 "compressor": "js",
@@ -12064,8 +12064,8 @@
 "level": 9,
 "out_size": 5529823,
 "ratio": 0.2559,
-"compress_mbps": 31.77,
-"decompress_mbps": 283.66
+"compress_mbps": 30.72,
+"decompress_mbps": 260.48
 },
 {
 "compressor": "js",
@@ -12074,8 +12074,8 @@
 "level": 1,
 "out_size": 5602819,
 "ratio": 0.7726,
-"compress_mbps": 47.71,
-"decompress_mbps": 152.61
+"compress_mbps": 48.76,
+"decompress_mbps": 114.67
 },
 {
 "compressor": "js",
@@ -12084,8 +12084,8 @@
 "level": 2,
 "out_size": 5504019,
 "ratio": 0.759,
-"compress_mbps": 42.75,
-"decompress_mbps": 151.51
+"compress_mbps": 43.41,
+"decompress_mbps": 154.89
 },
 {
 "compressor": "js",
@@ -12094,8 +12094,8 @@
 "level": 3,
 "out_size": 5452816,
 "ratio": 0.7519,
-"compress_mbps": 38.25,
-"decompress_mbps": 158.17
+"compress_mbps": 38.78,
+"decompress_mbps": 153
 },
 {
 "compressor": "js",
@@ -12104,8 +12104,8 @@
 "level": 4,
 "out_size": 5425752,
 "ratio": 0.7482,
-"compress_mbps": 35.24,
-"decompress_mbps": 160.79
+"compress_mbps": 35.26,
+"decompress_mbps": 178.09
 },
 {
 "compressor": "js",
@@ -12114,8 +12114,8 @@
 "level": 5,
 "out_size": 5425752,
 "ratio": 0.7482,
-"compress_mbps": 34.81,
-"decompress_mbps": 182.84
+"compress_mbps": 35.08,
+"decompress_mbps": 184.88
 },
 {
 "compressor": "js",
@@ -12124,8 +12124,8 @@
 "level": 6,
 "out_size": 5407602,
 "ratio": 0.7457,
-"compress_mbps": 30.78,
-"decompress_mbps": 158.1
+"compress_mbps": 31.2,
+"decompress_mbps": 122.27
 },
 {
 "compressor": "js",
@@ -12134,8 +12134,8 @@
 "level": 7,
 "out_size": 5406417,
 "ratio": 0.7455,
-"compress_mbps": 30.24,
-"decompress_mbps": 138.62
+"compress_mbps": 29.76,
+"decompress_mbps": 154.34
 },
 {
 "compressor": "js",
@@ -12144,8 +12144,8 @@
 "level": 8,
 "out_size": 5406380,
 "ratio": 0.7455,
-"compress_mbps": 30.66,
-"decompress_mbps": 157.3
+"compress_mbps": 30.74,
+"decompress_mbps": 155.22
 },
 {
 "compressor": "js",
@@ -12154,8 +12154,8 @@
 "level": 9,
 "out_size": 5406380,
 "ratio": 0.7455,
-"compress_mbps": 30.58,
-"decompress_mbps": 157.39
+"compress_mbps": 30.24,
+"decompress_mbps": 133.17
 },
 {
 "compressor": "js",
@@ -12164,8 +12164,8 @@
 "level": 1,
 "out_size": 14342407,
 "ratio": 0.3459,
-"compress_mbps": 72.92,
-"decompress_mbps": 186.6
+"compress_mbps": 74.52,
+"decompress_mbps": 184.57
 },
 {
 "compressor": "js",
@@ -12174,8 +12174,8 @@
 "level": 2,
 "out_size": 13424966,
 "ratio": 0.3238,
-"compress_mbps": 61.14,
-"decompress_mbps": 202.98
+"compress_mbps": 63.02,
+"decompress_mbps": 214.45
 },
 {
 "compressor": "js",
@@ -12185,7 +12185,7 @@
 "out_size": 13061399,
 "ratio": 0.315,
 "compress_mbps": 54.97,
-"decompress_mbps": 207.62
+"decompress_mbps": 214.04
 },
 {
 "compressor": "js",
@@ -12194,8 +12194,8 @@
 "level": 4,
 "out_size": 12877207,
 "ratio": 0.3106,
-"compress_mbps": 49.22,
-"decompress_mbps": 203.91
+"compress_mbps": 49.89,
+"decompress_mbps": 206.6
 },
 {
 "compressor": "js",
@@ -12204,8 +12204,8 @@
 "level": 5,
 "out_size": 12671090,
 "ratio": 0.3056,
-"compress_mbps": 48.01,
-"decompress_mbps": 202.02
+"compress_mbps": 47.61,
+"decompress_mbps": 211.34
 },
 {
 "compressor": "js",
@@ -12214,8 +12214,8 @@
 "level": 6,
 "out_size": 12511088,
 "ratio": 0.3018,
-"compress_mbps": 39.68,
-"decompress_mbps": 225.76
+"compress_mbps": 40.19,
+"decompress_mbps": 235.11
 },
 {
 "compressor": "js",
@@ -12224,8 +12224,8 @@
 "level": 7,
 "out_size": 12503313,
 "ratio": 0.3016,
-"compress_mbps": 39.12,
-"decompress_mbps": 235.62
+"compress_mbps": 38.49,
+"decompress_mbps": 227.8
 },
 {
 "compressor": "js",
@@ -12234,8 +12234,8 @@
 "level": 8,
 "out_size": 12502263,
 "ratio": 0.3016,
-"compress_mbps": 39.09,
-"decompress_mbps": 223.21
+"compress_mbps": 39.46,
+"decompress_mbps": 228.05
 },
 {
 "compressor": "js",
@@ -12244,8 +12244,8 @@
 "level": 9,
 "out_size": 12502263,
 "ratio": 0.3016,
-"compress_mbps": 38.9,
-"decompress_mbps": 225.72
+"compress_mbps": 39.56,
+"decompress_mbps": 231.18
 },
 {
 "compressor": "js",
@@ -12254,8 +12254,8 @@
 "level": 1,
 "out_size": 6022390,
 "ratio": 0.7107,
-"compress_mbps": 54.31,
-"decompress_mbps": 151.41
+"compress_mbps": 54.61,
+"decompress_mbps": 151.8
 },
 {
 "compressor": "js",
@@ -12264,8 +12264,8 @@
 "level": 2,
 "out_size": 5997124,
 "ratio": 0.7077,
-"compress_mbps": 48.29,
-"decompress_mbps": 140.98
+"compress_mbps": 47.3,
+"decompress_mbps": 153.84
 },
 {
 "compressor": "js",
@@ -12274,8 +12274,8 @@
 "level": 3,
 "out_size": 5979254,
 "ratio": 0.7056,
-"compress_mbps": 44.96,
-"decompress_mbps": 150.5
+"compress_mbps": 43.86,
+"decompress_mbps": 118
 },
 {
 "compressor": "js",
@@ -12284,8 +12284,8 @@
 "level": 4,
 "out_size": 5967955,
 "ratio": 0.7042,
-"compress_mbps": 42.39,
-"decompress_mbps": 183.02
+"compress_mbps": 41.7,
+"decompress_mbps": 187.4
 },
 {
 "compressor": "js",
@@ -12294,8 +12294,8 @@
 "level": 5,
 "out_size": 5967953,
 "ratio": 0.7042,
-"compress_mbps": 42.13,
-"decompress_mbps": 150.79
+"compress_mbps": 42.08,
+"decompress_mbps": 151.63
 },
 {
 "compressor": "js",
@@ -12304,8 +12304,8 @@
 "level": 6,
 "out_size": 5965386,
 "ratio": 0.7039,
-"compress_mbps": 41.82,
-"decompress_mbps": 156.24
+"compress_mbps": 41.41,
+"decompress_mbps": 152.09
 },
 {
 "compressor": "js",
@@ -12314,8 +12314,8 @@
 "level": 7,
 "out_size": 5965383,
 "ratio": 0.7039,
-"compress_mbps": 42.56,
-"decompress_mbps": 154.42
+"compress_mbps": 42.6,
+"decompress_mbps": 113.12
 },
 {
 "compressor": "js",
@@ -12324,8 +12324,8 @@
 "level": 8,
 "out_size": 5965383,
 "ratio": 0.7039,
-"compress_mbps": 41.87,
-"decompress_mbps": 155.96
+"compress_mbps": 41.02,
+"decompress_mbps": 156.65
 },
 {
 "compressor": "js",
@@ -12334,8 +12334,8 @@
 "level": 9,
 "out_size": 5965383,
 "ratio": 0.7039,
-"compress_mbps": 41.74,
-"decompress_mbps": 139.05
+"compress_mbps": 40.75,
+"decompress_mbps": 121.79
 },
 {
 "compressor": "js",
@@ -12344,8 +12344,8 @@
 "level": 1,
 "out_size": 985606,
 "ratio": 0.1844,
-"compress_mbps": 110.6,
-"decompress_mbps": 298.86
+"compress_mbps": 111.87,
+"decompress_mbps": 309.19
 },
 {
 "compressor": "js",
@@ -12354,8 +12354,8 @@
 "level": 2,
 "out_size": 852636,
 "ratio": 0.1595,
-"compress_mbps": 100.8,
-"decompress_mbps": 274.41
+"compress_mbps": 102.74,
+"decompress_mbps": 257.1
 },
 {
 "compressor": "js",
@@ -12364,8 +12364,8 @@
 "level": 3,
 "out_size": 814293,
 "ratio": 0.1523,
-"compress_mbps": 93.85,
-"decompress_mbps": 299.47
+"compress_mbps": 96.66,
+"decompress_mbps": 227.93
 },
 {
 "compressor": "js",
@@ -12374,8 +12374,8 @@
 "level": 4,
 "out_size": 788388,
 "ratio": 0.1475,
-"compress_mbps": 88.09,
-"decompress_mbps": 339.18
+"compress_mbps": 90.31,
+"decompress_mbps": 251.64
 },
 {
 "compressor": "js",
@@ -12384,8 +12384,8 @@
 "level": 5,
 "out_size": 749390,
 "ratio": 0.1402,
-"compress_mbps": 81.7,
-"decompress_mbps": 369.6
+"compress_mbps": 82.71,
+"decompress_mbps": 306.2
 },
 {
 "compressor": "js",
@@ -12394,8 +12394,8 @@
 "level": 6,
 "out_size": 706892,
 "ratio": 0.1322,
-"compress_mbps": 65.74,
-"decompress_mbps": 365.48
+"compress_mbps": 66.86,
+"decompress_mbps": 276.52
 },
 {
 "compressor": "js",
@@ -12404,8 +12404,8 @@
 "level": 7,
 "out_size": 705695,
 "ratio": 0.132,
-"compress_mbps": 63.12,
-"decompress_mbps": 386.31
+"compress_mbps": 64.85,
+"decompress_mbps": 317.35
 },
 {
 "compressor": "js",
@@ -12414,8 +12414,8 @@
 "level": 8,
 "out_size": 703904,
 "ratio": 0.1317,
-"compress_mbps": 60.63,
-"decompress_mbps": 366.67
+"compress_mbps": 60.82,
+"decompress_mbps": 273.88
 },
 {
 "compressor": "js",
@@ -12424,8 +12424,8 @@
 "level": 9,
 "out_size": 703900,
 "ratio": 0.1317,
-"compress_mbps": 60.35,
-"decompress_mbps": 382.97
+"compress_mbps": 61.01,
+"decompress_mbps": 296.54
 },
 {
 "compressor": "zig",
@@ -12434,8 +12434,8 @@
 "level": 1,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 86.82,
-"decompress_mbps": 315.4
+"compress_mbps": 88.95,
+"decompress_mbps": 310.06
 },
 {
 "compressor": "zig",
@@ -12444,8 +12444,8 @@
 "level": 2,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 89.42,
-"decompress_mbps": 311.77
+"compress_mbps": 88.26,
+"decompress_mbps": 309.23
 },
 {
 "compressor": "zig",
@@ -12454,8 +12454,8 @@
 "level": 3,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 86.83,
-"decompress_mbps": 314.65
+"compress_mbps": 87.99,
+"decompress_mbps": 315.28
 },
 {
 "compressor": "zig",
@@ -12464,8 +12464,8 @@
 "level": 4,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 89.43,
-"decompress_mbps": 316.53
+"compress_mbps": 88.16,
+"decompress_mbps": 313.07
 },
 {
 "compressor": "zig",
@@ -12474,8 +12474,8 @@
 "level": 5,
 "out_size": 54531,
 "ratio": 0.3585,
-"compress_mbps": 53.09,
-"decompress_mbps": 308.05
+"compress_mbps": 55.43,
+"decompress_mbps": 311.35
 },
 {
 "compressor": "zig",
@@ -12484,8 +12484,8 @@
 "level": 6,
 "out_size": 54068,
 "ratio": 0.3555,
-"compress_mbps": 41.02,
-"decompress_mbps": 307.38
+"compress_mbps": 42.01,
+"decompress_mbps": 307.06
 },
 {
 "compressor": "zig",
@@ -12494,8 +12494,8 @@
 "level": 7,
 "out_size": 54003,
 "ratio": 0.3551,
-"compress_mbps": 37.47,
-"decompress_mbps": 306.67
+"compress_mbps": 37.44,
+"decompress_mbps": 306.71
 },
 {
 "compressor": "zig",
@@ -12504,8 +12504,8 @@
 "level": 8,
 "out_size": 53974,
 "ratio": 0.3549,
-"compress_mbps": 33.22,
-"decompress_mbps": 313.16
+"compress_mbps": 33.12,
+"decompress_mbps": 308.78
 },
 {
 "compressor": "zig",
@@ -12514,8 +12514,8 @@
 "level": 9,
 "out_size": 53974,
 "ratio": 0.3549,
-"compress_mbps": 33.25,
-"decompress_mbps": 312.52
+"compress_mbps": 33.01,
+"decompress_mbps": 309.23
 },
 {
 "compressor": "zig",
@@ -12524,8 +12524,8 @@
 "level": 1,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 82.63,
-"decompress_mbps": 275.25
+"compress_mbps": 83.75,
+"decompress_mbps": 277.39
 },
 {
 "compressor": "zig",
@@ -12534,8 +12534,8 @@
 "level": 2,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 81.25,
-"decompress_mbps": 276.23
+"compress_mbps": 83.26,
+"decompress_mbps": 279.31
 },
 {
 "compressor": "zig",
@@ -12544,8 +12544,8 @@
 "level": 3,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 82.16,
-"decompress_mbps": 277.29
+"compress_mbps": 83.72,
+"decompress_mbps": 273.72
 },
 {
 "compressor": "zig",
@@ -12554,8 +12554,8 @@
 "level": 4,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 80.82,
-"decompress_mbps": 277.37
+"compress_mbps": 83.56,
+"decompress_mbps": 275.1
 },
 {
 "compressor": "zig",
@@ -12564,8 +12564,8 @@
 "level": 5,
 "out_size": 48753,
 "ratio": 0.3895,
-"compress_mbps": 49.79,
-"decompress_mbps": 276.67
+"compress_mbps": 50.83,
+"decompress_mbps": 271.14
 },
 {
 "compressor": "zig",
@@ -12574,8 +12574,8 @@
 "level": 6,
 "out_size": 48557,
 "ratio": 0.3879,
-"compress_mbps": 40.04,
-"decompress_mbps": 275.51
+"compress_mbps": 41.0,
+"decompress_mbps": 277.64
 },
 {
 "compressor": "zig",
@@ -12584,8 +12584,8 @@
 "level": 7,
 "out_size": 48523,
 "ratio": 0.3876,
-"compress_mbps": 37.51,
-"decompress_mbps": 275.35
+"compress_mbps": 38.68,
+"decompress_mbps": 277.51
 },
 {
 "compressor": "zig",
@@ -12594,8 +12594,8 @@
 "level": 8,
 "out_size": 48522,
 "ratio": 0.3876,
-"compress_mbps": 37.12,
-"decompress_mbps": 274.63
+"compress_mbps": 38.08,
+"decompress_mbps": 277.16
 },
 {
 "compressor": "zig",
@@ -12604,8 +12604,8 @@
 "level": 9,
 "out_size": 48522,
 "ratio": 0.3876,
-"compress_mbps": 37.16,
-"decompress_mbps": 273.67
+"compress_mbps": 38.04,
+"decompress_mbps": 275.77
 },
 {
 "compressor": "zig",
@@ -12614,8 +12614,8 @@
 "level": 1,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 165.38,
-"decompress_mbps": 283.77
+"compress_mbps": 160.13,
+"decompress_mbps": 280.7
 },
 {
 "compressor": "zig",
@@ -12624,8 +12624,8 @@
 "level": 2,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 160.83,
-"decompress_mbps": 282.03
+"compress_mbps": 159.01,
+"decompress_mbps": 280.89
 },
 {
 "compressor": "zig",
@@ -12634,8 +12634,8 @@
 "level": 3,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 162.22,
-"decompress_mbps": 282.91
+"compress_mbps": 164.82,
+"decompress_mbps": 279.19
 },
 {
 "compressor": "zig",
@@ -12644,8 +12644,8 @@
 "level": 4,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 167.0,
-"decompress_mbps": 282.85
+"compress_mbps": 164.72,
+"decompress_mbps": 279.87
 },
 {
 "compressor": "zig",
@@ -12654,8 +12654,8 @@
 "level": 5,
 "out_size": 7965,
 "ratio": 0.3237,
-"compress_mbps": 111.97,
-"decompress_mbps": 287.42
+"compress_mbps": 110.54,
+"decompress_mbps": 285.07
 },
 {
 "compressor": "zig",
@@ -12664,8 +12664,8 @@
 "level": 6,
 "out_size": 7914,
 "ratio": 0.3217,
-"compress_mbps": 88.06,
-"decompress_mbps": 288.33
+"compress_mbps": 88.58,
+"decompress_mbps": 287.27
 },
 {
 "compressor": "zig",
@@ -12674,8 +12674,8 @@
 "level": 7,
 "out_size": 7895,
 "ratio": 0.3209,
-"compress_mbps": 76.94,
-"decompress_mbps": 289.58
+"compress_mbps": 79.56,
+"decompress_mbps": 288.46
 },
 {
 "compressor": "zig",
@@ -12684,8 +12684,8 @@
 "level": 8,
 "out_size": 7896,
 "ratio": 0.3209,
-"compress_mbps": 72.57,
-"decompress_mbps": 291.39
+"compress_mbps": 73.38,
+"decompress_mbps": 286.96
 },
 {
 "compressor": "zig",
@@ -12694,8 +12694,8 @@
 "level": 9,
 "out_size": 7896,
 "ratio": 0.3209,
-"compress_mbps": 75.31,
-"decompress_mbps": 290.33
+"compress_mbps": 74.49,
+"decompress_mbps": 288.37
 },
 {
 "compressor": "zig",
@@ -12704,8 +12704,8 @@
 "level": 1,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 171.54,
-"decompress_mbps": 259.17
+"compress_mbps": 170.63,
+"decompress_mbps": 256.31
 },
 {
 "compressor": "zig",
@@ -12714,8 +12714,8 @@
 "level": 2,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 170.26,
-"decompress_mbps": 261.79
+"compress_mbps": 165.8,
+"decompress_mbps": 256.53
 },
 {
 "compressor": "zig",
@@ -12724,8 +12724,8 @@
 "level": 3,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 174.19,
-"decompress_mbps": 260.17
+"compress_mbps": 165.83,
+"decompress_mbps": 254.37
 },
 {
 "compressor": "zig",
@@ -12734,8 +12734,8 @@
 "level": 4,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 172.28,
-"decompress_mbps": 257.93
+"compress_mbps": 167.07,
+"decompress_mbps": 255.18
 },
 {
 "compressor": "zig",
@@ -12744,8 +12744,8 @@
 "level": 5,
 "out_size": 3136,
 "ratio": 0.2813,
-"compress_mbps": 144.35,
-"decompress_mbps": 263.5
+"compress_mbps": 142.63,
+"decompress_mbps": 264.86
 },
 {
 "compressor": "zig",
@@ -12754,8 +12754,8 @@
 "level": 6,
 "out_size": 3115,
 "ratio": 0.2794,
-"compress_mbps": 125.91,
-"decompress_mbps": 264.13
+"compress_mbps": 123.43,
+"decompress_mbps": 263.19
 },
 {
 "compressor": "zig",
@@ -12764,8 +12764,8 @@
 "level": 7,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 111.85,
-"decompress_mbps": 265.47
+"compress_mbps": 111.32,
+"decompress_mbps": 266.57
 },
 {
 "compressor": "zig",
@@ -12774,8 +12774,8 @@
 "level": 8,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 106.47,
-"decompress_mbps": 265.85
+"compress_mbps": 105.02,
+"decompress_mbps": 265.31
 },
 {
 "compressor": "zig",
@@ -12784,8 +12784,8 @@
 "level": 9,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 106.65,
-"decompress_mbps": 264.69
+"compress_mbps": 105.86,
+"decompress_mbps": 265.46
 },
 {
 "compressor": "zig",
@@ -12794,8 +12794,8 @@
 "level": 1,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 119.87,
-"decompress_mbps": 119.76
+"compress_mbps": 113.91,
+"decompress_mbps": 116.08
 },
 {
 "compressor": "zig",
@@ -12804,8 +12804,8 @@
 "level": 2,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 120.99,
-"decompress_mbps": 120.52
+"compress_mbps": 112.97,
+"decompress_mbps": 116.36
 },
 {
 "compressor": "zig",
@@ -12814,8 +12814,8 @@
 "level": 3,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 113.93,
-"decompress_mbps": 121.07
+"compress_mbps": 111.36,
+"decompress_mbps": 114.47
 },
 {
 "compressor": "zig",
@@ -12824,8 +12824,8 @@
 "level": 4,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 113.14,
-"decompress_mbps": 120.31
+"compress_mbps": 112.62,
+"decompress_mbps": 113.68
 },
 {
 "compressor": "zig",
@@ -12834,8 +12834,8 @@
 "level": 5,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 101.68,
-"decompress_mbps": 116.93
+"compress_mbps": 103.96,
+"decompress_mbps": 114.45
 },
 {
 "compressor": "zig",
@@ -12844,8 +12844,8 @@
 "level": 6,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 103.69,
-"decompress_mbps": 117.74
+"compress_mbps": 101.09,
+"decompress_mbps": 117.37
 },
 {
 "compressor": "zig",
@@ -12854,8 +12854,8 @@
 "level": 7,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 99.59,
-"decompress_mbps": 117.06
+"compress_mbps": 98.16,
+"decompress_mbps": 112.01
 },
 {
 "compressor": "zig",
@@ -12864,8 +12864,8 @@
 "level": 8,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 102.93,
-"decompress_mbps": 119.35
+"compress_mbps": 98.9,
+"decompress_mbps": 113.5
 },
 {
 "compressor": "zig",
@@ -12874,8 +12874,8 @@
 "level": 9,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 98.95,
-"decompress_mbps": 118.0
+"compress_mbps": 95.01,
+"decompress_mbps": 113.65
 },
 {
 "compressor": "zig",
@@ -12884,8 +12884,8 @@
 "level": 1,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 233.35,
-"decompress_mbps": 456.0
+"compress_mbps": 230.64,
+"decompress_mbps": 459.86
 },
 {
 "compressor": "zig",
@@ -12894,8 +12894,8 @@
 "level": 2,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 222.09,
-"decompress_mbps": 461.22
+"compress_mbps": 231.21,
+"decompress_mbps": 461.54
 },
 {
 "compressor": "zig",
@@ -12904,8 +12904,8 @@
 "level": 3,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 222.66,
-"decompress_mbps": 457.39
+"compress_mbps": 226.26,
+"decompress_mbps": 463.76
 },
 {
 "compressor": "zig",
@@ -12914,8 +12914,8 @@
 "level": 4,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 233.38,
-"decompress_mbps": 463.02
+"compress_mbps": 231.99,
+"decompress_mbps": 460.91
 },
 {
 "compressor": "zig",
@@ -12924,8 +12924,8 @@
 "level": 5,
 "out_size": 218313,
 "ratio": 0.212,
-"compress_mbps": 160.05,
-"decompress_mbps": 447.23
+"compress_mbps": 163.44,
+"decompress_mbps": 446.78
 },
 {
 "compressor": "zig",
@@ -12934,8 +12934,8 @@
 "level": 6,
 "out_size": 215095,
 "ratio": 0.2089,
-"compress_mbps": 105.43,
-"decompress_mbps": 446.98
+"compress_mbps": 106.34,
+"decompress_mbps": 446.0
 },
 {
 "compressor": "zig",
@@ -12944,8 +12944,8 @@
 "level": 7,
 "out_size": 213213,
 "ratio": 0.2071,
-"compress_mbps": 72.2,
-"decompress_mbps": 447.6
+"compress_mbps": 72.98,
+"decompress_mbps": 450.61
 },
 {
 "compressor": "zig",
@@ -12954,8 +12954,8 @@
 "level": 8,
 "out_size": 210955,
 "ratio": 0.2049,
-"compress_mbps": 9.4,
-"decompress_mbps": 450.36
+"compress_mbps": 9.37,
+"decompress_mbps": 450.93
 },
 {
 "compressor": "zig",
@@ -12964,8 +12964,8 @@
 "level": 9,
 "out_size": 210981,
 "ratio": 0.2049,
-"compress_mbps": 4.64,
-"decompress_mbps": 449.63
+"compress_mbps": 4.63,
+"decompress_mbps": 452.54
 },
 {
 "compressor": "zig",
@@ -12974,8 +12974,8 @@
 "level": 1,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 92.83,
-"decompress_mbps": 310.06
+"compress_mbps": 92.2,
+"decompress_mbps": 303.36
 },
 {
 "compressor": "zig",
@@ -12984,8 +12984,8 @@
 "level": 2,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 88.75,
-"decompress_mbps": 306.13
+"compress_mbps": 92.48,
+"decompress_mbps": 302.93
 },
 {
 "compressor": "zig",
@@ -12994,8 +12994,8 @@
 "level": 3,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 88.03,
-"decompress_mbps": 299.77
+"compress_mbps": 92.23,
+"decompress_mbps": 306.34
 },
 {
 "compressor": "zig",
@@ -13004,8 +13004,8 @@
 "level": 4,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 92.32,
-"decompress_mbps": 311.08
+"compress_mbps": 91.96,
+"decompress_mbps": 303.92
 },
 {
 "compressor": "zig",
@@ -13014,8 +13014,8 @@
 "level": 5,
 "out_size": 145024,
 "ratio": 0.3398,
-"compress_mbps": 56.34,
-"decompress_mbps": 302.6
+"compress_mbps": 57.59,
+"decompress_mbps": 306.1
 },
 {
 "compressor": "zig",
@@ -13024,8 +13024,8 @@
 "level": 6,
 "out_size": 144159,
 "ratio": 0.3378,
-"compress_mbps": 44.95,
-"decompress_mbps": 307.39
+"compress_mbps": 44.28,
+"decompress_mbps": 304.89
 },
 {
 "compressor": "zig",
@@ -13034,8 +13034,8 @@
 "level": 7,
 "out_size": 143991,
 "ratio": 0.3374,
-"compress_mbps": 38.79,
-"decompress_mbps": 305.16
+"compress_mbps": 40.25,
+"decompress_mbps": 305.98
 },
 {
 "compressor": "zig",
@@ -13044,8 +13044,8 @@
 "level": 8,
 "out_size": 143941,
 "ratio": 0.3373,
-"compress_mbps": 35.78,
-"decompress_mbps": 301.88
+"compress_mbps": 36.97,
+"decompress_mbps": 305.86
 },
 {
 "compressor": "zig",
@@ -13054,8 +13054,8 @@
 "level": 9,
 "out_size": 143939,
 "ratio": 0.3373,
-"compress_mbps": 36.13,
-"decompress_mbps": 300.59
+"compress_mbps": 36.78,
+"decompress_mbps": 302.04
 },
 {
 "compressor": "zig",
@@ -13064,8 +13064,8 @@
 "level": 1,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 82.03,
-"decompress_mbps": 259.67
+"compress_mbps": 81.42,
+"decompress_mbps": 261.6
 },
 {
 "compressor": "zig",
@@ -13074,8 +13074,8 @@
 "level": 2,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 79.26,
-"decompress_mbps": 256.17
+"compress_mbps": 81.35,
+"decompress_mbps": 259.11
 },
 {
 "compressor": "zig",
@@ -13084,8 +13084,8 @@
 "level": 3,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 78.18,
-"decompress_mbps": 256.92
+"compress_mbps": 81.8,
+"decompress_mbps": 256.43
 },
 {
 "compressor": "zig",
@@ -13094,8 +13094,8 @@
 "level": 4,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 81.98,
-"decompress_mbps": 258.54
+"compress_mbps": 81.25,
+"decompress_mbps": 254.43
 },
 {
 "compressor": "zig",
@@ -13104,8 +13104,8 @@
 "level": 5,
 "out_size": 194496,
 "ratio": 0.4036,
-"compress_mbps": 44.74,
-"decompress_mbps": 248.11
+"compress_mbps": 45.71,
+"decompress_mbps": 248.56
 },
 {
 "compressor": "zig",
@@ -13114,8 +13114,8 @@
 "level": 6,
 "out_size": 193176,
 "ratio": 0.4009,
-"compress_mbps": 34.56,
-"decompress_mbps": 253.31
+"compress_mbps": 34.49,
+"decompress_mbps": 252.44
 },
 {
 "compressor": "zig",
@@ -13124,8 +13124,8 @@
 "level": 7,
 "out_size": 192991,
 "ratio": 0.4005,
-"compress_mbps": 30.61,
-"decompress_mbps": 251.12
+"compress_mbps": 31.29,
+"decompress_mbps": 254.6
 },
 {
 "compressor": "zig",
@@ -13134,8 +13134,8 @@
 "level": 8,
 "out_size": 192980,
 "ratio": 0.4005,
-"compress_mbps": 29.23,
-"decompress_mbps": 251.4
+"compress_mbps": 29.76,
+"decompress_mbps": 250.82
 },
 {
 "compressor": "zig",
@@ -13144,8 +13144,8 @@
 "level": 9,
 "out_size": 192980,
 "ratio": 0.4005,
-"compress_mbps": 28.76,
-"decompress_mbps": 250.86
+"compress_mbps": 29.85,
+"decompress_mbps": 255.67
 },
 {
 "compressor": "zig",
@@ -13154,8 +13154,8 @@
 "level": 1,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 288.37,
-"decompress_mbps": 730.91
+"compress_mbps": 298.79,
+"decompress_mbps": 737.74
 },
 {
 "compressor": "zig",
@@ -13164,8 +13164,8 @@
 "level": 2,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 282.11,
-"decompress_mbps": 720.9
+"compress_mbps": 295.5,
+"decompress_mbps": 730.53
 },
 {
 "compressor": "zig",
@@ -13174,8 +13174,8 @@
 "level": 3,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 290.09,
-"decompress_mbps": 733.78
+"compress_mbps": 297.54,
+"decompress_mbps": 734.01
 },
 {
 "compressor": "zig",
@@ -13184,8 +13184,8 @@
 "level": 4,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 283.04,
-"decompress_mbps": 721.32
+"compress_mbps": 294.51,
+"decompress_mbps": 728.55
 },
 {
 "compressor": "zig",
@@ -13194,8 +13194,8 @@
 "level": 5,
 "out_size": 56050,
 "ratio": 0.1092,
-"compress_mbps": 225.04,
-"decompress_mbps": 756.94
+"compress_mbps": 230.35,
+"decompress_mbps": 759.24
 },
 {
 "compressor": "zig",
@@ -13204,8 +13204,8 @@
 "level": 6,
 "out_size": 55292,
 "ratio": 0.1077,
-"compress_mbps": 147.66,
-"decompress_mbps": 766.02
+"compress_mbps": 153.55,
+"decompress_mbps": 784.43
 },
 {
 "compressor": "zig",
@@ -13214,8 +13214,8 @@
 "level": 7,
 "out_size": 54651,
 "ratio": 0.1065,
-"compress_mbps": 124.58,
-"decompress_mbps": 799.34
+"compress_mbps": 123.6,
+"decompress_mbps": 788.74
 },
 {
 "compressor": "zig",
@@ -13224,8 +13224,8 @@
 "level": 8,
 "out_size": 52583,
 "ratio": 0.1025,
-"compress_mbps": 46.76,
-"decompress_mbps": 821.8
+"compress_mbps": 46.9,
+"decompress_mbps": 821.6
 },
 {
 "compressor": "zig",
@@ -13234,8 +13234,8 @@
 "level": 9,
 "out_size": 51816,
 "ratio": 0.101,
-"compress_mbps": 15.57,
-"decompress_mbps": 824.33
+"compress_mbps": 15.69,
+"decompress_mbps": 838.91
 },
 {
 "compressor": "zig",
@@ -13244,8 +13244,8 @@
 "level": 1,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 118.47,
-"decompress_mbps": 307.62
+"compress_mbps": 118.76,
+"decompress_mbps": 304.02
 },
 {
 "compressor": "zig",
@@ -13254,8 +13254,8 @@
 "level": 2,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 112.25,
-"decompress_mbps": 305.37
+"compress_mbps": 118.59,
+"decompress_mbps": 299.45
 },
 {
 "compressor": "zig",
@@ -13264,8 +13264,8 @@
 "level": 3,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 119.33,
-"decompress_mbps": 307.95
+"compress_mbps": 118.95,
+"decompress_mbps": 306.31
 },
 {
 "compressor": "zig",
@@ -13274,8 +13274,8 @@
 "level": 4,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 114.38,
-"decompress_mbps": 303.91
+"compress_mbps": 118.99,
+"decompress_mbps": 305.06
 },
 {
 "compressor": "zig",
@@ -13284,8 +13284,8 @@
 "level": 5,
 "out_size": 13290,
 "ratio": 0.3475,
-"compress_mbps": 84.74,
-"decompress_mbps": 316.83
+"compress_mbps": 88.47,
+"decompress_mbps": 315.02
 },
 {
 "compressor": "zig",
@@ -13294,8 +13294,8 @@
 "level": 6,
 "out_size": 13258,
 "ratio": 0.3467,
-"compress_mbps": 66.11,
-"decompress_mbps": 317.62
+"compress_mbps": 69.18,
+"decompress_mbps": 318.14
 },
 {
 "compressor": "zig",
@@ -13304,8 +13304,8 @@
 "level": 7,
 "out_size": 13246,
 "ratio": 0.3464,
-"compress_mbps": 54.97,
-"decompress_mbps": 321.06
+"compress_mbps": 55.92,
+"decompress_mbps": 315.51
 },
 {
 "compressor": "zig",
@@ -13314,8 +13314,8 @@
 "level": 8,
 "out_size": 13236,
 "ratio": 0.3461,
-"compress_mbps": 25.12,
-"decompress_mbps": 320.47
+"compress_mbps": 25.46,
+"decompress_mbps": 318.89
 },
 {
 "compressor": "zig",
@@ -13324,8 +13324,8 @@
 "level": 9,
 "out_size": 13233,
 "ratio": 0.3461,
-"compress_mbps": 16.0,
-"decompress_mbps": 324.13
+"compress_mbps": 16.18,
+"decompress_mbps": 318.09
 },
 {
 "compressor": "zig",
@@ -13334,8 +13334,8 @@
 "level": 1,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 94.53,
-"decompress_mbps": 133.3
+"compress_mbps": 93.55,
+"decompress_mbps": 132.26
 },
 {
 "compressor": "zig",
@@ -13344,8 +13344,8 @@
 "level": 2,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 94.54,
-"decompress_mbps": 133.64
+"compress_mbps": 97.87,
+"decompress_mbps": 131.51
 },
 {
 "compressor": "zig",
@@ -13354,8 +13354,8 @@
 "level": 3,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 101.96,
-"decompress_mbps": 136.22
+"compress_mbps": 99.52,
+"decompress_mbps": 132.24
 },
 {
 "compressor": "zig",
@@ -13364,8 +13364,8 @@
 "level": 4,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 100.35,
-"decompress_mbps": 134.73
+"compress_mbps": 99.66,
+"decompress_mbps": 131.33
 },
 {
 "compressor": "zig",
@@ -13374,8 +13374,8 @@
 "level": 5,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 100.06,
-"decompress_mbps": 136.05
+"compress_mbps": 93.96,
+"decompress_mbps": 132.09
 },
 {
 "compressor": "zig",
@@ -13384,8 +13384,8 @@
 "level": 6,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 96.62,
-"decompress_mbps": 135.96
+"compress_mbps": 92.06,
+"decompress_mbps": 131.97
 },
 {
 "compressor": "zig",
@@ -13394,8 +13394,8 @@
 "level": 7,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 99.76,
-"decompress_mbps": 135.28
+"compress_mbps": 93.19,
+"decompress_mbps": 132.96
 },
 {
 "compressor": "zig",
@@ -13404,8 +13404,8 @@
 "level": 8,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 97.62,
-"decompress_mbps": 136.11
+"compress_mbps": 93.02,
+"decompress_mbps": 131.79
 },
 {
 "compressor": "zig",
@@ -13414,8 +13414,8 @@
 "level": 9,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 99.7,
-"decompress_mbps": 135.55
+"compress_mbps": 93.34,
+"decompress_mbps": 132.53
 },
 {
 "compressor": "zig",
@@ -13424,8 +13424,8 @@
 "level": 1,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 80.5,
-"decompress_mbps": 270.02
+"compress_mbps": 84.03,
+"decompress_mbps": 273.24
 },
 {
 "compressor": "zig",
@@ -13434,8 +13434,8 @@
 "level": 2,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 80.34,
-"decompress_mbps": 272.01
+"compress_mbps": 83.7,
+"decompress_mbps": 272.45
 },
 {
 "compressor": "zig",
@@ -13444,8 +13444,8 @@
 "level": 3,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 80.16,
-"decompress_mbps": 268.86
+"compress_mbps": 84.04,
+"decompress_mbps": 271.18
 },
 {
 "compressor": "zig",
@@ -13454,8 +13454,8 @@
 "level": 4,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 84.1,
-"decompress_mbps": 275.83
+"compress_mbps": 84.43,
+"decompress_mbps": 273.17
 },
 {
 "compressor": "zig",
@@ -13464,8 +13464,8 @@
 "level": 5,
 "out_size": 3863846,
 "ratio": 0.3791,
-"compress_mbps": 48.23,
-"decompress_mbps": 267.45
+"compress_mbps": 49.45,
+"decompress_mbps": 271.03
 },
 {
 "compressor": "zig",
@@ -13474,8 +13474,8 @@
 "level": 6,
 "out_size": 3838854,
 "ratio": 0.3766,
-"compress_mbps": 36.07,
-"decompress_mbps": 268.91
+"compress_mbps": 37.59,
+"decompress_mbps": 272.02
 },
 {
 "compressor": "zig",
@@ -13484,8 +13484,8 @@
 "level": 7,
 "out_size": 3835182,
 "ratio": 0.3763,
-"compress_mbps": 33.7,
-"decompress_mbps": 272.13
+"compress_mbps": 33.58,
+"decompress_mbps": 271.81
 },
 {
 "compressor": "zig",
@@ -13494,8 +13494,8 @@
 "level": 8,
 "out_size": 3834518,
 "ratio": 0.3762,
-"compress_mbps": 30.71,
-"decompress_mbps": 265.25
+"compress_mbps": 31.48,
+"decompress_mbps": 273.75
 },
 {
 "compressor": "zig",
@@ -13504,8 +13504,8 @@
 "level": 9,
 "out_size": 3834518,
 "ratio": 0.3762,
-"compress_mbps": 30.4,
-"decompress_mbps": 267.67
+"compress_mbps": 31.64,
+"decompress_mbps": 271.14
 },
 {
 "compressor": "zig",
@@ -13514,8 +13514,8 @@
 "level": 1,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 99.52,
-"decompress_mbps": 248.43
+"compress_mbps": 103.99,
+"decompress_mbps": 250.23
 },
 {
 "compressor": "zig",
@@ -13524,8 +13524,8 @@
 "level": 2,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 103.96,
-"decompress_mbps": 251.54
+"compress_mbps": 104.04,
+"decompress_mbps": 251.99
 },
 {
 "compressor": "zig",
@@ -13534,8 +13534,8 @@
 "level": 3,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 98.03,
-"decompress_mbps": 246.33
+"compress_mbps": 103.6,
+"decompress_mbps": 251.63
 },
 {
 "compressor": "zig",
@@ -13544,8 +13544,8 @@
 "level": 4,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 97.89,
-"decompress_mbps": 245.31
+"compress_mbps": 103.94,
+"decompress_mbps": 250.93
 },
 {
 "compressor": "zig",
@@ -13554,8 +13554,8 @@
 "level": 5,
 "out_size": 19578840,
 "ratio": 0.3822,
-"compress_mbps": 74.48,
-"decompress_mbps": 256.06
+"compress_mbps": 77.79,
+"decompress_mbps": 260.24
 },
 {
 "compressor": "zig",
@@ -13564,8 +13564,8 @@
 "level": 6,
 "out_size": 19492445,
 "ratio": 0.3806,
-"compress_mbps": 56.32,
-"decompress_mbps": 258.17
+"compress_mbps": 57.93,
+"decompress_mbps": 262.86
 },
 {
 "compressor": "zig",
@@ -13574,8 +13574,8 @@
 "level": 7,
 "out_size": 19463481,
 "ratio": 0.38,
-"compress_mbps": 45.03,
-"decompress_mbps": 259.31
+"compress_mbps": 46.37,
+"decompress_mbps": 261.95
 },
 {
 "compressor": "zig",
@@ -13584,8 +13584,8 @@
 "level": 8,
 "out_size": 19444704,
 "ratio": 0.3796,
-"compress_mbps": 22.54,
-"decompress_mbps": 261.21
+"compress_mbps": 22.9,
+"decompress_mbps": 264.07
 },
 {
 "compressor": "zig",
@@ -13594,8 +13594,8 @@
 "level": 9,
 "out_size": 19440748,
 "ratio": 0.3796,
-"compress_mbps": 13.08,
-"decompress_mbps": 258.63
+"compress_mbps": 13.1,
+"decompress_mbps": 263.43
 },
 {
 "compressor": "zig",
@@ -13604,8 +13604,8 @@
 "level": 1,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 109.03,
-"decompress_mbps": 256.68
+"compress_mbps": 112.73,
+"decompress_mbps": 263.12
 },
 {
 "compressor": "zig",
@@ -13614,8 +13614,8 @@
 "level": 2,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 112.65,
-"decompress_mbps": 262.4
+"compress_mbps": 112.86,
+"decompress_mbps": 261.27
 },
 {
 "compressor": "zig",
@@ -13624,8 +13624,8 @@
 "level": 3,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 109.06,
-"decompress_mbps": 258.22
+"compress_mbps": 113.41,
+"decompress_mbps": 260.99
 },
 {
 "compressor": "zig",
@@ -13634,8 +13634,8 @@
 "level": 4,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 107.98,
-"decompress_mbps": 257.09
+"compress_mbps": 112.92,
+"decompress_mbps": 260.96
 },
 {
 "compressor": "zig",
@@ -13644,8 +13644,8 @@
 "level": 5,
 "out_size": 3637736,
 "ratio": 0.3648,
-"compress_mbps": 64.16,
-"decompress_mbps": 263.46
+"compress_mbps": 66.3,
+"decompress_mbps": 269.01
 },
 {
 "compressor": "zig",
@@ -13654,8 +13654,8 @@
 "level": 6,
 "out_size": 3621530,
 "ratio": 0.3632,
-"compress_mbps": 46.38,
-"decompress_mbps": 269.29
+"compress_mbps": 46.61,
+"decompress_mbps": 270.19
 },
 {
 "compressor": "zig",
@@ -13664,8 +13664,8 @@
 "level": 7,
 "out_size": 3623924,
 "ratio": 0.3635,
-"compress_mbps": 40.93,
-"decompress_mbps": 267.04
+"compress_mbps": 42.2,
+"decompress_mbps": 271.51
 },
 {
 "compressor": "zig",
@@ -13674,8 +13674,8 @@
 "level": 8,
 "out_size": 3623112,
 "ratio": 0.3634,
-"compress_mbps": 31.82,
-"decompress_mbps": 266.48
+"compress_mbps": 32.8,
+"decompress_mbps": 270.17
 },
 {
 "compressor": "zig",
@@ -13684,8 +13684,8 @@
 "level": 9,
 "out_size": 3623382,
 "ratio": 0.3634,
-"compress_mbps": 24.54,
-"decompress_mbps": 268.12
+"compress_mbps": 24.83,
+"decompress_mbps": 270.02
 },
 {
 "compressor": "zig",
@@ -13694,8 +13694,8 @@
 "level": 1,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 295.31,
-"decompress_mbps": 866.79
+"compress_mbps": 306.82,
+"decompress_mbps": 873.86
 },
 {
 "compressor": "zig",
@@ -13704,8 +13704,8 @@
 "level": 2,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 309.51,
-"decompress_mbps": 876.17
+"compress_mbps": 308.2,
+"decompress_mbps": 873.14
 },
 {
 "compressor": "zig",
@@ -13714,8 +13714,8 @@
 "level": 3,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 295.28,
-"decompress_mbps": 865.03
+"compress_mbps": 308.27,
+"decompress_mbps": 848.74
 },
 {
 "compressor": "zig",
@@ -13724,8 +13724,8 @@
 "level": 4,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 291.16,
-"decompress_mbps": 866.96
+"compress_mbps": 307.17,
+"decompress_mbps": 839.59
 },
 {
 "compressor": "zig",
@@ -13734,8 +13734,8 @@
 "level": 5,
 "out_size": 3268887,
 "ratio": 0.0974,
-"compress_mbps": 227.77,
-"decompress_mbps": 914.76
+"compress_mbps": 229.64,
+"decompress_mbps": 929.93
 },
 {
 "compressor": "zig",
@@ -13744,8 +13744,8 @@
 "level": 6,
 "out_size": 3131445,
 "ratio": 0.0933,
-"compress_mbps": 156.4,
-"decompress_mbps": 937.1
+"compress_mbps": 162.77,
+"decompress_mbps": 958.08
 },
 {
 "compressor": "zig",
@@ -13754,8 +13754,8 @@
 "level": 7,
 "out_size": 3080217,
 "ratio": 0.0918,
-"compress_mbps": 123.75,
-"decompress_mbps": 947.9
+"compress_mbps": 129.56,
+"decompress_mbps": 956.29
 },
 {
 "compressor": "zig",
@@ -13764,8 +13764,8 @@
 "level": 8,
 "out_size": 2978354,
 "ratio": 0.0888,
-"compress_mbps": 55.11,
-"decompress_mbps": 952.14
+"compress_mbps": 56.62,
+"decompress_mbps": 964.05
 },
 {
 "compressor": "zig",
@@ -13774,8 +13774,8 @@
 "level": 9,
 "out_size": 2947971,
 "ratio": 0.0879,
-"compress_mbps": 34.18,
-"decompress_mbps": 975.93
+"compress_mbps": 34.82,
+"decompress_mbps": 982.79
 },
 {
 "compressor": "zig",
@@ -13784,8 +13784,8 @@
 "level": 1,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 68.39,
-"decompress_mbps": 178.55
+"compress_mbps": 72.72,
+"decompress_mbps": 183.26
 },
 {
 "compressor": "zig",
@@ -13794,8 +13794,8 @@
 "level": 2,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 72.49,
-"decompress_mbps": 184.05
+"compress_mbps": 73.04,
+"decompress_mbps": 183.19
 },
 {
 "compressor": "zig",
@@ -13804,8 +13804,8 @@
 "level": 3,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 69.61,
-"decompress_mbps": 180.49
+"compress_mbps": 72.43,
+"decompress_mbps": 182.93
 },
 {
 "compressor": "zig",
@@ -13814,8 +13814,8 @@
 "level": 4,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 69.43,
-"decompress_mbps": 180.51
+"compress_mbps": 72.52,
+"decompress_mbps": 182.66
 },
 {
 "compressor": "zig",
@@ -13824,8 +13824,8 @@
 "level": 5,
 "out_size": 3178914,
 "ratio": 0.5167,
-"compress_mbps": 53.18,
-"decompress_mbps": 185.4
+"compress_mbps": 56.23,
+"decompress_mbps": 190.29
 },
 {
 "compressor": "zig",
@@ -13834,8 +13834,8 @@
 "level": 6,
 "out_size": 3174170,
 "ratio": 0.5159,
-"compress_mbps": 47.8,
-"decompress_mbps": 188.24
+"compress_mbps": 49.26,
+"decompress_mbps": 190.97
 },
 {
 "compressor": "zig",
@@ -13844,8 +13844,8 @@
 "level": 7,
 "out_size": 3172734,
 "ratio": 0.5157,
-"compress_mbps": 44.86,
-"decompress_mbps": 188.49
+"compress_mbps": 46.1,
+"decompress_mbps": 191.83
 },
 {
 "compressor": "zig",
@@ -13854,8 +13854,8 @@
 "level": 8,
 "out_size": 3171353,
 "ratio": 0.5155,
-"compress_mbps": 37.03,
-"decompress_mbps": 185.81
+"compress_mbps": 38.64,
+"decompress_mbps": 191.23
 },
 {
 "compressor": "zig",
@@ -13864,8 +13864,8 @@
 "level": 9,
 "out_size": 3171299,
 "ratio": 0.5155,
-"compress_mbps": 33.53,
-"decompress_mbps": 186.5
+"compress_mbps": 34.76,
+"decompress_mbps": 191.73
 },
 {
 "compressor": "zig",
@@ -13874,8 +13874,8 @@
 "level": 1,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 116.99,
-"decompress_mbps": 267.41
+"compress_mbps": 122.11,
+"decompress_mbps": 273.71
 },
 {
 "compressor": "zig",
@@ -13884,8 +13884,8 @@
 "level": 2,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 116.68,
-"decompress_mbps": 268.91
+"compress_mbps": 123.19,
+"decompress_mbps": 273.81
 },
 {
 "compressor": "zig",
@@ -13894,8 +13894,8 @@
 "level": 3,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 117.24,
-"decompress_mbps": 269.35
+"compress_mbps": 121.58,
+"decompress_mbps": 273.28
 },
 {
 "compressor": "zig",
@@ -13904,8 +13904,8 @@
 "level": 4,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 117.81,
-"decompress_mbps": 270.63
+"compress_mbps": 122.1,
+"decompress_mbps": 274.09
 },
 {
 "compressor": "zig",
@@ -13914,8 +13914,8 @@
 "level": 5,
 "out_size": 3654027,
 "ratio": 0.3623,
-"compress_mbps": 92.53,
-"decompress_mbps": 272.46
+"compress_mbps": 95.79,
+"decompress_mbps": 276.52
 },
 {
 "compressor": "zig",
@@ -13924,8 +13924,8 @@
 "level": 6,
 "out_size": 3652732,
 "ratio": 0.3622,
-"compress_mbps": 89.89,
-"decompress_mbps": 273.61
+"compress_mbps": 92.52,
+"decompress_mbps": 276.75
 },
 {
 "compressor": "zig",
@@ -13934,8 +13934,8 @@
 "level": 7,
 "out_size": 3652496,
 "ratio": 0.3621,
-"compress_mbps": 87.25,
-"decompress_mbps": 277.2
+"compress_mbps": 86.87,
+"decompress_mbps": 277.71
 },
 {
 "compressor": "zig",
@@ -13944,8 +13944,8 @@
 "level": 8,
 "out_size": 3652505,
 "ratio": 0.3621,
-"compress_mbps": 82.95,
-"decompress_mbps": 271.32
+"compress_mbps": 86.73,
+"decompress_mbps": 276.71
 },
 {
 "compressor": "zig",
@@ -13954,8 +13954,8 @@
 "level": 9,
 "out_size": 3652505,
 "ratio": 0.3621,
-"compress_mbps": 84.28,
-"decompress_mbps": 272.63
+"compress_mbps": 86.54,
+"decompress_mbps": 275.21
 },
 {
 "compressor": "zig",
@@ -13964,8 +13964,8 @@
 "level": 1,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 94.67,
-"decompress_mbps": 351.83
+"compress_mbps": 99.43,
+"decompress_mbps": 354.28
 },
 {
 "compressor": "zig",
@@ -13974,8 +13974,8 @@
 "level": 2,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 99.4,
-"decompress_mbps": 359.33
+"compress_mbps": 99.6,
+"decompress_mbps": 351.91
 },
 {
 "compressor": "zig",
@@ -13984,8 +13984,8 @@
 "level": 3,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 96.63,
-"decompress_mbps": 348.23
+"compress_mbps": 99.78,
+"decompress_mbps": 354.34
 },
 {
 "compressor": "zig",
@@ -13994,8 +13994,8 @@
 "level": 4,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 95.49,
-"decompress_mbps": 350.05
+"compress_mbps": 99.34,
+"decompress_mbps": 354.37
 },
 {
 "compressor": "zig",
@@ -14004,8 +14004,8 @@
 "level": 5,
 "out_size": 1892183,
 "ratio": 0.2855,
-"compress_mbps": 53.73,
-"decompress_mbps": 354.97
+"compress_mbps": 53.81,
+"decompress_mbps": 353.29
 },
 {
 "compressor": "zig",
@@ -14014,8 +14014,8 @@
 "level": 6,
 "out_size": 1837957,
 "ratio": 0.2773,
-"compress_mbps": 30.53,
-"decompress_mbps": 362.71
+"compress_mbps": 30.66,
+"decompress_mbps": 361.71
 },
 {
 "compressor": "zig",
@@ -14024,8 +14024,8 @@
 "level": 7,
 "out_size": 1826603,
 "ratio": 0.2756,
-"compress_mbps": 23.66,
-"decompress_mbps": 354.83
+"compress_mbps": 24.5,
+"decompress_mbps": 361.49
 },
 {
 "compressor": "zig",
@@ -14034,8 +14034,8 @@
 "level": 8,
 "out_size": 1818702,
 "ratio": 0.2744,
-"compress_mbps": 15.73,
-"decompress_mbps": 355.56
+"compress_mbps": 15.94,
+"decompress_mbps": 361.97
 },
 {
 "compressor": "zig",
@@ -14044,8 +14044,8 @@
 "level": 9,
 "out_size": 1818702,
 "ratio": 0.2744,
-"compress_mbps": 15.55,
-"decompress_mbps": 353.78
+"compress_mbps": 16.06,
+"decompress_mbps": 364.57
 },
 {
 "compressor": "zig",
@@ -14054,8 +14054,8 @@
 "level": 1,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 137.96,
-"decompress_mbps": 395.85
+"compress_mbps": 145.36,
+"decompress_mbps": 402.11
 },
 {
 "compressor": "zig",
@@ -14064,8 +14064,8 @@
 "level": 2,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 139.45,
-"decompress_mbps": 394.53
+"compress_mbps": 145.93,
+"decompress_mbps": 404.95
 },
 {
 "compressor": "zig",
@@ -14074,8 +14074,8 @@
 "level": 3,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 140.25,
-"decompress_mbps": 392.6
+"compress_mbps": 145.31,
+"decompress_mbps": 402.16
 },
 {
 "compressor": "zig",
@@ -14084,8 +14084,8 @@
 "level": 4,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 145.53,
-"decompress_mbps": 402.59
+"compress_mbps": 145.35,
+"decompress_mbps": 399.05
 },
 {
 "compressor": "zig",
@@ -14094,8 +14094,8 @@
 "level": 5,
 "out_size": 5501344,
 "ratio": 0.2546,
-"compress_mbps": 103.32,
-"decompress_mbps": 405.45
+"compress_mbps": 103.26,
+"decompress_mbps": 404.85
 },
 {
 "compressor": "zig",
@@ -14104,8 +14104,8 @@
 "level": 6,
 "out_size": 5464646,
 "ratio": 0.2529,
-"compress_mbps": 79.75,
-"decompress_mbps": 408.99
+"compress_mbps": 79.34,
+"decompress_mbps": 410.26
 },
 {
 "compressor": "zig",
@@ -14114,8 +14114,8 @@
 "level": 7,
 "out_size": 5429975,
 "ratio": 0.2513,
-"compress_mbps": 67.02,
-"decompress_mbps": 409.42
+"compress_mbps": 66.92,
+"decompress_mbps": 408.67
 },
 {
 "compressor": "zig",
@@ -14124,8 +14124,8 @@
 "level": 8,
 "out_size": 5419566,
 "ratio": 0.2508,
-"compress_mbps": 45.46,
-"decompress_mbps": 401.85
+"compress_mbps": 49.29,
+"decompress_mbps": 412.61
 },
 {
 "compressor": "zig",
@@ -14134,8 +14134,8 @@
 "level": 9,
 "out_size": 5417952,
 "ratio": 0.2508,
-"compress_mbps": 45.14,
-"decompress_mbps": 409.63
+"compress_mbps": 45.43,
+"decompress_mbps": 410.38
 },
 {
 "compressor": "zig",
@@ -14144,8 +14144,8 @@
 "level": 1,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 57.54,
-"decompress_mbps": 163.29
+"compress_mbps": 59.93,
+"decompress_mbps": 161.48
 },
 {
 "compressor": "zig",
@@ -14154,8 +14154,8 @@
 "level": 2,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 57.82,
-"decompress_mbps": 163.99
+"compress_mbps": 60.2,
+"decompress_mbps": 159.86
 },
 {
 "compressor": "zig",
@@ -14164,8 +14164,8 @@
 "level": 3,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 60.4,
-"decompress_mbps": 162.16
+"compress_mbps": 60.28,
+"decompress_mbps": 160.49
 },
 {
 "compressor": "zig",
@@ -14174,8 +14174,8 @@
 "level": 4,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 60.49,
-"decompress_mbps": 160.03
+"compress_mbps": 60.32,
+"decompress_mbps": 161.28
 },
 {
 "compressor": "zig",
@@ -14184,8 +14184,8 @@
 "level": 5,
 "out_size": 5450496,
 "ratio": 0.7516,
-"compress_mbps": 45.4,
-"decompress_mbps": 166.39
+"compress_mbps": 46.77,
+"decompress_mbps": 164.06
 },
 {
 "compressor": "zig",
@@ -14194,8 +14194,8 @@
 "level": 6,
 "out_size": 5440281,
 "ratio": 0.7502,
-"compress_mbps": 40.78,
-"decompress_mbps": 165.99
+"compress_mbps": 42.16,
+"decompress_mbps": 164.57
 },
 {
 "compressor": "zig",
@@ -14204,8 +14204,8 @@
 "level": 7,
 "out_size": 5439077,
 "ratio": 0.75,
-"compress_mbps": 39.55,
-"decompress_mbps": 165.55
+"compress_mbps": 40.8,
+"decompress_mbps": 164.13
 },
 {
 "compressor": "zig",
@@ -14214,8 +14214,8 @@
 "level": 8,
 "out_size": 5438787,
 "ratio": 0.75,
-"compress_mbps": 38.21,
-"decompress_mbps": 165.36
+"compress_mbps": 39.86,
+"decompress_mbps": 164.23
 },
 {
 "compressor": "zig",
@@ -14224,8 +14224,8 @@
 "level": 9,
 "out_size": 5438787,
 "ratio": 0.75,
-"compress_mbps": 38.17,
-"decompress_mbps": 164.93
+"compress_mbps": 40.0,
+"decompress_mbps": 163.95
 },
 {
 "compressor": "zig",
@@ -14234,8 +14234,8 @@
 "level": 1,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 105.14,
-"decompress_mbps": 312.39
+"compress_mbps": 108.65,
+"decompress_mbps": 315.26
 },
 {
 "compressor": "zig",
@@ -14244,8 +14244,8 @@
 "level": 2,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 102.93,
-"decompress_mbps": 312.28
+"compress_mbps": 108.04,
+"decompress_mbps": 314.18
 },
 {
 "compressor": "zig",
@@ -14254,8 +14254,8 @@
 "level": 3,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 108.81,
-"decompress_mbps": 318.51
+"compress_mbps": 108.74,
+"decompress_mbps": 314.35
 },
 {
 "compressor": "zig",
@@ -14264,8 +14264,8 @@
 "level": 4,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 108.69,
-"decompress_mbps": 313.17
+"compress_mbps": 108.13,
+"decompress_mbps": 317.98
 },
 {
 "compressor": "zig",
@@ -14274,8 +14274,8 @@
 "level": 5,
 "out_size": 12238874,
 "ratio": 0.2952,
-"compress_mbps": 68.77,
-"decompress_mbps": 309.47
+"compress_mbps": 72.5,
+"decompress_mbps": 319.12
 },
 {
 "compressor": "zig",
@@ -14284,8 +14284,8 @@
 "level": 6,
 "out_size": 12086531,
 "ratio": 0.2915,
-"compress_mbps": 52.29,
-"decompress_mbps": 320.74
+"compress_mbps": 53.59,
+"decompress_mbps": 322.81
 },
 {
 "compressor": "zig",
@@ -14294,8 +14294,8 @@
 "level": 7,
 "out_size": 12020742,
 "ratio": 0.2899,
-"compress_mbps": 44.63,
-"decompress_mbps": 316.82
+"compress_mbps": 46.3,
+"decompress_mbps": 323.61
 },
 {
 "compressor": "zig",
@@ -14304,8 +14304,8 @@
 "level": 8,
 "out_size": 11987253,
 "ratio": 0.2891,
-"compress_mbps": 36.94,
-"decompress_mbps": 316.47
+"compress_mbps": 38.17,
+"decompress_mbps": 324.88
 },
 {
 "compressor": "zig",
@@ -14314,8 +14314,8 @@
 "level": 9,
 "out_size": 11987245,
 "ratio": 0.2891,
-"compress_mbps": 37.14,
-"decompress_mbps": 317.03
+"compress_mbps": 38.1,
+"decompress_mbps": 321.56
 },
 {
 "compressor": "zig",
@@ -14324,8 +14324,8 @@
 "level": 1,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 57.58,
-"decompress_mbps": 145.27
+"compress_mbps": 60.14,
+"decompress_mbps": 146.87
 },
 {
 "compressor": "zig",
@@ -14334,8 +14334,8 @@
 "level": 2,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 57.2,
-"decompress_mbps": 144.54
+"compress_mbps": 60.57,
+"decompress_mbps": 146.81
 },
 {
 "compressor": "zig",
@@ -14344,8 +14344,8 @@
 "level": 3,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 58.06,
-"decompress_mbps": 145.75
+"compress_mbps": 60.61,
+"decompress_mbps": 146.74
 },
 {
 "compressor": "zig",
@@ -14354,8 +14354,8 @@
 "level": 4,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 58.12,
-"decompress_mbps": 145.21
+"compress_mbps": 60.51,
+"decompress_mbps": 146.74
 },
 {
 "compressor": "zig",
@@ -14364,8 +14364,8 @@
 "level": 5,
 "out_size": 6244483,
 "ratio": 0.7369,
-"compress_mbps": 53.15,
-"decompress_mbps": 147.05
+"compress_mbps": 54.99,
+"decompress_mbps": 148.41
 },
 {
 "compressor": "zig",
@@ -14374,8 +14374,8 @@
 "level": 6,
 "out_size": 6244482,
 "ratio": 0.7369,
-"compress_mbps": 51.89,
-"decompress_mbps": 145.75
+"compress_mbps": 55.44,
+"decompress_mbps": 148.8
 },
 {
 "compressor": "zig",
@@ -14384,8 +14384,8 @@
 "level": 7,
 "out_size": 6244482,
 "ratio": 0.7369,
-"compress_mbps": 52.85,
-"decompress_mbps": 147.14
+"compress_mbps": 55.56,
+"decompress_mbps": 148.37
 },
 {
 "compressor": "zig",
@@ -14394,8 +14394,8 @@
 "level": 8,
 "out_size": 6244480,
 "ratio": 0.7369,
-"compress_mbps": 53.36,
-"decompress_mbps": 147.37
+"compress_mbps": 55.58,
+"decompress_mbps": 148.49
 },
 {
 "compressor": "zig",
@@ -14404,8 +14404,8 @@
 "level": 9,
 "out_size": 6244480,
 "ratio": 0.7369,
-"compress_mbps": 52.55,
-"decompress_mbps": 146.06
+"compress_mbps": 54.79,
+"decompress_mbps": 147.76
 },
 {
 "compressor": "zig",
@@ -14414,8 +14414,8 @@
 "level": 1,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 224.43,
-"decompress_mbps": 667.81
+"compress_mbps": 230.07,
+"decompress_mbps": 671.22
 },
 {
 "compressor": "zig",
@@ -14424,8 +14424,8 @@
 "level": 2,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 221.39,
-"decompress_mbps": 661.83
+"compress_mbps": 230.71,
+"decompress_mbps": 677.7
 },
 {
 "compressor": "zig",
@@ -14434,8 +14434,8 @@
 "level": 3,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 221.56,
-"decompress_mbps": 669.32
+"compress_mbps": 229.2,
+"decompress_mbps": 671.23
 },
 {
 "compressor": "zig",
@@ -14444,8 +14444,8 @@
 "level": 4,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 221.79,
-"decompress_mbps": 666.62
+"compress_mbps": 230.33,
+"decompress_mbps": 675.75
 },
 {
 "compressor": "zig",
@@ -14454,8 +14454,8 @@
 "level": 5,
 "out_size": 716461,
 "ratio": 0.134,
-"compress_mbps": 160.89,
-"decompress_mbps": 706.92
+"compress_mbps": 166.03,
+"decompress_mbps": 714.12
 },
 {
 "compressor": "zig",
@@ -14464,8 +14464,8 @@
 "level": 6,
 "out_size": 687053,
 "ratio": 0.1285,
-"compress_mbps": 121.63,
-"decompress_mbps": 728.89
+"compress_mbps": 123.93,
+"decompress_mbps": 737.13
 },
 {
 "compressor": "zig",
@@ -14474,8 +14474,8 @@
 "level": 7,
 "out_size": 673597,
 "ratio": 0.126,
-"compress_mbps": 97.69,
-"decompress_mbps": 730.71
+"compress_mbps": 101.0,
+"decompress_mbps": 752.07
 },
 {
 "compressor": "zig",
@@ -14484,8 +14484,8 @@
 "level": 8,
 "out_size": 662156,
 "ratio": 0.1239,
-"compress_mbps": 63.5,
-"decompress_mbps": 744.51
+"compress_mbps": 65.54,
+"decompress_mbps": 751.78
 },
 {
 "compressor": "zig",
@@ -14494,8 +14494,8 @@
 "level": 9,
 "out_size": 661610,
 "ratio": 0.1238,
-"compress_mbps": 59.5,
-"decompress_mbps": 741.46
+"compress_mbps": 60.91,
+"decompress_mbps": 755.71
 },
 {
 "compressor": "ocaml",
@@ -14504,8 +14504,8 @@
 "level": 1,
 "out_size": 73589,
 "ratio": 0.4839,
-"compress_mbps": 32.98,
-"decompress_mbps": 56.39
+"compress_mbps": 33.7,
+"decompress_mbps": 56.65
 },
 {
 "compressor": "ocaml",
@@ -14514,8 +14514,8 @@
 "level": 2,
 "out_size": 69878,
 "ratio": 0.4595,
-"compress_mbps": 30.91,
-"decompress_mbps": 57.07
+"compress_mbps": 32.1,
+"decompress_mbps": 58.01
 },
 {
 "compressor": "ocaml",
@@ -14524,8 +14524,8 @@
 "level": 3,
 "out_size": 66917,
 "ratio": 0.44,
-"compress_mbps": 26.3,
-"decompress_mbps": 66.07
+"compress_mbps": 26.84,
+"decompress_mbps": 66.22
 },
 {
 "compressor": "ocaml",
@@ -14534,8 +14534,8 @@
 "level": 4,
 "out_size": 59388,
 "ratio": 0.3905,
-"compress_mbps": 30.69,
-"decompress_mbps": 78.39
+"compress_mbps": 31.24,
+"decompress_mbps": 79.63
 },
 {
 "compressor": "ocaml",
@@ -14544,8 +14544,8 @@
 "level": 5,
 "out_size": 57062,
 "ratio": 0.3752,
-"compress_mbps": 22.12,
-"decompress_mbps": 79.43
+"compress_mbps": 22.6,
+"decompress_mbps": 78.83
 },
 {
 "compressor": "ocaml",
@@ -14554,8 +14554,8 @@
 "level": 6,
 "out_size": 55472,
 "ratio": 0.3647,
-"compress_mbps": 16.01,
-"decompress_mbps": 79.84
+"compress_mbps": 16.18,
+"decompress_mbps": 78.52
 },
 {
 "compressor": "ocaml",
@@ -14564,8 +14564,8 @@
 "level": 7,
 "out_size": 55265,
 "ratio": 0.3634,
-"compress_mbps": 13.97,
-"decompress_mbps": 77.77
+"compress_mbps": 14.28,
+"decompress_mbps": 78.61
 },
 {
 "compressor": "ocaml",
@@ -14574,8 +14574,8 @@
 "level": 8,
 "out_size": 55168,
 "ratio": 0.3627,
-"compress_mbps": 11.77,
-"decompress_mbps": 78.91
+"compress_mbps": 11.94,
+"decompress_mbps": 78.29
 },
 {
 "compressor": "ocaml",
@@ -14584,8 +14584,8 @@
 "level": 9,
 "out_size": 55168,
 "ratio": 0.3627,
-"compress_mbps": 11.79,
-"decompress_mbps": 78.77
+"compress_mbps": 11.86,
+"decompress_mbps": 79.16
 },
 {
 "compressor": "ocaml",
@@ -14594,8 +14594,8 @@
 "level": 1,
 "out_size": 64551,
 "ratio": 0.5157,
-"compress_mbps": 31.6,
-"decompress_mbps": 53.18
+"compress_mbps": 32.2,
+"decompress_mbps": 54.09
 },
 {
 "compressor": "ocaml",
@@ -14604,8 +14604,8 @@
 "level": 2,
 "out_size": 62089,
 "ratio": 0.496,
-"compress_mbps": 29.97,
-"decompress_mbps": 57.81
+"compress_mbps": 30.28,
+"decompress_mbps": 56.87
 },
 {
 "compressor": "ocaml",
@@ -14614,8 +14614,8 @@
 "level": 3,
 "out_size": 58690,
 "ratio": 0.4688,
-"compress_mbps": 24.09,
-"decompress_mbps": 59.33
+"compress_mbps": 24.62,
+"decompress_mbps": 59.34
 },
 {
 "compressor": "ocaml",
@@ -14624,8 +14624,8 @@
 "level": 4,
 "out_size": 53521,
 "ratio": 0.4276,
-"compress_mbps": 29.42,
-"decompress_mbps": 79.33
+"compress_mbps": 30.14,
+"decompress_mbps": 80.01
 },
 {
 "compressor": "ocaml",
@@ -14634,8 +14634,8 @@
 "level": 5,
 "out_size": 51677,
 "ratio": 0.4128,
-"compress_mbps": 20.39,
-"decompress_mbps": 77.94
+"compress_mbps": 20.84,
+"decompress_mbps": 76.53
 },
 {
 "compressor": "ocaml",
@@ -14644,8 +14644,8 @@
 "level": 6,
 "out_size": 50638,
 "ratio": 0.4045,
-"compress_mbps": 14.72,
-"decompress_mbps": 82.81
+"compress_mbps": 15.0,
+"decompress_mbps": 82.97
 },
 {
 "compressor": "ocaml",
@@ -14654,8 +14654,8 @@
 "level": 7,
 "out_size": 50501,
 "ratio": 0.4034,
-"compress_mbps": 13.44,
-"decompress_mbps": 79.24
+"compress_mbps": 13.52,
+"decompress_mbps": 79.81
 },
 {
 "compressor": "ocaml",
@@ -14664,8 +14664,8 @@
 "level": 8,
 "out_size": 50452,
 "ratio": 0.403,
-"compress_mbps": 12.47,
-"decompress_mbps": 82.14
+"compress_mbps": 12.55,
+"decompress_mbps": 83.02
 },
 {
 "compressor": "ocaml",
@@ -14674,8 +14674,8 @@
 "level": 9,
 "out_size": 50452,
 "ratio": 0.403,
-"compress_mbps": 12.44,
-"decompress_mbps": 81.43
+"compress_mbps": 12.61,
+"decompress_mbps": 83.15
 },
 {
 "compressor": "ocaml",
@@ -14684,8 +14684,8 @@
 "level": 1,
 "out_size": 9859,
 "ratio": 0.4007,
-"compress_mbps": 43.17,
-"decompress_mbps": 111.05
+"compress_mbps": 43.54,
+"decompress_mbps": 111.31
 },
 {
 "compressor": "ocaml",
@@ -14694,8 +14694,8 @@
 "level": 2,
 "out_size": 10473,
 "ratio": 0.4257,
-"compress_mbps": 47.13,
-"decompress_mbps": 149.74
+"compress_mbps": 46.87,
+"decompress_mbps": 149.71
 },
 {
 "compressor": "ocaml",
@@ -14704,8 +14704,8 @@
 "level": 3,
 "out_size": 10172,
 "ratio": 0.4134,
-"compress_mbps": 42.9,
-"decompress_mbps": 152.76
+"compress_mbps": 42.71,
+"decompress_mbps": 153.65
 },
 {
 "compressor": "ocaml",
@@ -14714,8 +14714,8 @@
 "level": 4,
 "out_size": 8692,
 "ratio": 0.3533,
-"compress_mbps": 40.18,
-"decompress_mbps": 151.47
+"compress_mbps": 40.71,
+"decompress_mbps": 153.37
 },
 {
 "compressor": "ocaml",
@@ -14724,8 +14724,8 @@
 "level": 5,
 "out_size": 8440,
 "ratio": 0.343,
-"compress_mbps": 35.81,
-"decompress_mbps": 156.86
+"compress_mbps": 36.08,
+"decompress_mbps": 158.21
 },
 {
 "compressor": "ocaml",
@@ -14734,8 +14734,8 @@
 "level": 6,
 "out_size": 8385,
 "ratio": 0.3408,
-"compress_mbps": 30.79,
-"decompress_mbps": 158.1
+"compress_mbps": 31.73,
+"decompress_mbps": 157.16
 },
 {
 "compressor": "ocaml",
@@ -14744,8 +14744,8 @@
 "level": 7,
 "out_size": 8366,
 "ratio": 0.34,
-"compress_mbps": 29.75,
-"decompress_mbps": 159.29
+"compress_mbps": 30.2,
+"decompress_mbps": 158.76
 },
 {
 "compressor": "ocaml",
@@ -14754,8 +14754,8 @@
 "level": 8,
 "out_size": 8367,
 "ratio": 0.3401,
-"compress_mbps": 28.46,
-"decompress_mbps": 155.58
+"compress_mbps": 28.66,
+"decompress_mbps": 157.83
 },
 {
 "compressor": "ocaml",
@@ -14764,8 +14764,8 @@
 "level": 9,
 "out_size": 8367,
 "ratio": 0.3401,
-"compress_mbps": 28.32,
-"decompress_mbps": 160.4
+"compress_mbps": 28.99,
+"decompress_mbps": 158.84
 },
 {
 "compressor": "ocaml",
@@ -14774,8 +14774,8 @@
 "level": 1,
 "out_size": 4822,
 "ratio": 0.4325,
-"compress_mbps": 54.31,
-"decompress_mbps": 188.8
+"compress_mbps": 53.77,
+"decompress_mbps": 185.7
 },
 {
 "compressor": "ocaml",
@@ -14784,8 +14784,8 @@
 "level": 2,
 "out_size": 4593,
 "ratio": 0.4119,
-"compress_mbps": 54.72,
-"decompress_mbps": 194.53
+"compress_mbps": 53.98,
+"decompress_mbps": 192.69
 },
 {
 "compressor": "ocaml",
@@ -14794,8 +14794,8 @@
 "level": 3,
 "out_size": 4381,
 "ratio": 0.3929,
-"compress_mbps": 51.78,
-"decompress_mbps": 200.26
+"compress_mbps": 49.66,
+"decompress_mbps": 199.95
 },
 {
 "compressor": "ocaml",
@@ -14804,8 +14804,8 @@
 "level": 4,
 "out_size": 3725,
 "ratio": 0.3341,
-"compress_mbps": 51.41,
-"decompress_mbps": 204.03
+"compress_mbps": 49.25,
+"decompress_mbps": 202.48
 },
 {
 "compressor": "ocaml",
@@ -14814,8 +14814,8 @@
 "level": 5,
 "out_size": 3614,
 "ratio": 0.3241,
-"compress_mbps": 43.8,
-"decompress_mbps": 210.08
+"compress_mbps": 44.83,
+"decompress_mbps": 207.77
 },
 {
 "compressor": "ocaml",
@@ -14824,8 +14824,8 @@
 "level": 6,
 "out_size": 3578,
 "ratio": 0.3209,
-"compress_mbps": 38.72,
-"decompress_mbps": 209.42
+"compress_mbps": 39.17,
+"decompress_mbps": 212.51
 },
 {
 "compressor": "ocaml",
@@ -14834,8 +14834,8 @@
 "level": 7,
 "out_size": 3572,
 "ratio": 0.3204,
-"compress_mbps": 36.4,
-"decompress_mbps": 207.75
+"compress_mbps": 35.82,
+"decompress_mbps": 207.62
 },
 {
 "compressor": "ocaml",
@@ -14844,8 +14844,8 @@
 "level": 8,
 "out_size": 3568,
 "ratio": 0.32,
-"compress_mbps": 34.31,
-"decompress_mbps": 210.06
+"compress_mbps": 34.39,
+"decompress_mbps": 207.77
 },
 {
 "compressor": "ocaml",
@@ -14854,8 +14854,8 @@
 "level": 9,
 "out_size": 3568,
 "ratio": 0.32,
-"compress_mbps": 32.71,
-"decompress_mbps": 208.67
+"compress_mbps": 34.56,
+"decompress_mbps": 208.5
 },
 {
 "compressor": "ocaml",
@@ -14864,8 +14864,8 @@
 "level": 1,
 "out_size": 1738,
 "ratio": 0.4671,
-"compress_mbps": 31.49,
-"decompress_mbps": 176.54
+"compress_mbps": 32.48,
+"decompress_mbps": 174.63
 },
 {
 "compressor": "ocaml",
@@ -14874,8 +14874,8 @@
 "level": 2,
 "out_size": 1709,
 "ratio": 0.4593,
-"compress_mbps": 31.3,
-"decompress_mbps": 174.1
+"compress_mbps": 31.71,
+"decompress_mbps": 177.26
 },
 {
 "compressor": "ocaml",
@@ -14884,8 +14884,8 @@
 "level": 3,
 "out_size": 1694,
 "ratio": 0.4553,
-"compress_mbps": 32.15,
-"decompress_mbps": 179.56
+"compress_mbps": 29.7,
+"decompress_mbps": 178.26
 },
 {
 "compressor": "ocaml",
@@ -14894,8 +14894,8 @@
 "level": 4,
 "out_size": 1458,
 "ratio": 0.3918,
-"compress_mbps": 29.79,
-"decompress_mbps": 186.21
+"compress_mbps": 29.97,
+"decompress_mbps": 186.97
 },
 {
 "compressor": "ocaml",
@@ -14904,8 +14904,8 @@
 "level": 5,
 "out_size": 1441,
 "ratio": 0.3873,
-"compress_mbps": 27.88,
-"decompress_mbps": 189.73
+"compress_mbps": 28.83,
+"decompress_mbps": 189.52
 },
 {
 "compressor": "ocaml",
@@ -14914,8 +14914,8 @@
 "level": 6,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 27.43,
-"decompress_mbps": 190.2
+"compress_mbps": 28.26,
+"decompress_mbps": 189.58
 },
 {
 "compressor": "ocaml",
@@ -14924,8 +14924,8 @@
 "level": 7,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 27.75,
-"decompress_mbps": 189.99
+"compress_mbps": 27.56,
+"decompress_mbps": 188.96
 },
 {
 "compressor": "ocaml",
@@ -14934,8 +14934,8 @@
 "level": 8,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 26.93,
-"decompress_mbps": 189.16
+"compress_mbps": 27.47,
+"decompress_mbps": 188.08
 },
 {
 "compressor": "ocaml",
@@ -14944,8 +14944,8 @@
 "level": 9,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 27.06,
-"decompress_mbps": 189.11
+"compress_mbps": 26.24,
+"decompress_mbps": 189.94
 },
 {
 "compressor": "ocaml",
@@ -14954,8 +14954,8 @@
 "level": 1,
 "out_size": 260073,
 "ratio": 0.2526,
-"compress_mbps": 51.81,
-"decompress_mbps": 56.81
+"compress_mbps": 52.66,
+"decompress_mbps": 56.46
 },
 {
 "compressor": "ocaml",
@@ -14964,8 +14964,8 @@
 "level": 2,
 "out_size": 296764,
 "ratio": 0.2882,
-"compress_mbps": 49.08,
-"decompress_mbps": 77.21
+"compress_mbps": 49.0,
+"decompress_mbps": 76.74
 },
 {
 "compressor": "ocaml",
@@ -14974,8 +14974,8 @@
 "level": 3,
 "out_size": 288989,
 "ratio": 0.2806,
-"compress_mbps": 37.29,
-"decompress_mbps": 77.77
+"compress_mbps": 37.68,
+"decompress_mbps": 78.07
 },
 {
 "compressor": "ocaml",
@@ -14984,7 +14984,7 @@
 "level": 4,
 "out_size": 246442,
 "ratio": 0.2393,
-"compress_mbps": 54.05,
+"compress_mbps": 54.41,
 "decompress_mbps": 82.33
 },
 {
@@ -14994,8 +14994,8 @@
 "level": 5,
 "out_size": 218888,
 "ratio": 0.2126,
-"compress_mbps": 40.22,
-"decompress_mbps": 76.98
+"compress_mbps": 40.32,
+"decompress_mbps": 75.78
 },
 {
 "compressor": "ocaml",
@@ -15005,7 +15005,7 @@
 "out_size": 217830,
 "ratio": 0.2115,
 "compress_mbps": 24.1,
-"decompress_mbps": 87.7
+"decompress_mbps": 86.8
 },
 {
 "compressor": "ocaml",
@@ -15014,8 +15014,8 @@
 "level": 7,
 "out_size": 221437,
 "ratio": 0.215,
-"compress_mbps": 19.08,
-"decompress_mbps": 86.08
+"compress_mbps": 19.14,
+"decompress_mbps": 86.26
 },
 {
 "compressor": "ocaml",
@@ -15024,8 +15024,8 @@
 "level": 8,
 "out_size": 219666,
 "ratio": 0.2133,
-"compress_mbps": 5.51,
-"decompress_mbps": 85.9
+"compress_mbps": 5.5,
+"decompress_mbps": 85.14
 },
 {
 "compressor": "ocaml",
@@ -15034,8 +15034,8 @@
 "level": 9,
 "out_size": 219921,
 "ratio": 0.2136,
-"compress_mbps": 2.78,
-"decompress_mbps": 86.47
+"compress_mbps": 2.8,
+"decompress_mbps": 86.65
 },
 {
 "compressor": "ocaml",
@@ -15044,8 +15044,8 @@
 "level": 1,
 "out_size": 194588,
 "ratio": 0.456,
-"compress_mbps": 33.63,
-"decompress_mbps": 50.66
+"compress_mbps": 34.52,
+"decompress_mbps": 51.66
 },
 {
 "compressor": "ocaml",
@@ -15054,8 +15054,8 @@
 "level": 2,
 "out_size": 185757,
 "ratio": 0.4353,
-"compress_mbps": 32.08,
-"decompress_mbps": 48.38
+"compress_mbps": 33.15,
+"decompress_mbps": 49.3
 },
 {
 "compressor": "ocaml",
@@ -15064,8 +15064,8 @@
 "level": 3,
 "out_size": 175850,
 "ratio": 0.4121,
-"compress_mbps": 26.9,
-"decompress_mbps": 60.28
+"compress_mbps": 27.26,
+"decompress_mbps": 59.72
 },
 {
 "compressor": "ocaml",
@@ -15074,8 +15074,8 @@
 "level": 4,
 "out_size": 155951,
 "ratio": 0.3654,
-"compress_mbps": 31.36,
-"decompress_mbps": 71.42
+"compress_mbps": 32.27,
+"decompress_mbps": 72.52
 },
 {
 "compressor": "ocaml",
@@ -15084,8 +15084,8 @@
 "level": 5,
 "out_size": 150274,
 "ratio": 0.3521,
-"compress_mbps": 22.49,
-"decompress_mbps": 70.19
+"compress_mbps": 23.03,
+"decompress_mbps": 71.42
 },
 {
 "compressor": "ocaml",
@@ -15094,8 +15094,8 @@
 "level": 6,
 "out_size": 147958,
 "ratio": 0.3467,
-"compress_mbps": 16.44,
-"decompress_mbps": 71.91
+"compress_mbps": 16.76,
+"decompress_mbps": 73.05
 },
 {
 "compressor": "ocaml",
@@ -15104,8 +15104,8 @@
 "level": 7,
 "out_size": 147522,
 "ratio": 0.3457,
-"compress_mbps": 14.83,
-"decompress_mbps": 70.62
+"compress_mbps": 15.07,
+"decompress_mbps": 71.55
 },
 {
 "compressor": "ocaml",
@@ -15114,8 +15114,8 @@
 "level": 8,
 "out_size": 147331,
 "ratio": 0.3452,
-"compress_mbps": 13.29,
-"decompress_mbps": 70.51
+"compress_mbps": 13.67,
+"decompress_mbps": 71.85
 },
 {
 "compressor": "ocaml",
@@ -15124,8 +15124,8 @@
 "level": 9,
 "out_size": 147328,
 "ratio": 0.3452,
-"compress_mbps": 13.48,
-"decompress_mbps": 72.46
+"compress_mbps": 13.47,
+"decompress_mbps": 72.05
 },
 {
 "compressor": "ocaml",
@@ -15134,8 +15134,8 @@
 "level": 1,
 "out_size": 256904,
 "ratio": 0.5331,
-"compress_mbps": 29.27,
-"decompress_mbps": 46.15
+"compress_mbps": 30.1,
+"decompress_mbps": 47.01
 },
 {
 "compressor": "ocaml",
@@ -15144,8 +15144,8 @@
 "level": 2,
 "out_size": 245675,
 "ratio": 0.5098,
-"compress_mbps": 28.15,
-"decompress_mbps": 50.28
+"compress_mbps": 28.47,
+"decompress_mbps": 49.62
 },
 {
 "compressor": "ocaml",
@@ -15154,8 +15154,8 @@
 "level": 3,
 "out_size": 231519,
 "ratio": 0.4805,
-"compress_mbps": 22.21,
-"decompress_mbps": 55.85
+"compress_mbps": 22.44,
+"decompress_mbps": 56.21
 },
 {
 "compressor": "ocaml",
@@ -15164,8 +15164,8 @@
 "level": 4,
 "out_size": 210028,
 "ratio": 0.4359,
-"compress_mbps": 26.92,
-"decompress_mbps": 63.6
+"compress_mbps": 27.54,
+"decompress_mbps": 64.63
 },
 {
 "compressor": "ocaml",
@@ -15174,8 +15174,8 @@
 "level": 5,
 "out_size": 203312,
 "ratio": 0.4219,
-"compress_mbps": 18.18,
-"decompress_mbps": 60.76
+"compress_mbps": 18.62,
+"decompress_mbps": 61.83
 },
 {
 "compressor": "ocaml",
@@ -15184,8 +15184,8 @@
 "level": 6,
 "out_size": 199287,
 "ratio": 0.4136,
-"compress_mbps": 12.64,
-"decompress_mbps": 65.84
+"compress_mbps": 12.8,
+"decompress_mbps": 65.1
 },
 {
 "compressor": "ocaml",
@@ -15194,8 +15194,8 @@
 "level": 7,
 "out_size": 198474,
 "ratio": 0.4119,
-"compress_mbps": 11.07,
-"decompress_mbps": 64.82
+"compress_mbps": 11.19,
+"decompress_mbps": 65.82
 },
 {
 "compressor": "ocaml",
@@ -15204,8 +15204,8 @@
 "level": 8,
 "out_size": 198080,
 "ratio": 0.4111,
-"compress_mbps": 8.69,
-"decompress_mbps": 64.04
+"compress_mbps": 8.83,
+"decompress_mbps": 65.58
 },
 {
 "compressor": "ocaml",
@@ -15214,8 +15214,8 @@
 "level": 9,
 "out_size": 198080,
 "ratio": 0.4111,
-"compress_mbps": 8.8,
-"decompress_mbps": 65.34
+"compress_mbps": 8.81,
+"decompress_mbps": 65.07
 },
 {
 "compressor": "ocaml",
@@ -15224,8 +15224,8 @@
 "level": 1,
 "out_size": 71229,
 "ratio": 0.1388,
-"compress_mbps": 81.03,
-"decompress_mbps": 132.98
+"compress_mbps": 82.51,
+"decompress_mbps": 135.63
 },
 {
 "compressor": "ocaml",
@@ -15234,8 +15234,8 @@
 "level": 2,
 "out_size": 69946,
 "ratio": 0.1363,
-"compress_mbps": 78.22,
-"decompress_mbps": 137.65
+"compress_mbps": 79.09,
+"decompress_mbps": 136.69
 },
 {
 "compressor": "ocaml",
@@ -15244,8 +15244,8 @@
 "level": 3,
 "out_size": 68538,
 "ratio": 0.1335,
-"compress_mbps": 68.96,
-"decompress_mbps": 150.72
+"compress_mbps": 69.6,
+"decompress_mbps": 151.25
 },
 {
 "compressor": "ocaml",
@@ -15254,8 +15254,8 @@
 "level": 4,
 "out_size": 61320,
 "ratio": 0.1195,
-"compress_mbps": 63.77,
-"decompress_mbps": 163.86
+"compress_mbps": 65.9,
+"decompress_mbps": 163.79
 },
 {
 "compressor": "ocaml",
@@ -15264,8 +15264,8 @@
 "level": 5,
 "out_size": 59993,
 "ratio": 0.1169,
-"compress_mbps": 56.63,
-"decompress_mbps": 166.48
+"compress_mbps": 56.97,
+"decompress_mbps": 167.46
 },
 {
 "compressor": "ocaml",
@@ -15274,8 +15274,8 @@
 "level": 6,
 "out_size": 58637,
 "ratio": 0.1143,
-"compress_mbps": 40.57,
-"decompress_mbps": 165.63
+"compress_mbps": 41.11,
+"decompress_mbps": 168.0
 },
 {
 "compressor": "ocaml",
@@ -15284,8 +15284,8 @@
 "level": 7,
 "out_size": 58209,
 "ratio": 0.1134,
-"compress_mbps": 34.82,
-"decompress_mbps": 169.55
+"compress_mbps": 35.31,
+"decompress_mbps": 171.67
 },
 {
 "compressor": "ocaml",
@@ -15294,8 +15294,8 @@
 "level": 8,
 "out_size": 55749,
 "ratio": 0.1086,
-"compress_mbps": 19.17,
-"decompress_mbps": 176.5
+"compress_mbps": 19.28,
+"decompress_mbps": 176.91
 },
 {
 "compressor": "ocaml",
@@ -15304,8 +15304,8 @@
 "level": 9,
 "out_size": 54927,
 "ratio": 0.107,
-"compress_mbps": 7.46,
-"decompress_mbps": 174.49
+"compress_mbps": 7.51,
+"decompress_mbps": 177.06
 },
 {
 "compressor": "ocaml",
@@ -15314,8 +15314,8 @@
 "level": 1,
 "out_size": 16399,
 "ratio": 0.4288,
-"compress_mbps": 36.23,
-"decompress_mbps": 86.68
+"compress_mbps": 36.54,
+"decompress_mbps": 89.88
 },
 {
 "compressor": "ocaml",
@@ -15324,8 +15324,8 @@
 "level": 2,
 "out_size": 15933,
 "ratio": 0.4167,
-"compress_mbps": 33.59,
-"decompress_mbps": 88.69
+"compress_mbps": 33.58,
+"decompress_mbps": 91.22
 },
 {
 "compressor": "ocaml",
@@ -15334,8 +15334,8 @@
 "level": 3,
 "out_size": 15739,
 "ratio": 0.4116,
-"compress_mbps": 27.74,
-"decompress_mbps": 88.76
+"compress_mbps": 28.25,
+"decompress_mbps": 88.9
 },
 {
 "compressor": "ocaml",
@@ -15344,8 +15344,8 @@
 "level": 4,
 "out_size": 13834,
 "ratio": 0.3618,
-"compress_mbps": 31.57,
-"decompress_mbps": 106.95
+"compress_mbps": 31.89,
+"decompress_mbps": 108.89
 },
 {
 "compressor": "ocaml",
@@ -15354,8 +15354,8 @@
 "level": 5,
 "out_size": 13463,
 "ratio": 0.3521,
-"compress_mbps": 26.05,
-"decompress_mbps": 110.01
+"compress_mbps": 26.23,
+"decompress_mbps": 109.05
 },
 {
 "compressor": "ocaml",
@@ -15364,8 +15364,8 @@
 "level": 6,
 "out_size": 13353,
 "ratio": 0.3492,
-"compress_mbps": 18.59,
-"decompress_mbps": 109.84
+"compress_mbps": 18.79,
+"decompress_mbps": 111.32
 },
 {
 "compressor": "ocaml",
@@ -15374,8 +15374,8 @@
 "level": 7,
 "out_size": 13317,
 "ratio": 0.3482,
-"compress_mbps": 16.08,
-"decompress_mbps": 111.6
+"compress_mbps": 15.84,
+"decompress_mbps": 110.95
 },
 {
 "compressor": "ocaml",
@@ -15384,8 +15384,8 @@
 "level": 8,
 "out_size": 13255,
 "ratio": 0.3466,
-"compress_mbps": 8.31,
-"decompress_mbps": 109.02
+"compress_mbps": 8.39,
+"decompress_mbps": 111.15
 },
 {
 "compressor": "ocaml",
@@ -15395,7 +15395,7 @@
 "out_size": 13171,
 "ratio": 0.3444,
 "compress_mbps": 4.16,
-"decompress_mbps": 112.67
+"decompress_mbps": 112.86
 },
 {
 "compressor": "ocaml",
@@ -15404,8 +15404,8 @@
 "level": 1,
 "out_size": 2512,
 "ratio": 0.5943,
-"compress_mbps": 28.59,
-"decompress_mbps": 157.34
+"compress_mbps": 29.81,
+"decompress_mbps": 154.08
 },
 {
 "compressor": "ocaml",
@@ -15414,8 +15414,8 @@
 "level": 2,
 "out_size": 2477,
 "ratio": 0.586,
-"compress_mbps": 30.62,
-"decompress_mbps": 160.88
+"compress_mbps": 29.79,
+"decompress_mbps": 155.26
 },
 {
 "compressor": "ocaml",
@@ -15424,8 +15424,8 @@
 "level": 3,
 "out_size": 2452,
 "ratio": 0.5801,
-"compress_mbps": 30.5,
-"decompress_mbps": 156.0
+"compress_mbps": 31.0,
+"decompress_mbps": 151.67
 },
 {
 "compressor": "ocaml",
@@ -15434,8 +15434,8 @@
 "level": 4,
 "out_size": 2110,
 "ratio": 0.4992,
-"compress_mbps": 29.57,
-"decompress_mbps": 161.34
+"compress_mbps": 30.3,
+"decompress_mbps": 161.11
 },
 {
 "compressor": "ocaml",
@@ -15444,8 +15444,8 @@
 "level": 5,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 28.43,
-"decompress_mbps": 168.67
+"compress_mbps": 29.02,
+"decompress_mbps": 165.2
 },
 {
 "compressor": "ocaml",
@@ -15454,8 +15454,8 @@
 "level": 6,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 29.07,
-"decompress_mbps": 167.95
+"compress_mbps": 29.08,
+"decompress_mbps": 165.34
 },
 {
 "compressor": "ocaml",
@@ -15464,8 +15464,8 @@
 "level": 7,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 27.41,
-"decompress_mbps": 167.27
+"compress_mbps": 28.71,
+"decompress_mbps": 166.7
 },
 {
 "compressor": "ocaml",
@@ -15474,8 +15474,8 @@
 "level": 8,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 28.33,
-"decompress_mbps": 164.27
+"compress_mbps": 28.43,
+"decompress_mbps": 166.88
 },
 {
 "compressor": "ocaml",
@@ -15484,8 +15484,8 @@
 "level": 9,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 28.09,
-"decompress_mbps": 169.39
+"compress_mbps": 28.46,
+"decompress_mbps": 164.41
 },
 {
 "compressor": "ocaml",
@@ -15494,8 +15494,8 @@
 "level": 1,
 "out_size": 5183792,
 "ratio": 0.5086,
-"compress_mbps": 30.77,
-"decompress_mbps": 39.93
+"compress_mbps": 31.47,
+"decompress_mbps": 38.98
 },
 {
 "compressor": "ocaml",
@@ -15504,8 +15504,8 @@
 "level": 2,
 "out_size": 4956750,
 "ratio": 0.4863,
-"compress_mbps": 29.29,
-"decompress_mbps": 42.84
+"compress_mbps": 30.25,
+"decompress_mbps": 43.89
 },
 {
 "compressor": "ocaml",
@@ -15514,8 +15514,8 @@
 "level": 3,
 "out_size": 4644095,
 "ratio": 0.4556,
-"compress_mbps": 23.47,
-"decompress_mbps": 47.4
+"compress_mbps": 23.95,
+"decompress_mbps": 47.67
 },
 {
 "compressor": "ocaml",
@@ -15524,8 +15524,8 @@
 "level": 4,
 "out_size": 4178564,
 "ratio": 0.41,
-"compress_mbps": 28.65,
-"decompress_mbps": 61.76
+"compress_mbps": 29.16,
+"decompress_mbps": 61.79
 },
 {
 "compressor": "ocaml",
@@ -15534,8 +15534,8 @@
 "level": 5,
 "out_size": 4034632,
 "ratio": 0.3958,
-"compress_mbps": 19.49,
-"decompress_mbps": 59.37
+"compress_mbps": 19.82,
+"decompress_mbps": 59.29
 },
 {
 "compressor": "ocaml",
@@ -15544,8 +15544,8 @@
 "level": 6,
 "out_size": 3952244,
 "ratio": 0.3878,
-"compress_mbps": 14.0,
-"decompress_mbps": 61.27
+"compress_mbps": 13.96,
+"decompress_mbps": 60.98
 },
 {
 "compressor": "ocaml",
@@ -15554,8 +15554,8 @@
 "level": 7,
 "out_size": 3938822,
 "ratio": 0.3864,
-"compress_mbps": 12.03,
-"decompress_mbps": 61.12
+"compress_mbps": 12.24,
+"decompress_mbps": 62.47
 },
 {
 "compressor": "ocaml",
@@ -15564,8 +15564,8 @@
 "level": 8,
 "out_size": 3935171,
 "ratio": 0.3861,
-"compress_mbps": 10.86,
-"decompress_mbps": 60.97
+"compress_mbps": 10.71,
+"decompress_mbps": 60.98
 },
 {
 "compressor": "ocaml",
@@ -15574,8 +15574,8 @@
 "level": 9,
 "out_size": 3935171,
 "ratio": 0.3861,
-"compress_mbps": 10.73,
-"decompress_mbps": 60.32
+"compress_mbps": 10.81,
+"decompress_mbps": 61.24
 },
 {
 "compressor": "ocaml",
@@ -15584,8 +15584,8 @@
 "level": 1,
 "out_size": 25320013,
 "ratio": 0.4943,
-"compress_mbps": 32.17,
-"decompress_mbps": 35.27
+"compress_mbps": 31.93,
+"decompress_mbps": 33.07
 },
 {
 "compressor": "ocaml",
@@ -15594,8 +15594,8 @@
 "level": 2,
 "out_size": 24804084,
 "ratio": 0.4843,
-"compress_mbps": 29.68,
-"decompress_mbps": 36.27
+"compress_mbps": 30.27,
+"decompress_mbps": 36.09
 },
 {
 "compressor": "ocaml",
@@ -15604,8 +15604,8 @@
 "level": 3,
 "out_size": 24241121,
 "ratio": 0.4733,
-"compress_mbps": 25.65,
-"decompress_mbps": 37.86
+"compress_mbps": 25.61,
+"decompress_mbps": 37.55
 },
 {
 "compressor": "ocaml",
@@ -15614,8 +15614,8 @@
 "level": 4,
 "out_size": 20950547,
 "ratio": 0.409,
-"compress_mbps": 29.21,
-"decompress_mbps": 44.17
+"compress_mbps": 29.06,
+"decompress_mbps": 43.69
 },
 {
 "compressor": "ocaml",
@@ -15624,8 +15624,8 @@
 "level": 5,
 "out_size": 20592289,
 "ratio": 0.402,
-"compress_mbps": 23.88,
-"decompress_mbps": 45.98
+"compress_mbps": 24.48,
+"decompress_mbps": 45.78
 },
 {
 "compressor": "ocaml",
@@ -15634,8 +15634,8 @@
 "level": 6,
 "out_size": 20445232,
 "ratio": 0.3992,
-"compress_mbps": 18.44,
-"decompress_mbps": 45.64
+"compress_mbps": 18.62,
+"decompress_mbps": 45.31
 },
 {
 "compressor": "ocaml",
@@ -15644,8 +15644,8 @@
 "level": 7,
 "out_size": 20407676,
 "ratio": 0.3984,
-"compress_mbps": 15.82,
-"decompress_mbps": 46.85
+"compress_mbps": 15.97,
+"decompress_mbps": 46.23
 },
 {
 "compressor": "ocaml",
@@ -15655,7 +15655,7 @@
 "out_size": 20389473,
 "ratio": 0.3981,
 "compress_mbps": 10.05,
-"decompress_mbps": 45.49
+"decompress_mbps": 44.91
 },
 {
 "compressor": "ocaml",
@@ -15664,8 +15664,8 @@
 "level": 9,
 "out_size": 20386824,
 "ratio": 0.398,
-"compress_mbps": 6.72,
-"decompress_mbps": 45.98
+"compress_mbps": 6.78,
+"decompress_mbps": 45.36
 },
 {
 "compressor": "ocaml",
@@ -15674,8 +15674,8 @@
 "level": 1,
 "out_size": 3964698,
 "ratio": 0.3976,
-"compress_mbps": 37.43,
-"decompress_mbps": 48.15
+"compress_mbps": 38.0,
+"decompress_mbps": 48.02
 },
 {
 "compressor": "ocaml",
@@ -15684,8 +15684,8 @@
 "level": 2,
 "out_size": 3936391,
 "ratio": 0.3948,
-"compress_mbps": 35.0,
-"decompress_mbps": 47.82
+"compress_mbps": 35.55,
+"decompress_mbps": 47.72
 },
 {
 "compressor": "ocaml",
@@ -15694,8 +15694,8 @@
 "level": 3,
 "out_size": 3823540,
 "ratio": 0.3835,
-"compress_mbps": 27.24,
-"decompress_mbps": 50.96
+"compress_mbps": 27.57,
+"decompress_mbps": 51.37
 },
 {
 "compressor": "ocaml",
@@ -15704,8 +15704,8 @@
 "level": 4,
 "out_size": 3799601,
 "ratio": 0.3811,
-"compress_mbps": 32.51,
-"decompress_mbps": 63.18
+"compress_mbps": 32.67,
+"decompress_mbps": 63.56
 },
 {
 "compressor": "ocaml",
@@ -15714,8 +15714,8 @@
 "level": 5,
 "out_size": 3830938,
 "ratio": 0.3842,
-"compress_mbps": 22.12,
-"decompress_mbps": 57.68
+"compress_mbps": 22.43,
+"decompress_mbps": 57.66
 },
 {
 "compressor": "ocaml",
@@ -15724,8 +15724,8 @@
 "level": 6,
 "out_size": 3808303,
 "ratio": 0.382,
-"compress_mbps": 14.51,
-"decompress_mbps": 57.17
+"compress_mbps": 14.66,
+"decompress_mbps": 57.39
 },
 {
 "compressor": "ocaml",
@@ -15734,8 +15734,8 @@
 "level": 7,
 "out_size": 3802814,
 "ratio": 0.3814,
-"compress_mbps": 11.93,
-"decompress_mbps": 57.1
+"compress_mbps": 12.05,
+"decompress_mbps": 57.75
 },
 {
 "compressor": "ocaml",
@@ -15744,8 +15744,8 @@
 "level": 8,
 "out_size": 3800355,
 "ratio": 0.3812,
-"compress_mbps": 6.76,
-"decompress_mbps": 59.02
+"compress_mbps": 6.78,
+"decompress_mbps": 57.82
 },
 {
 "compressor": "ocaml",
@@ -15754,8 +15754,8 @@
 "level": 9,
 "out_size": 3799676,
 "ratio": 0.3811,
-"compress_mbps": 5.98,
-"decompress_mbps": 58.97
+"compress_mbps": 6.04,
+"decompress_mbps": 59.04
 },
 {
 "compressor": "ocaml",
@@ -15764,8 +15764,8 @@
 "level": 1,
 "out_size": 4899547,
 "ratio": 0.146,
-"compress_mbps": 94.34,
-"decompress_mbps": 131.22
+"compress_mbps": 96.35,
+"decompress_mbps": 131.72
 },
 {
 "compressor": "ocaml",
@@ -15774,8 +15774,8 @@
 "level": 2,
 "out_size": 4587004,
 "ratio": 0.1367,
-"compress_mbps": 93.15,
-"decompress_mbps": 140.57
+"compress_mbps": 95.35,
+"decompress_mbps": 143.05
 },
 {
 "compressor": "ocaml",
@@ -15784,8 +15784,8 @@
 "level": 3,
 "out_size": 4229035,
 "ratio": 0.126,
-"compress_mbps": 90.53,
-"decompress_mbps": 151.34
+"compress_mbps": 90.34,
+"decompress_mbps": 152.49
 },
 {
 "compressor": "ocaml",
@@ -15794,8 +15794,8 @@
 "level": 4,
 "out_size": 3791322,
 "ratio": 0.113,
-"compress_mbps": 82.2,
-"decompress_mbps": 160.57
+"compress_mbps": 82.35,
+"decompress_mbps": 160.6
 },
 {
 "compressor": "ocaml",
@@ -15804,8 +15804,8 @@
 "level": 5,
 "out_size": 3449193,
 "ratio": 0.1028,
-"compress_mbps": 71.51,
-"decompress_mbps": 167.62
+"compress_mbps": 73.32,
+"decompress_mbps": 168.31
 },
 {
 "compressor": "ocaml",
@@ -15814,8 +15814,8 @@
 "level": 6,
 "out_size": 3269452,
 "ratio": 0.0974,
-"compress_mbps": 57.64,
-"decompress_mbps": 172.59
+"compress_mbps": 58.73,
+"decompress_mbps": 173.11
 },
 {
 "compressor": "ocaml",
@@ -15824,8 +15824,8 @@
 "level": 7,
 "out_size": 3211286,
 "ratio": 0.0957,
-"compress_mbps": 49.22,
-"decompress_mbps": 172.53
+"compress_mbps": 50.41,
+"decompress_mbps": 174.21
 },
 {
 "compressor": "ocaml",
@@ -15834,8 +15834,8 @@
 "level": 8,
 "out_size": 3101534,
 "ratio": 0.0924,
-"compress_mbps": 27.08,
-"decompress_mbps": 173.54
+"compress_mbps": 27.51,
+"decompress_mbps": 174.65
 },
 {
 "compressor": "ocaml",
@@ -15844,8 +15844,8 @@
 "level": 9,
 "out_size": 3058177,
 "ratio": 0.0911,
-"compress_mbps": 16.37,
-"decompress_mbps": 176.74
+"compress_mbps": 16.54,
+"decompress_mbps": 176.1
 },
 {
 "compressor": "ocaml",
@@ -15854,8 +15854,8 @@
 "level": 1,
 "out_size": 4024327,
 "ratio": 0.6541,
-"compress_mbps": 22.94,
-"decompress_mbps": 29.96
+"compress_mbps": 22.72,
+"decompress_mbps": 29.81
 },
 {
 "compressor": "ocaml",
@@ -15864,8 +15864,8 @@
 "level": 2,
 "out_size": 3953722,
 "ratio": 0.6427,
-"compress_mbps": 21.26,
-"decompress_mbps": 30.38
+"compress_mbps": 21.74,
+"decompress_mbps": 30.42
 },
 {
 "compressor": "ocaml",
@@ -15874,8 +15874,8 @@
 "level": 3,
 "out_size": 3887921,
 "ratio": 0.632,
-"compress_mbps": 18.13,
-"decompress_mbps": 31.3
+"compress_mbps": 18.56,
+"decompress_mbps": 30.97
 },
 {
 "compressor": "ocaml",
@@ -15884,8 +15884,8 @@
 "level": 4,
 "out_size": 3320440,
 "ratio": 0.5397,
-"compress_mbps": 20.42,
-"decompress_mbps": 36.94
+"compress_mbps": 21.3,
+"decompress_mbps": 37.18
 },
 {
 "compressor": "ocaml",
@@ -15894,8 +15894,8 @@
 "level": 5,
 "out_size": 3279338,
 "ratio": 0.533,
-"compress_mbps": 17.4,
-"decompress_mbps": 37.54
+"compress_mbps": 17.79,
+"decompress_mbps": 38.17
 },
 {
 "compressor": "ocaml",
@@ -15904,8 +15904,8 @@
 "level": 6,
 "out_size": 3254309,
 "ratio": 0.529,
-"compress_mbps": 13.65,
-"decompress_mbps": 37.69
+"compress_mbps": 13.86,
+"decompress_mbps": 37.85
 },
 {
 "compressor": "ocaml",
@@ -15914,8 +15914,8 @@
 "level": 7,
 "out_size": 3250139,
 "ratio": 0.5283,
-"compress_mbps": 12.25,
-"decompress_mbps": 37.8
+"compress_mbps": 12.23,
+"decompress_mbps": 37.74
 },
 {
 "compressor": "ocaml",
@@ -15924,8 +15924,8 @@
 "level": 8,
 "out_size": 3247018,
 "ratio": 0.5278,
-"compress_mbps": 9.97,
-"decompress_mbps": 37.8
+"compress_mbps": 10.19,
+"decompress_mbps": 37.83
 },
 {
 "compressor": "ocaml",
@@ -15934,8 +15934,8 @@
 "level": 9,
 "out_size": 3246865,
 "ratio": 0.5278,
-"compress_mbps": 9.28,
-"decompress_mbps": 37.98
+"compress_mbps": 9.46,
+"decompress_mbps": 37.95
 },
 {
 "compressor": "ocaml",
@@ -15944,8 +15944,8 @@
 "level": 1,
 "out_size": 4471091,
 "ratio": 0.4433,
-"compress_mbps": 33.93,
-"decompress_mbps": 68.82
+"compress_mbps": 34.99,
+"decompress_mbps": 69.27
 },
 {
 "compressor": "ocaml",
@@ -15954,8 +15954,8 @@
 "level": 2,
 "out_size": 4372105,
 "ratio": 0.4335,
-"compress_mbps": 32.87,
-"decompress_mbps": 71.25
+"compress_mbps": 33.79,
+"decompress_mbps": 71.12
 },
 {
 "compressor": "ocaml",
@@ -15964,8 +15964,8 @@
 "level": 3,
 "out_size": 4305270,
 "ratio": 0.4269,
-"compress_mbps": 30.38,
-"decompress_mbps": 73.65
+"compress_mbps": 30.3,
+"decompress_mbps": 73.46
 },
 {
 "compressor": "ocaml",
@@ -15974,8 +15974,8 @@
 "level": 4,
 "out_size": 3920495,
 "ratio": 0.3887,
-"compress_mbps": 29.41,
-"decompress_mbps": 63.86
+"compress_mbps": 30.27,
+"decompress_mbps": 63.98
 },
 {
 "compressor": "ocaml",
@@ -15984,8 +15984,8 @@
 "level": 5,
 "out_size": 3853177,
 "ratio": 0.382,
-"compress_mbps": 26.8,
-"decompress_mbps": 63.63
+"compress_mbps": 26.68,
+"decompress_mbps": 63.59
 },
 {
 "compressor": "ocaml",
@@ -15994,8 +15994,8 @@
 "level": 6,
 "out_size": 3780878,
 "ratio": 0.3749,
-"compress_mbps": 22.82,
-"decompress_mbps": 63.71
+"compress_mbps": 23.33,
+"decompress_mbps": 64.2
 },
 {
 "compressor": "ocaml",
@@ -16004,8 +16004,8 @@
 "level": 7,
 "out_size": 3763880,
 "ratio": 0.3732,
-"compress_mbps": 20.08,
-"decompress_mbps": 72.97
+"compress_mbps": 20.0,
+"decompress_mbps": 72.69
 },
 {
 "compressor": "ocaml",
@@ -16014,8 +16014,8 @@
 "level": 8,
 "out_size": 3757719,
 "ratio": 0.3726,
-"compress_mbps": 18.13,
-"decompress_mbps": 73.12
+"compress_mbps": 18.2,
+"decompress_mbps": 73.09
 },
 {
 "compressor": "ocaml",
@@ -16024,8 +16024,8 @@
 "level": 9,
 "out_size": 3757719,
 "ratio": 0.3726,
-"compress_mbps": 18.21,
-"decompress_mbps": 72.47
+"compress_mbps": 18.29,
+"decompress_mbps": 72.86
 },
 {
 "compressor": "ocaml",
@@ -16034,8 +16034,8 @@
 "level": 1,
 "out_size": 2722387,
 "ratio": 0.4108,
-"compress_mbps": 37.19,
-"decompress_mbps": 64.08
+"compress_mbps": 38.07,
+"decompress_mbps": 64.75
 },
 {
 "compressor": "ocaml",
@@ -16044,8 +16044,8 @@
 "level": 2,
 "out_size": 2572544,
 "ratio": 0.3882,
-"compress_mbps": 37.09,
-"decompress_mbps": 70.76
+"compress_mbps": 37.05,
+"decompress_mbps": 71.13
 },
 {
 "compressor": "ocaml",
@@ -16054,8 +16054,8 @@
 "level": 3,
 "out_size": 2384328,
 "ratio": 0.3598,
-"compress_mbps": 28.74,
-"decompress_mbps": 78.08
+"compress_mbps": 29.52,
+"decompress_mbps": 78.46
 },
 {
 "compressor": "ocaml",
@@ -16064,8 +16064,8 @@
 "level": 4,
 "out_size": 2112060,
 "ratio": 0.3187,
-"compress_mbps": 35.58,
-"decompress_mbps": 84.42
+"compress_mbps": 36.41,
+"decompress_mbps": 85.81
 },
 {
 "compressor": "ocaml",
@@ -16074,8 +16074,8 @@
 "level": 5,
 "out_size": 1991581,
 "ratio": 0.3005,
-"compress_mbps": 24.78,
-"decompress_mbps": 89.92
+"compress_mbps": 25.5,
+"decompress_mbps": 89.89
 },
 {
 "compressor": "ocaml",
@@ -16084,8 +16084,8 @@
 "level": 6,
 "out_size": 1917866,
 "ratio": 0.2894,
-"compress_mbps": 14.81,
-"decompress_mbps": 89.37
+"compress_mbps": 15.01,
+"decompress_mbps": 90.4
 },
 {
 "compressor": "ocaml",
@@ -16094,8 +16094,8 @@
 "level": 7,
 "out_size": 1895353,
 "ratio": 0.286,
-"compress_mbps": 10.94,
-"decompress_mbps": 88.74
+"compress_mbps": 11.08,
+"decompress_mbps": 90.35
 },
 {
 "compressor": "ocaml",
@@ -16104,8 +16104,8 @@
 "level": 8,
 "out_size": 1880740,
 "ratio": 0.2838,
-"compress_mbps": 5.52,
-"decompress_mbps": 90.29
+"compress_mbps": 5.58,
+"decompress_mbps": 90.54
 },
 {
 "compressor": "ocaml",
@@ -16114,8 +16114,8 @@
 "level": 9,
 "out_size": 1880711,
 "ratio": 0.2838,
-"compress_mbps": 5.53,
-"decompress_mbps": 91.07
+"compress_mbps": 5.57,
+"decompress_mbps": 91.23
 },
 {
 "compressor": "ocaml",
@@ -16124,8 +16124,8 @@
 "level": 1,
 "out_size": 7441483,
 "ratio": 0.3444,
-"compress_mbps": 43.36,
-"decompress_mbps": 66.13
+"compress_mbps": 44.39,
+"decompress_mbps": 66.76
 },
 {
 "compressor": "ocaml",
@@ -16134,8 +16134,8 @@
 "level": 2,
 "out_size": 7229248,
 "ratio": 0.3346,
-"compress_mbps": 42.24,
-"decompress_mbps": 67.56
+"compress_mbps": 43.15,
+"decompress_mbps": 68.57
 },
 {
 "compressor": "ocaml",
@@ -16144,8 +16144,8 @@
 "level": 3,
 "out_size": 7083451,
 "ratio": 0.3278,
-"compress_mbps": 38.01,
-"decompress_mbps": 70.34
+"compress_mbps": 39.07,
+"decompress_mbps": 70.94
 },
 {
 "compressor": "ocaml",
@@ -16154,8 +16154,8 @@
 "level": 4,
 "out_size": 6189639,
 "ratio": 0.2865,
-"compress_mbps": 41.23,
-"decompress_mbps": 91.83
+"compress_mbps": 42.2,
+"decompress_mbps": 93.13
 },
 {
 "compressor": "ocaml",
@@ -16164,8 +16164,8 @@
 "level": 5,
 "out_size": 6053058,
 "ratio": 0.2802,
-"compress_mbps": 34.37,
-"decompress_mbps": 95.58
+"compress_mbps": 34.69,
+"decompress_mbps": 93.37
 },
 {
 "compressor": "ocaml",
@@ -16174,8 +16174,8 @@
 "level": 6,
 "out_size": 5988137,
 "ratio": 0.2771,
-"compress_mbps": 28.02,
-"decompress_mbps": 101.76
+"compress_mbps": 28.56,
+"decompress_mbps": 102.36
 },
 {
 "compressor": "ocaml",
@@ -16184,8 +16184,8 @@
 "level": 7,
 "out_size": 5949908,
 "ratio": 0.2754,
-"compress_mbps": 24.66,
-"decompress_mbps": 101.54
+"compress_mbps": 25.11,
+"decompress_mbps": 101.73
 },
 {
 "compressor": "ocaml",
@@ -16194,8 +16194,8 @@
 "level": 8,
 "out_size": 5936656,
 "ratio": 0.2748,
-"compress_mbps": 18.99,
-"decompress_mbps": 105.82
+"compress_mbps": 19.15,
+"decompress_mbps": 106.27
 },
 {
 "compressor": "ocaml",
@@ -16204,8 +16204,8 @@
 "level": 9,
 "out_size": 5934701,
 "ratio": 0.2747,
-"compress_mbps": 17.78,
-"decompress_mbps": 104.33
+"compress_mbps": 18.0,
+"decompress_mbps": 99.41
 },
 {
 "compressor": "ocaml",
@@ -16214,8 +16214,8 @@
 "level": 1,
 "out_size": 6335542,
 "ratio": 0.8736,
-"compress_mbps": 18.13,
-"decompress_mbps": 31.3
+"compress_mbps": 18.35,
+"decompress_mbps": 29.49
 },
 {
 "compressor": "ocaml",
@@ -16224,8 +16224,8 @@
 "level": 2,
 "out_size": 6247260,
 "ratio": 0.8615,
-"compress_mbps": 17.6,
-"decompress_mbps": 48.49
+"compress_mbps": 17.47,
+"decompress_mbps": 44.37
 },
 {
 "compressor": "ocaml",
@@ -16234,8 +16234,8 @@
 "level": 3,
 "out_size": 6064713,
 "ratio": 0.8363,
-"compress_mbps": 14.88,
-"decompress_mbps": 56.5
+"compress_mbps": 14.74,
+"decompress_mbps": 55.04
 },
 {
 "compressor": "ocaml",
@@ -16244,8 +16244,8 @@
 "level": 4,
 "out_size": 5568111,
 "ratio": 0.7678,
-"compress_mbps": 17.19,
-"decompress_mbps": 58.38
+"compress_mbps": 17.37,
+"decompress_mbps": 57.52
 },
 {
 "compressor": "ocaml",
@@ -16254,8 +16254,8 @@
 "level": 5,
 "out_size": 5544524,
 "ratio": 0.7646,
-"compress_mbps": 14.13,
-"decompress_mbps": 65.64
+"compress_mbps": 14.36,
+"decompress_mbps": 65.16
 },
 {
 "compressor": "ocaml",
@@ -16264,8 +16264,8 @@
 "level": 6,
 "out_size": 5513056,
 "ratio": 0.7602,
-"compress_mbps": 11.96,
-"decompress_mbps": 62.66
+"compress_mbps": 11.92,
+"decompress_mbps": 62.7
 },
 {
 "compressor": "ocaml",
@@ -16274,8 +16274,8 @@
 "level": 7,
 "out_size": 5508915,
 "ratio": 0.7596,
-"compress_mbps": 11.1,
-"decompress_mbps": 63.28
+"compress_mbps": 11.27,
+"decompress_mbps": 64.41
 },
 {
 "compressor": "ocaml",
@@ -16284,8 +16284,8 @@
 "level": 8,
 "out_size": 5508365,
 "ratio": 0.7596,
-"compress_mbps": 10.36,
-"decompress_mbps": 63.64
+"compress_mbps": 10.55,
+"decompress_mbps": 64.12
 },
 {
 "compressor": "ocaml",
@@ -16294,8 +16294,8 @@
 "level": 9,
 "out_size": 5508365,
 "ratio": 0.7596,
-"compress_mbps": 10.36,
-"decompress_mbps": 65.01
+"compress_mbps": 10.57,
+"decompress_mbps": 65.17
 },
 {
 "compressor": "ocaml",
@@ -16304,8 +16304,8 @@
 "level": 1,
 "out_size": 16776095,
 "ratio": 0.4046,
-"compress_mbps": 37.17,
-"decompress_mbps": 50.66
+"compress_mbps": 38.08,
+"decompress_mbps": 50.78
 },
 {
 "compressor": "ocaml",
@@ -16314,8 +16314,8 @@
 "level": 2,
 "out_size": 16032651,
 "ratio": 0.3867,
-"compress_mbps": 35.4,
-"decompress_mbps": 54.37
+"compress_mbps": 36.26,
+"decompress_mbps": 54.51
 },
 {
 "compressor": "ocaml",
@@ -16324,8 +16324,8 @@
 "level": 3,
 "out_size": 15180334,
 "ratio": 0.3662,
-"compress_mbps": 30.64,
-"decompress_mbps": 51.91
+"compress_mbps": 31.16,
+"decompress_mbps": 51.55
 },
 {
 "compressor": "ocaml",
@@ -16334,8 +16334,8 @@
 "level": 4,
 "out_size": 13261924,
 "ratio": 0.3199,
-"compress_mbps": 36.0,
-"decompress_mbps": 68.1
+"compress_mbps": 35.95,
+"decompress_mbps": 68.04
 },
 {
 "compressor": "ocaml",
@@ -16344,8 +16344,8 @@
 "level": 5,
 "out_size": 12706028,
 "ratio": 0.3065,
-"compress_mbps": 27.09,
-"decompress_mbps": 71.18
+"compress_mbps": 27.59,
+"decompress_mbps": 71.25
 },
 {
 "compressor": "ocaml",
@@ -16354,8 +16354,8 @@
 "level": 6,
 "out_size": 12464158,
 "ratio": 0.3006,
-"compress_mbps": 20.69,
-"decompress_mbps": 69.84
+"compress_mbps": 21.19,
+"decompress_mbps": 70.45
 },
 {
 "compressor": "ocaml",
@@ -16364,8 +16364,8 @@
 "level": 7,
 "out_size": 12375954,
 "ratio": 0.2985,
-"compress_mbps": 18.23,
-"decompress_mbps": 72.89
+"compress_mbps": 18.25,
+"decompress_mbps": 73.12
 },
 {
 "compressor": "ocaml",
@@ -16374,8 +16374,8 @@
 "level": 8,
 "out_size": 12321552,
 "ratio": 0.2972,
-"compress_mbps": 14.15,
-"decompress_mbps": 69.43
+"compress_mbps": 14.46,
+"decompress_mbps": 70.1
 },
 {
 "compressor": "ocaml",
@@ -16384,8 +16384,8 @@
 "level": 9,
 "out_size": 12320276,
 "ratio": 0.2972,
-"compress_mbps": 14.2,
-"decompress_mbps": 70.41
+"compress_mbps": 14.38,
+"decompress_mbps": 70.13
 },
 {
 "compressor": "ocaml",
@@ -16394,8 +16394,8 @@
 "level": 1,
 "out_size": 6799201,
 "ratio": 0.8023,
-"compress_mbps": 18.38,
-"decompress_mbps": 18.32
+"compress_mbps": 18.32,
+"decompress_mbps": 18.04
 },
 {
 "compressor": "ocaml",
@@ -16404,8 +16404,8 @@
 "level": 2,
 "out_size": 6800500,
 "ratio": 0.8025,
-"compress_mbps": 16.95,
-"decompress_mbps": 18.53
+"compress_mbps": 16.92,
+"decompress_mbps": 18.39
 },
 {
 "compressor": "ocaml",
@@ -16414,8 +16414,8 @@
 "level": 3,
 "out_size": 6803212,
 "ratio": 0.8028,
-"compress_mbps": 14.94,
-"decompress_mbps": 18.45
+"compress_mbps": 14.82,
+"decompress_mbps": 18.26
 },
 {
 "compressor": "ocaml",
@@ -16424,8 +16424,8 @@
 "level": 4,
 "out_size": 6264611,
 "ratio": 0.7393,
-"compress_mbps": 17.34,
-"decompress_mbps": 24.89
+"compress_mbps": 17.39,
+"decompress_mbps": 24.22
 },
 {
 "compressor": "ocaml",
@@ -16434,8 +16434,8 @@
 "level": 5,
 "out_size": 6217901,
 "ratio": 0.7337,
-"compress_mbps": 15.52,
-"decompress_mbps": 25.2
+"compress_mbps": 15.81,
+"decompress_mbps": 25.19
 },
 {
 "compressor": "ocaml",
@@ -16444,8 +16444,8 @@
 "level": 6,
 "out_size": 6201999,
 "ratio": 0.7319,
-"compress_mbps": 15.33,
-"decompress_mbps": 25.26
+"compress_mbps": 15.29,
+"decompress_mbps": 25.07
 },
 {
 "compressor": "ocaml",
@@ -16454,8 +16454,8 @@
 "level": 7,
 "out_size": 6201883,
 "ratio": 0.7319,
-"compress_mbps": 14.95,
-"decompress_mbps": 24.75
+"compress_mbps": 15.23,
+"decompress_mbps": 24.7
 },
 {
 "compressor": "ocaml",
@@ -16464,8 +16464,8 @@
 "level": 8,
 "out_size": 6201887,
 "ratio": 0.7319,
-"compress_mbps": 14.95,
-"decompress_mbps": 24.76
+"compress_mbps": 15.23,
+"decompress_mbps": 24.58
 },
 {
 "compressor": "ocaml",
@@ -16474,8 +16474,8 @@
 "level": 9,
 "out_size": 6201887,
 "ratio": 0.7319,
-"compress_mbps": 14.95,
-"decompress_mbps": 24.88
+"compress_mbps": 15.29,
+"decompress_mbps": 24.13
 },
 {
 "compressor": "ocaml",
@@ -16484,8 +16484,8 @@
 "level": 1,
 "out_size": 1081679,
 "ratio": 0.2024,
-"compress_mbps": 72.85,
-"decompress_mbps": 106.29
+"compress_mbps": 74.47,
+"decompress_mbps": 106.65
 },
 {
 "compressor": "ocaml",
@@ -16494,8 +16494,8 @@
 "level": 2,
 "out_size": 1001890,
 "ratio": 0.1874,
-"compress_mbps": 71.86,
-"decompress_mbps": 116.0
+"compress_mbps": 74.13,
+"decompress_mbps": 117.16
 },
 {
 "compressor": "ocaml",
@@ -16504,8 +16504,8 @@
 "level": 3,
 "out_size": 921722,
 "ratio": 0.1724,
-"compress_mbps": 64.79,
-"decompress_mbps": 126.92
+"compress_mbps": 66.44,
+"decompress_mbps": 127.48
 },
 {
 "compressor": "ocaml",
@@ -16514,8 +16514,8 @@
 "level": 4,
 "out_size": 849263,
 "ratio": 0.1589,
-"compress_mbps": 63.42,
-"decompress_mbps": 141.39
+"compress_mbps": 64.75,
+"decompress_mbps": 141.9
 },
 {
 "compressor": "ocaml",
@@ -16524,8 +16524,8 @@
 "level": 5,
 "out_size": 771964,
 "ratio": 0.1444,
-"compress_mbps": 54.19,
-"decompress_mbps": 142.42
+"compress_mbps": 55.1,
+"decompress_mbps": 143.09
 },
 {
 "compressor": "ocaml",
@@ -16534,8 +16534,8 @@
 "level": 6,
 "out_size": 728098,
 "ratio": 0.1362,
-"compress_mbps": 42.6,
-"decompress_mbps": 149.24
+"compress_mbps": 42.63,
+"decompress_mbps": 149.54
 },
 {
 "compressor": "ocaml",
@@ -16544,8 +16544,8 @@
 "level": 7,
 "out_size": 713635,
 "ratio": 0.1335,
-"compress_mbps": 36.77,
-"decompress_mbps": 153.34
+"compress_mbps": 37.43,
+"decompress_mbps": 153.92
 },
 {
 "compressor": "ocaml",
@@ -16554,8 +16554,8 @@
 "level": 8,
 "out_size": 699093,
 "ratio": 0.1308,
-"compress_mbps": 27.13,
-"decompress_mbps": 146.97
+"compress_mbps": 27.39,
+"decompress_mbps": 147.86
 },
 {
 "compressor": "ocaml",
@@ -16564,8 +16564,8 @@
 "level": 9,
 "out_size": 698459,
 "ratio": 0.1307,
-"compress_mbps": 24.94,
-"decompress_mbps": 149.33
+"compress_mbps": 25.78,
+"decompress_mbps": 149.76
 }
 ]
 }


### PR DESCRIPTION
This PR regenerates the Track D dashboard on current master (commit 1779a506, the P1a USize-`countMatch` merge), since the committed graphs still dated from the Wave-5 refresh (#2563) and did not reflect P1a. The native compress curve lifts across every level — on Silesia native's frontier now dominates pure-OCaml `decompress` across 8 of 9 levels (native L1 beats OCaml L1 on both speed and ratio; only OCaml L6 is a ~4% near-miss), and Canterbury is nearly there (its tiny files still pay native's fixed per-compress setup). Ratio is unchanged (P1a is byte-identical), so only the speed axis shifts; decode is unchanged.

🤖 Prepared with Claude Code