### PR TITLE
perf: match prefilter — skip countMatch for candidates that cannot beat best (W8)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -792,15 +792,26 @@ def chainWalkPacked (data : ByteArray) (prev : Array Nat) (windowSize pos maxLen
   if fuel = 0 then bestPos * 512 + bestLen
   else if hc : cand < pos ∧ pos - cand ≤ windowSize then
     have hcand : cand + maxLen ≤ data.size := by omega
-    let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
-    let bl := if ml > bestLen then ml else bestLen
-    let bp := if ml > bestLen then cand else bestPos
-    if bl ≥ maxLen then bp * 512 + bl
-    else chainWalkPacked data prev windowSize pos maxLen hpm hps
-      (prev[cand]'(by omega)) (fuel - 1) bl bp
+    -- Match prefilter (zlib `scan_end`): a candidate can only *beat* the current
+    -- best length if its byte at offset `bestLen` matches the one at `pos`;
+    -- otherwise `countMatch ≤ bestLen` and the update test `ml > bestLen` fails,
+    -- so the full compare is wasted. Skipping it is output-preserving.
+    let skip : Bool := if hbl : bestLen < maxLen then
+        data[cand + bestLen]'(by omega) != data[pos + bestLen]'(by omega)
+      else false
+    if skip then
+      chainWalkPacked data prev windowSize pos maxLen hpm hps
+        (prev[cand]'(by omega)) (fuel - 1) bestLen bestPos
+    else
+      let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
+      let bl := if ml > bestLen then ml else bestLen
+      let bp := if ml > bestLen then cand else bestPos
+      if bl ≥ maxLen then bp * 512 + bl
+      else chainWalkPacked data prev windowSize pos maxLen hpm hps
+        (prev[cand]'(by omega)) (fuel - 1) bl bp
   else bestPos * 512 + bestLen
 termination_by fuel
-decreasing_by omega
+decreasing_by all_goals omega
 
 /-- One runtime `pos ≤ prev.size` check guards the whole `chainWalkPacked`
     inner loop; the (unreachable) fallback packs the reference walk's pair, so

--- a/Zip/Spec/LZ77ChainCorrect.lean
+++ b/Zip/Spec/LZ77ChainCorrect.lean
@@ -249,6 +249,19 @@ result back to the reference walk's components exactly. The iterative-vs-
 recursive mainLoop proofs rewrite with the decode lemmas (side condition
 discharged by `min258_le_511`) and then proceed exactly as before. -/
 
+/-- Contrapositive of `countMatch_matches`: if the byte at offset `k` mismatches,
+    the match cannot reach length `k`, so `countMatch ≤ k`. This is what makes the
+    `chainWalkPacked` prefilter output-preserving — a candidate whose byte at the
+    current best length differs cannot beat it, so skipping its full compare loses
+    nothing. -/
+theorem countMatch_le_of_byte_ne (data : ByteArray) (cand pos maxLen : Nat)
+    (hcand : cand + maxLen ≤ data.size) (hpm : pos + maxLen ≤ data.size)
+    (k : Nat) (hne : data[cand + k]! ≠ data[pos + k]!) :
+    lz77Greedy.countMatch data cand pos maxLen hcand hpm ≤ k := by
+  rcases Nat.lt_or_ge k (lz77Greedy.countMatch data cand pos maxLen hcand hpm) with h | h
+  · exact absurd ((lz77Greedy.countMatch_matches data cand pos maxLen hcand hpm).1 k h) hne
+  · exact h
+
 /-- The packed walk computes exactly the packed image of the proven-bounds
     walk: identical control flow, with the pair accumulator carried as
     `bestPos * 512 + bestLen` at every step. -/
@@ -266,13 +279,37 @@ theorem chainWalkPacked_eq (data : ByteArray) (prev : Array Nat)
     by_cases hc : cand < pos ∧ pos - cand ≤ windowSize
     · have hcand : cand + maxLen ≤ data.size := by omega
       simp only [dif_pos hc, Nat.add_sub_cancel]
-      by_cases hml : lz77Greedy.countMatch data cand pos maxLen hcand hpm > bestLen
-      · by_cases hb : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≥ maxLen
-        · simp only [hml, hb, ↓reduceIte]
-        · simp only [hml, hb, ↓reduceIte, ih]
-      · by_cases hb : bestLen ≥ maxLen
-        · simp only [hml, hb, ↓reduceIte]
-        · simp only [hml, hb, ↓reduceIte, ih]
+      -- The prefilter `skip` only fires when the byte at offset `bestLen`
+      -- mismatches; then `countMatch ≤ bestLen` (contrapositive of
+      -- `countMatch_matches`), so the un-prefiltered `chainWalkFast` does not
+      -- update either and recurses with `(bestLen, bestPos)` — same as the skip.
+      by_cases hbl : bestLen < maxLen
+      · simp only [dif_pos hbl]
+        by_cases hbyte : data[cand + bestLen]'(by omega) = data[pos + bestLen]'(by omega)
+        · -- bytes equal → skip = false → the full-compare path
+          rw [hbyte]
+          simp only [bne_self_eq_false, Bool.false_eq_true, ↓reduceIte]
+          by_cases hml : lz77Greedy.countMatch data cand pos maxLen hcand hpm > bestLen
+          · by_cases hb : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≥ maxLen
+            · simp only [hml, hb, ↓reduceIte]
+            · simp only [hml, hb, ↓reduceIte, ih]
+          · by_cases hb : bestLen ≥ maxLen
+            · simp only [hml, hb, ↓reduceIte]
+            · simp only [hml, hb, ↓reduceIte, ih]
+        · -- bytes differ → skip = true → both sides recurse with (bestLen, bestPos)
+          have hne! : data[cand + bestLen]! ≠ data[pos + bestLen]! := by
+            rw [getElem!_pos data (cand + bestLen) (by omega),
+              getElem!_pos data (pos + bestLen) (by omega)]
+            exact hbyte
+          have hle := countMatch_le_of_byte_ne data cand pos maxLen hcand hpm bestLen hne!
+          simp only [bne_iff_ne.mpr hbyte, ↓reduceIte, Nat.not_lt.mpr hle,
+            Nat.not_le.mpr hbl, ih]
+      · -- bestLen ≥ maxLen → skip = false; countMatch ≤ maxLen ≤ bestLen, no update
+        simp only [dif_neg hbl, Bool.false_eq_true, ↓reduceIte]
+        have hle : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≤ bestLen :=
+          Nat.le_trans (lz77Greedy.countMatch_matches data cand pos maxLen hcand hpm).2
+            (Nat.le_of_not_lt hbl)
+        simp only [Nat.not_lt.mpr hle, ge_iff_le, Nat.le_of_not_lt hbl, ↓reduceIte]
     · simp only [dif_neg hc]
 
 /-- One runtime guard collapses the packed walk to the packed image of the

--- a/ZipBench.lean
+++ b/ZipBench.lean
@@ -257,6 +257,35 @@ where
       let rest := times.toList.drop 1
       let restMean := (rest.foldl (· + ·) 0).toFloat / rest.length.toFloat
       IO.println s!"size={data.size} lvl={level}: first={first}ns restMean={restMean.toString.take 9}ns ratio={(first.toFloat/restMean).toString.take 5}x"
+    -- Pareto measurement for matcher-policy experiments: steady-state compress
+    -- throughput (MB/s) AND output size (compression ratio), both axes from one
+    -- run. Builds distinct inputs (perturb one byte) to defeat CSE/memoisation.
+    | "compress-pareto" =>
+      let nin := 4
+      let reps := 12
+      let mut inputs : Array ByteArray := #[]
+      for i in [0:nin] do
+        let d := if data.size == 0 then data else
+          (data.extract 0 data.size).set! (i % data.size) (data[i % data.size]!.toNat.toUInt8 ^^^ 1)
+        inputs := inputs.push d
+      let sink (x : ByteArray) : IO UInt64 :=
+        pure (x.size.toUInt64 + (if x.size > 0 then x[0]!.toUInt64 else 0))
+      let mut acc : UInt64 := 0
+      -- warm
+      for c in inputs do acc := acc + (← sink (Zip.Native.Deflate.deflateRaw c level.toUInt8))
+      let outSize := (Zip.Native.Deflate.deflateRaw (inputs[0]!) level.toUInt8).size
+      let mut tot : Nat := 0
+      for _ in [0:reps] do
+        for c in inputs do
+          let a ← IO.monoNanosNow
+          acc := acc + (← sink (Zip.Native.Deflate.deflateRaw c level.toUInt8))
+          let b ← IO.monoNanosNow
+          tot := tot + (b - a)
+      if acc == 0xFFFFFFFFFFFFFFFF then IO.println "x"
+      let n := (reps * nin).toFloat
+      let mbps : Float := (data.size.toFloat * n) / (tot.toFloat / 1.0e9) / 1.0e6
+      let ratio : Float := 100.0 * outSize.toFloat / data.size.toFloat
+      IO.println s!"size={data.size} lvl={level}: {mbps.toString.take 7} MB/s  out={outSize} ratio={ratio.toString.take 5}%"
     -- P1 gate 2: match-length histogram of the packed matcher stream at `level`.
     -- A reference token has bit 31 set; length sits in bits 16..30. Reports the
     -- literal/reference split and how many references have ≥8 bytes of runway
@@ -268,6 +297,9 @@ where
       let mut totLen : Nat := 0
       let mut ge8 : Nat := 0
       let mut ge16 : Nat := 0
+      let mut ge32 : Nat := 0
+      let mut ge64 : Nat := 0
+      let mut ge128 : Nat := 0
       let mut buckets : Array Nat := Array.replicate 9 0  -- len 3..10 then 11+
       for w in ptoks do
         if w &&& ((1 : UInt32) <<< 31) == 0 then
@@ -278,10 +310,15 @@ where
           totLen := totLen + len
           if len ≥ 8 then ge8 := ge8 + 1
           if len ≥ 16 then ge16 := ge16 + 1
+          if len ≥ 32 then ge32 := ge32 + 1
+          if len ≥ 64 then ge64 := ge64 + 1
+          if len ≥ 128 then ge128 := ge128 + 1
           let b := if len ≤ 10 then len - 3 else 8
           buckets := buckets.set! b (buckets[b]! + 1)
       let refsF := if refs == 0 then 1.0 else refs.toFloat
-      IO.println s!"size={data.size} lvl={level}: lits={lits} refs={refs} avgLen={(totLen.toFloat/refsF).toString.take 5} ge8={ge8}({(100.0*ge8.toFloat/refsF).toString.take 4}%) ge16={ge16}({(100.0*ge16.toFloat/refsF).toString.take 4}%)"
+      let pct (n : Nat) := (100.0*n.toFloat/refsF).toString.take 4
+      IO.println s!"size={data.size} lvl={level}: lits={lits} refs={refs} avgLen={(totLen.toFloat/refsF).toString.take 5} ge8={ge8}({pct ge8}%) ge16={ge16}({pct ge16}%)"
+      IO.println s!"  nice-thresholds: ge32={ge32}({pct ge32}%) ge64={ge64}({pct ge64}%) ge128={ge128}({pct ge128}%)"
       IO.println s!"  len-buckets [3,4,5,6,7,8,9,10,11+]: {buckets.toList}"
     -- Checksum benchmarks
     | "crc32" =>

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pb0ab6e847f)">
+   <g clip-path="url(#p9e899d71ef)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJD0lEQVR4nO3YQY5lYxyH4bpVVwtBGtEtOhIJGzCU2ICplViAXViCgZEZAzE2sQMhBoLQOqW10nVbVd9raEzeL39unmcFv5Oc8+U932b/20eHE/5fdhfTC9bZPZhesMTh6s/pCctsnrs1PWGNJ5+eXsA/dbWbXrDO6XZ6wRKH8++nJyxzOj0AAODYCCwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj2u8359IYlHj1+OD1hmds3X5uesMxz+1vTE5bYXD6YnrDMF5dfTU9Y4s6Tt6cnLHO1301PWOLi8XE+18nJycnuz6vpCUu89eyr0xOWcYMFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsc2DRx8fpkescHl9MT1hmZeub0xPWGe/n16wxh/n0wvWufXG9IIlHp8d7//nvd2P0xOWuH1yc3rCMj/s705PWOLO/d30hGWO9wQBABgisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYttnfr03vWGJZzZH3I6H3fSCZQ73f5mesMZ+P71gmc1Td6cnLHG2vTE9YZnbN16YnrDGw/vTC5a5czjO9/Hw+8/TE5Y54goBAJghsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2Pdz7aXoD/G2/n17AP3T44dvpCWuc+v/833F+8B/iBAEAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY9r17301vWOL+7vH0hGW+/PH36QnLfPLu29MTlnj56demJyzz5ocfTk9Y4p3Xn5+esMzX57vpCUucbTbTE5b59LOvpycs8fCD96cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGKb6/3nh+kRKxwO++kJ/AtnlxfTE9bY3phesM4f59MLltg//8r0hGWO9Xw8O+I7g6vD9fSEJZ64Ps7nOjlxgwUAkBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx7enP30xvWGNzxO346GJ6wTKHy8vpCWvs99MLltncfHF6whKnd7+dnrDOsZ6PV7vpBcs8cbadnrDE4ddfpicsc6RfGQDAHIEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABD7Cy+xibqchBzFAAAAAElFTkSuQmCC" id="imaged3c10148a0" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJHElEQVR4nO3YTY5cVx2H4a7usgGrlQRF+VAiIgaBPTBgzg5YA3vILpgyYcCQFXiAGLEGpCAhSCILNx3j9Ic7LtdlxjzoPfpD6XlW8CvdW0fvPbvj17/bzk7R+fn0gnVe3UwvWOfVy+kFS2wPD9MTltm9/d70hDUeP5lesM6pno+vX00vWGd3ms9s++eX0xOWOc0nBgAwSGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT2fz2/nt6wxMObu+kJy3z8zqfTE5a5PL4/PWGJ3d2L6QnL/PHuz9MTlvjkex9MT1jmcPx2esISLw630xOWORyP0xOW+NnbP5qesIwbLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIjtXj78fpsescL94WZ6wjLvHZ9MT1jn9avpBWvcXk8vWOf9T6cXLHFzdqLv4tnZ2e3h5fSEJT7Y3pqesMyX29X0hCU+ev5iesIybrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtr+8/sf0hiUuLx5PT1jn4avpBcts3/xresIax216wTK7J1fTE5a43J/uGXK5f2d6whqPvz+9YJmP79+anrDEdvdsesIybrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL77fmz6Q18V8fj9AL4j+3vn09PWOPc9+f/HWcj/0OcIAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDb/+r5F9Mblri+fz09YZk/ffFyesIyf/jlz6cnLPHhkx9PT1jmp7/57fSEJX7xk3enJyzz+fX99IQlfvDodO8Mnj79y/SEJe5+/dn0hGVO920EABgisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYrvD8ek2PWKFbTtOT+C/cHF/Mz1hjf3j6QXr3FxNL1jizQ8/mp7Ad3RxwncGr7fD9IQlHh1O83ednbnBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj+/Opv0xvWuNhPL1jn9np6wTLb3e30hDUOb6YXLLP78JPpCUtcfP3V9IR1dif6bX34dnrBMo+24/SEJbarZ9MTljnRfxkAwByBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ+zdzhYjd/MyrmAAAAABJRU5ErkJggg==" id="image15e7df3913" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9ae49af2a0" d="M 0 0 
+       <path id="m06c7850c92" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9ae49af2a0" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9ae49af2a0" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06c7850c92" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mb78c258f68" d="M 0 0 
+       <path id="m5c1063bce0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb78c258f68" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c1063bce0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mb78c258f68" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c1063bce0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb78c258f68" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c1063bce0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mb78c258f68" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c1063bce0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mb78c258f68" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c1063bce0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mb78c258f68" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c1063bce0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb78c258f68" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c1063bce0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mb78c258f68" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c1063bce0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,135 +1303,28 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -60 -->
+    <!-- -48 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
 z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- -56 -->
-    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -76 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -90 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -95 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -63 -->
-    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -58 -->
-    <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1473,40 +1366,132 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- -53 -->
-    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
+   <g id="text_21">
+    <!-- -45 -->
+    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -65 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- -62 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+   <g id="text_22">
+    <!-- -71 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -89 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -94 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -46 -->
+    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -46 -->
+    <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -42 -->
+    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_28">
+    <!-- -51 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -55 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_30">
-    <!-- -95 -->
+    <!-- -94 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1526,6 +1511,38 @@ L 678 2272
 L 2419 2272 
 L 2419 4013 
 L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1566,27 +1583,6 @@ z
    <g id="text_36">
     <!-- -46 -->
     <g transform="translate(306.247477 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1607,10 +1603,10 @@ z
     </g>
    </g>
    <g id="text_39">
-    <!-- -4 -->
+    <!-- -3 -->
     <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_40">
@@ -1622,11 +1618,11 @@ z
     </g>
    </g>
    <g id="text_41">
-    <!-- -17 -->
+    <!-- -18 -->
     <g transform="translate(502.50147 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_42">
@@ -1639,29 +1635,29 @@ z
     </g>
    </g>
    <g id="text_43">
-    <!-- +247 -->
+    <!-- +246 -->
     <g transform="translate(145.625612 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- +300 -->
+    <!-- +302 -->
     <g transform="translate(184.87641 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +72 -->
+    <!-- +73 -->
     <g transform="translate(226.195021 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_46">
@@ -1673,48 +1669,48 @@ z
     </g>
    </g>
    <g id="text_47">
-    <!-- +306 -->
+    <!-- +309 -->
     <g transform="translate(302.628805 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_48">
-    <!-- +229 -->
+    <!-- +234 -->
     <g transform="translate(341.879604 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +269 -->
+    <!-- +270 -->
     <g transform="translate(381.130402 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +265 -->
+    <!-- +263 -->
     <g transform="translate(420.381201 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +396 -->
+    <!-- +383 -->
     <g transform="translate(459.631999 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
@@ -1768,11 +1764,12 @@ z
     </g>
    </g>
    <g id="text_58">
-    <!-- -99 -->
-    <g transform="translate(306.247477 174.957073) scale(0.065 -0.065)">
+    <!-- -100 -->
+    <g transform="translate(304.179665 174.957073) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(163.330078 0)"/>
     </g>
    </g>
    <g id="text_59">
@@ -1819,27 +1816,27 @@ z
     </g>
    </g>
    <g id="text_64">
-    <!-- -57 -->
+    <!-- -58 -->
     <g transform="translate(109.993485 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_65">
-    <!-- -55 -->
+    <!-- -49 -->
     <g transform="translate(149.244284 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_66">
-    <!-- -58 -->
+    <!-- -67 -->
     <g transform="translate(188.495082 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_67">
@@ -1867,51 +1864,51 @@ z
     </g>
    </g>
    <g id="text_70">
-    <!-- -35 -->
+    <!-- -34 -->
     <g transform="translate(345.498276 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_71">
-    <!-- -19 -->
+    <!-- -22 -->
     <g transform="translate(384.749074 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_72">
-    <!-- -45 -->
+    <!-- -10 -->
     <g transform="translate(423.999873 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_73">
-    <!-- -48 -->
+    <!-- -34 -->
     <g transform="translate(463.250671 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_74">
-    <!-- -95 -->
+    <!-- -94 -->
     <g transform="translate(502.50147 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_75">
-    <!-- +27 -->
+    <!-- +25 -->
     <g transform="translate(108.442626 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_76">
@@ -1923,19 +1920,19 @@ z
     </g>
    </g>
    <g id="text_77">
-    <!-- -34 -->
+    <!-- -30 -->
     <g transform="translate(188.495082 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_78">
-    <!-- -38 -->
+    <!-- -39 -->
     <g transform="translate(227.74588 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_79">
@@ -1955,42 +1952,43 @@ z
     </g>
    </g>
    <g id="text_81">
-    <!-- +8 -->
-    <g transform="translate(346.015229 245.658775) scale(0.065 -0.065)">
+    <!-- +25 -->
+    <g transform="translate(343.947416 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_82">
-    <!-- +47 -->
+    <!-- +46 -->
     <g transform="translate(383.198215 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_83">
-    <!-- -24 -->
-    <g transform="translate(423.999873 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_84">
-    <!-- +56 -->
-    <g transform="translate(461.699812 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_83">
+    <!-- -26 -->
+    <g transform="translate(423.999873 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_84">
+    <!-- +54 -->
+    <g transform="translate(461.699812 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_85">
-    <!-- -71 -->
+    <!-- -80 -->
     <g transform="translate(502.50147 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_86">
@@ -2002,27 +2000,27 @@ z
     </g>
    </g>
    <g id="text_87">
-    <!-- +79 -->
+    <!-- +78 -->
     <g transform="translate(147.693424 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_88">
-    <!-- +28 -->
-    <g transform="translate(186.944223 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_88">
+    <!-- +26 -->
+    <g transform="translate(186.944223 281.009626) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_89">
-    <!-- -20 -->
+    <!-- -18 -->
     <g transform="translate(227.74588 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_90">
@@ -2034,12 +2032,12 @@ z
     </g>
    </g>
    <g id="text_91">
-    <!-- +113 -->
+    <!-- +114 -->
     <g transform="translate(302.628805 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_92">
@@ -2059,28 +2057,28 @@ z
     </g>
    </g>
    <g id="text_94">
-    <!-- +98 -->
+    <!-- +99 -->
     <g transform="translate(422.449013 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
-    <!-- +109 -->
+    <!-- +107 -->
     <g transform="translate(459.631999 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_96">
-    <!-- -54 -->
+    <!-- -52 -->
     <g transform="translate(502.50147 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_97">
@@ -2116,11 +2114,11 @@ z
     </g>
    </g>
    <g id="text_101">
-    <!-- -84 -->
+    <!-- -85 -->
     <g transform="translate(266.996679 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_102">
@@ -2148,11 +2146,11 @@ z
     </g>
    </g>
    <g id="text_105">
-    <!-- -47 -->
+    <!-- -46 -->
     <g transform="translate(423.999873 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_106">
@@ -2164,11 +2162,11 @@ z
     </g>
    </g>
    <g id="text_107">
-    <!-- -85 -->
+    <!-- -86 -->
     <g transform="translate(502.50147 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2182,23 +2180,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagef7f631ce7b" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagef515d4aa22" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="me2db0268bc" d="M 0 0 
+       <path id="md7027e99ee" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me2db0268bc" x="547.779688" y="276.375472" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md7027e99ee" x="547.779688" y="279.422655" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
       <!-- −3 -->
-      <g transform="translate(554.779688 280.174691) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 283.221874) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2216,12 +2214,12 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#me2db0268bc" x="547.779688" y="247.863283" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md7027e99ee" x="547.779688" y="249.894738" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
       <!-- −2 -->
-      <g transform="translate(554.779688 251.662502) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 253.693957) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2230,12 +2228,12 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#me2db0268bc" x="547.779688" y="219.351094" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md7027e99ee" x="547.779688" y="220.366821" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
       <!-- −1 -->
-      <g transform="translate(554.779688 223.150313) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 224.16604) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2244,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#me2db0268bc" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md7027e99ee" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2257,12 +2255,12 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me2db0268bc" x="547.779688" y="162.326715" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md7027e99ee" x="547.779688" y="161.310988" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
       <!-- 1 -->
-      <g transform="translate(554.779688 166.125934) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 165.110207) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2270,12 +2268,12 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#me2db0268bc" x="547.779688" y="133.814526" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md7027e99ee" x="547.779688" y="131.783071" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
       <!-- 2 -->
-      <g transform="translate(554.779688 137.613745) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 135.58229) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2283,12 +2281,12 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#me2db0268bc" x="547.779688" y="105.302337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md7027e99ee" x="547.779688" y="102.255154" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
       <!-- 3 -->
-      <g transform="translate(554.779688 109.101556) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 106.054373) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2944,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.689297 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.074844 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3012,16 +3010,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3060,109 +3058,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb0ab6e847f">
+  <clipPath id="p9e899d71ef">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m3fccace49c" d="M 0 0 
+       <path id="mac14b36524" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3fccace49c" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mac14b36524" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3fccace49c" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mac14b36524" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3fccace49c" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mac14b36524" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3fccace49c" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mac14b36524" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3fccace49c" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mac14b36524" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m3fccace49c" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mac14b36524" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3fccace49c" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mac14b36524" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -852,23 +852,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 347.768205 
-L 637.2 347.768205 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 347.808005 
+L 637.2 347.808005 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="maffba18dc0" d="M 0 0 
+       <path id="m5e76200a3f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#maffba18dc0" x="49.078125" y="347.768205" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e76200a3f" x="49.078125" y="347.808005" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 351.567424) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 351.607224) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -893,18 +893,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 238.587166 
-L 637.2 238.587166 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 238.716621 
+L 637.2 238.716621 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#maffba18dc0" x="49.078125" y="238.587166" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e76200a3f" x="49.078125" y="238.716621" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 242.386384) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 242.51584) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -913,18 +913,18 @@ L 637.2 238.587166
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 129.406126 
-L 637.2 129.406126 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 129.625237 
+L 637.2 129.625237 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#maffba18dc0" x="49.078125" y="129.406126" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5e76200a3f" x="49.078125" y="129.625237" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 133.205345) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 133.424456) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -933,330 +933,330 @@ L 637.2 129.406126
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 404.85665 
-L 637.2 404.85665 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 404.849571 
+L 637.2 404.849571 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m1c87952350" d="M 0 0 
+       <path id="m0a8cb54ee8" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="404.85665" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="404.849571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 391.215709 
-L 637.2 391.215709 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.219831 
+L 637.2 391.219831 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="391.215709" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="391.219831" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 380.634973 
-L 637.2 380.634973 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.647784 
+L 637.2 380.647784 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="380.634973" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="380.647784" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 371.989882 
-L 637.2 371.989882 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 372.009792 
+L 637.2 372.009792 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="371.989882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="372.009792" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 364.680562 
-L 637.2 364.680562 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 364.706474 
+L 637.2 364.706474 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="364.680562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="364.706474" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 358.348941 
-L 637.2 358.348941 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 358.380053 
+L 637.2 358.380053 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="358.348941" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="358.380053" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 352.764055 
-L 637.2 352.764055 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 352.799753 
+L 637.2 352.799753 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="352.764055" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="352.799753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 314.901437 
-L 637.2 314.901437 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 314.968226 
+L 637.2 314.968226 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="314.901437" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="314.968226" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 295.67561 
-L 637.2 295.67561 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 295.758187 
+L 637.2 295.758187 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="295.67561" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="295.758187" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 282.034669 
-L 637.2 282.034669 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 282.128447 
+L 637.2 282.128447 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="282.034669" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="282.128447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 271.453933 
-L 637.2 271.453933 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.5564 
+L 637.2 271.5564 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="271.453933" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="271.5564" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 262.808843 
-L 637.2 262.808843 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.918408 
+L 637.2 262.918408 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="262.808843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="262.918408" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 255.499523 
-L 637.2 255.499523 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.61509 
+L 637.2 255.61509 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="255.499523" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="255.61509" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 249.167901 
-L 637.2 249.167901 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.288669 
+L 637.2 249.288669 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="249.167901" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="249.288669" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 243.583016 
-L 637.2 243.583016 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.708369 
+L 637.2 243.708369 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="243.583016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="243.708369" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 205.720398 
-L 637.2 205.720398 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.876842 
+L 637.2 205.876842 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="205.720398" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="205.876842" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 186.494571 
-L 637.2 186.494571 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 186.666803 
+L 637.2 186.666803 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="186.494571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="186.666803" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 172.85363 
-L 637.2 172.85363 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 173.037064 
+L 637.2 173.037064 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="172.85363" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="173.037064" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 162.272894 
-L 637.2 162.272894 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 162.465016 
+L 637.2 162.465016 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="162.272894" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="162.465016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 153.627803 
-L 637.2 153.627803 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 153.827024 
+L 637.2 153.827024 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="153.627803" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="153.827024" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 146.318483 
-L 637.2 146.318483 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.523706 
+L 637.2 146.523706 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="146.318483" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="146.523706" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 139.986862 
-L 637.2 139.986862 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 140.197285 
+L 637.2 140.197285 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="139.986862" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="140.197285" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 134.401977 
-L 637.2 134.401977 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 134.616985 
+L 637.2 134.616985 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="134.401977" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="134.616985" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 49.078125 96.539358 
-L 637.2 96.539358 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 96.785458 
+L 637.2 96.785458 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="96.539358" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="96.785458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 49.078125 77.313532 
-L 637.2 77.313532 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 77.575419 
+L 637.2 77.575419 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="77.313532" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="77.575419" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 49.078125 63.672591 
-L 637.2 63.672591 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 63.94568 
+L 637.2 63.94568 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="63.672591" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="63.94568" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 49.078125 53.091855 
-L 637.2 53.091855 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 53.373632 
+L 637.2 53.373632 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m1c87952350" x="49.078125" y="53.091855" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="53.373632" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(271.439833 188.758605) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(271.439833 184.880722) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 345.33651) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 343.51445) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1739,124 +1739,124 @@ z
     </g>
    </g>
    <g id="line2d_75">
-    <path d="M 355.479835 95.278691 
-L 308.273931 102.206002 
-L 271.230161 116.230694 
-L 217.83458 119.782864 
-L 177.077692 138.265045 
-L 162.880539 157.567628 
-L 160.741445 165.005291 
-L 153.966678 183.308691 
-L 151.589614 194.442272 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 355.479835 95.429129 
+L 308.273931 102.643215 
+L 271.230161 116.329646 
+L 217.83458 119.884966 
+L 177.077692 138.271575 
+L 162.880539 157.657599 
+L 160.741445 165.059068 
+L 153.966678 183.326897 
+L 151.589614 194.435065 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me8fe847fe0" d="M -2.5 2.5 
+     <path id="mea8ad5ce55" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4926299bef)">
-     <use xlink:href="#me8fe847fe0" x="355.479835" y="95.278691" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fe847fe0" x="308.273931" y="102.206002" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fe847fe0" x="271.230161" y="116.230694" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fe847fe0" x="217.83458" y="119.782864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fe847fe0" x="177.077692" y="138.265045" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fe847fe0" x="162.880539" y="157.567628" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fe847fe0" x="160.741445" y="165.005291" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fe847fe0" x="153.966678" y="183.308691" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8fe847fe0" x="151.589614" y="194.442272" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pea58e2e697)">
+     <use xlink:href="#mea8ad5ce55" x="355.479835" y="95.429129" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea8ad5ce55" x="308.273931" y="102.643215" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea8ad5ce55" x="271.230161" y="116.329646" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea8ad5ce55" x="217.83458" y="119.884966" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea8ad5ce55" x="177.077692" y="138.271575" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea8ad5ce55" x="162.880539" y="157.657599" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea8ad5ce55" x="160.741445" y="165.059068" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea8ad5ce55" x="153.966678" y="183.326897" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea8ad5ce55" x="151.589614" y="194.435065" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
-    <path d="M 531.649087 76.330772 
-L 283.721324 99.021337 
-L 218.882044 120.996965 
-L 187.447228 127.017902 
-L 176.342474 138.373995 
-L 163.054314 161.362501 
-L 162.210539 168.791628 
-L 159.303811 175.802394 
-L 157.793928 179.547126 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 531.649087 76.334942 
+L 283.721324 99.105471 
+L 218.882044 121.035708 
+L 187.447228 127.081538 
+L 176.342474 138.415762 
+L 163.054314 161.392184 
+L 162.210539 168.835144 
+L 159.303811 175.792312 
+L 157.793928 179.565972 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mfe539309d3" d="M 0 -2.5 
+     <path id="m2c92bfb742" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4926299bef)">
-     <use xlink:href="#mfe539309d3" x="531.649087" y="76.330772" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe539309d3" x="283.721324" y="99.021337" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe539309d3" x="218.882044" y="120.996965" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe539309d3" x="187.447228" y="127.017902" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe539309d3" x="176.342474" y="138.373995" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe539309d3" x="163.054314" y="161.362501" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe539309d3" x="162.210539" y="168.791628" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe539309d3" x="159.303811" y="175.802394" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfe539309d3" x="157.793928" y="179.547126" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pea58e2e697)">
+     <use xlink:href="#m2c92bfb742" x="531.649087" y="76.334942" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c92bfb742" x="283.721324" y="99.105471" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c92bfb742" x="218.882044" y="121.035708" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c92bfb742" x="187.447228" y="127.081538" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c92bfb742" x="176.342474" y="138.415762" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c92bfb742" x="163.054314" y="161.392184" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c92bfb742" x="162.210539" y="168.835144" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c92bfb742" x="159.303811" y="175.792312" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2c92bfb742" x="157.793928" y="179.565972" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
     <path d="M 251.559581 64.890426 
-L 203.775848 81.617123 
-L 186.982691 88.05226 
-L 179.779306 90.917043 
-L 157.610419 99.408941 
-L 148.722526 107.813396 
-L 144.388162 121.522092 
-L 127.071247 144.494333 
-L 124.491988 152.190225 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 203.775848 82.063415 
+L 186.982691 88.556403 
+L 179.779306 91.272263 
+L 157.610419 99.495121 
+L 148.722526 107.987171 
+L 144.388162 121.598806 
+L 127.071247 144.809212 
+L 124.491988 152.211151 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m8b2a39f3ee" d="M -0 3.535534 
+     <path id="m86e920e76b" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4926299bef)">
-     <use xlink:href="#m8b2a39f3ee" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b2a39f3ee" x="203.775848" y="81.617123" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b2a39f3ee" x="186.982691" y="88.05226" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b2a39f3ee" x="179.779306" y="90.917043" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b2a39f3ee" x="157.610419" y="99.408941" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b2a39f3ee" x="148.722526" y="107.813396" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b2a39f3ee" x="144.388162" y="121.522092" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b2a39f3ee" x="127.071247" y="144.494333" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8b2a39f3ee" x="124.491988" y="152.190225" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pea58e2e697)">
+     <use xlink:href="#m86e920e76b" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m86e920e76b" x="203.775848" y="82.063415" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m86e920e76b" x="186.982691" y="88.556403" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m86e920e76b" x="179.779306" y="91.272263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m86e920e76b" x="157.610419" y="99.495121" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m86e920e76b" x="148.722526" y="107.987171" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m86e920e76b" x="144.388162" y="121.598806" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m86e920e76b" x="127.071247" y="144.809212" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m86e920e76b" x="124.491988" y="152.211151" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m4c9f2bbafd" d="M -0 2.5 
+     <path id="m2c29801148" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4926299bef)">
-     <use xlink:href="#m4c9f2bbafd" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pea58e2e697)">
+     <use xlink:href="#m2c29801148" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
-    <path d="M 362.865999 182.809456 
-L 278.798176 179.080364 
-L 251.17632 184.93796 
-L 200.806828 189.540566 
-L 169.803221 198.145566 
-L 161.916638 214.740625 
-L 158.697104 219.16589 
-L 154.26679 229.22131 
-L 153.096464 238.528884 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 362.865999 178.208265 
+L 278.798176 181.115507 
+L 251.17632 188.728803 
+L 200.806828 186.370878 
+L 169.803221 202.802663 
+L 161.916638 211.201944 
+L 158.697104 214.083876 
+L 154.26679 230.403077 
+L 153.096464 236.374892 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m58855acfbb" d="M -0.833333 2.5 
+     <path id="mdc895f0b95" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,31 +1871,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4926299bef)">
-     <use xlink:href="#m58855acfbb" x="362.865999" y="182.809456" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m58855acfbb" x="278.798176" y="179.080364" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m58855acfbb" x="251.17632" y="184.93796" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m58855acfbb" x="200.806828" y="189.540566" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m58855acfbb" x="169.803221" y="198.145566" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m58855acfbb" x="161.916638" y="214.740625" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m58855acfbb" x="158.697104" y="219.16589" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m58855acfbb" x="154.26679" y="229.22131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m58855acfbb" x="153.096464" y="238.528884" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pea58e2e697)">
+     <use xlink:href="#mdc895f0b95" x="362.865999" y="178.208265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc895f0b95" x="278.798176" y="181.115507" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc895f0b95" x="251.17632" y="188.728803" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc895f0b95" x="200.806828" y="186.370878" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc895f0b95" x="169.803221" y="202.802663" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc895f0b95" x="161.916638" y="211.201944" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc895f0b95" x="158.697104" y="214.083876" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc895f0b95" x="154.26679" y="230.403077" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdc895f0b95" x="153.096464" y="236.374892" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
-    <path d="M 301.619021 143.481454 
-L 250.236474 149.524207 
-L 225.418659 152.89052 
-L 212.328936 156.129994 
-L 209.030149 158.171613 
-L 197.547749 166.895646 
-L 194.819287 169.79597 
-L 193.12279 177.428816 
-L 192.79794 184.292145 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 301.619021 144.709332 
+L 250.236474 147.250669 
+L 225.418659 152.855905 
+L 212.328936 158.971358 
+L 209.030149 156.876474 
+L 197.547749 168.035549 
+L 194.819287 169.543563 
+L 193.12279 177.055726 
+L 192.79794 181.903106 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me0286527cd" d="M -1.25 2.5 
+     <path id="m9590c0b7b2" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,31 +1910,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4926299bef)">
-     <use xlink:href="#me0286527cd" x="301.619021" y="143.481454" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me0286527cd" x="250.236474" y="149.524207" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me0286527cd" x="225.418659" y="152.89052" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me0286527cd" x="212.328936" y="156.129994" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me0286527cd" x="209.030149" y="158.171613" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me0286527cd" x="197.547749" y="166.895646" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me0286527cd" x="194.819287" y="169.79597" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me0286527cd" x="193.12279" y="177.428816" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me0286527cd" x="192.79794" y="184.292145" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pea58e2e697)">
+     <use xlink:href="#m9590c0b7b2" x="301.619021" y="144.709332" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9590c0b7b2" x="250.236474" y="147.250669" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9590c0b7b2" x="225.418659" y="152.855905" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9590c0b7b2" x="212.328936" y="158.971358" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9590c0b7b2" x="209.030149" y="156.876474" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9590c0b7b2" x="197.547749" y="168.035549" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9590c0b7b2" x="194.819287" y="169.543563" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9590c0b7b2" x="193.12279" y="177.055726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9590c0b7b2" x="192.79794" y="181.903106" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
-    <path d="M 206.45578 118.242887 
-L 206.45578 118.330806 
-L 206.45578 118.193052 
-L 206.45578 118.085508 
-L 171.767499 133.571824 
-L 163.54283 144.487998 
-L 160.174881 150.52417 
-L 154.179217 168.694796 
-L 152.4406 178.494998 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.329216 
+L 206.45578 118.007744 
+L 206.45578 118.087977 
+L 206.45578 118.073237 
+L 171.767499 133.56872 
+L 163.54283 144.454763 
+L 160.174881 150.352936 
+L 154.179217 168.648736 
+L 152.4406 178.37478 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m99c90dff6f" d="M 0 -2.5 
+     <path id="mc68bb09df7" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,31 +1947,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p4926299bef)">
-     <use xlink:href="#m99c90dff6f" x="206.45578" y="118.242887" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m99c90dff6f" x="206.45578" y="118.330806" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m99c90dff6f" x="206.45578" y="118.193052" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m99c90dff6f" x="206.45578" y="118.085508" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m99c90dff6f" x="171.767499" y="133.571824" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m99c90dff6f" x="163.54283" y="144.487998" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m99c90dff6f" x="160.174881" y="150.52417" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m99c90dff6f" x="154.179217" y="168.694796" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m99c90dff6f" x="152.4406" y="178.494998" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pea58e2e697)">
+     <use xlink:href="#mc68bb09df7" x="206.45578" y="118.329216" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc68bb09df7" x="206.45578" y="118.007744" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc68bb09df7" x="206.45578" y="118.087977" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc68bb09df7" x="206.45578" y="118.073237" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc68bb09df7" x="171.767499" y="133.56872" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc68bb09df7" x="163.54283" y="144.454763" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc68bb09df7" x="160.174881" y="150.352936" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc68bb09df7" x="154.179217" y="168.648736" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc68bb09df7" x="152.4406" y="178.37478" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
-    <path d="M 610.467188 172.996304 
-L 592.067397 174.514522 
-L 534.807821 181.346402 
-L 327.802209 176.641094 
-L 275.83761 186.809327 
-L 258.25125 198.928292 
-L 256.777056 204.098979 
-L 248.769854 217.81346 
-L 246.264594 228.015907 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467188 173.64683 
+L 592.067397 175.079335 
+L 534.807821 181.440237 
+L 327.802209 176.754212 
+L 275.83761 187.092383 
+L 258.25125 199.202588 
+L 256.777056 204.152158 
+L 248.769854 218.291924 
+L 246.264594 228.041024 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m776252f175" d="M 0 -2.5 
+     <path id="m10bdf6687a" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p4926299bef)">
-     <use xlink:href="#m776252f175" x="610.467188" y="172.996304" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m776252f175" x="592.067397" y="174.514522" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m776252f175" x="534.807821" y="181.346402" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m776252f175" x="327.802209" y="176.641094" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m776252f175" x="275.83761" y="186.809327" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m776252f175" x="258.25125" y="198.928292" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m776252f175" x="256.777056" y="204.098979" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m776252f175" x="248.769854" y="217.81346" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m776252f175" x="246.264594" y="228.015907" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pea58e2e697)">
+     <use xlink:href="#m10bdf6687a" x="610.467188" y="173.64683" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10bdf6687a" x="592.067397" y="175.079335" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10bdf6687a" x="534.807821" y="181.440237" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10bdf6687a" x="327.802209" y="176.754212" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10bdf6687a" x="275.83761" y="187.092383" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10bdf6687a" x="258.25125" y="199.202588" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10bdf6687a" x="256.777056" y="204.152158" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10bdf6687a" x="248.769854" y="218.291924" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10bdf6687a" x="246.264594" y="228.041024" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m6a60366e9f" d="M 0 3.5 
+      <path id="ma7d6e2f99f" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m6a60366e9f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma7d6e2f99f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me8fe847fe0" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mea8ad5ce55" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mfe539309d3" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2c92bfb742" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m8b2a39f3ee" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m86e920e76b" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m4c9f2bbafd" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2c29801148" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m58855acfbb" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdc895f0b95" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me0286527cd" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9590c0b7b2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m99c90dff6f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mc68bb09df7" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m776252f175" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m10bdf6687a" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 266.439833 193.758605 
-L 243.627793 198.139471 
-L 229.515893 202.166366 
-L 184.409647 217.469977 
-L 180.806615 220.037622 
-L 175.118498 226.382018 
-L 162.683902 262.929286 
-L 160.786938 266.413087 
-L 98.348822 350.33651 
-" clip-path="url(#p4926299bef)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p4926299bef)">
-     <use xlink:href="#m6a60366e9f" x="266.439833" y="193.758605" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6a60366e9f" x="243.627793" y="198.139471" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6a60366e9f" x="229.515893" y="202.166366" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6a60366e9f" x="184.409647" y="217.469977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6a60366e9f" x="180.806615" y="220.037622" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6a60366e9f" x="175.118498" y="226.382018" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6a60366e9f" x="162.683902" y="262.929286" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6a60366e9f" x="160.786938" y="266.413087" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6a60366e9f" x="98.348822" y="350.33651" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 266.439833 189.880722 
+L 243.627793 193.091839 
+L 229.515893 196.509364 
+L 184.409647 209.30855 
+L 180.806615 211.443994 
+L 175.118498 217.015324 
+L 162.683902 257.310681 
+L 160.786938 260.103623 
+L 98.348822 348.51445 
+" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pea58e2e697)">
+     <use xlink:href="#ma7d6e2f99f" x="266.439833" y="189.880722" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma7d6e2f99f" x="243.627793" y="193.091839" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma7d6e2f99f" x="229.515893" y="196.509364" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma7d6e2f99f" x="184.409647" y="209.30855" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma7d6e2f99f" x="180.806615" y="211.443994" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma7d6e2f99f" x="175.118498" y="217.015324" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma7d6e2f99f" x="162.683902" y="257.310681" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma7d6e2f99f" x="160.786938" y="260.103623" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma7d6e2f99f" x="98.348822" y="348.51445" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,34 +2891,9 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.689297 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.074844 465.66) scale(0.07 -0.07)">
     <defs>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -3000,14 +2975,29 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-39" d="M 703 97 
@@ -3078,16 +3068,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3126,109 +3116,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p4926299bef">
+  <clipPath id="pea58e2e697">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p64dc78ff50)">
+   <g clip-path="url(#p9216063857)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+UlEQVR4nO3YwYqkVx2H4aqe7rYnwUFlEsMshewkuHDjbLL2TnIFWYp7r8PkBgQRMZugZONG3IkbEQkhmSSTmaG7p/orL2ESOPKXep/nCn5nUafe7+y3L3973J2aZ59PL1jq+MVpnWe32+3+/f7vpics9c+/PZ+esNy7H/xyesJy+5/9fHrCWvuz6QXrPf10esF6Vw+mFyz14Y9/Mz1huRP8JQEAfHtiCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbX9z+P1xesRqx902PWGp/Qk268XZ5fSEpW636+kJy138/ZPpCcsdfvp4esJSh+12esJyzw9Ppycs9/DEroeXDx5OT1ju9P5lAQC+AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvH8q+kN6928mF6w1nGbXrDe/QfTC5a6nB7wP3B8+nx6wnIX3zyZnrDUxXaYnrDc/VO8766fTS9Y6uL89G48L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2Px6nR6x2PG7TE5baTuw8u91ud3F2OT1hqbvjYXrCcveePZmesN7335xesNTL7XZ6wnJfXP9nesJyb92cT09Yavvho+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSzv/62Z+nNyx3tttPT1jqjdceTk9Y7m47TE9Y6vLe1fSE5d776OPpCcv9+hdvT09Y6nDcpics96u//GN6wnKPH70+PWGp9955PD1hOS9DAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASNu/vPvDcXrEard319MTlrq/v5qewCvc7g/TE5b7+ubz6QnL/ejqrekJS23HbXrCcl/dfDY9YbknN59OT1jqJw/emZ6wnJchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO237U/H6RHA/6HD7fSC9c4vpxfwCtd3L6YnLHd177XpCbyClyEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkne9uX0xvWO9wO71grXvn0wvWOzuxM+1P8Lviyb+mF6z3g0fTC9Y6tbtut9vtvnc5vWC94za9YK0T7IYTvMEBAL49MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfwb+IB8PIhC4AAAAASUVORK5CYII=" id="image6fd0861d98" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+UlEQVR4nO3YwYqkVx2H4aqe7rYnwUFlEsMshewkuHDjbLL2TnIFWYp7r8PkBgQRMZugZONG3IkbEQkhmSSTmaG7p/orL2ESOPKXep/nCn5nUafe7+y3L3973J2aZ59PL1jq+MVpnWe32+3+/f7vpics9c+/PZ+esNy7H/xyesJy+5/9fHrCWvuz6QXrPf10esF6Vw+mFyz14Y9/Mz1huRP8JQEAfHtiCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbX9z+P1xesRqx902PWGp/Qk268XZ5fSEpW636+kJy138/ZPpCcsdfvp4esJSh+12esJyzw9Ppycs9/DEroeXDx5OT1ju9P5lAQC+AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvH8q+kN6928mF6w1nGbXrDe/QfTC5a6nB7wP3B8+nx6wnIX3zyZnrDUxXaYnrDc/VO8766fTS9Y6uL89G48L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2Px6nR6x2PG7TE5baTuw8u91ud3F2OT1hqbvjYXrCcveePZmesN7335xesNTL7XZ6wnJfXP9nesJyb92cT09Yavvho+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSzv/62Z+nNyx3tttPT1jqjdceTk9Y7m47TE9Y6vLe1fSE5d776OPpCcv9+hdvT09Y6nDcpics96u//GN6wnKPH70+PWGp9955PD1hOS9DAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASNu/vPvDcXrEard319MTlrq/v5qewCvc7g/TE5b7+ubz6QnL/ejqrekJS23HbXrCcl/dfDY9YbknN59OT1jqJw/emZ6wnJchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO237U/H6RHA/6HD7fSC9c4vpxfwCtd3L6YnLHd177XpCbyClyEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkne9uX0xvWO9wO71grXvn0wvWOzuxM+1P8Lviyb+mF6z3g0fTC9Y6tbtut9vtvnc5vWC94za9YK0T7IYTvMEBAL49MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfwb+IB8PIhC4AAAAASUVORK5CYII=" id="imagead4fff4c38" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mde4fc4d5bc" d="M 0 0 
+       <path id="m3f04088619" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mde4fc4d5bc" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3f04088619" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m18ee76f799" d="M 0 0 
+       <path id="mdbf7757ac4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m18ee76f799" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbf7757ac4" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m18ee76f799" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbf7757ac4" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m18ee76f799" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbf7757ac4" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m18ee76f799" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbf7757ac4" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m18ee76f799" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbf7757ac4" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m18ee76f799" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbf7757ac4" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m18ee76f799" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbf7757ac4" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m18ee76f799" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbf7757ac4" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagec0062db962" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8ba8190e13" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m7cac281c11" d="M 0 0 
+       <path id="m1d6f68f366" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7cac281c11" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d6f68f366" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m7cac281c11" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d6f68f366" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m7cac281c11" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d6f68f366" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m7cac281c11" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d6f68f366" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7cac281c11" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d6f68f366" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m7cac281c11" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d6f68f366" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7cac281c11" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d6f68f366" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m7cac281c11" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d6f68f366" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m7cac281c11" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1d6f68f366" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.689297 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.074844 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,16 +2950,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2998,109 +2998,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p64dc78ff50">
+  <clipPath id="p9216063857">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="571.021406pt" height="386.202469pt" viewBox="0 0 571.021406 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.250313pt" height="386.202469pt" viewBox="0 0 570.250313 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 571.021406 386.202469 
-L 571.021406 0 
+L 570.250313 386.202469 
+L 570.250313 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.635703 104.1264 
-L 292.260703 104.1264 
-L 292.260703 74.7432 
-L 187.635703 74.7432 
+    <path d="M 187.250156 104.1264 
+L 291.875156 104.1264 
+L 291.875156 74.7432 
+L 187.250156 74.7432 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.260703 104.1264 
-L 396.885703 104.1264 
-L 396.885703 74.7432 
-L 292.260703 74.7432 
+    <path d="M 291.875156 104.1264 
+L 396.500156 104.1264 
+L 396.500156 74.7432 
+L 291.875156 74.7432 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.885703 104.1264 
-L 501.510703 104.1264 
-L 501.510703 74.7432 
-L 396.885703 74.7432 
+    <path d="M 396.500156 104.1264 
+L 501.125156 104.1264 
+L 501.125156 74.7432 
+L 396.500156 74.7432 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.635703 133.5096 
-L 292.260703 133.5096 
-L 292.260703 104.1264 
-L 187.635703 104.1264 
+    <path d="M 187.250156 133.5096 
+L 291.875156 133.5096 
+L 291.875156 104.1264 
+L 187.250156 104.1264 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.260703 133.5096 
-L 396.885703 133.5096 
-L 396.885703 104.1264 
-L 292.260703 104.1264 
+    <path d="M 291.875156 133.5096 
+L 396.500156 133.5096 
+L 396.500156 104.1264 
+L 291.875156 104.1264 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #fff7b2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.885703 133.5096 
-L 501.510703 133.5096 
-L 501.510703 104.1264 
-L 396.885703 104.1264 
+    <path d="M 396.500156 133.5096 
+L 501.125156 133.5096 
+L 501.125156 104.1264 
+L 396.500156 104.1264 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #fdb163; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.635703 162.8928 
-L 292.260703 162.8928 
-L 292.260703 133.5096 
-L 187.635703 133.5096 
+    <path d="M 187.250156 162.8928 
+L 291.875156 162.8928 
+L 291.875156 133.5096 
+L 187.250156 133.5096 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.260703 162.8928 
-L 396.885703 162.8928 
-L 396.885703 133.5096 
-L 292.260703 133.5096 
+    <path d="M 291.875156 162.8928 
+L 396.500156 162.8928 
+L 396.500156 133.5096 
+L 291.875156 133.5096 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.885703 162.8928 
-L 501.510703 162.8928 
-L 501.510703 133.5096 
-L 396.885703 133.5096 
+    <path d="M 396.500156 162.8928 
+L 501.125156 162.8928 
+L 501.125156 133.5096 
+L 396.500156 133.5096 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #c1e57b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #bde379; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.635703 192.276 
-L 292.260703 192.276 
-L 292.260703 162.8928 
-L 187.635703 162.8928 
+    <path d="M 187.250156 192.276 
+L 291.875156 192.276 
+L 291.875156 162.8928 
+L 187.250156 162.8928 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.260703 192.276 
-L 396.885703 192.276 
-L 396.885703 162.8928 
-L 292.260703 162.8928 
+    <path d="M 291.875156 192.276 
+L 396.500156 192.276 
+L 396.500156 162.8928 
+L 291.875156 162.8928 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.885703 192.276 
-L 501.510703 192.276 
-L 501.510703 162.8928 
-L 396.885703 162.8928 
+    <path d="M 396.500156 192.276 
+L 501.125156 192.276 
+L 501.125156 162.8928 
+L 396.500156 162.8928 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #b5df74; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #abdb6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.635703 221.6592 
-L 292.260703 221.6592 
-L 292.260703 192.276 
-L 187.635703 192.276 
+    <path d="M 187.250156 221.6592 
+L 291.875156 221.6592 
+L 291.875156 192.276 
+L 187.250156 192.276 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.260703 221.6592 
-L 396.885703 221.6592 
-L 396.885703 192.276 
-L 292.260703 192.276 
+    <path d="M 291.875156 221.6592 
+L 396.500156 221.6592 
+L 396.500156 192.276 
+L 291.875156 192.276 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.885703 221.6592 
-L 501.510703 221.6592 
-L 501.510703 192.276 
-L 396.885703 192.276 
+    <path d="M 396.500156 221.6592 
+L 501.125156 221.6592 
+L 501.125156 192.276 
+L 396.500156 192.276 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.635703 251.0424 
-L 292.260703 251.0424 
-L 292.260703 221.6592 
-L 187.635703 221.6592 
+    <path d="M 187.250156 251.0424 
+L 291.875156 251.0424 
+L 291.875156 221.6592 
+L 187.250156 221.6592 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.260703 251.0424 
-L 396.885703 251.0424 
-L 396.885703 221.6592 
-L 292.260703 221.6592 
+    <path d="M 291.875156 251.0424 
+L 396.500156 251.0424 
+L 396.500156 221.6592 
+L 291.875156 221.6592 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.885703 251.0424 
-L 501.510703 251.0424 
-L 501.510703 221.6592 
-L 396.885703 221.6592 
+    <path d="M 396.500156 251.0424 
+L 501.125156 251.0424 
+L 501.125156 221.6592 
+L 396.500156 221.6592 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.635703 280.4256 
-L 292.260703 280.4256 
-L 292.260703 251.0424 
-L 187.635703 251.0424 
+    <path d="M 187.250156 280.4256 
+L 291.875156 280.4256 
+L 291.875156 251.0424 
+L 187.250156 251.0424 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.260703 280.4256 
-L 396.885703 280.4256 
-L 396.885703 251.0424 
-L 292.260703 251.0424 
+    <path d="M 291.875156 280.4256 
+L 396.500156 280.4256 
+L 396.500156 251.0424 
+L 291.875156 251.0424 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #f67a49; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.885703 280.4256 
-L 501.510703 280.4256 
-L 501.510703 251.0424 
-L 396.885703 251.0424 
+    <path d="M 396.500156 280.4256 
+L 501.125156 280.4256 
+L 501.125156 251.0424 
+L 396.500156 251.0424 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #e65036; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.635703 309.8088 
-L 292.260703 309.8088 
-L 292.260703 280.4256 
-L 187.635703 280.4256 
+    <path d="M 187.250156 309.8088 
+L 291.875156 309.8088 
+L 291.875156 280.4256 
+L 187.250156 280.4256 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.260703 309.8088 
-L 396.885703 309.8088 
-L 396.885703 280.4256 
-L 292.260703 280.4256 
+    <path d="M 291.875156 309.8088 
+L 396.500156 309.8088 
+L 396.500156 280.4256 
+L 291.875156 280.4256 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #f47044; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #f57748; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.885703 309.8088 
-L 501.510703 309.8088 
-L 501.510703 280.4256 
-L 396.885703 280.4256 
+    <path d="M 396.500156 309.8088 
+L 501.125156 309.8088 
+L 501.125156 280.4256 
+L 396.500156 280.4256 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #e65036; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.635703 339.192 
-L 292.260703 339.192 
-L 292.260703 309.8088 
-L 187.635703 309.8088 
+    <path d="M 187.250156 339.192 
+L 291.875156 339.192 
+L 291.875156 309.8088 
+L 187.250156 309.8088 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.260703 339.192 
-L 396.885703 339.192 
-L 396.885703 309.8088 
-L 292.260703 309.8088 
+    <path d="M 291.875156 339.192 
+L 396.500156 339.192 
+L 396.500156 309.8088 
+L 291.875156 309.8088 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.885703 339.192 
-L 501.510703 339.192 
-L 501.510703 309.8088 
-L 396.885703 309.8088 
+    <path d="M 396.500156 339.192 
+L 501.125156 339.192 
+L 501.125156 309.8088 
+L 396.500156 309.8088 
 z
-" clip-path="url(#p0a9814b1b2)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p549027855d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.622969 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.237422 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.907188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.521641 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.479297 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.09375 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.831016 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.445469 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.560703 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.175156 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.496953 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.938203 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.552656 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1033,37 +1033,50 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 941 -->
-    <g transform="translate(441.563203 91.6423) scale(0.08 -0.08)">
+    <!-- 931 -->
+    <g transform="translate(441.177656 91.6423) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.198828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.813281 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1162,7 +1175,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.496953 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1172,7 +1185,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.483203 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.097656 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1184,38 +1197,6 @@ L 525 4134
 L 525 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
@@ -1223,7 +1204,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.563203 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.177656 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1231,7 +1212,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.461953 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.076406 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1255,7 +1236,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.496953 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1265,22 +1246,22 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.483203 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.097656 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 693 -->
-    <g transform="translate(441.563203 150.4087) scale(0.08 -0.08)">
+    <!-- 696 -->
+    <g transform="translate(441.177656 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.768203 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.382656 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1390,7 +1371,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.496953 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1400,22 +1381,22 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.483203 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.097656 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 723 -->
-    <g transform="translate(441.563203 179.7919) scale(0.08 -0.08)">
+    <!-- 735 -->
+    <g transform="translate(441.177656 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.924453 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.538906 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1475,7 +1456,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.496953 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1484,15 +1465,36 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- 45 -->
-    <g transform="translate(339.483203 209.1751) scale(0.08 -0.08)">
+    <!-- 44 -->
+    <g transform="translate(339.097656 209.1751) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.563203 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.177656 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1502,7 @@ z
    </g>
    <g id="text_25">
     <!-- OCaml decompress -->
-    <g transform="translate(96.385078 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(95.999531 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1629,7 +1631,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.321 -->
-    <g transform="translate(228.496953 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1639,22 +1641,22 @@ z
    </g>
    <g id="text_27">
     <!-- 23 -->
-    <g transform="translate(339.483203 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.097656 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 116 -->
-    <g transform="translate(441.563203 238.5583) scale(0.08 -0.08)">
+    <!-- 117 -->
+    <g transform="translate(441.177656 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- Go compress/flate -->
-    <g transform="translate(98.891953 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(98.506406 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1710,7 +1712,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.299 -->
-    <g transform="translate(228.496953 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1719,23 +1721,22 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 17 -->
-    <g transform="translate(339.483203 267.9415) scale(0.08 -0.08)">
+    <!-- 18 -->
+    <g transform="translate(339.097656 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 100 -->
-    <g transform="translate(441.563203 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+    <!-- 88 -->
+    <g transform="translate(443.722656 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.270078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.884531 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1844,7 +1845,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.302 -->
-    <g transform="translate(227.296328 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(226.910781 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1937,8 +1938,8 @@ z
     </g>
    </g>
    <g id="text_35">
-    <!-- 13 -->
-    <g transform="translate(339.006953 297.3247) scale(0.08 -0.08)">
+    <!-- 16 -->
+    <g transform="translate(338.621406 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1954,14 +1955,44 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 92 -->
-    <g transform="translate(443.631953 297.3247) scale(0.08 -0.08)">
+    <!-- 93 -->
+    <g transform="translate(443.246406 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1995,12 +2026,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-39"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.606328 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.220781 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2011,7 +2042,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.496953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2021,13 +2052,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(342.028203 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.642656 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.198203 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.812656 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2043,7 +2074,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(135.019453 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.633906 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2182,36 +2213,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2256,7 +2257,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2395,16 +2396,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2443,110 +2444,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0a9814b1b2">
-   <rect x="83.010703" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p549027855d">
+   <rect x="82.625156" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p876fc6873b)">
+   <g clip-path="url(#pd2c1437810)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ5klEQVR4nO3YP44caR3HYXqmZzzYrHcAB4tBIALI0MqEJNyAkxCRcQLuQEbMCRDZJkQrEAFIRANopWVXi5CNBrt7/nACotH7+Q2l5znBt/V2VX2qdndf/Or+S1t2uJ5esNbuZHrBWnc30wvW2vr53RymF6z19HJ6wVrv/j29gIc4PZ9esNbW/59nF9MLltr40w8AgMdGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNp/fLya3rDU+X4/PWGpw+3N9ISlPnjvg+kJS129/vv0hLU2/or7/YvL6QlL3T65mJ6w1F/f/G16wlIvv7zt++e787vpCUvtdm+nJyy18ccDAACPjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO2/9d63pzcs9eLi5fSEpT69vpqesNQ3/7OfnrDUV77+g+kJS+1Pzqcn8ADP7rd9fqfPt31/ef/Ji+kJSx3vDtMTlnp2u+1vhNv+dQAAPDoCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1P7s5Hx6w1KvD/+cnrDU0/3z6QlLHb92OT1hqU9f/3F6wlLXx8P0hKVeXf5wesJSx9Ntf6M4HN5OT+AB/vD5x9MTlvrwxavpCUtt++4CAMCjI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtbj/62f30iKXu7qYXwP924h2QR2zr98+tX3/O7//bxs9v46cHAMBjI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEjtv/H7v0xv4AE++/Pn0xOW+uVPX01PWOoXv/vH9ISlfvydy+kJS/36o6vpCUv9/Cffm56w1G+v3kxPWOq7lxfTE5b65M276QlL/ejls+kJS/kCCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHbH29/cT49Y6fR4mJ6w1tnF9IK1DtfTC9Y6fzq9YK3dxt9x7++mF6x1fDu9YK2t/z9P9tMLljrutn39nd3cTE9YauNXHwAAj40ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtT/95E/TG9a6v5tesNbZxfSCpe7/9cX0hKV2z786PWGtjV9/9++upyfwALsnT6cnLHV/fDs9Yamz842f3/Wb6QlL+QIKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkPovPSZ5iy+SXHwAAAAASUVORK5CYII=" id="image62068b65a1" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ90lEQVR4nO3YPY5k1R2HYWq6ppkPGNAMAjRIiAQ5NBCSsAN24sQZK2AVDpw5JiOEyAmSHSIkviRrsBGI0UDDVHdXewWO0Hn/7avnWcFPOnXPfW/tjj/89eqZLTucTS9Ya3djesFax4vpBWtt/fwuDtML1rrz4vSCtZ7+PL2A3+PkdHrBWlv/fZ7emV6w1MbffgAAXDcCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1P6z86+nNyx16+bp9ISlDpcX0xOWeuXeq9MTlvrq8TfTE5a6cbLtb9w3b9+fnrDUxbO3pics9c2Tb6cnLPXw9rbvz6enx+kJS+12Z9MTltr22wEAgGtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9q8//8b0hqUe3H44PWGpR798OT1hqYdn2/5Geu6lP05PWOpkt5+esNTl1cX0hKVeOrk/PWGp/Qun0xOWune67fM7Px6mJyx193CcnrDUtt/uAABcOwIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDUfrfbdoM+Ofw4PWGpO/t70xOWunxwf3rCUo8e/2N6wlJn54fpCUu9/cJb0xOWOuynF6z169Ofpycsde902/fnT0//Mz1hrWdfnl6w1LbrEwCAa0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2l1++uer6RFLHY/TC+B/u+EbkGts6/fn1p8/5/f/bePnt/HTAwDguhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9q9+9vn0hqX2t/bTE5Z69M/vpics9Zc/vTM9YakP//7v6QlLvff6i9MTlvrbJ19NT1jqg/ffnJ6w1EdfPJ6esNQfHtyenrDUv54cpics9e5rd6cnLOUfUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU7v/z4anrESifnh+kJa928Nb1grcPZ9IK19hs/v5P99IK1ro7TC9Y6/216wVq7jf8Hc2Pbz9/5btvP382Li+kJS2386QMA4LoRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPYn3389vWGtq+P0grV22/6GuDr7aXrCUru796cnrHV5mF6w1nHj98vW78/TO9ML1jr/bXrBUjdP9tMT1jqcTS9Yatv1AgDAtSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI/RcUuXuq55miFwAAAABJRU5ErkJggg==" id="image7172971adf" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc037f1c601" d="M 0 0 
+       <path id="m1cd5c4f25e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc037f1c601" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc037f1c601" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc037f1c601" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc037f1c601" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc037f1c601" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc037f1c601" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc037f1c601" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc037f1c601" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc037f1c601" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc037f1c601" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc037f1c601" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc037f1c601" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cd5c4f25e" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mdf8741d2ac" d="M 0 0 
+       <path id="m42b1d9905e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdf8741d2ac" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42b1d9905e" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdf8741d2ac" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42b1d9905e" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mdf8741d2ac" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42b1d9905e" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdf8741d2ac" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42b1d9905e" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mdf8741d2ac" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42b1d9905e" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdf8741d2ac" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42b1d9905e" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mdf8741d2ac" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42b1d9905e" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdf8741d2ac" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m42b1d9905e" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,9 +1138,28 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- -56 -->
+    <!-- -45 -->
     <g transform="translate(110.506785 69.553235) scale(0.065 -0.065)">
      <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
 L 3169 4134 
@@ -1166,6 +1185,44 @@ Q 953 2441 691 2322
 L 691 4666 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -47 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -45 -->
+    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -63 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1194,95 +1251,6 @@ Q 447 3434 972 4092
 Q 1497 4750 2381 4750 
 Q 2619 4750 2861 4703 
 Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -59 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -49 -->
-    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -73 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1319,77 +1287,108 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -51 -->
+    <!-- -43 -->
     <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -49 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -50 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -54 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -65 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -64 -->
+    <!-- -53 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -55 -->
+    <!-- -43 -->
     <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -64 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
     <!-- -52 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1421,131 +1420,17 @@ z
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_31">
+    <!-- -47 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_32">
-    <!-- -69 -->
+    <!-- -58 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +6 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -13 -->
-    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -4 -->
-    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -16 -->
-    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_37">
-    <!-- -4 -->
-    <g transform="translate(273.684192 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_38">
-    <!-- +0 -->
-    <g transform="translate(312.410731 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_39">
-    <!-- -4 -->
-    <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- -13 -->
-    <g transform="translate(392.448575 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- -10 -->
-    <g transform="translate(432.725974 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- -6 -->
-    <g transform="translate(475.071185 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- +8 -->
-    <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1587,34 +1472,149 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_44">
+   <g id="text_33">
+    <!-- +6 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -14 -->
+    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -4 -->
+    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -16 -->
+    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_37">
+    <!-- -5 -->
+    <g transform="translate(273.684192 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_38">
+    <!-- -1 -->
+    <g transform="translate(313.961591 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_39">
+    <!-- -4 -->
+    <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_40">
     <!-- -13 -->
-    <g transform="translate(553.558169 106.389018) scale(0.065 -0.065)">
+    <g transform="translate(392.448575 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_41">
+    <!-- -10 -->
+    <g transform="translate(432.725974 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- -6 -->
+    <g transform="translate(475.071185 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- +8 -->
+    <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- -12 -->
+    <g transform="translate(553.558169 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_45">
-    <!-- +252 -->
+    <!-- +255 -->
     <g transform="translate(106.888113 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- +252 -->
+    <!-- +245 -->
     <g transform="translate(147.165512 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_47">
@@ -1627,84 +1627,84 @@ z
     </g>
    </g>
    <g id="text_48">
-    <!-- +133 -->
+    <!-- +131 -->
     <g transform="translate(227.720309 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +237 -->
+    <!-- +235 -->
     <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +188 -->
+    <!-- +186 -->
     <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +277 -->
+    <!-- +279 -->
     <g transform="translate(348.552505 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
-    <!-- +154 -->
+    <!-- +155 -->
     <g transform="translate(388.829903 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_53">
-    <!-- +212 -->
+    <!-- +220 -->
     <g transform="translate(429.107302 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_54">
-    <!-- +187 -->
+    <!-- +191 -->
     <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_55">
-    <!-- +209 -->
+    <!-- +211 -->
     <g transform="translate(509.662099 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_56">
-    <!-- +159 -->
+    <!-- +160 -->
     <g transform="translate(549.939498 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_57">
@@ -1805,19 +1805,19 @@ z
     </g>
    </g>
    <g id="text_69">
-    <!-- +30 -->
+    <!-- +31 -->
     <g transform="translate(108.955926 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_70">
-    <!-- +28 -->
+    <!-- +26 -->
     <g transform="translate(149.233324 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
@@ -1829,26 +1829,26 @@ z
     </g>
    </g>
    <g id="text_72">
-    <!-- +9 -->
+    <!-- +5 -->
     <g transform="translate(231.855934 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_73">
-    <!-- +64 -->
+    <!-- +62 -->
     <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_74">
-    <!-- +74 -->
+    <!-- +75 -->
     <g transform="translate(310.342919 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_75">
@@ -1860,81 +1860,82 @@ z
     </g>
    </g>
    <g id="text_76">
-    <!-- +9 -->
-    <g transform="translate(392.965528 216.896366) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_77">
-    <!-- +44 -->
-    <g transform="translate(431.175114 216.896366) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_78">
-    <!-- +12 -->
-    <g transform="translate(471.452513 216.896366) scale(0.065 -0.065)">
+    <!-- +10 -->
+    <g transform="translate(390.897716 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_79">
-    <!-- +86 -->
-    <g transform="translate(511.729912 216.896366) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_80">
-    <!-- +20 -->
-    <g transform="translate(552.00731 216.896366) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_81">
-    <!-- +38 -->
-    <g transform="translate(108.955926 253.732149) scale(0.065 -0.065)">
+   <g id="text_77">
+    <!-- +46 -->
+    <g transform="translate(431.175114 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_78">
+    <!-- +11 -->
+    <g transform="translate(471.452513 216.896366) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_79">
+    <!-- +45 -->
+    <g transform="translate(511.729912 216.896366) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_80">
+    <!-- +18 -->
+    <g transform="translate(552.00731 216.896366) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_81">
+    <!-- +35 -->
+    <g transform="translate(108.955926 253.732149) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_82">
-    <!-- +6 -->
+    <!-- +4 -->
     <g transform="translate(151.301137 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_83">
-    <!-- +44 -->
+    <!-- +43 -->
     <g transform="translate(189.510723 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_84">
-    <!-- -39 -->
+    <!-- -40 -->
     <g transform="translate(231.338981 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_85">
-    <!-- +26 -->
+    <!-- +24 -->
     <g transform="translate(270.06552 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_86">
@@ -1946,51 +1947,51 @@ z
     </g>
    </g>
    <g id="text_87">
-    <!-- +19 -->
+    <!-- +22 -->
     <g transform="translate(350.620317 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_88">
-    <!-- -10 -->
+    <!-- -11 -->
     <g transform="translate(392.448575 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_89">
-    <!-- +35 -->
+    <!-- +32 -->
     <g transform="translate(431.175114 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_90">
-    <!-- +10 -->
+    <!-- +12 -->
     <g transform="translate(471.452513 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_91">
-    <!-- +19 -->
+    <!-- +18 -->
     <g transform="translate(511.729912 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_92">
-    <!-- -16 -->
+    <!-- -19 -->
     <g transform="translate(553.558169 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_93">
@@ -2002,51 +2003,51 @@ z
     </g>
    </g>
    <g id="text_94">
-    <!-- +69 -->
+    <!-- +68 -->
     <g transform="translate(149.233324 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
-    <!-- +78 -->
+    <!-- +76 -->
     <g transform="translate(189.510723 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_96">
-    <!-- +44 -->
+    <!-- +43 -->
     <g transform="translate(229.788122 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_97">
-    <!-- +88 -->
+    <!-- +86 -->
     <g transform="translate(270.06552 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_98">
-    <!-- +88 -->
+    <!-- +84 -->
     <g transform="translate(310.342919 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_99">
-    <!-- +34 -->
+    <!-- +33 -->
     <g transform="translate(350.620317 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_100">
@@ -2058,11 +2059,11 @@ z
     </g>
    </g>
    <g id="text_101">
-    <!-- +83 -->
+    <!-- +81 -->
     <g transform="translate(431.175114 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_102">
@@ -2074,11 +2075,11 @@ z
     </g>
    </g>
    <g id="text_103">
-    <!-- +59 -->
+    <!-- +58 -->
     <g transform="translate(511.729912 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_104">
@@ -2090,11 +2091,11 @@ z
     </g>
    </g>
    <g id="text_105">
-    <!-- -34 -->
+    <!-- -35 -->
     <g transform="translate(110.506785 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_106">
@@ -2114,11 +2115,11 @@ z
     </g>
    </g>
    <g id="text_108">
-    <!-- -48 -->
+    <!-- -49 -->
     <g transform="translate(231.338981 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_109">
@@ -2154,11 +2155,11 @@ z
     </g>
    </g>
    <g id="text_113">
-    <!-- -48 -->
+    <!-- -49 -->
     <g transform="translate(432.725974 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_114">
@@ -2178,11 +2179,11 @@ z
     </g>
    </g>
    <g id="text_116">
-    <!-- -46 -->
+    <!-- -45 -->
     <g transform="translate(553.558169 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2196,23 +2197,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagee6a33c4b7e" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image56c3c682f6" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m1851fbc74e" d="M 0 0 
+       <path id="m339af26341" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1851fbc74e" x="601.779688" y="320.964625" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m339af26341" x="601.779688" y="320.934248" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
       <!-- −3 -->
-      <g transform="translate(608.779688 324.763844) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 324.733467) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2230,12 +2231,12 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1851fbc74e" x="601.779688" y="279.538044" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m339af26341" x="601.779688" y="279.517792" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
       <!-- −2 -->
-      <g transform="translate(608.779688 283.337263) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 283.317011) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2244,12 +2245,12 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m1851fbc74e" x="601.779688" y="238.111462" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m339af26341" x="601.779688" y="238.101337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
       <!-- −1 -->
-      <g transform="translate(608.779688 241.910681) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 241.900555) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2258,7 +2259,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1851fbc74e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m339af26341" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2271,12 +2272,12 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m1851fbc74e" x="601.779688" y="155.258299" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m339af26341" x="601.779688" y="155.268425" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
       <!-- 1 -->
-      <g transform="translate(608.779688 159.057518) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 159.067644) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2284,12 +2285,12 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1851fbc74e" x="601.779688" y="113.831718" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m339af26341" x="601.779688" y="113.851969" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
       <!-- 2 -->
-      <g transform="translate(608.779688 117.630936) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 117.651188) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2297,12 +2298,12 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m1851fbc74e" x="601.779688" y="72.405136" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m339af26341" x="601.779688" y="72.435513" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
       <!-- 3 -->
-      <g transform="translate(608.779688 76.204355) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 76.234732) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2913,8 +2914,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.689297 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.074844 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3003,16 +3004,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3051,109 +3052,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p876fc6873b">
+  <clipPath id="pd2c1437810">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m6629c9d6d7" d="M 0 0 
+       <path id="m224eef2a4f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6629c9d6d7" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m224eef2a4f" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6629c9d6d7" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m224eef2a4f" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6629c9d6d7" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m224eef2a4f" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6629c9d6d7" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m224eef2a4f" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6629c9d6d7" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m224eef2a4f" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6629c9d6d7" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m224eef2a4f" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6629c9d6d7" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m224eef2a4f" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,23 +854,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 368.059703 
-L 637.2 368.059703 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 368.095486 
+L 637.2 368.095486 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m0e79191dd5" d="M 0 0 
+       <path id="m5243c90bac" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e79191dd5" x="49.078125" y="368.059703" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5243c90bac" x="49.078125" y="368.095486" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 371.858922) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 371.894705) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -895,18 +895,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 243.320785 
-L 637.2 243.320785 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.514978 
+L 637.2 243.514978 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0e79191dd5" x="49.078125" y="243.320785" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5243c90bac" x="49.078125" y="243.514978" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 247.120003) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 247.314197) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -915,18 +915,18 @@ L 637.2 243.320785
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 118.581866 
-L 637.2 118.581866 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 118.93447 
+L 637.2 118.93447 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0e79191dd5" x="49.078125" y="118.581866" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5243c90bac" x="49.078125" y="118.93447" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 122.381085) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 122.733688) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -935,282 +935,282 @@ L 637.2 118.581866
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 405.609859 
-L 637.2 405.609859 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 405.597956 
+L 637.2 405.597956 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m6031043c9a" d="M 0 0 
+       <path id="m3cfac4c507" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="405.609859" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="405.597956" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 395.732876 
-L 637.2 395.732876 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 395.733516 
+L 637.2 395.733516 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="395.732876" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="395.733516" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 387.382006 
-L 637.2 387.382006 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 387.393251 
+L 637.2 387.393251 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="387.382006" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="387.393251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 380.148154 
-L 637.2 380.148154 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.168585 
+L 637.2 380.168585 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="380.148154" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="380.168585" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 373.767443 
-L 637.2 373.767443 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 373.795977 
+L 637.2 373.795977 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="373.767443" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="373.795977" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 330.509547 
-L 637.2 330.509547 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.593016 
+L 637.2 330.593016 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="330.509547" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="330.593016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 308.544114 
-L 637.2 308.544114 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 308.655478 
+L 637.2 308.655478 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="308.544114" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="308.655478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 292.959391 
-L 637.2 292.959391 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 293.090546 
+L 637.2 293.090546 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="292.959391" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="293.090546" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 280.870941 
-L 637.2 280.870941 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 281.017448 
+L 637.2 281.017448 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="280.870941" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="281.017448" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 270.993958 
-L 637.2 270.993958 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.153008 
+L 637.2 271.153008 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="270.993958" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="271.153008" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 262.643088 
-L 637.2 262.643088 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.812743 
+L 637.2 262.812743 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="262.643088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="262.812743" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 255.409235 
-L 637.2 255.409235 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.588076 
+L 637.2 255.588076 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="255.409235" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="255.588076" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 249.028525 
-L 637.2 249.028525 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.215469 
+L 637.2 249.215469 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="249.028525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="249.215469" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 205.770629 
-L 637.2 205.770629 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 206.012508 
+L 637.2 206.012508 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="205.770629" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="206.012508" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 183.805195 
-L 637.2 183.805195 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 184.074969 
+L 637.2 184.074969 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="183.805195" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="184.074969" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 168.220473 
-L 637.2 168.220473 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 168.510038 
+L 637.2 168.510038 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="168.220473" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="168.510038" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 156.132022 
-L 637.2 156.132022 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 156.436939 
+L 637.2 156.436939 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="156.132022" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="156.436939" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 146.255039 
-L 637.2 146.255039 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.5725 
+L 637.2 146.5725 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="146.255039" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="146.5725" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 137.904169 
-L 637.2 137.904169 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 138.232234 
+L 637.2 138.232234 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="137.904169" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="138.232234" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 130.670316 
-L 637.2 130.670316 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 131.007568 
+L 637.2 131.007568 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="130.670316" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="131.007568" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 124.289606 
-L 637.2 124.289606 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 124.634961 
+L 637.2 124.634961 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="124.289606" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="124.634961" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 81.03171 
-L 637.2 81.03171 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 81.432 
+L 637.2 81.432 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="81.03171" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="81.432" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 59.066277 
-L 637.2 59.066277 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 59.494461 
+L 637.2 59.494461 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m6031043c9a" x="49.078125" y="59.066277" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m3cfac4c507" x="49.078125" y="59.494461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(292.62732 166.925173) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(292.62732 162.108449) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 372.040131) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 370.528992) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1693,124 +1693,124 @@ z
     </g>
    </g>
    <g id="line2d_67">
-    <path d="M 377.110281 104.476795 
-L 323.801439 110.1742 
-L 272.665744 126.042664 
-L 235.168828 127.741969 
-L 186.228265 149.260285 
-L 158.303164 171.349246 
-L 149.489547 181.995408 
-L 140.563162 202.380879 
-L 138.984853 209.278136 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 377.110281 104.391138 
+L 323.801439 110.203287 
+L 272.665744 126.045731 
+L 235.168828 127.593835 
+L 186.228265 149.028964 
+L 158.303164 171.270867 
+L 149.489547 181.98161 
+L 140.563162 202.351012 
+L 138.984853 209.277481 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m3aeea44e58" d="M -2.5 2.5 
+     <path id="md0d172f3d7" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa7c61f1ff8)">
-     <use xlink:href="#m3aeea44e58" x="377.110281" y="104.476795" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aeea44e58" x="323.801439" y="110.1742" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aeea44e58" x="272.665744" y="126.042664" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aeea44e58" x="235.168828" y="127.741969" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aeea44e58" x="186.228265" y="149.260285" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aeea44e58" x="158.303164" y="171.349246" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aeea44e58" x="149.489547" y="181.995408" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aeea44e58" x="140.563162" y="202.380879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3aeea44e58" x="138.984853" y="209.278136" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd292e4bb55)">
+     <use xlink:href="#md0d172f3d7" x="377.110281" y="104.391138" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md0d172f3d7" x="323.801439" y="110.203287" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md0d172f3d7" x="272.665744" y="126.045731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md0d172f3d7" x="235.168828" y="127.593835" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md0d172f3d7" x="186.228265" y="149.028964" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md0d172f3d7" x="158.303164" y="171.270867" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md0d172f3d7" x="149.489547" y="181.98161" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md0d172f3d7" x="140.563162" y="202.351012" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md0d172f3d7" x="138.984853" y="209.277481" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 610.467187 72.446247 
-L 319.880958 101.582306 
-L 210.281253 129.577346 
-L 196.287076 133.421684 
-L 176.054419 147.286251 
-L 152.161413 174.673849 
-L 146.720208 186.506557 
-L 143.994022 196.286928 
-L 142.666037 200.119488 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467187 72.524581 
+L 319.880958 101.728242 
+L 210.281253 129.683647 
+L 196.287076 133.431152 
+L 176.054419 147.356758 
+L 152.161413 174.758772 
+L 146.720208 186.571841 
+L 143.994022 196.316094 
+L 142.666037 200.148909 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf0c7d06de1" d="M 0 -2.5 
+     <path id="m020dddbb6b" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa7c61f1ff8)">
-     <use xlink:href="#mf0c7d06de1" x="610.467187" y="72.446247" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf0c7d06de1" x="319.880958" y="101.582306" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf0c7d06de1" x="210.281253" y="129.577346" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf0c7d06de1" x="196.287076" y="133.421684" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf0c7d06de1" x="176.054419" y="147.286251" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf0c7d06de1" x="152.161413" y="174.673849" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf0c7d06de1" x="146.720208" y="186.506557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf0c7d06de1" x="143.994022" y="196.286928" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf0c7d06de1" x="142.666037" y="200.119488" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd292e4bb55)">
+     <use xlink:href="#m020dddbb6b" x="610.467187" y="72.524581" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m020dddbb6b" x="319.880958" y="101.728242" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m020dddbb6b" x="210.281253" y="129.683647" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m020dddbb6b" x="196.287076" y="133.431152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m020dddbb6b" x="176.054419" y="147.356758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m020dddbb6b" x="152.161413" y="174.758772" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m020dddbb6b" x="146.720208" y="186.571841" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m020dddbb6b" x="143.994022" y="196.316094" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m020dddbb6b" x="142.666037" y="200.148909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <path d="M 292.033351 64.890426 
-L 242.839153 80.451036 
-L 218.251194 85.933106 
-L 197.814984 89.953903 
-L 166.378359 98.896585 
-L 145.830392 110.0649 
-L 134.598477 125.704711 
-L 124.077268 148.888112 
-L 122.462976 156.968181 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 242.839153 80.480439 
+L 218.251194 86.014806 
+L 197.814984 89.997741 
+L 166.378359 98.587012 
+L 145.830392 110.01759 
+L 134.598477 125.768606 
+L 124.077268 148.876447 
+L 122.462976 156.979282 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m3c28dc27b0" d="M -0 3.535534 
+     <path id="m40a0c4fa26" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa7c61f1ff8)">
-     <use xlink:href="#m3c28dc27b0" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c28dc27b0" x="242.839153" y="80.451036" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c28dc27b0" x="218.251194" y="85.933106" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c28dc27b0" x="197.814984" y="89.953903" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c28dc27b0" x="166.378359" y="98.896585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c28dc27b0" x="145.830392" y="110.0649" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c28dc27b0" x="134.598477" y="125.704711" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c28dc27b0" x="124.077268" y="148.888112" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3c28dc27b0" x="122.462976" y="156.968181" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd292e4bb55)">
+     <use xlink:href="#m40a0c4fa26" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a0c4fa26" x="242.839153" y="80.480439" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a0c4fa26" x="218.251194" y="86.014806" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a0c4fa26" x="197.814984" y="89.997741" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a0c4fa26" x="166.378359" y="98.587012" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a0c4fa26" x="145.830392" y="110.01759" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a0c4fa26" x="134.598477" y="125.768606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a0c4fa26" x="124.077268" y="148.876447" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40a0c4fa26" x="122.462976" y="156.979282" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m670004073f" d="M -0 2.5 
+     <path id="mde5cf0bd64" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa7c61f1ff8)">
-     <use xlink:href="#m670004073f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd292e4bb55)">
+     <use xlink:href="#mde5cf0bd64" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
-    <path d="M 432.495268 105.373939 
-L 300.62247 117.177091 
-L 266.967623 123.759295 
-L 226.040946 126.259461 
-L 180.985721 144.677352 
-L 164.441833 157.23271 
-L 157.761315 167.586504 
-L 151.269082 181.579391 
-L 150.327087 187.56157 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 432.495268 103.747894 
+L 300.62247 118.094143 
+L 266.967623 125.752499 
+L 226.040946 126.221492 
+L 180.985721 144.145532 
+L 164.441833 158.518967 
+L 157.761315 167.060702 
+L 151.269082 181.300035 
+L 150.327087 187.035947 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf2ef07587c" d="M -0.833333 2.5 
+     <path id="me81b3c870e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,31 +1825,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa7c61f1ff8)">
-     <use xlink:href="#mf2ef07587c" x="432.495268" y="105.373939" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2ef07587c" x="300.62247" y="117.177091" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2ef07587c" x="266.967623" y="123.759295" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2ef07587c" x="226.040946" y="126.259461" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2ef07587c" x="180.985721" y="144.677352" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2ef07587c" x="164.441833" y="157.23271" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2ef07587c" x="157.761315" y="167.586504" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2ef07587c" x="151.269082" y="181.579391" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2ef07587c" x="150.327087" y="187.56157" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd292e4bb55)">
+     <use xlink:href="#me81b3c870e" x="432.495268" y="103.747894" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me81b3c870e" x="300.62247" y="118.094143" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me81b3c870e" x="266.967623" y="125.752499" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me81b3c870e" x="226.040946" y="126.221492" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me81b3c870e" x="180.985721" y="144.145532" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me81b3c870e" x="164.441833" y="158.518967" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me81b3c870e" x="157.761315" y="167.060702" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me81b3c870e" x="151.269082" y="181.300035" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me81b3c870e" x="150.327087" y="187.035947" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
-    <path d="M 345.030867 134.75287 
-L 273.364924 141.598901 
-L 240.719951 147.702825 
-L 221.353978 153.07281 
-L 207.129625 155.347785 
-L 181.064802 166.351853 
-L 179.282169 169.729244 
-L 177.719335 175.157022 
-L 177.643939 180.932541 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 345.030867 135.154118 
+L 273.364924 141.958777 
+L 240.719951 147.997792 
+L 221.353978 153.310468 
+L 207.129625 155.25199 
+L 181.064802 166.749271 
+L 179.282169 170.34322 
+L 177.719335 175.716295 
+L 177.643939 181.088361 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m78d243becf" d="M -1.25 2.5 
+     <path id="m9747e96383" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,31 +1864,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa7c61f1ff8)">
-     <use xlink:href="#m78d243becf" x="345.030867" y="134.75287" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m78d243becf" x="273.364924" y="141.598901" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m78d243becf" x="240.719951" y="147.702825" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m78d243becf" x="221.353978" y="153.07281" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m78d243becf" x="207.129625" y="155.347785" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m78d243becf" x="181.064802" y="166.351853" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m78d243becf" x="179.282169" y="169.729244" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m78d243becf" x="177.719335" y="175.157022" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m78d243becf" x="177.643939" y="180.932541" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd292e4bb55)">
+     <use xlink:href="#m9747e96383" x="345.030867" y="135.154118" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9747e96383" x="273.364924" y="141.958777" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9747e96383" x="240.719951" y="147.997792" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9747e96383" x="221.353978" y="153.310468" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9747e96383" x="207.129625" y="155.25199" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9747e96383" x="181.064802" y="166.749271" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9747e96383" x="179.282169" y="170.34322" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9747e96383" x="177.719335" y="175.716295" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9747e96383" x="177.643939" y="181.088361" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
-    <path d="M 226.871027 112.933127 
-L 226.871027 112.798724 
-L 226.871027 112.876417 
-L 226.871027 112.877898 
-L 177.768423 131.736519 
-L 160.37503 145.049305 
-L 153.995779 152.129164 
-L 147.106887 167.533036 
-L 145.871703 174.69283 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 226.871027 113.151264 
+L 226.871027 113.175348 
+L 226.871027 113.32385 
+L 226.871027 113.232532 
+L 177.768423 132.166507 
+L 160.37503 145.356614 
+L 153.995779 152.489967 
+L 147.106887 167.695749 
+L 145.871703 174.967742 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb0d7fe242a" d="M 0 -2.5 
+     <path id="m883388886a" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,31 +1901,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pa7c61f1ff8)">
-     <use xlink:href="#mb0d7fe242a" x="226.871027" y="112.933127" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0d7fe242a" x="226.871027" y="112.798724" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0d7fe242a" x="226.871027" y="112.876417" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0d7fe242a" x="226.871027" y="112.877898" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0d7fe242a" x="177.768423" y="131.736519" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0d7fe242a" x="160.37503" y="145.049305" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0d7fe242a" x="153.995779" y="152.129164" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0d7fe242a" x="147.106887" y="167.533036" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb0d7fe242a" x="145.871703" y="174.69283" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pd292e4bb55)">
+     <use xlink:href="#m883388886a" x="226.871027" y="113.151264" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m883388886a" x="226.871027" y="113.175348" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m883388886a" x="226.871027" y="113.32385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m883388886a" x="226.871027" y="113.232532" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m883388886a" x="177.768423" y="132.166507" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m883388886a" x="160.37503" y="145.356614" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m883388886a" x="153.995779" y="152.489967" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m883388886a" x="147.106887" y="167.695749" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m883388886a" x="145.871703" y="174.967742" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
-    <path d="M 585.66883 173.953565 
-L 527.144592 176.150645 
-L 457.339427 184.575146 
-L 292.124837 178.863413 
-L 243.129344 190.690705 
-L 213.541392 204.774318 
-L 204.551957 212.379925 
-L 195.860087 228.732183 
-L 194.019853 234.158871 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 585.66883 174.431162 
+L 527.144592 176.495916 
+L 457.339427 184.579548 
+L 292.124837 179.274159 
+L 243.129344 190.954641 
+L 213.541392 204.889391 
+L 204.551957 212.504047 
+L 195.860087 228.932983 
+L 194.019853 234.446928 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9d398a4719" d="M 0 -2.5 
+     <path id="m653b3c45b0" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pa7c61f1ff8)">
-     <use xlink:href="#m9d398a4719" x="585.66883" y="173.953565" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d398a4719" x="527.144592" y="176.150645" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d398a4719" x="457.339427" y="184.575146" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d398a4719" x="292.124837" y="178.863413" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d398a4719" x="243.129344" y="190.690705" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d398a4719" x="213.541392" y="204.774318" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d398a4719" x="204.551957" y="212.379925" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d398a4719" x="195.860087" y="228.732183" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9d398a4719" x="194.019853" y="234.158871" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd292e4bb55)">
+     <use xlink:href="#m653b3c45b0" x="585.66883" y="174.431162" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m653b3c45b0" x="527.144592" y="176.495916" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m653b3c45b0" x="457.339427" y="184.579548" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m653b3c45b0" x="292.124837" y="179.274159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m653b3c45b0" x="243.129344" y="190.954641" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m653b3c45b0" x="213.541392" y="204.889391" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m653b3c45b0" x="204.551957" y="212.504047" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m653b3c45b0" x="195.860087" y="228.932983" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m653b3c45b0" x="194.019853" y="234.446928" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="macd1361e6b" d="M 0 3.5 
+      <path id="m0881d40586" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#macd1361e6b" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m0881d40586" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m3aeea44e58" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md0d172f3d7" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf0c7d06de1" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m020dddbb6b" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m3c28dc27b0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m40a0c4fa26" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m670004073f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mde5cf0bd64" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf2ef07587c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me81b3c870e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m78d243becf" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9747e96383" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb0d7fe242a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m883388886a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9d398a4719" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m653b3c45b0" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 287.62732 171.925173 
-L 253.661767 178.377903 
-L 230.111105 184.430053 
-L 195.337271 206.809398 
-L 190.545203 210.991717 
-L 182.839694 220.762209 
-L 155.420659 260.947327 
-L 153.649656 266.084668 
-L 95.319203 377.040131 
-" clip-path="url(#pa7c61f1ff8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pa7c61f1ff8)">
-     <use xlink:href="#macd1361e6b" x="287.62732" y="171.925173" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#macd1361e6b" x="253.661767" y="178.377903" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#macd1361e6b" x="230.111105" y="184.430053" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#macd1361e6b" x="195.337271" y="206.809398" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#macd1361e6b" x="190.545203" y="210.991717" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#macd1361e6b" x="182.839694" y="220.762209" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#macd1361e6b" x="155.420659" y="260.947327" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#macd1361e6b" x="153.649656" y="266.084668" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#macd1361e6b" x="95.319203" y="377.040131" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 287.62732 167.108449 
+L 253.661767 172.302702 
+L 230.111105 177.486697 
+L 195.337271 196.421643 
+L 190.545203 199.822777 
+L 182.839694 208.616652 
+L 155.420659 253.828387 
+L 153.649656 258.139219 
+L 95.319203 375.528992 
+" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pd292e4bb55)">
+     <use xlink:href="#m0881d40586" x="287.62732" y="167.108449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0881d40586" x="253.661767" y="172.302702" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0881d40586" x="230.111105" y="177.486697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0881d40586" x="195.337271" y="196.421643" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0881d40586" x="190.545203" y="199.822777" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0881d40586" x="182.839694" y="208.616652" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0881d40586" x="155.420659" y="253.828387" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0881d40586" x="153.649656" y="258.139219" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0881d40586" x="95.319203" y="375.528992" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,34 +2803,9 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.689297 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.074844 465.66) scale(0.07 -0.07)">
     <defs>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2912,14 +2887,29 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-39" d="M 703 97 
@@ -2990,16 +2980,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3038,109 +3028,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa7c61f1ff8">
+  <clipPath id="pd292e4bb55">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p49a8e5e518)">
+   <g clip-path="url(#p06274544d0)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKBUlEQVR4nO3Yz4qddx3H8TOdSRMyaSYJGotVFFPcxOpGkLpw1ZXowhtw0ytw48qVeAeuvAHBhRQ3QjZdFqr1X8WFxaqlKiE2TRrTmEwmc7yC90Lqj68cXq8r+MA5fJ/38+yd3vzRdrODjn98Y3rCEmdeemF6wjJ7Vz85PWGJ7W9/Nz1hib0vXp+esMT2wb3pCcvc+u4r0xOWuPqDb0xPWGLvyiemJ6xx/GB6wTKnv9jNe//U9AAAAP5/iUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLev45f2U6PWOHw/VvTE5Z47+L56QnL/Pvk/vSEJT79wfH0hCU++Piz0xOWON2eTk9Y5vLBlekJa9z+6/SCJe5d3s3f65m//HF6wjLbz39lesISviwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJAODm/fnN6wxvlL0wuW2G6Ppycs86lX35iesMZLX59esMTRe/+YnrDG6cn0gnUOd/R+nL0wvWCJi//czefznc9cm56wzOV335yesIQviwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDae/zkxnZ6xAr7t/48PWGJm888PT1hmfuP705PWOLaO3enJyxx8oWvTk9Y4sHJvekJyxztX5qesMT27V9OT1ji4edemJ6wxLk3X5+esMyjL704PWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPezt7+znR6xwpVzh9MTlnjr7u3pCcu8/MNfT09Y4jff/+b0hCWOzh5NT1jie6/9anrCMl977tz0hCW+de3F6QlLvPq316cnLHHhzG7+Dzebzeanf7ozPWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPf4yY3t9IgV7jy6NT1hicODi9MTlnnr7u+nJyzx/KXr0xOW2G5PpycsceFkd9+h/366m3fxucPnpycs8fDJg+kJS+zq7dhsNpv9pw6mJyyxu1cRAICPTCwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6WB/72B6wxIf278yPWGN/aenFyxzdPZoesIShwcXpycs8WR7Mj1hidMzu/sO/ez2/PQE/gu7+nw+3j6cnrDMvUe3picssbtXEQCAj0wsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQDjYfvj+9YYntH96YnrDE3vUvT09Y5rMf7ui7y7mH0wuW2D89mZ6wxo7exM1ms3n8k59PT1hi/+VvT09Y4sz2dHrCEvc3u3kTN5vN5uo7705PWGJHn84AAPwviEUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANJ/AJkNm8+5AYuWAAAAAElFTkSuQmCC" id="imagee611d700c9" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKBUlEQVR4nO3Yz4qddx3H8TOdSRMyaSYJGotVFFPcxOpGkLpw1ZXowhtw0ytw48qVeAeuvAHBhRQ3QjZdFqr1X8WFxaqlKiE2TRrTmEwmc7yC90Lqj68cXq8r+MA5fJ/38+yd3vzRdrODjn98Y3rCEmdeemF6wjJ7Vz85PWGJ7W9/Nz1hib0vXp+esMT2wb3pCcvc+u4r0xOWuPqDb0xPWGLvyiemJ6xx/GB6wTKnv9jNe//U9AAAAP5/iUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLev45f2U6PWOHw/VvTE5Z47+L56QnL/Pvk/vSEJT79wfH0hCU++Piz0xOWON2eTk9Y5vLBlekJa9z+6/SCJe5d3s3f65m//HF6wjLbz39lesISviwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJAODm/fnN6wxvlL0wuW2G6Ppycs86lX35iesMZLX59esMTRe/+YnrDG6cn0gnUOd/R+nL0wvWCJi//czefznc9cm56wzOV335yesIQviwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDae/zkxnZ6xAr7t/48PWGJm888PT1hmfuP705PWOLaO3enJyxx8oWvTk9Y4sHJvekJyxztX5qesMT27V9OT1ji4edemJ6wxLk3X5+esMyjL704PWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPezt7+znR6xwpVzh9MTlnjr7u3pCcu8/MNfT09Y4jff/+b0hCWOzh5NT1jie6/9anrCMl977tz0hCW+de3F6QlLvPq316cnLHHhzG7+Dzebzeanf7ozPWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPf4yY3t9IgV7jy6NT1hicODi9MTlnnr7u+nJyzx/KXr0xOW2G5PpycsceFkd9+h/366m3fxucPnpycs8fDJg+kJS+zq7dhsNpv9pw6mJyyxu1cRAICPTCwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6WB/72B6wxIf278yPWGN/aenFyxzdPZoesIShwcXpycs8WR7Mj1hidMzu/sO/ez2/PQE/gu7+nw+3j6cnrDMvUe3picssbtXEQCAj0wsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQDjYfvj+9YYntH96YnrDE3vUvT09Y5rMf7ui7y7mH0wuW2D89mZ6wxo7exM1ms3n8k59PT1hi/+VvT09Y4sz2dHrCEvc3u3kTN5vN5uo7705PWGJHn84AAPwviEUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANJ/AJkNm8+5AYuWAAAAAElFTkSuQmCC" id="image90271cbc7c" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m0552f7de56" d="M 0 0 
+       <path id="m39dfe71dff" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0552f7de56" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m0552f7de56" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m0552f7de56" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0552f7de56" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m0552f7de56" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0552f7de56" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m0552f7de56" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0552f7de56" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m0552f7de56" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0552f7de56" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m0552f7de56" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0552f7de56" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m39dfe71dff" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="ma0d14abbe9" d="M 0 0 
+       <path id="ma10520c7c7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma0d14abbe9" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma10520c7c7" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma0d14abbe9" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma10520c7c7" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma0d14abbe9" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma10520c7c7" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma0d14abbe9" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma10520c7c7" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma0d14abbe9" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma10520c7c7" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma0d14abbe9" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma10520c7c7" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma0d14abbe9" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma10520c7c7" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma0d14abbe9" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma10520c7c7" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagef7f2c29df6" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageeb8d76ba13" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m6af03cf0e4" d="M 0 0 
+       <path id="m9c0c03f34a" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6af03cf0e4" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c0c03f34a" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6af03cf0e4" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c0c03f34a" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m6af03cf0e4" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c0c03f34a" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6af03cf0e4" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c0c03f34a" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m6af03cf0e4" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c0c03f34a" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.689297 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.074844 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2764,44 +2764,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-b7" d="M 684 2619 
-L 1344 2619 
-L 1344 1825 
-L 684 1825 
-L 684 2619 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-4c" d="M 628 4666 
-L 1259 4666 
-L 1259 531 
-L 3531 531 
-L 3531 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-38" d="M 2034 2216 
@@ -2843,6 +2805,44 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3b" d="M 750 3309 
 L 1409 3309 
 L 1409 2516 
@@ -2868,16 +2868,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2916,109 +2916,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p49a8e5e518">
+  <clipPath id="p06274544d0">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="571.021406pt" height="386.202469pt" viewBox="0 0 571.021406 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.250313pt" height="386.202469pt" viewBox="0 0 570.250313 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 571.021406 386.202469 
-L 571.021406 0 
+L 570.250313 386.202469 
+L 570.250313 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.635703 104.1264 
-L 292.260703 104.1264 
-L 292.260703 74.7432 
-L 187.635703 74.7432 
+    <path d="M 187.250156 104.1264 
+L 291.875156 104.1264 
+L 291.875156 74.7432 
+L 187.250156 74.7432 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.260703 104.1264 
-L 396.885703 104.1264 
-L 396.885703 74.7432 
-L 292.260703 74.7432 
+    <path d="M 291.875156 104.1264 
+L 396.500156 104.1264 
+L 396.500156 74.7432 
+L 291.875156 74.7432 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.885703 104.1264 
-L 501.510703 104.1264 
-L 501.510703 74.7432 
-L 396.885703 74.7432 
+    <path d="M 396.500156 104.1264 
+L 501.125156 104.1264 
+L 501.125156 74.7432 
+L 396.500156 74.7432 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.635703 133.5096 
-L 292.260703 133.5096 
-L 292.260703 104.1264 
-L 187.635703 104.1264 
+    <path d="M 187.250156 133.5096 
+L 291.875156 133.5096 
+L 291.875156 104.1264 
+L 187.250156 104.1264 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.260703 133.5096 
-L 396.885703 133.5096 
-L 396.885703 104.1264 
-L 292.260703 104.1264 
+    <path d="M 291.875156 133.5096 
+L 396.500156 133.5096 
+L 396.500156 104.1264 
+L 291.875156 104.1264 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.885703 133.5096 
-L 501.510703 133.5096 
-L 501.510703 104.1264 
-L 396.885703 104.1264 
+    <path d="M 396.500156 133.5096 
+L 501.125156 133.5096 
+L 501.125156 104.1264 
+L 396.500156 104.1264 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.635703 162.8928 
-L 292.260703 162.8928 
-L 292.260703 133.5096 
-L 187.635703 133.5096 
+    <path d="M 187.250156 162.8928 
+L 291.875156 162.8928 
+L 291.875156 133.5096 
+L 187.250156 133.5096 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.260703 162.8928 
-L 396.885703 162.8928 
-L 396.885703 133.5096 
-L 292.260703 133.5096 
+    <path d="M 291.875156 162.8928 
+L 396.500156 162.8928 
+L 396.500156 133.5096 
+L 291.875156 133.5096 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #feec9f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.885703 162.8928 
-L 501.510703 162.8928 
-L 501.510703 133.5096 
-L 396.885703 133.5096 
+    <path d="M 396.500156 162.8928 
+L 501.125156 162.8928 
+L 501.125156 133.5096 
+L 396.500156 133.5096 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.635703 192.276 
-L 292.260703 192.276 
-L 292.260703 162.8928 
-L 187.635703 162.8928 
+    <path d="M 187.250156 192.276 
+L 291.875156 192.276 
+L 291.875156 162.8928 
+L 187.250156 162.8928 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.260703 192.276 
-L 396.885703 192.276 
-L 396.885703 162.8928 
-L 292.260703 162.8928 
+    <path d="M 291.875156 192.276 
+L 396.500156 192.276 
+L 396.500156 162.8928 
+L 291.875156 162.8928 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.885703 192.276 
-L 501.510703 192.276 
-L 501.510703 162.8928 
-L 396.885703 162.8928 
+    <path d="M 396.500156 192.276 
+L 501.125156 192.276 
+L 501.125156 162.8928 
+L 396.500156 162.8928 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.635703 221.6592 
-L 292.260703 221.6592 
-L 292.260703 192.276 
-L 187.635703 192.276 
+    <path d="M 187.250156 221.6592 
+L 291.875156 221.6592 
+L 291.875156 192.276 
+L 187.250156 192.276 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.260703 221.6592 
-L 396.885703 221.6592 
-L 396.885703 192.276 
-L 292.260703 192.276 
+    <path d="M 291.875156 221.6592 
+L 396.500156 221.6592 
+L 396.500156 192.276 
+L 291.875156 192.276 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.885703 221.6592 
-L 501.510703 221.6592 
-L 501.510703 192.276 
-L 396.885703 192.276 
+    <path d="M 396.500156 221.6592 
+L 501.125156 221.6592 
+L 501.125156 192.276 
+L 396.500156 192.276 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fff7b2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.635703 251.0424 
-L 292.260703 251.0424 
-L 292.260703 221.6592 
-L 187.635703 221.6592 
+    <path d="M 187.250156 251.0424 
+L 291.875156 251.0424 
+L 291.875156 221.6592 
+L 187.250156 221.6592 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.260703 251.0424 
-L 396.885703 251.0424 
-L 396.885703 221.6592 
-L 292.260703 221.6592 
+    <path d="M 291.875156 251.0424 
+L 396.500156 251.0424 
+L 396.500156 221.6592 
+L 291.875156 221.6592 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.885703 251.0424 
-L 501.510703 251.0424 
-L 501.510703 221.6592 
-L 396.885703 221.6592 
+    <path d="M 396.500156 251.0424 
+L 501.125156 251.0424 
+L 501.125156 221.6592 
+L 396.500156 221.6592 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.635703 280.4256 
-L 292.260703 280.4256 
-L 292.260703 251.0424 
-L 187.635703 251.0424 
+    <path d="M 187.250156 280.4256 
+L 291.875156 280.4256 
+L 291.875156 251.0424 
+L 187.250156 251.0424 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.260703 280.4256 
-L 396.885703 280.4256 
-L 396.885703 251.0424 
-L 292.260703 251.0424 
+    <path d="M 291.875156 280.4256 
+L 396.500156 280.4256 
+L 396.500156 251.0424 
+L 291.875156 251.0424 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.885703 280.4256 
-L 501.510703 280.4256 
-L 501.510703 251.0424 
-L 396.885703 251.0424 
+    <path d="M 396.500156 280.4256 
+L 501.125156 280.4256 
+L 501.125156 251.0424 
+L 396.500156 251.0424 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.635703 309.8088 
-L 292.260703 309.8088 
-L 292.260703 280.4256 
-L 187.635703 280.4256 
+    <path d="M 187.250156 309.8088 
+L 291.875156 309.8088 
+L 291.875156 280.4256 
+L 187.250156 280.4256 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #fdb163; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #fdb163; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.260703 309.8088 
-L 396.885703 309.8088 
-L 396.885703 280.4256 
-L 292.260703 280.4256 
+    <path d="M 291.875156 309.8088 
+L 396.500156 309.8088 
+L 396.500156 280.4256 
+L 291.875156 280.4256 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.885703 309.8088 
-L 501.510703 309.8088 
-L 501.510703 280.4256 
-L 396.885703 280.4256 
+    <path d="M 396.500156 309.8088 
+L 501.125156 309.8088 
+L 501.125156 280.4256 
+L 396.500156 280.4256 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.635703 339.192 
-L 292.260703 339.192 
-L 292.260703 309.8088 
-L 187.635703 309.8088 
+    <path d="M 187.250156 339.192 
+L 291.875156 339.192 
+L 291.875156 309.8088 
+L 187.250156 309.8088 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.260703 339.192 
-L 396.885703 339.192 
-L 396.885703 309.8088 
-L 292.260703 309.8088 
+    <path d="M 291.875156 339.192 
+L 396.500156 339.192 
+L 396.500156 309.8088 
+L 291.875156 309.8088 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.885703 339.192 
-L 501.510703 339.192 
-L 501.510703 309.8088 
-L 396.885703 309.8088 
+    <path d="M 396.500156 339.192 
+L 501.125156 339.192 
+L 501.125156 309.8088 
+L 396.500156 309.8088 
 z
-" clip-path="url(#pc7d960504a)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p26675f7d94)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.622969 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.237422 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.907188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.521641 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.479297 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.09375 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.831016 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.445469 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.560703 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.175156 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.496953 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -917,8 +917,8 @@ z
     </g>
    </g>
    <g id="text_7">
-    <!-- 117 -->
-    <g transform="translate(336.938203 91.6423) scale(0.08 -0.08)">
+    <!-- 118 -->
+    <g transform="translate(336.552656 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -934,26 +934,6 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_8">
-    <!-- 871 -->
-    <g transform="translate(441.563203 91.6423) scale(0.08 -0.08)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -994,14 +974,54 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- 891 -->
+    <g transform="translate(441.177656 91.6423) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.198828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.813281 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1120,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.496953 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.483203 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.097656 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1169,16 +1189,16 @@ z
     </g>
    </g>
    <g id="text_12">
-    <!-- 312 -->
-    <g transform="translate(441.563203 121.0255) scale(0.08 -0.08)">
+    <!-- 311 -->
+    <g transform="translate(441.177656 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.891953 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.506406 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1369,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.496953 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1385,55 +1405,23 @@ z
     </g>
    </g>
    <g id="text_15">
-    <!-- 49 -->
-    <g transform="translate(339.483203 150.4087) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 48 -->
+    <g transform="translate(339.097656 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 168 -->
-    <g transform="translate(441.563203 150.4087) scale(0.08 -0.08)">
+    <!-- 180 -->
+    <g transform="translate(441.177656 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.924453 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.538906 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1493,7 +1481,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.496953 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1503,22 +1491,22 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.483203 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.097656 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 203 -->
-    <g transform="translate(441.563203 179.7919) scale(0.08 -0.08)">
+    <!-- 205 -->
+    <g transform="translate(441.177656 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.461953 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.076406 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1530,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.496953 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,22 +1540,22 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(339.483203 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.097656 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 442 -->
-    <g transform="translate(441.563203 209.1751) scale(0.08 -0.08)">
+    <!-- 445 -->
+    <g transform="translate(441.177656 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.768203 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(111.382656 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1614,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.496953 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,22 +1624,22 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(339.483203 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.097656 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 529 -->
-    <g transform="translate(441.563203 238.5583) scale(0.08 -0.08)">
+    <!-- 544 -->
+    <g transform="translate(441.177656 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.385078 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.999531 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1716,7 +1704,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.336 -->
-    <g transform="translate(228.496953 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1726,21 +1714,21 @@ z
    </g>
    <g id="text_31">
     <!-- 20 -->
-    <g transform="translate(339.483203 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.097656 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 68 -->
-    <g transform="translate(444.108203 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(443.722656 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.270078 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.884531 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1849,7 +1837,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.329 -->
-    <g transform="translate(227.296328 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(226.910781 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1972,8 +1960,8 @@ z
     </g>
    </g>
    <g id="text_35">
-    <!-- 15 -->
-    <g transform="translate(339.006953 297.3247) scale(0.08 -0.08)">
+    <!-- 19 -->
+    <g transform="translate(338.621406 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1989,47 +1977,43 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 104 -->
+    <g transform="translate(440.463281 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 103 -->
-    <g transform="translate(440.848828 297.3247) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.606328 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.220781 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2040,7 +2024,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.496953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.111406 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2050,13 +2034,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(342.028203 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.642656 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.198203 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.812656 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2072,7 +2056,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(152.112422 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.726875 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2216,7 +2200,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-15T05:16:55Z  ·  Linux chungus x86_64  ·  commit 1779a506  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2355,16 +2339,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2403,110 +2387,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc7d960504a">
-   <rect x="83.010703" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p26675f7d94">
+   <rect x="82.625156" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
 "meta": {
-"date": "2026-06-15T05:16:55Z",
+"date": "2026-06-16T01:38:48Z",
 "machine": "Linux chungus x86_64",
-"git_commit": "1779a506",
+"git_commit": "5acdb3e9",
 "toolchain": "leanprover/lean4:v4.30.0-rc2",
 "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
 },
@@ -14,8 +14,8 @@
 "level": 1,
 "out_size": 59545,
 "ratio": 0.3915,
-"compress_mbps": 27.47,
-"decompress_mbps": 85.94
+"compress_mbps": 30.99,
+"decompress_mbps": 85.04
 },
 {
 "compressor": "native",
@@ -24,8 +24,8 @@
 "level": 2,
 "out_size": 57936,
 "ratio": 0.3809,
-"compress_mbps": 23.82,
-"decompress_mbps": 94.35
+"compress_mbps": 28.02,
+"decompress_mbps": 94.27
 },
 {
 "compressor": "native",
@@ -34,8 +34,8 @@
 "level": 3,
 "out_size": 56891,
 "ratio": 0.3741,
-"compress_mbps": 20.5,
-"decompress_mbps": 103.65
+"compress_mbps": 24.67,
+"decompress_mbps": 103.69
 },
 {
 "compressor": "native",
@@ -44,8 +44,8 @@
 "level": 4,
 "out_size": 55541,
 "ratio": 0.3652,
-"compress_mbps": 12.8,
-"decompress_mbps": 104.08
+"compress_mbps": 16.52,
+"decompress_mbps": 103.94
 },
 {
 "compressor": "native",
@@ -54,8 +54,8 @@
 "level": 5,
 "out_size": 55282,
 "ratio": 0.3635,
-"compress_mbps": 11.98,
-"decompress_mbps": 106.59
+"compress_mbps": 15.61,
+"decompress_mbps": 105.63
 },
 {
 "compressor": "native",
@@ -64,8 +64,8 @@
 "level": 6,
 "out_size": 54902,
 "ratio": 0.361,
-"compress_mbps": 10.13,
-"decompress_mbps": 111.22
+"compress_mbps": 13.31,
+"decompress_mbps": 110.55
 },
 {
 "compressor": "native",
@@ -74,8 +74,8 @@
 "level": 7,
 "out_size": 54533,
 "ratio": 0.3586,
-"compress_mbps": 5.91,
-"decompress_mbps": 109.14
+"compress_mbps": 6.98,
+"decompress_mbps": 109.04
 },
 {
 "compressor": "native",
@@ -84,8 +84,8 @@
 "level": 8,
 "out_size": 54492,
 "ratio": 0.3583,
-"compress_mbps": 5.61,
-"decompress_mbps": 110.09
+"compress_mbps": 6.57,
+"decompress_mbps": 109.62
 },
 {
 "compressor": "native",
@@ -94,8 +94,8 @@
 "level": 9,
 "out_size": 52111,
 "ratio": 0.3426,
-"compress_mbps": 0.94,
-"decompress_mbps": 110.14
+"compress_mbps": 0.97,
+"decompress_mbps": 110.73
 },
 {
 "compressor": "native",
@@ -104,8 +104,8 @@
 "level": 1,
 "out_size": 52768,
 "ratio": 0.4215,
-"compress_mbps": 26.19,
-"decompress_mbps": 81.75
+"compress_mbps": 29.26,
+"decompress_mbps": 82.01
 },
 {
 "compressor": "native",
@@ -114,8 +114,8 @@
 "level": 2,
 "out_size": 51760,
 "ratio": 0.4135,
-"compress_mbps": 22.62,
-"decompress_mbps": 86.16
+"compress_mbps": 26.03,
+"decompress_mbps": 86.34
 },
 {
 "compressor": "native",
@@ -124,8 +124,8 @@
 "level": 3,
 "out_size": 51056,
 "ratio": 0.4079,
-"compress_mbps": 19.77,
-"decompress_mbps": 92.41
+"compress_mbps": 22.99,
+"decompress_mbps": 92.27
 },
 {
 "compressor": "native",
@@ -134,8 +134,8 @@
 "level": 4,
 "out_size": 49963,
 "ratio": 0.3991,
-"compress_mbps": 12.69,
-"decompress_mbps": 93.12
+"compress_mbps": 15.43,
+"decompress_mbps": 93.92
 },
 {
 "compressor": "native",
@@ -144,8 +144,8 @@
 "level": 5,
 "out_size": 49779,
 "ratio": 0.3977,
-"compress_mbps": 11.7,
-"decompress_mbps": 96.45
+"compress_mbps": 14.43,
+"decompress_mbps": 97.07
 },
 {
 "compressor": "native",
@@ -154,8 +154,8 @@
 "level": 6,
 "out_size": 49540,
 "ratio": 0.3958,
-"compress_mbps": 10.13,
-"decompress_mbps": 97.73
+"compress_mbps": 12.69,
+"decompress_mbps": 98.27
 },
 {
 "compressor": "native",
@@ -164,8 +164,8 @@
 "level": 7,
 "out_size": 49161,
 "ratio": 0.3927,
-"compress_mbps": 5.76,
-"decompress_mbps": 97.71
+"compress_mbps": 6.62,
+"decompress_mbps": 98.52
 },
 {
 "compressor": "native",
@@ -174,8 +174,8 @@
 "level": 8,
 "out_size": 49153,
 "ratio": 0.3927,
-"compress_mbps": 5.63,
-"decompress_mbps": 98.33
+"compress_mbps": 6.48,
+"decompress_mbps": 99.19
 },
 {
 "compressor": "native",
@@ -184,8 +184,8 @@
 "level": 9,
 "out_size": 46881,
 "ratio": 0.3745,
-"compress_mbps": 1.07,
-"decompress_mbps": 97.71
+"compress_mbps": 1.12,
+"decompress_mbps": 98.49
 },
 {
 "compressor": "native",
@@ -194,8 +194,8 @@
 "level": 1,
 "out_size": 8430,
 "ratio": 0.3426,
-"compress_mbps": 26.27,
-"decompress_mbps": 84.46
+"compress_mbps": 27.79,
+"decompress_mbps": 84.75
 },
 {
 "compressor": "native",
@@ -204,8 +204,8 @@
 "level": 2,
 "out_size": 8297,
 "ratio": 0.3372,
-"compress_mbps": 24.94,
-"decompress_mbps": 88.28
+"compress_mbps": 26.79,
+"decompress_mbps": 88.38
 },
 {
 "compressor": "native",
@@ -214,8 +214,8 @@
 "level": 3,
 "out_size": 8218,
 "ratio": 0.334,
-"compress_mbps": 23.87,
-"decompress_mbps": 89.19
+"compress_mbps": 26.08,
+"decompress_mbps": 90.89
 },
 {
 "compressor": "native",
@@ -224,8 +224,8 @@
 "level": 4,
 "out_size": 8055,
 "ratio": 0.3274,
-"compress_mbps": 18.52,
-"decompress_mbps": 88.1
+"compress_mbps": 21.82,
+"decompress_mbps": 89.76
 },
 {
 "compressor": "native",
@@ -234,8 +234,8 @@
 "level": 5,
 "out_size": 8049,
 "ratio": 0.3272,
-"compress_mbps": 17.79,
-"decompress_mbps": 89.91
+"compress_mbps": 21.31,
+"decompress_mbps": 92.19
 },
 {
 "compressor": "native",
@@ -244,8 +244,8 @@
 "level": 6,
 "out_size": 8043,
 "ratio": 0.3269,
-"compress_mbps": 16.63,
-"decompress_mbps": 91.27
+"compress_mbps": 20.26,
+"decompress_mbps": 91.84
 },
 {
 "compressor": "native",
@@ -254,8 +254,8 @@
 "level": 7,
 "out_size": 8038,
 "ratio": 0.3267,
-"compress_mbps": 7.58,
-"decompress_mbps": 91.72
+"compress_mbps": 8.32,
+"decompress_mbps": 93.29
 },
 {
 "compressor": "native",
@@ -264,8 +264,8 @@
 "level": 8,
 "out_size": 8038,
 "ratio": 0.3267,
-"compress_mbps": 7.63,
-"decompress_mbps": 92.03
+"compress_mbps": 8.33,
+"decompress_mbps": 92.72
 },
 {
 "compressor": "native",
@@ -274,8 +274,8 @@
 "level": 9,
 "out_size": 7727,
 "ratio": 0.3141,
-"compress_mbps": 1.25,
-"decompress_mbps": 92.45
+"compress_mbps": 1.28,
+"decompress_mbps": 93.44
 },
 {
 "compressor": "native",
@@ -284,8 +284,8 @@
 "level": 1,
 "out_size": 3325,
 "ratio": 0.2982,
-"compress_mbps": 20.25,
-"decompress_mbps": 75.19
+"compress_mbps": 20.86,
+"decompress_mbps": 75.55
 },
 {
 "compressor": "native",
@@ -294,8 +294,8 @@
 "level": 2,
 "out_size": 3251,
 "ratio": 0.2916,
-"compress_mbps": 19.5,
-"decompress_mbps": 77.69
+"compress_mbps": 20.26,
+"decompress_mbps": 78.08
 },
 {
 "compressor": "native",
@@ -304,8 +304,8 @@
 "level": 3,
 "out_size": 3202,
 "ratio": 0.2872,
-"compress_mbps": 18.92,
-"decompress_mbps": 79.79
+"compress_mbps": 19.87,
+"decompress_mbps": 80.03
 },
 {
 "compressor": "native",
@@ -314,8 +314,8 @@
 "level": 4,
 "out_size": 3150,
 "ratio": 0.2825,
-"compress_mbps": 15.86,
-"decompress_mbps": 80.3
+"compress_mbps": 17.36,
+"decompress_mbps": 81.89
 },
 {
 "compressor": "native",
@@ -324,8 +324,8 @@
 "level": 5,
 "out_size": 3141,
 "ratio": 0.2817,
-"compress_mbps": 15.56,
-"decompress_mbps": 81.4
+"compress_mbps": 17.12,
+"decompress_mbps": 82.55
 },
 {
 "compressor": "native",
@@ -334,8 +334,8 @@
 "level": 6,
 "out_size": 3136,
 "ratio": 0.2813,
-"compress_mbps": 14.81,
-"decompress_mbps": 82.21
+"compress_mbps": 16.53,
+"decompress_mbps": 83.26
 },
 {
 "compressor": "native",
@@ -344,8 +344,8 @@
 "level": 7,
 "out_size": 3134,
 "ratio": 0.2811,
-"compress_mbps": 6.07,
-"decompress_mbps": 81.55
+"compress_mbps": 6.45,
+"decompress_mbps": 83.16
 },
 {
 "compressor": "native",
@@ -354,8 +354,8 @@
 "level": 8,
 "out_size": 3134,
 "ratio": 0.2811,
-"compress_mbps": 6.06,
-"decompress_mbps": 83.22
+"compress_mbps": 6.43,
+"decompress_mbps": 83.72
 },
 {
 "compressor": "native",
@@ -364,8 +364,8 @@
 "level": 9,
 "out_size": 3027,
 "ratio": 0.2715,
-"compress_mbps": 1.32,
-"decompress_mbps": 82.54
+"compress_mbps": 1.35,
+"decompress_mbps": 83.06
 },
 {
 "compressor": "native",
@@ -374,8 +374,8 @@
 "level": 1,
 "out_size": 1251,
 "ratio": 0.3362,
-"compress_mbps": 10.57,
-"decompress_mbps": 41.68
+"compress_mbps": 10.6,
+"decompress_mbps": 42.34
 },
 {
 "compressor": "native",
@@ -384,8 +384,8 @@
 "level": 2,
 "out_size": 1241,
 "ratio": 0.3335,
-"compress_mbps": 10.44,
-"decompress_mbps": 41.96
+"compress_mbps": 10.54,
+"decompress_mbps": 42.71
 },
 {
 "compressor": "native",
@@ -394,8 +394,8 @@
 "level": 3,
 "out_size": 1241,
 "ratio": 0.3335,
-"compress_mbps": 10.3,
-"decompress_mbps": 42.73
+"compress_mbps": 10.42,
+"decompress_mbps": 43.01
 },
 {
 "compressor": "native",
@@ -404,8 +404,8 @@
 "level": 4,
 "out_size": 1225,
 "ratio": 0.3292,
-"compress_mbps": 9.79,
-"decompress_mbps": 43.19
+"compress_mbps": 10.04,
+"decompress_mbps": 43.87
 },
 {
 "compressor": "native",
@@ -414,8 +414,8 @@
 "level": 5,
 "out_size": 1224,
 "ratio": 0.3289,
-"compress_mbps": 9.86,
-"decompress_mbps": 43.48
+"compress_mbps": 10.0,
+"decompress_mbps": 43.96
 },
 {
 "compressor": "native",
@@ -424,8 +424,8 @@
 "level": 6,
 "out_size": 1224,
 "ratio": 0.3289,
-"compress_mbps": 9.75,
-"decompress_mbps": 43.61
+"compress_mbps": 9.98,
+"decompress_mbps": 44.04
 },
 {
 "compressor": "native",
@@ -434,8 +434,8 @@
 "level": 7,
 "out_size": 1224,
 "ratio": 0.3289,
-"compress_mbps": 3.61,
-"decompress_mbps": 43.76
+"compress_mbps": 3.64,
+"decompress_mbps": 44.2
 },
 {
 "compressor": "native",
@@ -444,8 +444,8 @@
 "level": 8,
 "out_size": 1224,
 "ratio": 0.3289,
-"compress_mbps": 3.61,
-"decompress_mbps": 43.53
+"compress_mbps": 3.65,
+"decompress_mbps": 44.02
 },
 {
 "compressor": "native",
@@ -455,7 +455,7 @@
 "out_size": 1190,
 "ratio": 0.3198,
 "compress_mbps": 1.14,
-"decompress_mbps": 43.3
+"decompress_mbps": 44.05
 },
 {
 "compressor": "native",
@@ -464,8 +464,8 @@
 "level": 1,
 "out_size": 248840,
 "ratio": 0.2417,
-"compress_mbps": 52.92,
-"decompress_mbps": 128.08
+"compress_mbps": 61.7,
+"decompress_mbps": 128.75
 },
 {
 "compressor": "native",
@@ -474,8 +474,8 @@
 "level": 2,
 "out_size": 247429,
 "ratio": 0.2403,
-"compress_mbps": 47.08,
-"decompress_mbps": 148.22
+"compress_mbps": 57.96,
+"decompress_mbps": 148.45
 },
 {
 "compressor": "native",
@@ -484,8 +484,8 @@
 "level": 3,
 "out_size": 246442,
 "ratio": 0.2393,
-"compress_mbps": 45.5,
-"decompress_mbps": 155.05
+"compress_mbps": 55.72,
+"decompress_mbps": 155.35
 },
 {
 "compressor": "native",
@@ -494,8 +494,8 @@
 "level": 4,
 "out_size": 213851,
 "ratio": 0.2077,
-"compress_mbps": 27.65,
-"decompress_mbps": 161.61
+"compress_mbps": 38.52,
+"decompress_mbps": 161.69
 },
 {
 "compressor": "native",
@@ -504,8 +504,8 @@
 "level": 5,
 "out_size": 212782,
 "ratio": 0.2066,
-"compress_mbps": 25.32,
-"decompress_mbps": 130.39
+"compress_mbps": 35.55,
+"decompress_mbps": 129.14
 },
 {
 "compressor": "native",
@@ -514,8 +514,8 @@
 "level": 6,
 "out_size": 210061,
 "ratio": 0.204,
-"compress_mbps": 18.28,
-"decompress_mbps": 129.34
+"compress_mbps": 26.91,
+"decompress_mbps": 130.13
 },
 {
 "compressor": "native",
@@ -524,8 +524,8 @@
 "level": 7,
 "out_size": 201296,
 "ratio": 0.1955,
-"compress_mbps": 7.52,
-"decompress_mbps": 121.16
+"compress_mbps": 9.44,
+"decompress_mbps": 120.7
 },
 {
 "compressor": "native",
@@ -534,8 +534,8 @@
 "level": 8,
 "out_size": 201458,
 "ratio": 0.1956,
-"compress_mbps": 5.61,
-"decompress_mbps": 119.52
+"compress_mbps": 7.47,
+"decompress_mbps": 119.5
 },
 {
 "compressor": "native",
@@ -544,8 +544,8 @@
 "level": 9,
 "out_size": 178311,
 "ratio": 0.1732,
-"compress_mbps": 0.66,
-"decompress_mbps": 118.58
+"compress_mbps": 0.73,
+"decompress_mbps": 118.28
 },
 {
 "compressor": "native",
@@ -554,8 +554,8 @@
 "level": 1,
 "out_size": 158127,
 "ratio": 0.3705,
-"compress_mbps": 29.95,
-"decompress_mbps": 89.2
+"compress_mbps": 33.58,
+"decompress_mbps": 90.25
 },
 {
 "compressor": "native",
@@ -564,8 +564,8 @@
 "level": 2,
 "out_size": 153708,
 "ratio": 0.3602,
-"compress_mbps": 25.81,
-"decompress_mbps": 96.07
+"compress_mbps": 29.81,
+"decompress_mbps": 96.74
 },
 {
 "compressor": "native",
@@ -574,8 +574,8 @@
 "level": 3,
 "out_size": 150718,
 "ratio": 0.3532,
-"compress_mbps": 22.08,
-"decompress_mbps": 105.8
+"compress_mbps": 26.24,
+"decompress_mbps": 106.55
 },
 {
 "compressor": "native",
@@ -584,8 +584,8 @@
 "level": 4,
 "out_size": 147481,
 "ratio": 0.3456,
-"compress_mbps": 13.93,
-"decompress_mbps": 106.97
+"compress_mbps": 17.48,
+"decompress_mbps": 107.74
 },
 {
 "compressor": "native",
@@ -594,8 +594,8 @@
 "level": 5,
 "out_size": 146857,
 "ratio": 0.3441,
-"compress_mbps": 12.95,
-"decompress_mbps": 110.51
+"compress_mbps": 16.42,
+"decompress_mbps": 111.59
 },
 {
 "compressor": "native",
@@ -604,8 +604,8 @@
 "level": 6,
 "out_size": 146118,
 "ratio": 0.3424,
-"compress_mbps": 11.17,
-"decompress_mbps": 112.33
+"compress_mbps": 14.27,
+"decompress_mbps": 113.34
 },
 {
 "compressor": "native",
@@ -614,8 +614,8 @@
 "level": 7,
 "out_size": 145400,
 "ratio": 0.3407,
-"compress_mbps": 6.47,
-"decompress_mbps": 112.63
+"compress_mbps": 7.55,
+"decompress_mbps": 113.49
 },
 {
 "compressor": "native",
@@ -624,8 +624,8 @@
 "level": 8,
 "out_size": 145324,
 "ratio": 0.3405,
-"compress_mbps": 6.27,
-"decompress_mbps": 113.05
+"compress_mbps": 7.33,
+"decompress_mbps": 113.82
 },
 {
 "compressor": "native",
@@ -634,8 +634,8 @@
 "level": 9,
 "out_size": 138661,
 "ratio": 0.3249,
-"compress_mbps": 0.99,
-"decompress_mbps": 112.48
+"compress_mbps": 1.01,
+"decompress_mbps": 113.96
 },
 {
 "compressor": "native",
@@ -644,8 +644,8 @@
 "level": 1,
 "out_size": 212305,
 "ratio": 0.4406,
-"compress_mbps": 24.9,
-"decompress_mbps": 77.97
+"compress_mbps": 28.92,
+"decompress_mbps": 78.62
 },
 {
 "compressor": "native",
@@ -654,8 +654,8 @@
 "level": 2,
 "out_size": 207350,
 "ratio": 0.4303,
-"compress_mbps": 21.62,
-"decompress_mbps": 84.66
+"compress_mbps": 25.25,
+"decompress_mbps": 85.25
 },
 {
 "compressor": "native",
@@ -664,8 +664,8 @@
 "level": 3,
 "out_size": 203699,
 "ratio": 0.4227,
-"compress_mbps": 18.69,
-"decompress_mbps": 89.62
+"compress_mbps": 21.86,
+"decompress_mbps": 90.71
 },
 {
 "compressor": "native",
@@ -674,8 +674,8 @@
 "level": 4,
 "out_size": 200054,
 "ratio": 0.4152,
-"compress_mbps": 11.61,
-"decompress_mbps": 90.29
+"compress_mbps": 14.12,
+"decompress_mbps": 91.26
 },
 {
 "compressor": "native",
@@ -684,8 +684,8 @@
 "level": 5,
 "out_size": 199229,
 "ratio": 0.4135,
-"compress_mbps": 10.74,
-"decompress_mbps": 92.84
+"compress_mbps": 13.15,
+"decompress_mbps": 94.44
 },
 {
 "compressor": "native",
@@ -694,8 +694,8 @@
 "level": 6,
 "out_size": 198023,
 "ratio": 0.411,
-"compress_mbps": 9.16,
-"decompress_mbps": 95.48
+"compress_mbps": 11.24,
+"decompress_mbps": 96.68
 },
 {
 "compressor": "native",
@@ -704,8 +704,8 @@
 "level": 7,
 "out_size": 197186,
 "ratio": 0.4092,
-"compress_mbps": 5.32,
-"decompress_mbps": 96.45
+"compress_mbps": 6.04,
+"decompress_mbps": 97.18
 },
 {
 "compressor": "native",
@@ -714,8 +714,8 @@
 "level": 8,
 "out_size": 197001,
 "ratio": 0.4088,
-"compress_mbps": 4.94,
-"decompress_mbps": 96.77
+"compress_mbps": 5.64,
+"decompress_mbps": 97.05
 },
 {
 "compressor": "native",
@@ -724,8 +724,8 @@
 "level": 9,
 "out_size": 186472,
 "ratio": 0.387,
-"compress_mbps": 0.96,
-"decompress_mbps": 96.74
+"compress_mbps": 0.99,
+"decompress_mbps": 97.66
 },
 {
 "compressor": "native",
@@ -734,8 +734,8 @@
 "level": 1,
 "out_size": 60352,
 "ratio": 0.1176,
-"compress_mbps": 84.55,
-"decompress_mbps": 238.04
+"compress_mbps": 97.11,
+"decompress_mbps": 242.37
 },
 {
 "compressor": "native",
@@ -744,8 +744,8 @@
 "level": 2,
 "out_size": 59696,
 "ratio": 0.1163,
-"compress_mbps": 71.65,
-"decompress_mbps": 250.95
+"compress_mbps": 86.58,
+"decompress_mbps": 254.25
 },
 {
 "compressor": "native",
@@ -754,8 +754,8 @@
 "level": 3,
 "out_size": 59069,
 "ratio": 0.1151,
-"compress_mbps": 60.28,
-"decompress_mbps": 265.78
+"compress_mbps": 75.9,
+"decompress_mbps": 268.26
 },
 {
 "compressor": "native",
@@ -764,8 +764,8 @@
 "level": 4,
 "out_size": 56435,
 "ratio": 0.11,
-"compress_mbps": 38.5,
-"decompress_mbps": 239.04
+"compress_mbps": 51.74,
+"decompress_mbps": 244.45
 },
 {
 "compressor": "native",
@@ -774,8 +774,8 @@
 "level": 5,
 "out_size": 56350,
 "ratio": 0.1098,
-"compress_mbps": 34.74,
-"decompress_mbps": 252.85
+"compress_mbps": 47.86,
+"decompress_mbps": 257.64
 },
 {
 "compressor": "native",
@@ -784,8 +784,8 @@
 "level": 6,
 "out_size": 56014,
 "ratio": 0.1091,
-"compress_mbps": 26.78,
-"decompress_mbps": 268.03
+"compress_mbps": 37.68,
+"decompress_mbps": 272.61
 },
 {
 "compressor": "native",
@@ -794,8 +794,8 @@
 "level": 7,
 "out_size": 54820,
 "ratio": 0.1068,
-"compress_mbps": 13.6,
-"decompress_mbps": 277.59
+"compress_mbps": 17.43,
+"decompress_mbps": 282.71
 },
 {
 "compressor": "native",
@@ -804,8 +804,8 @@
 "level": 8,
 "out_size": 54111,
 "ratio": 0.1054,
-"compress_mbps": 10.93,
-"decompress_mbps": 290.35
+"compress_mbps": 15.5,
+"decompress_mbps": 293.42
 },
 {
 "compressor": "native",
@@ -814,8 +814,8 @@
 "level": 9,
 "out_size": 51490,
 "ratio": 0.1003,
-"compress_mbps": 0.4,
-"decompress_mbps": 294.91
+"compress_mbps": 0.42,
+"decompress_mbps": 296.74
 },
 {
 "compressor": "native",
@@ -824,8 +824,8 @@
 "level": 1,
 "out_size": 13725,
 "ratio": 0.3589,
-"compress_mbps": 21.42,
-"decompress_mbps": 65.02
+"compress_mbps": 22.47,
+"decompress_mbps": 65.6
 },
 {
 "compressor": "native",
@@ -834,8 +834,8 @@
 "level": 2,
 "out_size": 13615,
 "ratio": 0.356,
-"compress_mbps": 20.43,
-"decompress_mbps": 68.36
+"compress_mbps": 21.8,
+"decompress_mbps": 69.1
 },
 {
 "compressor": "native",
@@ -844,8 +844,8 @@
 "level": 3,
 "out_size": 13548,
 "ratio": 0.3543,
-"compress_mbps": 19.44,
-"decompress_mbps": 71.3
+"compress_mbps": 20.97,
+"decompress_mbps": 71.76
 },
 {
 "compressor": "native",
@@ -854,7 +854,7 @@
 "level": 4,
 "out_size": 13080,
 "ratio": 0.3421,
-"compress_mbps": 15.36,
+"compress_mbps": 17.27,
 "decompress_mbps": 69.52
 },
 {
@@ -864,8 +864,8 @@
 "level": 5,
 "out_size": 13060,
 "ratio": 0.3415,
-"compress_mbps": 14.52,
-"decompress_mbps": 73.11
+"compress_mbps": 16.63,
+"decompress_mbps": 73.31
 },
 {
 "compressor": "native",
@@ -874,8 +874,8 @@
 "level": 6,
 "out_size": 13015,
 "ratio": 0.3404,
-"compress_mbps": 12.66,
-"decompress_mbps": 73.7
+"compress_mbps": 14.92,
+"decompress_mbps": 74.2
 },
 {
 "compressor": "native",
@@ -884,8 +884,8 @@
 "level": 7,
 "out_size": 12823,
 "ratio": 0.3353,
-"compress_mbps": 4.64,
-"decompress_mbps": 73.15
+"compress_mbps": 5.05,
+"decompress_mbps": 73.57
 },
 {
 "compressor": "native",
@@ -894,8 +894,8 @@
 "level": 8,
 "out_size": 12811,
 "ratio": 0.335,
-"compress_mbps": 4.1,
-"decompress_mbps": 76.92
+"compress_mbps": 4.5,
+"decompress_mbps": 77.44
 },
 {
 "compressor": "native",
@@ -904,8 +904,8 @@
 "level": 9,
 "out_size": 12278,
 "ratio": 0.3211,
-"compress_mbps": 0.9,
-"decompress_mbps": 74.97
+"compress_mbps": 0.98,
+"decompress_mbps": 75.8
 },
 {
 "compressor": "native",
@@ -914,8 +914,8 @@
 "level": 1,
 "out_size": 1781,
 "ratio": 0.4213,
-"compress_mbps": 11.36,
-"decompress_mbps": 41.28
+"compress_mbps": 11.53,
+"decompress_mbps": 42.26
 },
 {
 "compressor": "native",
@@ -924,8 +924,8 @@
 "level": 2,
 "out_size": 1764,
 "ratio": 0.4173,
-"compress_mbps": 11.3,
-"decompress_mbps": 42.39
+"compress_mbps": 11.6,
+"decompress_mbps": 43.15
 },
 {
 "compressor": "native",
@@ -934,8 +934,8 @@
 "level": 3,
 "out_size": 1765,
 "ratio": 0.4176,
-"compress_mbps": 11.26,
-"decompress_mbps": 42.45
+"compress_mbps": 11.57,
+"decompress_mbps": 43.28
 },
 {
 "compressor": "native",
@@ -944,8 +944,8 @@
 "level": 4,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 10.86,
-"decompress_mbps": 43.15
+"compress_mbps": 11.21,
+"decompress_mbps": 44.04
 },
 {
 "compressor": "native",
@@ -954,8 +954,8 @@
 "level": 5,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 10.88,
-"decompress_mbps": 43.11
+"compress_mbps": 11.2,
+"decompress_mbps": 43.89
 },
 {
 "compressor": "native",
@@ -964,8 +964,8 @@
 "level": 6,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 10.86,
-"decompress_mbps": 43.12
+"compress_mbps": 11.26,
+"decompress_mbps": 44.08
 },
 {
 "compressor": "native",
@@ -974,8 +974,8 @@
 "level": 7,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 3.82,
-"decompress_mbps": 43.02
+"compress_mbps": 3.9,
+"decompress_mbps": 43.71
 },
 {
 "compressor": "native",
@@ -984,8 +984,8 @@
 "level": 8,
 "out_size": 1747,
 "ratio": 0.4133,
-"compress_mbps": 3.83,
-"decompress_mbps": 42.83
+"compress_mbps": 3.89,
+"decompress_mbps": 43.69
 },
 {
 "compressor": "native",
@@ -994,8 +994,8 @@
 "level": 9,
 "out_size": 1696,
 "ratio": 0.4012,
-"compress_mbps": 1.29,
-"decompress_mbps": 43.06
+"compress_mbps": 1.32,
+"decompress_mbps": 43.65
 },
 {
 "compressor": "zlib",
@@ -1004,8 +1004,8 @@
 "level": 1,
 "out_size": 65130,
 "ratio": 0.4282,
-"compress_mbps": 119.32,
-"decompress_mbps": 390.02
+"compress_mbps": 119.77,
+"decompress_mbps": 398.47
 },
 {
 "compressor": "zlib",
@@ -1014,8 +1014,8 @@
 "level": 2,
 "out_size": 62270,
 "ratio": 0.4094,
-"compress_mbps": 102.29,
-"decompress_mbps": 409.1
+"compress_mbps": 102.25,
+"decompress_mbps": 414.68
 },
 {
 "compressor": "zlib",
@@ -1024,8 +1024,8 @@
 "level": 3,
 "out_size": 59488,
 "ratio": 0.3911,
-"compress_mbps": 67.41,
-"decompress_mbps": 421.58
+"compress_mbps": 67.37,
+"decompress_mbps": 427.91
 },
 {
 "compressor": "zlib",
@@ -1034,8 +1034,8 @@
 "level": 4,
 "out_size": 57679,
 "ratio": 0.3792,
-"compress_mbps": 72.12,
-"decompress_mbps": 405.97
+"compress_mbps": 72.22,
+"decompress_mbps": 410.29
 },
 {
 "compressor": "zlib",
@@ -1044,8 +1044,8 @@
 "level": 5,
 "out_size": 55616,
 "ratio": 0.3657,
-"compress_mbps": 42.01,
-"decompress_mbps": 396.31
+"compress_mbps": 42.21,
+"decompress_mbps": 400.75
 },
 {
 "compressor": "zlib",
@@ -1054,8 +1054,8 @@
 "level": 6,
 "out_size": 54398,
 "ratio": 0.3577,
-"compress_mbps": 25.63,
-"decompress_mbps": 412.54
+"compress_mbps": 25.7,
+"decompress_mbps": 413.9
 },
 {
 "compressor": "zlib",
@@ -1064,8 +1064,8 @@
 "level": 7,
 "out_size": 54253,
 "ratio": 0.3567,
-"compress_mbps": 21.51,
-"decompress_mbps": 415.03
+"compress_mbps": 21.57,
+"decompress_mbps": 419.24
 },
 {
 "compressor": "zlib",
@@ -1074,8 +1074,8 @@
 "level": 8,
 "out_size": 54164,
 "ratio": 0.3561,
-"compress_mbps": 17.05,
-"decompress_mbps": 415.18
+"compress_mbps": 17.1,
+"decompress_mbps": 418.49
 },
 {
 "compressor": "zlib",
@@ -1084,8 +1084,8 @@
 "level": 9,
 "out_size": 54164,
 "ratio": 0.3561,
-"compress_mbps": 17.04,
-"decompress_mbps": 414.11
+"compress_mbps": 17.09,
+"decompress_mbps": 417.81
 },
 {
 "compressor": "zlib",
@@ -1094,8 +1094,8 @@
 "level": 1,
 "out_size": 56791,
 "ratio": 0.4537,
-"compress_mbps": 115.79,
-"decompress_mbps": 382.78
+"compress_mbps": 116.39,
+"decompress_mbps": 389.77
 },
 {
 "compressor": "zlib",
@@ -1104,8 +1104,8 @@
 "level": 2,
 "out_size": 54652,
 "ratio": 0.4366,
-"compress_mbps": 98.29,
-"decompress_mbps": 398.58
+"compress_mbps": 98.68,
+"decompress_mbps": 401.91
 },
 {
 "compressor": "zlib",
@@ -1114,8 +1114,8 @@
 "level": 3,
 "out_size": 52663,
 "ratio": 0.4207,
-"compress_mbps": 62.75,
-"decompress_mbps": 417.94
+"compress_mbps": 62.8,
+"decompress_mbps": 423.51
 },
 {
 "compressor": "zlib",
@@ -1124,8 +1124,8 @@
 "level": 4,
 "out_size": 51266,
 "ratio": 0.4095,
-"compress_mbps": 67.82,
-"decompress_mbps": 396.24
+"compress_mbps": 67.91,
+"decompress_mbps": 393.09
 },
 {
 "compressor": "zlib",
@@ -1134,8 +1134,8 @@
 "level": 5,
 "out_size": 49622,
 "ratio": 0.3964,
-"compress_mbps": 37.62,
-"decompress_mbps": 383.2
+"compress_mbps": 37.73,
+"decompress_mbps": 383.82
 },
 {
 "compressor": "zlib",
@@ -1144,8 +1144,8 @@
 "level": 6,
 "out_size": 48891,
 "ratio": 0.3906,
-"compress_mbps": 22.91,
-"decompress_mbps": 392.14
+"compress_mbps": 22.94,
+"decompress_mbps": 387.58
 },
 {
 "compressor": "zlib",
@@ -1154,8 +1154,8 @@
 "level": 7,
 "out_size": 48801,
 "ratio": 0.3898,
-"compress_mbps": 20.1,
-"decompress_mbps": 391.22
+"compress_mbps": 20.17,
+"decompress_mbps": 385.91
 },
 {
 "compressor": "zlib",
@@ -1164,8 +1164,8 @@
 "level": 8,
 "out_size": 48772,
 "ratio": 0.3896,
-"compress_mbps": 18.18,
-"decompress_mbps": 391.09
+"compress_mbps": 18.27,
+"decompress_mbps": 386.5
 },
 {
 "compressor": "zlib",
@@ -1174,8 +1174,8 @@
 "level": 9,
 "out_size": 48772,
 "ratio": 0.3896,
-"compress_mbps": 18.14,
-"decompress_mbps": 391.96
+"compress_mbps": 18.26,
+"decompress_mbps": 387.67
 },
 {
 "compressor": "zlib",
@@ -1184,8 +1184,8 @@
 "level": 1,
 "out_size": 9028,
 "ratio": 0.3669,
-"compress_mbps": 412.4,
-"decompress_mbps": 1051.79
+"compress_mbps": 401.07,
+"decompress_mbps": 1060.82
 },
 {
 "compressor": "zlib",
@@ -1194,8 +1194,8 @@
 "level": 2,
 "out_size": 8811,
 "ratio": 0.3581,
-"compress_mbps": 237.96,
-"decompress_mbps": 1072.8
+"compress_mbps": 216.25,
+"decompress_mbps": 1089.95
 },
 {
 "compressor": "zlib",
@@ -1204,8 +1204,8 @@
 "level": 3,
 "out_size": 8616,
 "ratio": 0.3502,
-"compress_mbps": 159.07,
-"decompress_mbps": 1104.72
+"compress_mbps": 159.42,
+"decompress_mbps": 1097.49
 },
 {
 "compressor": "zlib",
@@ -1214,8 +1214,8 @@
 "level": 4,
 "out_size": 8219,
 "ratio": 0.3341,
-"compress_mbps": 117.08,
-"decompress_mbps": 1119.16
+"compress_mbps": 117.61,
+"decompress_mbps": 1125.44
 },
 {
 "compressor": "zlib",
@@ -1224,8 +1224,8 @@
 "level": 5,
 "out_size": 8001,
 "ratio": 0.3252,
-"compress_mbps": 85.13,
-"decompress_mbps": 1143.54
+"compress_mbps": 85.21,
+"decompress_mbps": 1143.43
 },
 {
 "compressor": "zlib",
@@ -1234,8 +1234,8 @@
 "level": 6,
 "out_size": 7955,
 "ratio": 0.3233,
-"compress_mbps": 69.08,
-"decompress_mbps": 1147.96
+"compress_mbps": 68.99,
+"decompress_mbps": 1151.46
 },
 {
 "compressor": "zlib",
@@ -1244,8 +1244,8 @@
 "level": 7,
 "out_size": 7933,
 "ratio": 0.3224,
-"compress_mbps": 63.06,
-"decompress_mbps": 1152.87
+"compress_mbps": 63.45,
+"decompress_mbps": 1160.4
 },
 {
 "compressor": "zlib",
@@ -1254,8 +1254,8 @@
 "level": 8,
 "out_size": 7934,
 "ratio": 0.3225,
-"compress_mbps": 57.89,
-"decompress_mbps": 1156.74
+"compress_mbps": 58.21,
+"decompress_mbps": 1151.8
 },
 {
 "compressor": "zlib",
@@ -1264,8 +1264,8 @@
 "level": 9,
 "out_size": 7934,
 "ratio": 0.3225,
-"compress_mbps": 57.64,
-"decompress_mbps": 1154.63
+"compress_mbps": 58.06,
+"decompress_mbps": 1156.68
 },
 {
 "compressor": "zlib",
@@ -1274,7 +1274,7 @@
 "level": 1,
 "out_size": 3647,
 "ratio": 0.3271,
-"compress_mbps": 423.31,
+"compress_mbps": 427.42,
 "decompress_mbps": 1062.5
 },
 {
@@ -1284,8 +1284,8 @@
 "level": 2,
 "out_size": 3501,
 "ratio": 0.314,
-"compress_mbps": 405.47,
-"decompress_mbps": 1105.92
+"compress_mbps": 411.29,
+"decompress_mbps": 1112.87
 },
 {
 "compressor": "zlib",
@@ -1294,8 +1294,8 @@
 "level": 3,
 "out_size": 3393,
 "ratio": 0.3043,
-"compress_mbps": 337.24,
-"decompress_mbps": 1137.27
+"compress_mbps": 340.67,
+"decompress_mbps": 1144.37
 },
 {
 "compressor": "zlib",
@@ -1304,8 +1304,8 @@
 "level": 4,
 "out_size": 3215,
 "ratio": 0.2883,
-"compress_mbps": 272.95,
-"decompress_mbps": 1165.06
+"compress_mbps": 275.8,
+"decompress_mbps": 1171.86
 },
 {
 "compressor": "zlib",
@@ -1314,8 +1314,8 @@
 "level": 5,
 "out_size": 3140,
 "ratio": 0.2816,
-"compress_mbps": 205.24,
-"decompress_mbps": 1194.24
+"compress_mbps": 207.2,
+"decompress_mbps": 1198.41
 },
 {
 "compressor": "zlib",
@@ -1324,8 +1324,8 @@
 "level": 6,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 153.89,
-"decompress_mbps": 1206.84
+"compress_mbps": 155.1,
+"decompress_mbps": 1212.48
 },
 {
 "compressor": "zlib",
@@ -1334,8 +1334,8 @@
 "level": 7,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 131.84,
-"decompress_mbps": 1209.17
+"compress_mbps": 132.68,
+"decompress_mbps": 1216.5
 },
 {
 "compressor": "zlib",
@@ -1344,8 +1344,8 @@
 "level": 8,
 "out_size": 3109,
 "ratio": 0.2788,
-"compress_mbps": 111.1,
-"decompress_mbps": 1221.82
+"compress_mbps": 111.99,
+"decompress_mbps": 1214.28
 },
 {
 "compressor": "zlib",
@@ -1354,8 +1354,8 @@
 "level": 9,
 "out_size": 3109,
 "ratio": 0.2788,
-"compress_mbps": 110.57,
-"decompress_mbps": 1214.84
+"compress_mbps": 111.59,
+"decompress_mbps": 1213.73
 },
 {
 "compressor": "zlib",
@@ -1364,8 +1364,8 @@
 "level": 1,
 "out_size": 1326,
 "ratio": 0.3564,
-"compress_mbps": 314.59,
-"decompress_mbps": 780.6
+"compress_mbps": 318.69,
+"decompress_mbps": 785.96
 },
 {
 "compressor": "zlib",
@@ -1374,8 +1374,8 @@
 "level": 2,
 "out_size": 1306,
 "ratio": 0.351,
-"compress_mbps": 309.46,
-"decompress_mbps": 778.89
+"compress_mbps": 311.15,
+"decompress_mbps": 793.52
 },
 {
 "compressor": "zlib",
@@ -1384,8 +1384,8 @@
 "level": 3,
 "out_size": 1301,
 "ratio": 0.3496,
-"compress_mbps": 290.44,
-"decompress_mbps": 789.99
+"compress_mbps": 293.25,
+"decompress_mbps": 796.91
 },
 {
 "compressor": "zlib",
@@ -1394,8 +1394,8 @@
 "level": 4,
 "out_size": 1228,
 "ratio": 0.33,
-"compress_mbps": 232.65,
-"decompress_mbps": 818.41
+"compress_mbps": 234.5,
+"decompress_mbps": 822.39
 },
 {
 "compressor": "zlib",
@@ -1404,8 +1404,8 @@
 "level": 5,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 198.08,
-"decompress_mbps": 824.88
+"compress_mbps": 199.33,
+"decompress_mbps": 829.5
 },
 {
 "compressor": "zlib",
@@ -1414,8 +1414,8 @@
 "level": 6,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 177.82,
-"decompress_mbps": 826.61
+"compress_mbps": 178.66,
+"decompress_mbps": 830.28
 },
 {
 "compressor": "zlib",
@@ -1424,8 +1424,8 @@
 "level": 7,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 170.42,
-"decompress_mbps": 824.49
+"compress_mbps": 171.22,
+"decompress_mbps": 826.22
 },
 {
 "compressor": "zlib",
@@ -1434,8 +1434,8 @@
 "level": 8,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 167.47,
-"decompress_mbps": 825.26
+"compress_mbps": 168.55,
+"decompress_mbps": 828.54
 },
 {
 "compressor": "zlib",
@@ -1444,8 +1444,8 @@
 "level": 9,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 167.55,
-"decompress_mbps": 825.26
+"compress_mbps": 168.56,
+"decompress_mbps": 830.48
 },
 {
 "compressor": "zlib",
@@ -1454,8 +1454,8 @@
 "level": 1,
 "out_size": 242293,
 "ratio": 0.2353,
-"compress_mbps": 261.09,
-"decompress_mbps": 837.67
+"compress_mbps": 262.57,
+"decompress_mbps": 846.48
 },
 {
 "compressor": "zlib",
@@ -1464,8 +1464,8 @@
 "level": 2,
 "out_size": 233553,
 "ratio": 0.2268,
-"compress_mbps": 247.86,
-"decompress_mbps": 990.25
+"compress_mbps": 249.26,
+"decompress_mbps": 1003.16
 },
 {
 "compressor": "zlib",
@@ -1474,8 +1474,8 @@
 "level": 3,
 "out_size": 228222,
 "ratio": 0.2216,
-"compress_mbps": 195.83,
-"decompress_mbps": 1051.94
+"compress_mbps": 196.63,
+"decompress_mbps": 1061.75
 },
 {
 "compressor": "zlib",
@@ -1484,8 +1484,8 @@
 "level": 4,
 "out_size": 223668,
 "ratio": 0.2172,
-"compress_mbps": 176.6,
-"decompress_mbps": 1078.14
+"compress_mbps": 177.77,
+"decompress_mbps": 1088.45
 },
 {
 "compressor": "zlib",
@@ -1494,8 +1494,8 @@
 "level": 5,
 "out_size": 205994,
 "ratio": 0.2,
-"compress_mbps": 109.61,
-"decompress_mbps": 1039.6
+"compress_mbps": 111.43,
+"decompress_mbps": 1046.69
 },
 {
 "compressor": "zlib",
@@ -1504,8 +1504,8 @@
 "level": 6,
 "out_size": 203986,
 "ratio": 0.1981,
-"compress_mbps": 49.97,
-"decompress_mbps": 1037.88
+"compress_mbps": 50.09,
+"decompress_mbps": 1050.83
 },
 {
 "compressor": "zlib",
@@ -1514,8 +1514,8 @@
 "level": 7,
 "out_size": 207681,
 "ratio": 0.2017,
-"compress_mbps": 37.05,
-"decompress_mbps": 1032.63
+"compress_mbps": 37.08,
+"decompress_mbps": 1042.31
 },
 {
 "compressor": "zlib",
@@ -1524,8 +1524,8 @@
 "level": 8,
 "out_size": 206827,
 "ratio": 0.2009,
-"compress_mbps": 7.28,
-"decompress_mbps": 1006.1
+"compress_mbps": 7.29,
+"decompress_mbps": 1009.11
 },
 {
 "compressor": "zlib",
@@ -1534,8 +1534,8 @@
 "level": 9,
 "out_size": 207023,
 "ratio": 0.201,
-"compress_mbps": 3.41,
-"decompress_mbps": 1004.17
+"compress_mbps": 3.42,
+"decompress_mbps": 1011.27
 },
 {
 "compressor": "zlib",
@@ -1544,8 +1544,8 @@
 "level": 1,
 "out_size": 174124,
 "ratio": 0.408,
-"compress_mbps": 123.85,
-"decompress_mbps": 392.35
+"compress_mbps": 124.11,
+"decompress_mbps": 396.62
 },
 {
 "compressor": "zlib",
@@ -1554,8 +1554,8 @@
 "level": 2,
 "out_size": 166150,
 "ratio": 0.3893,
-"compress_mbps": 105.43,
-"decompress_mbps": 403.94
+"compress_mbps": 105.44,
+"decompress_mbps": 408.59
 },
 {
 "compressor": "zlib",
@@ -1564,8 +1564,8 @@
 "level": 3,
 "out_size": 158784,
 "ratio": 0.3721,
-"compress_mbps": 70.51,
-"decompress_mbps": 419.28
+"compress_mbps": 70.36,
+"decompress_mbps": 424.58
 },
 {
 "compressor": "zlib",
@@ -1574,8 +1574,8 @@
 "level": 4,
 "out_size": 152782,
 "ratio": 0.358,
-"compress_mbps": 74.24,
-"decompress_mbps": 407.07
+"compress_mbps": 73.9,
+"decompress_mbps": 410.85
 },
 {
 "compressor": "zlib",
@@ -1584,8 +1584,8 @@
 "level": 5,
 "out_size": 147196,
 "ratio": 0.3449,
-"compress_mbps": 43.62,
-"decompress_mbps": 403.07
+"compress_mbps": 43.56,
+"decompress_mbps": 408.28
 },
 {
 "compressor": "zlib",
@@ -1594,8 +1594,8 @@
 "level": 6,
 "out_size": 144898,
 "ratio": 0.3395,
-"compress_mbps": 26.41,
-"decompress_mbps": 413.65
+"compress_mbps": 26.46,
+"decompress_mbps": 416.34
 },
 {
 "compressor": "zlib",
@@ -1604,8 +1604,8 @@
 "level": 7,
 "out_size": 144589,
 "ratio": 0.3388,
-"compress_mbps": 22.89,
-"decompress_mbps": 415.63
+"compress_mbps": 22.93,
+"decompress_mbps": 416.12
 },
 {
 "compressor": "zlib",
@@ -1614,8 +1614,8 @@
 "level": 8,
 "out_size": 144436,
 "ratio": 0.3385,
-"compress_mbps": 19.66,
-"decompress_mbps": 417.23
+"compress_mbps": 19.73,
+"decompress_mbps": 422.96
 },
 {
 "compressor": "zlib",
@@ -1624,8 +1624,8 @@
 "level": 9,
 "out_size": 144433,
 "ratio": 0.3384,
-"compress_mbps": 19.58,
-"decompress_mbps": 416.8
+"compress_mbps": 19.67,
+"decompress_mbps": 421.31
 },
 {
 "compressor": "zlib",
@@ -1634,8 +1634,8 @@
 "level": 1,
 "out_size": 228883,
 "ratio": 0.475,
-"compress_mbps": 108.55,
-"decompress_mbps": 370.7
+"compress_mbps": 108.67,
+"decompress_mbps": 374.75
 },
 {
 "compressor": "zlib",
@@ -1644,8 +1644,8 @@
 "level": 2,
 "out_size": 219047,
 "ratio": 0.4546,
-"compress_mbps": 91.19,
-"decompress_mbps": 384.69
+"compress_mbps": 91.2,
+"decompress_mbps": 392.5
 },
 {
 "compressor": "zlib",
@@ -1654,8 +1654,8 @@
 "level": 3,
 "out_size": 209408,
 "ratio": 0.4346,
-"compress_mbps": 55.63,
-"decompress_mbps": 398.48
+"compress_mbps": 55.53,
+"decompress_mbps": 407.38
 },
 {
 "compressor": "zlib",
@@ -1664,8 +1664,8 @@
 "level": 4,
 "out_size": 205916,
 "ratio": 0.4273,
-"compress_mbps": 62.54,
-"decompress_mbps": 374.43
+"compress_mbps": 62.69,
+"decompress_mbps": 379.86
 },
 {
 "compressor": "zlib",
@@ -1674,8 +1674,8 @@
 "level": 5,
 "out_size": 199188,
 "ratio": 0.4134,
-"compress_mbps": 33.15,
-"decompress_mbps": 356.87
+"compress_mbps": 33.16,
+"decompress_mbps": 364.05
 },
 {
 "compressor": "zlib",
@@ -1684,8 +1684,8 @@
 "level": 6,
 "out_size": 195255,
 "ratio": 0.4052,
-"compress_mbps": 19.42,
-"decompress_mbps": 365.73
+"compress_mbps": 19.45,
+"decompress_mbps": 370.07
 },
 {
 "compressor": "zlib",
@@ -1694,8 +1694,8 @@
 "level": 7,
 "out_size": 194657,
 "ratio": 0.404,
-"compress_mbps": 16.43,
-"decompress_mbps": 368.02
+"compress_mbps": 16.47,
+"decompress_mbps": 375.18
 },
 {
 "compressor": "zlib",
@@ -1704,8 +1704,8 @@
 "level": 8,
 "out_size": 194326,
 "ratio": 0.4033,
-"compress_mbps": 12.97,
-"decompress_mbps": 367.49
+"compress_mbps": 13.0,
+"decompress_mbps": 373.15
 },
 {
 "compressor": "zlib",
@@ -1714,8 +1714,8 @@
 "level": 9,
 "out_size": 194326,
 "ratio": 0.4033,
-"compress_mbps": 12.96,
-"decompress_mbps": 368.35
+"compress_mbps": 13.0,
+"decompress_mbps": 370.32
 },
 {
 "compressor": "zlib",
@@ -1724,8 +1724,8 @@
 "level": 1,
 "out_size": 65553,
 "ratio": 0.1277,
-"compress_mbps": 274.89,
-"decompress_mbps": 883.45
+"compress_mbps": 275.43,
+"decompress_mbps": 902.03
 },
 {
 "compressor": "zlib",
@@ -1734,8 +1734,8 @@
 "level": 2,
 "out_size": 63891,
 "ratio": 0.1245,
-"compress_mbps": 247.97,
-"decompress_mbps": 922.92
+"compress_mbps": 248.32,
+"decompress_mbps": 933.77
 },
 {
 "compressor": "zlib",
@@ -1744,8 +1744,8 @@
 "level": 3,
 "out_size": 62515,
 "ratio": 0.1218,
-"compress_mbps": 194.77,
-"decompress_mbps": 991.64
+"compress_mbps": 194.05,
+"decompress_mbps": 996.45
 },
 {
 "compressor": "zlib",
@@ -1754,8 +1754,8 @@
 "level": 4,
 "out_size": 58451,
 "ratio": 0.1139,
-"compress_mbps": 169.93,
-"decompress_mbps": 699.01
+"compress_mbps": 169.58,
+"decompress_mbps": 703.31
 },
 {
 "compressor": "zlib",
@@ -1764,8 +1764,8 @@
 "level": 5,
 "out_size": 57410,
 "ratio": 0.1119,
-"compress_mbps": 130.72,
-"decompress_mbps": 729.68
+"compress_mbps": 130.49,
+"decompress_mbps": 735.57
 },
 {
 "compressor": "zlib",
@@ -1774,8 +1774,8 @@
 "level": 6,
 "out_size": 56459,
 "ratio": 0.11,
-"compress_mbps": 77.36,
-"decompress_mbps": 778.51
+"compress_mbps": 77.12,
+"decompress_mbps": 786.95
 },
 {
 "compressor": "zlib",
@@ -1784,8 +1784,8 @@
 "level": 7,
 "out_size": 55358,
 "ratio": 0.1079,
-"compress_mbps": 60.48,
-"decompress_mbps": 812.99
+"compress_mbps": 60.33,
+"decompress_mbps": 822.55
 },
 {
 "compressor": "zlib",
@@ -1794,8 +1794,8 @@
 "level": 8,
 "out_size": 52991,
 "ratio": 0.1033,
-"compress_mbps": 27.48,
-"decompress_mbps": 867.55
+"compress_mbps": 27.36,
+"decompress_mbps": 877.49
 },
 {
 "compressor": "zlib",
@@ -1804,8 +1804,8 @@
 "level": 9,
 "out_size": 52215,
 "ratio": 0.1017,
-"compress_mbps": 9.79,
-"decompress_mbps": 888.09
+"compress_mbps": 9.72,
+"decompress_mbps": 899.03
 },
 {
 "compressor": "zlib",
@@ -1814,8 +1814,8 @@
 "level": 1,
 "out_size": 14112,
 "ratio": 0.369,
-"compress_mbps": 129.27,
-"decompress_mbps": 921.43
+"compress_mbps": 130.01,
+"decompress_mbps": 929.35
 },
 {
 "compressor": "zlib",
@@ -1824,8 +1824,8 @@
 "level": 2,
 "out_size": 13815,
 "ratio": 0.3613,
-"compress_mbps": 109.53,
-"decompress_mbps": 972.83
+"compress_mbps": 110.48,
+"decompress_mbps": 965.85
 },
 {
 "compressor": "zlib",
@@ -1834,8 +1834,8 @@
 "level": 3,
 "out_size": 13795,
 "ratio": 0.3607,
-"compress_mbps": 79.26,
-"decompress_mbps": 1008.45
+"compress_mbps": 79.46,
+"decompress_mbps": 1011.13
 },
 {
 "compressor": "zlib",
@@ -1844,8 +1844,8 @@
 "level": 4,
 "out_size": 13375,
 "ratio": 0.3498,
-"compress_mbps": 81.03,
-"decompress_mbps": 997.39
+"compress_mbps": 81.06,
+"decompress_mbps": 997.63
 },
 {
 "compressor": "zlib",
@@ -1854,8 +1854,8 @@
 "level": 5,
 "out_size": 13062,
 "ratio": 0.3416,
-"compress_mbps": 55.88,
-"decompress_mbps": 1030.77
+"compress_mbps": 56.29,
+"decompress_mbps": 1035.01
 },
 {
 "compressor": "zlib",
@@ -1864,8 +1864,8 @@
 "level": 6,
 "out_size": 12984,
 "ratio": 0.3395,
-"compress_mbps": 33.17,
-"decompress_mbps": 1041.9
+"compress_mbps": 33.21,
+"decompress_mbps": 1046.47
 },
 {
 "compressor": "zlib",
@@ -1874,8 +1874,8 @@
 "level": 7,
 "out_size": 12949,
 "ratio": 0.3386,
-"compress_mbps": 25.47,
-"decompress_mbps": 1064.25
+"compress_mbps": 25.5,
+"decompress_mbps": 1053.09
 },
 {
 "compressor": "zlib",
@@ -1885,7 +1885,7 @@
 "out_size": 12894,
 "ratio": 0.3372,
 "compress_mbps": 11.06,
-"decompress_mbps": 1075.51
+"decompress_mbps": 1073.52
 },
 {
 "compressor": "zlib",
@@ -1894,8 +1894,8 @@
 "level": 9,
 "out_size": 12832,
 "ratio": 0.3356,
-"compress_mbps": 5.08,
-"decompress_mbps": 1064.71
+"compress_mbps": 5.09,
+"decompress_mbps": 1082.02
 },
 {
 "compressor": "zlib",
@@ -1904,8 +1904,8 @@
 "level": 1,
 "out_size": 1846,
 "ratio": 0.4367,
-"compress_mbps": 289.91,
-"decompress_mbps": 707.1
+"compress_mbps": 290.56,
+"decompress_mbps": 709.09
 },
 {
 "compressor": "zlib",
@@ -1914,8 +1914,8 @@
 "level": 2,
 "out_size": 1820,
 "ratio": 0.4306,
-"compress_mbps": 283.11,
-"decompress_mbps": 719.6
+"compress_mbps": 286.26,
+"decompress_mbps": 720.24
 },
 {
 "compressor": "zlib",
@@ -1924,8 +1924,8 @@
 "level": 3,
 "out_size": 1808,
 "ratio": 0.4277,
-"compress_mbps": 271.95,
-"decompress_mbps": 725.69
+"compress_mbps": 274.49,
+"decompress_mbps": 723.34
 },
 {
 "compressor": "zlib",
@@ -1934,8 +1934,8 @@
 "level": 4,
 "out_size": 1749,
 "ratio": 0.4138,
-"compress_mbps": 227.07,
-"decompress_mbps": 742.94
+"compress_mbps": 227.24,
+"decompress_mbps": 737.37
 },
 {
 "compressor": "zlib",
@@ -1944,8 +1944,8 @@
 "level": 5,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 202.25,
-"decompress_mbps": 746.65
+"compress_mbps": 202.72,
+"decompress_mbps": 752.09
 },
 {
 "compressor": "zlib",
@@ -1954,8 +1954,8 @@
 "level": 6,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 199.26,
-"decompress_mbps": 749.85
+"compress_mbps": 200.34,
+"decompress_mbps": 752.37
 },
 {
 "compressor": "zlib",
@@ -1964,8 +1964,8 @@
 "level": 7,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 197.02,
-"decompress_mbps": 745.55
+"compress_mbps": 197.9,
+"decompress_mbps": 751.67
 },
 {
 "compressor": "zlib",
@@ -1974,8 +1974,8 @@
 "level": 8,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 196.93,
-"decompress_mbps": 748.87
+"compress_mbps": 198.06,
+"decompress_mbps": 749.99
 },
 {
 "compressor": "zlib",
@@ -1984,8 +1984,8 @@
 "level": 9,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 197.32,
-"decompress_mbps": 747.21
+"compress_mbps": 197.87,
+"decompress_mbps": 750.83
 },
 {
 "compressor": "miniz_oxide",
@@ -1994,8 +1994,8 @@
 "level": 1,
 "out_size": 76470,
 "ratio": 0.5028,
-"compress_mbps": 152.87,
-"decompress_mbps": 440.71
+"compress_mbps": 155.5,
+"decompress_mbps": 455.94
 },
 {
 "compressor": "miniz_oxide",
@@ -2004,8 +2004,8 @@
 "level": 2,
 "out_size": 62765,
 "ratio": 0.4127,
-"compress_mbps": 132.63,
-"decompress_mbps": 491.14
+"compress_mbps": 132.65,
+"decompress_mbps": 505.78
 },
 {
 "compressor": "miniz_oxide",
@@ -2014,8 +2014,8 @@
 "level": 3,
 "out_size": 57162,
 "ratio": 0.3758,
-"compress_mbps": 72.1,
-"decompress_mbps": 547.09
+"compress_mbps": 72.27,
+"decompress_mbps": 564.54
 },
 {
 "compressor": "miniz_oxide",
@@ -2024,8 +2024,8 @@
 "level": 4,
 "out_size": 56826,
 "ratio": 0.3736,
-"compress_mbps": 63.96,
-"decompress_mbps": 536.21
+"compress_mbps": 64.36,
+"decompress_mbps": 550.57
 },
 {
 "compressor": "miniz_oxide",
@@ -2034,8 +2034,8 @@
 "level": 5,
 "out_size": 55696,
 "ratio": 0.3662,
-"compress_mbps": 46.65,
-"decompress_mbps": 524.91
+"compress_mbps": 46.82,
+"decompress_mbps": 539.47
 },
 {
 "compressor": "miniz_oxide",
@@ -2044,8 +2044,8 @@
 "level": 6,
 "out_size": 54440,
 "ratio": 0.3579,
-"compress_mbps": 26.47,
-"decompress_mbps": 538.34
+"compress_mbps": 26.53,
+"decompress_mbps": 554.14
 },
 {
 "compressor": "miniz_oxide",
@@ -2054,8 +2054,8 @@
 "level": 7,
 "out_size": 54283,
 "ratio": 0.3569,
-"compress_mbps": 22.33,
-"decompress_mbps": 540.87
+"compress_mbps": 22.41,
+"decompress_mbps": 551.14
 },
 {
 "compressor": "miniz_oxide",
@@ -2064,8 +2064,8 @@
 "level": 8,
 "out_size": 54221,
 "ratio": 0.3565,
-"compress_mbps": 19.67,
-"decompress_mbps": 540.9
+"compress_mbps": 19.74,
+"decompress_mbps": 552.91
 },
 {
 "compressor": "miniz_oxide",
@@ -2074,8 +2074,8 @@
 "level": 9,
 "out_size": 54217,
 "ratio": 0.3565,
-"compress_mbps": 19.43,
-"decompress_mbps": 540.5
+"compress_mbps": 19.49,
+"decompress_mbps": 550.89
 },
 {
 "compressor": "miniz_oxide",
@@ -2084,8 +2084,8 @@
 "level": 1,
 "out_size": 64926,
 "ratio": 0.5187,
-"compress_mbps": 148.15,
-"decompress_mbps": 416.51
+"compress_mbps": 150.12,
+"decompress_mbps": 432.58
 },
 {
 "compressor": "miniz_oxide",
@@ -2094,8 +2094,8 @@
 "level": 2,
 "out_size": 54985,
 "ratio": 0.4393,
-"compress_mbps": 124.16,
-"decompress_mbps": 465.42
+"compress_mbps": 124.34,
+"decompress_mbps": 480.11
 },
 {
 "compressor": "miniz_oxide",
@@ -2104,8 +2104,8 @@
 "level": 3,
 "out_size": 51148,
 "ratio": 0.4086,
-"compress_mbps": 67.05,
-"decompress_mbps": 532.33
+"compress_mbps": 67.19,
+"decompress_mbps": 546.47
 },
 {
 "compressor": "miniz_oxide",
@@ -2114,8 +2114,8 @@
 "level": 4,
 "out_size": 50599,
 "ratio": 0.4042,
-"compress_mbps": 58.81,
-"decompress_mbps": 521.49
+"compress_mbps": 59.16,
+"decompress_mbps": 534.67
 },
 {
 "compressor": "miniz_oxide",
@@ -2124,8 +2124,8 @@
 "level": 5,
 "out_size": 49775,
 "ratio": 0.3976,
-"compress_mbps": 42.5,
-"decompress_mbps": 505.22
+"compress_mbps": 42.66,
+"decompress_mbps": 516.46
 },
 {
 "compressor": "miniz_oxide",
@@ -2134,8 +2134,8 @@
 "level": 6,
 "out_size": 48967,
 "ratio": 0.3912,
-"compress_mbps": 24.9,
-"decompress_mbps": 520.0
+"compress_mbps": 24.97,
+"decompress_mbps": 530.41
 },
 {
 "compressor": "miniz_oxide",
@@ -2144,8 +2144,8 @@
 "level": 7,
 "out_size": 48870,
 "ratio": 0.3904,
-"compress_mbps": 22.11,
-"decompress_mbps": 521.81
+"compress_mbps": 22.19,
+"decompress_mbps": 532.32
 },
 {
 "compressor": "miniz_oxide",
@@ -2154,8 +2154,8 @@
 "level": 8,
 "out_size": 48845,
 "ratio": 0.3902,
-"compress_mbps": 20.82,
-"decompress_mbps": 522.22
+"compress_mbps": 20.91,
+"decompress_mbps": 532.64
 },
 {
 "compressor": "miniz_oxide",
@@ -2164,8 +2164,8 @@
 "level": 9,
 "out_size": 48845,
 "ratio": 0.3902,
-"compress_mbps": 20.83,
-"decompress_mbps": 522.52
+"compress_mbps": 20.92,
+"decompress_mbps": 529.78
 },
 {
 "compressor": "miniz_oxide",
@@ -2174,8 +2174,8 @@
 "level": 1,
 "out_size": 10024,
 "ratio": 0.4074,
-"compress_mbps": 558.45,
-"decompress_mbps": 901.5
+"compress_mbps": 565.11,
+"decompress_mbps": 903.2
 },
 {
 "compressor": "miniz_oxide",
@@ -2184,8 +2184,8 @@
 "level": 2,
 "out_size": 8577,
 "ratio": 0.3486,
-"compress_mbps": 252.04,
-"decompress_mbps": 922.84
+"compress_mbps": 257.53,
+"decompress_mbps": 932.75
 },
 {
 "compressor": "miniz_oxide",
@@ -2194,8 +2194,8 @@
 "level": 3,
 "out_size": 8168,
 "ratio": 0.332,
-"compress_mbps": 153.41,
-"decompress_mbps": 945.3
+"compress_mbps": 157.93,
+"decompress_mbps": 954.26
 },
 {
 "compressor": "miniz_oxide",
@@ -2204,8 +2204,8 @@
 "level": 4,
 "out_size": 8069,
 "ratio": 0.328,
-"compress_mbps": 114.91,
-"decompress_mbps": 960.03
+"compress_mbps": 115.26,
+"decompress_mbps": 968.4
 },
 {
 "compressor": "miniz_oxide",
@@ -2214,8 +2214,8 @@
 "level": 5,
 "out_size": 7997,
 "ratio": 0.325,
-"compress_mbps": 99.19,
-"decompress_mbps": 990.3
+"compress_mbps": 100.39,
+"decompress_mbps": 996.15
 },
 {
 "compressor": "miniz_oxide",
@@ -2224,8 +2224,8 @@
 "level": 6,
 "out_size": 7952,
 "ratio": 0.3232,
-"compress_mbps": 74.62,
-"decompress_mbps": 995.3
+"compress_mbps": 74.67,
+"decompress_mbps": 1002.62
 },
 {
 "compressor": "miniz_oxide",
@@ -2234,8 +2234,8 @@
 "level": 7,
 "out_size": 7947,
 "ratio": 0.323,
-"compress_mbps": 72.01,
-"decompress_mbps": 1001.38
+"compress_mbps": 72.27,
+"decompress_mbps": 1006.62
 },
 {
 "compressor": "miniz_oxide",
@@ -2244,8 +2244,8 @@
 "level": 8,
 "out_size": 7947,
 "ratio": 0.323,
-"compress_mbps": 70.88,
-"decompress_mbps": 1000.05
+"compress_mbps": 71.37,
+"decompress_mbps": 1004.94
 },
 {
 "compressor": "miniz_oxide",
@@ -2254,8 +2254,8 @@
 "level": 9,
 "out_size": 7947,
 "ratio": 0.323,
-"compress_mbps": 70.74,
-"decompress_mbps": 999.93
+"compress_mbps": 70.98,
+"decompress_mbps": 1005.5
 },
 {
 "compressor": "miniz_oxide",
@@ -2264,8 +2264,8 @@
 "level": 1,
 "out_size": 4061,
 "ratio": 0.3642,
-"compress_mbps": 496.71,
-"decompress_mbps": 850.68
+"compress_mbps": 504.79,
+"decompress_mbps": 854.51
 },
 {
 "compressor": "miniz_oxide",
@@ -2274,8 +2274,8 @@
 "level": 2,
 "out_size": 3446,
 "ratio": 0.3091,
-"compress_mbps": 300.12,
-"decompress_mbps": 886.42
+"compress_mbps": 306.11,
+"decompress_mbps": 897.11
 },
 {
 "compressor": "miniz_oxide",
@@ -2284,8 +2284,8 @@
 "level": 3,
 "out_size": 3201,
 "ratio": 0.2871,
-"compress_mbps": 232.44,
-"decompress_mbps": 916.05
+"compress_mbps": 234.65,
+"decompress_mbps": 919.77
 },
 {
 "compressor": "miniz_oxide",
@@ -2294,8 +2294,8 @@
 "level": 4,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 192.39,
-"decompress_mbps": 944.19
+"compress_mbps": 194.54,
+"decompress_mbps": 950.86
 },
 {
 "compressor": "miniz_oxide",
@@ -2304,8 +2304,8 @@
 "level": 5,
 "out_size": 3139,
 "ratio": 0.2815,
-"compress_mbps": 161.86,
-"decompress_mbps": 959.79
+"compress_mbps": 162.89,
+"decompress_mbps": 976.98
 },
 {
 "compressor": "miniz_oxide",
@@ -2314,8 +2314,8 @@
 "level": 6,
 "out_size": 3115,
 "ratio": 0.2794,
-"compress_mbps": 115.09,
-"decompress_mbps": 973.23
+"compress_mbps": 116.43,
+"decompress_mbps": 985.22
 },
 {
 "compressor": "miniz_oxide",
@@ -2324,8 +2324,8 @@
 "level": 7,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 105.62,
-"decompress_mbps": 976.35
+"compress_mbps": 106.4,
+"decompress_mbps": 986.86
 },
 {
 "compressor": "miniz_oxide",
@@ -2334,8 +2334,8 @@
 "level": 8,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 102.68,
-"decompress_mbps": 973.94
+"compress_mbps": 103.31,
+"decompress_mbps": 990.08
 },
 {
 "compressor": "miniz_oxide",
@@ -2344,8 +2344,8 @@
 "level": 9,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 102.3,
-"decompress_mbps": 975.19
+"compress_mbps": 103.15,
+"decompress_mbps": 984.12
 },
 {
 "compressor": "miniz_oxide",
@@ -2354,8 +2354,8 @@
 "level": 1,
 "out_size": 1410,
 "ratio": 0.3789,
-"compress_mbps": 365.76,
-"decompress_mbps": 582.7
+"compress_mbps": 364.75,
+"decompress_mbps": 585.97
 },
 {
 "compressor": "miniz_oxide",
@@ -2364,8 +2364,8 @@
 "level": 2,
 "out_size": 1262,
 "ratio": 0.3392,
-"compress_mbps": 238.08,
-"decompress_mbps": 589.86
+"compress_mbps": 233.69,
+"decompress_mbps": 605.67
 },
 {
 "compressor": "miniz_oxide",
@@ -2374,8 +2374,8 @@
 "level": 3,
 "out_size": 1238,
 "ratio": 0.3327,
-"compress_mbps": 206.69,
-"decompress_mbps": 591.63
+"compress_mbps": 203.84,
+"decompress_mbps": 602.07
 },
 {
 "compressor": "miniz_oxide",
@@ -2384,8 +2384,8 @@
 "level": 4,
 "out_size": 1219,
 "ratio": 0.3276,
-"compress_mbps": 177.6,
-"decompress_mbps": 609.0
+"compress_mbps": 173.55,
+"decompress_mbps": 620.28
 },
 {
 "compressor": "miniz_oxide",
@@ -2394,8 +2394,8 @@
 "level": 5,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 161.68,
-"decompress_mbps": 614.27
+"compress_mbps": 160.48,
+"decompress_mbps": 625.42
 },
 {
 "compressor": "miniz_oxide",
@@ -2404,8 +2404,8 @@
 "level": 6,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 147.07,
-"decompress_mbps": 615.55
+"compress_mbps": 147.66,
+"decompress_mbps": 631.65
 },
 {
 "compressor": "miniz_oxide",
@@ -2414,8 +2414,8 @@
 "level": 7,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 146.18,
-"decompress_mbps": 617.37
+"compress_mbps": 147.04,
+"decompress_mbps": 631.88
 },
 {
 "compressor": "miniz_oxide",
@@ -2424,8 +2424,8 @@
 "level": 8,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 146.2,
-"decompress_mbps": 617.47
+"compress_mbps": 147.13,
+"decompress_mbps": 629.97
 },
 {
 "compressor": "miniz_oxide",
@@ -2434,8 +2434,8 @@
 "level": 9,
 "out_size": 1216,
 "ratio": 0.3268,
-"compress_mbps": 146.11,
-"decompress_mbps": 617.58
+"compress_mbps": 147.07,
+"decompress_mbps": 630.98
 },
 {
 "compressor": "miniz_oxide",
@@ -2444,8 +2444,8 @@
 "level": 1,
 "out_size": 274412,
 "ratio": 0.2665,
-"compress_mbps": 445.07,
-"decompress_mbps": 792.24
+"compress_mbps": 448.5,
+"decompress_mbps": 803.0
 },
 {
 "compressor": "miniz_oxide",
@@ -2454,8 +2454,8 @@
 "level": 2,
 "out_size": 213239,
 "ratio": 0.2071,
-"compress_mbps": 273.07,
-"decompress_mbps": 872.8
+"compress_mbps": 273.8,
+"decompress_mbps": 885.6
 },
 {
 "compressor": "miniz_oxide",
@@ -2464,8 +2464,8 @@
 "level": 3,
 "out_size": 232107,
 "ratio": 0.2254,
-"compress_mbps": 136.26,
-"decompress_mbps": 912.41
+"compress_mbps": 137.01,
+"decompress_mbps": 926.6
 },
 {
 "compressor": "miniz_oxide",
@@ -2474,8 +2474,8 @@
 "level": 4,
 "out_size": 202733,
 "ratio": 0.1969,
-"compress_mbps": 129.09,
-"decompress_mbps": 921.92
+"compress_mbps": 130.13,
+"decompress_mbps": 928.25
 },
 {
 "compressor": "miniz_oxide",
@@ -2484,8 +2484,8 @@
 "level": 5,
 "out_size": 207803,
 "ratio": 0.2018,
-"compress_mbps": 83.85,
-"decompress_mbps": 943.24
+"compress_mbps": 84.43,
+"decompress_mbps": 950.78
 },
 {
 "compressor": "miniz_oxide",
@@ -2494,8 +2494,8 @@
 "level": 6,
 "out_size": 205270,
 "ratio": 0.1993,
-"compress_mbps": 27.2,
-"decompress_mbps": 970.44
+"compress_mbps": 27.28,
+"decompress_mbps": 978.56
 },
 {
 "compressor": "miniz_oxide",
@@ -2504,8 +2504,8 @@
 "level": 7,
 "out_size": 209951,
 "ratio": 0.2039,
-"compress_mbps": 19.26,
-"decompress_mbps": 978.2
+"compress_mbps": 19.3,
+"decompress_mbps": 989.27
 },
 {
 "compressor": "miniz_oxide",
@@ -2514,8 +2514,8 @@
 "level": 8,
 "out_size": 209656,
 "ratio": 0.2036,
-"compress_mbps": 12.19,
-"decompress_mbps": 992.97
+"compress_mbps": 12.23,
+"decompress_mbps": 1005.97
 },
 {
 "compressor": "miniz_oxide",
@@ -2524,8 +2524,8 @@
 "level": 9,
 "out_size": 209189,
 "ratio": 0.2031,
-"compress_mbps": 8.92,
-"decompress_mbps": 995.87
+"compress_mbps": 8.96,
+"decompress_mbps": 1008.08
 },
 {
 "compressor": "miniz_oxide",
@@ -2534,8 +2534,8 @@
 "level": 1,
 "out_size": 208640,
 "ratio": 0.4889,
-"compress_mbps": 153.33,
-"decompress_mbps": 425.13
+"compress_mbps": 155.24,
+"decompress_mbps": 439.81
 },
 {
 "compressor": "miniz_oxide",
@@ -2544,8 +2544,8 @@
 "level": 2,
 "out_size": 167329,
 "ratio": 0.3921,
-"compress_mbps": 138.14,
-"decompress_mbps": 463.41
+"compress_mbps": 138.06,
+"decompress_mbps": 475.7
 },
 {
 "compressor": "miniz_oxide",
@@ -2554,8 +2554,8 @@
 "level": 3,
 "out_size": 151097,
 "ratio": 0.3541,
-"compress_mbps": 73.45,
-"decompress_mbps": 511.24
+"compress_mbps": 73.64,
+"decompress_mbps": 525.67
 },
 {
 "compressor": "miniz_oxide",
@@ -2564,8 +2564,8 @@
 "level": 4,
 "out_size": 150035,
 "ratio": 0.3516,
-"compress_mbps": 66.08,
-"decompress_mbps": 509.43
+"compress_mbps": 66.46,
+"decompress_mbps": 518.68
 },
 {
 "compressor": "miniz_oxide",
@@ -2574,8 +2574,8 @@
 "level": 5,
 "out_size": 147375,
 "ratio": 0.3453,
-"compress_mbps": 47.89,
-"decompress_mbps": 508.24
+"compress_mbps": 48.11,
+"decompress_mbps": 517.72
 },
 {
 "compressor": "miniz_oxide",
@@ -2584,8 +2584,8 @@
 "level": 6,
 "out_size": 144908,
 "ratio": 0.3396,
-"compress_mbps": 27.93,
-"decompress_mbps": 519.21
+"compress_mbps": 28.05,
+"decompress_mbps": 528.33
 },
 {
 "compressor": "miniz_oxide",
@@ -2594,8 +2594,8 @@
 "level": 7,
 "out_size": 144562,
 "ratio": 0.3387,
-"compress_mbps": 24.54,
-"decompress_mbps": 516.85
+"compress_mbps": 24.62,
+"decompress_mbps": 527.36
 },
 {
 "compressor": "miniz_oxide",
@@ -2604,8 +2604,8 @@
 "level": 8,
 "out_size": 144449,
 "ratio": 0.3385,
-"compress_mbps": 22.31,
-"decompress_mbps": 520.45
+"compress_mbps": 22.39,
+"decompress_mbps": 528.46
 },
 {
 "compressor": "miniz_oxide",
@@ -2614,8 +2614,8 @@
 "level": 9,
 "out_size": 144438,
 "ratio": 0.3385,
-"compress_mbps": 22.22,
-"decompress_mbps": 520.53
+"compress_mbps": 22.31,
+"decompress_mbps": 528.19
 },
 {
 "compressor": "miniz_oxide",
@@ -2624,8 +2624,8 @@
 "level": 1,
 "out_size": 264549,
 "ratio": 0.549,
-"compress_mbps": 132.45,
-"decompress_mbps": 374.64
+"compress_mbps": 133.4,
+"decompress_mbps": 390.2
 },
 {
 "compressor": "miniz_oxide",
@@ -2634,8 +2634,8 @@
 "level": 2,
 "out_size": 223724,
 "ratio": 0.4643,
-"compress_mbps": 118.56,
-"decompress_mbps": 420.68
+"compress_mbps": 118.5,
+"decompress_mbps": 437.39
 },
 {
 "compressor": "miniz_oxide",
@@ -2644,8 +2644,8 @@
 "level": 3,
 "out_size": 204825,
 "ratio": 0.4251,
-"compress_mbps": 60.49,
-"decompress_mbps": 474.79
+"compress_mbps": 60.63,
+"decompress_mbps": 488.64
 },
 {
 "compressor": "miniz_oxide",
@@ -2654,8 +2654,8 @@
 "level": 4,
 "out_size": 203945,
 "ratio": 0.4232,
-"compress_mbps": 53.65,
-"decompress_mbps": 471.13
+"compress_mbps": 53.99,
+"decompress_mbps": 480.14
 },
 {
 "compressor": "miniz_oxide",
@@ -2664,8 +2664,8 @@
 "level": 5,
 "out_size": 199780,
 "ratio": 0.4146,
-"compress_mbps": 37.72,
-"decompress_mbps": 456.42
+"compress_mbps": 37.87,
+"decompress_mbps": 462.15
 },
 {
 "compressor": "miniz_oxide",
@@ -2674,8 +2674,8 @@
 "level": 6,
 "out_size": 195417,
 "ratio": 0.4055,
-"compress_mbps": 21.1,
-"decompress_mbps": 467.0
+"compress_mbps": 21.16,
+"decompress_mbps": 476.94
 },
 {
 "compressor": "miniz_oxide",
@@ -2684,8 +2684,8 @@
 "level": 7,
 "out_size": 194796,
 "ratio": 0.4043,
-"compress_mbps": 17.81,
-"decompress_mbps": 465.7
+"compress_mbps": 17.88,
+"decompress_mbps": 475.83
 },
 {
 "compressor": "miniz_oxide",
@@ -2694,8 +2694,8 @@
 "level": 8,
 "out_size": 194543,
 "ratio": 0.4037,
-"compress_mbps": 15.63,
-"decompress_mbps": 467.23
+"compress_mbps": 15.7,
+"decompress_mbps": 475.76
 },
 {
 "compressor": "miniz_oxide",
@@ -2704,8 +2704,8 @@
 "level": 9,
 "out_size": 194460,
 "ratio": 0.4036,
-"compress_mbps": 14.97,
-"decompress_mbps": 466.59
+"compress_mbps": 15.04,
+"decompress_mbps": 476.04
 },
 {
 "compressor": "miniz_oxide",
@@ -2714,8 +2714,8 @@
 "level": 1,
 "out_size": 67436,
 "ratio": 0.1314,
-"compress_mbps": 618.78,
-"decompress_mbps": 1006.9
+"compress_mbps": 622.92,
+"decompress_mbps": 1031.11
 },
 {
 "compressor": "miniz_oxide",
@@ -2724,8 +2724,8 @@
 "level": 2,
 "out_size": 59257,
 "ratio": 0.1155,
-"compress_mbps": 276.86,
-"decompress_mbps": 1061.42
+"compress_mbps": 277.97,
+"decompress_mbps": 1093.09
 },
 {
 "compressor": "miniz_oxide",
@@ -2734,8 +2734,8 @@
 "level": 3,
 "out_size": 58316,
 "ratio": 0.1136,
-"compress_mbps": 180.8,
-"decompress_mbps": 1148.4
+"compress_mbps": 181.59,
+"decompress_mbps": 1174.33
 },
 {
 "compressor": "miniz_oxide",
@@ -2744,8 +2744,8 @@
 "level": 4,
 "out_size": 56291,
 "ratio": 0.1097,
-"compress_mbps": 183.3,
-"decompress_mbps": 1152.65
+"compress_mbps": 184.63,
+"decompress_mbps": 1185.14
 },
 {
 "compressor": "miniz_oxide",
@@ -2754,8 +2754,8 @@
 "level": 5,
 "out_size": 56220,
 "ratio": 0.1095,
-"compress_mbps": 145.07,
-"decompress_mbps": 1210.99
+"compress_mbps": 145.94,
+"decompress_mbps": 1241.33
 },
 {
 "compressor": "miniz_oxide",
@@ -2764,8 +2764,8 @@
 "level": 6,
 "out_size": 55972,
 "ratio": 0.1091,
-"compress_mbps": 74.22,
-"decompress_mbps": 1271.04
+"compress_mbps": 74.51,
+"decompress_mbps": 1306.71
 },
 {
 "compressor": "miniz_oxide",
@@ -2774,8 +2774,8 @@
 "level": 7,
 "out_size": 55121,
 "ratio": 0.1074,
-"compress_mbps": 51.96,
-"decompress_mbps": 1315.79
+"compress_mbps": 52.11,
+"decompress_mbps": 1344.87
 },
 {
 "compressor": "miniz_oxide",
@@ -2784,8 +2784,8 @@
 "level": 8,
 "out_size": 54124,
 "ratio": 0.1055,
-"compress_mbps": 36.55,
-"decompress_mbps": 1376.8
+"compress_mbps": 36.67,
+"decompress_mbps": 1417.73
 },
 {
 "compressor": "miniz_oxide",
@@ -2794,8 +2794,8 @@
 "level": 9,
 "out_size": 53699,
 "ratio": 0.1046,
-"compress_mbps": 28.57,
-"decompress_mbps": 1409.51
+"compress_mbps": 28.65,
+"decompress_mbps": 1443.69
 },
 {
 "compressor": "miniz_oxide",
@@ -2804,8 +2804,8 @@
 "level": 1,
 "out_size": 15612,
 "ratio": 0.4083,
-"compress_mbps": 505.31,
-"decompress_mbps": 846.57
+"compress_mbps": 495.66,
+"decompress_mbps": 854.66
 },
 {
 "compressor": "miniz_oxide",
@@ -2814,8 +2814,8 @@
 "level": 2,
 "out_size": 14133,
 "ratio": 0.3696,
-"compress_mbps": 144.56,
-"decompress_mbps": 871.76
+"compress_mbps": 145.29,
+"decompress_mbps": 882.18
 },
 {
 "compressor": "miniz_oxide",
@@ -2824,8 +2824,8 @@
 "level": 3,
 "out_size": 13341,
 "ratio": 0.3489,
-"compress_mbps": 88.14,
-"decompress_mbps": 903.8
+"compress_mbps": 88.03,
+"decompress_mbps": 911.74
 },
 {
 "compressor": "miniz_oxide",
@@ -2834,8 +2834,8 @@
 "level": 4,
 "out_size": 13289,
 "ratio": 0.3475,
-"compress_mbps": 82.56,
-"decompress_mbps": 937.73
+"compress_mbps": 83.11,
+"decompress_mbps": 945.2
 },
 {
 "compressor": "miniz_oxide",
@@ -2844,8 +2844,8 @@
 "level": 5,
 "out_size": 13052,
 "ratio": 0.3413,
-"compress_mbps": 66.32,
-"decompress_mbps": 973.12
+"compress_mbps": 66.63,
+"decompress_mbps": 974.55
 },
 {
 "compressor": "miniz_oxide",
@@ -2854,8 +2854,8 @@
 "level": 6,
 "out_size": 12996,
 "ratio": 0.3399,
-"compress_mbps": 37.0,
-"decompress_mbps": 990.59
+"compress_mbps": 37.11,
+"decompress_mbps": 994.8
 },
 {
 "compressor": "miniz_oxide",
@@ -2864,8 +2864,8 @@
 "level": 7,
 "out_size": 12972,
 "ratio": 0.3392,
-"compress_mbps": 27.13,
-"decompress_mbps": 986.81
+"compress_mbps": 27.18,
+"decompress_mbps": 997.66
 },
 {
 "compressor": "miniz_oxide",
@@ -2874,8 +2874,8 @@
 "level": 8,
 "out_size": 12951,
 "ratio": 0.3387,
-"compress_mbps": 18.96,
-"decompress_mbps": 994.64
+"compress_mbps": 19.02,
+"decompress_mbps": 1005.89
 },
 {
 "compressor": "miniz_oxide",
@@ -2884,8 +2884,8 @@
 "level": 9,
 "out_size": 12933,
 "ratio": 0.3382,
-"compress_mbps": 14.8,
-"decompress_mbps": 1004.37
+"compress_mbps": 14.84,
+"decompress_mbps": 1008.14
 },
 {
 "compressor": "miniz_oxide",
@@ -2894,8 +2894,8 @@
 "level": 1,
 "out_size": 1988,
 "ratio": 0.4703,
-"compress_mbps": 342.64,
-"decompress_mbps": 536.78
+"compress_mbps": 339.21,
+"decompress_mbps": 542.7
 },
 {
 "compressor": "miniz_oxide",
@@ -2904,8 +2904,8 @@
 "level": 2,
 "out_size": 1802,
 "ratio": 0.4263,
-"compress_mbps": 216.93,
-"decompress_mbps": 541.32
+"compress_mbps": 217.41,
+"decompress_mbps": 550.26
 },
 {
 "compressor": "miniz_oxide",
@@ -2914,8 +2914,8 @@
 "level": 3,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 204.64,
-"decompress_mbps": 549.58
+"compress_mbps": 204.83,
+"decompress_mbps": 555.34
 },
 {
 "compressor": "miniz_oxide",
@@ -2924,8 +2924,8 @@
 "level": 4,
 "out_size": 1732,
 "ratio": 0.4097,
-"compress_mbps": 170.14,
-"decompress_mbps": 562.46
+"compress_mbps": 170.03,
+"decompress_mbps": 567.05
 },
 {
 "compressor": "miniz_oxide",
@@ -2934,8 +2934,8 @@
 "level": 5,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 166.51,
-"decompress_mbps": 570.26
+"compress_mbps": 165.69,
+"decompress_mbps": 577.12
 },
 {
 "compressor": "miniz_oxide",
@@ -2944,8 +2944,8 @@
 "level": 6,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 164.58,
-"decompress_mbps": 569.78
+"compress_mbps": 164.52,
+"decompress_mbps": 577.04
 },
 {
 "compressor": "miniz_oxide",
@@ -2954,8 +2954,8 @@
 "level": 7,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 165.23,
-"decompress_mbps": 566.34
+"compress_mbps": 164.45,
+"decompress_mbps": 574.57
 },
 {
 "compressor": "miniz_oxide",
@@ -2964,8 +2964,8 @@
 "level": 8,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 164.87,
-"decompress_mbps": 570.67
+"compress_mbps": 164.77,
+"decompress_mbps": 578.03
 },
 {
 "compressor": "miniz_oxide",
@@ -2974,8 +2974,8 @@
 "level": 9,
 "out_size": 1730,
 "ratio": 0.4093,
-"compress_mbps": 165.35,
-"decompress_mbps": 571.72
+"compress_mbps": 164.14,
+"decompress_mbps": 577.62
 },
 {
 "compressor": "libdeflate",
@@ -2984,8 +2984,8 @@
 "level": 1,
 "out_size": 59790,
 "ratio": 0.3931,
-"compress_mbps": 261.17,
-"decompress_mbps": 994.53
+"compress_mbps": 263.2,
+"decompress_mbps": 1001.42
 },
 {
 "compressor": "libdeflate",
@@ -2994,8 +2994,8 @@
 "level": 2,
 "out_size": 57173,
 "ratio": 0.3759,
-"compress_mbps": 179.51,
-"decompress_mbps": 1063.95
+"compress_mbps": 181.59,
+"decompress_mbps": 1075.31
 },
 {
 "compressor": "libdeflate",
@@ -3004,8 +3004,8 @@
 "level": 3,
 "out_size": 56189,
 "ratio": 0.3694,
-"compress_mbps": 149.83,
-"decompress_mbps": 1138.09
+"compress_mbps": 151.17,
+"decompress_mbps": 1147.2
 },
 {
 "compressor": "libdeflate",
@@ -3014,8 +3014,8 @@
 "level": 4,
 "out_size": 55816,
 "ratio": 0.367,
-"compress_mbps": 137.87,
-"decompress_mbps": 1176.78
+"compress_mbps": 138.47,
+"decompress_mbps": 1191.79
 },
 {
 "compressor": "libdeflate",
@@ -3024,8 +3024,8 @@
 "level": 5,
 "out_size": 54758,
 "ratio": 0.36,
-"compress_mbps": 108.49,
-"decompress_mbps": 1235.72
+"compress_mbps": 108.98,
+"decompress_mbps": 1242.52
 },
 {
 "compressor": "libdeflate",
@@ -3034,8 +3034,8 @@
 "level": 6,
 "out_size": 54220,
 "ratio": 0.3565,
-"compress_mbps": 83.91,
-"decompress_mbps": 1270.36
+"compress_mbps": 84.13,
+"decompress_mbps": 1278.22
 },
 {
 "compressor": "libdeflate",
@@ -3044,8 +3044,8 @@
 "level": 7,
 "out_size": 53801,
 "ratio": 0.3537,
-"compress_mbps": 61.12,
-"decompress_mbps": 1274.01
+"compress_mbps": 61.41,
+"decompress_mbps": 1285.49
 },
 {
 "compressor": "libdeflate",
@@ -3054,8 +3054,8 @@
 "level": 8,
 "out_size": 53573,
 "ratio": 0.3522,
-"compress_mbps": 38.87,
-"decompress_mbps": 1279.62
+"compress_mbps": 39.03,
+"decompress_mbps": 1285.81
 },
 {
 "compressor": "libdeflate",
@@ -3064,8 +3064,8 @@
 "level": 9,
 "out_size": 53546,
 "ratio": 0.3521,
-"compress_mbps": 34.42,
-"decompress_mbps": 1278.28
+"compress_mbps": 34.48,
+"decompress_mbps": 1289.86
 },
 {
 "compressor": "libdeflate",
@@ -3074,8 +3074,8 @@
 "level": 1,
 "out_size": 52276,
 "ratio": 0.4176,
-"compress_mbps": 242.59,
-"decompress_mbps": 937.06
+"compress_mbps": 243.31,
+"decompress_mbps": 942.37
 },
 {
 "compressor": "libdeflate",
@@ -3084,8 +3084,8 @@
 "level": 2,
 "out_size": 50534,
 "ratio": 0.4037,
-"compress_mbps": 168.27,
-"decompress_mbps": 982.37
+"compress_mbps": 169.24,
+"decompress_mbps": 995.26
 },
 {
 "compressor": "libdeflate",
@@ -3094,8 +3094,8 @@
 "level": 3,
 "out_size": 49919,
 "ratio": 0.3988,
-"compress_mbps": 141.77,
-"decompress_mbps": 1050.54
+"compress_mbps": 141.81,
+"decompress_mbps": 1059.73
 },
 {
 "compressor": "libdeflate",
@@ -3104,8 +3104,8 @@
 "level": 4,
 "out_size": 49715,
 "ratio": 0.3972,
-"compress_mbps": 130.85,
-"decompress_mbps": 1083.77
+"compress_mbps": 131.26,
+"decompress_mbps": 1094.97
 },
 {
 "compressor": "libdeflate",
@@ -3114,8 +3114,8 @@
 "level": 5,
 "out_size": 48735,
 "ratio": 0.3893,
-"compress_mbps": 100.6,
-"decompress_mbps": 1133.24
+"compress_mbps": 100.85,
+"decompress_mbps": 1140.16
 },
 {
 "compressor": "libdeflate",
@@ -3124,8 +3124,8 @@
 "level": 6,
 "out_size": 48422,
 "ratio": 0.3868,
-"compress_mbps": 79.44,
-"decompress_mbps": 1158.78
+"compress_mbps": 79.38,
+"decompress_mbps": 1166.67
 },
 {
 "compressor": "libdeflate",
@@ -3134,8 +3134,8 @@
 "level": 7,
 "out_size": 48249,
 "ratio": 0.3854,
-"compress_mbps": 61.16,
-"decompress_mbps": 1158.43
+"compress_mbps": 61.36,
+"decompress_mbps": 1170.75
 },
 {
 "compressor": "libdeflate",
@@ -3144,8 +3144,8 @@
 "level": 8,
 "out_size": 47977,
 "ratio": 0.3833,
-"compress_mbps": 42.91,
-"decompress_mbps": 1158.7
+"compress_mbps": 43.05,
+"decompress_mbps": 1170.48
 },
 {
 "compressor": "libdeflate",
@@ -3154,8 +3154,8 @@
 "level": 9,
 "out_size": 47971,
 "ratio": 0.3832,
-"compress_mbps": 40.93,
-"decompress_mbps": 1161.94
+"compress_mbps": 41.12,
+"decompress_mbps": 1171.55
 },
 {
 "compressor": "libdeflate",
@@ -3164,8 +3164,8 @@
 "level": 1,
 "out_size": 8385,
 "ratio": 0.3408,
-"compress_mbps": 688.7,
-"decompress_mbps": 948.24
+"compress_mbps": 691.83,
+"decompress_mbps": 957.33
 },
 {
 "compressor": "libdeflate",
@@ -3174,8 +3174,8 @@
 "level": 2,
 "out_size": 8380,
 "ratio": 0.3406,
-"compress_mbps": 438.34,
-"decompress_mbps": 970.72
+"compress_mbps": 441.02,
+"decompress_mbps": 980.78
 },
 {
 "compressor": "libdeflate",
@@ -3184,8 +3184,8 @@
 "level": 3,
 "out_size": 8286,
 "ratio": 0.3368,
-"compress_mbps": 403.66,
-"decompress_mbps": 979.8
+"compress_mbps": 403.63,
+"decompress_mbps": 998.52
 },
 {
 "compressor": "libdeflate",
@@ -3194,8 +3194,8 @@
 "level": 4,
 "out_size": 8163,
 "ratio": 0.3318,
-"compress_mbps": 376.61,
-"decompress_mbps": 989.34
+"compress_mbps": 376.96,
+"decompress_mbps": 1004.46
 },
 {
 "compressor": "libdeflate",
@@ -3204,8 +3204,8 @@
 "level": 5,
 "out_size": 8053,
 "ratio": 0.3273,
-"compress_mbps": 338.25,
-"decompress_mbps": 1016.25
+"compress_mbps": 339.99,
+"decompress_mbps": 1033.12
 },
 {
 "compressor": "libdeflate",
@@ -3214,8 +3214,8 @@
 "level": 6,
 "out_size": 7986,
 "ratio": 0.3246,
-"compress_mbps": 276.66,
-"decompress_mbps": 1007.05
+"compress_mbps": 277.58,
+"decompress_mbps": 1032.8
 },
 {
 "compressor": "libdeflate",
@@ -3225,7 +3225,7 @@
 "out_size": 7954,
 "ratio": 0.3233,
 "compress_mbps": 191.57,
-"decompress_mbps": 1019.08
+"decompress_mbps": 1035.54
 },
 {
 "compressor": "libdeflate",
@@ -3234,8 +3234,8 @@
 "level": 8,
 "out_size": 7916,
 "ratio": 0.3217,
-"compress_mbps": 129.03,
-"decompress_mbps": 1018.06
+"compress_mbps": 122.86,
+"decompress_mbps": 1039.85
 },
 {
 "compressor": "libdeflate",
@@ -3244,8 +3244,8 @@
 "level": 9,
 "out_size": 7916,
 "ratio": 0.3217,
-"compress_mbps": 122.49,
-"decompress_mbps": 1018.11
+"compress_mbps": 123.45,
+"decompress_mbps": 1037.0
 },
 {
 "compressor": "libdeflate",
@@ -3254,8 +3254,8 @@
 "level": 1,
 "out_size": 3401,
 "ratio": 0.305,
-"compress_mbps": 585.7,
-"decompress_mbps": 752.76
+"compress_mbps": 585.0,
+"decompress_mbps": 769.76
 },
 {
 "compressor": "libdeflate",
@@ -3264,8 +3264,8 @@
 "level": 2,
 "out_size": 3307,
 "ratio": 0.2966,
-"compress_mbps": 397.65,
-"decompress_mbps": 781.07
+"compress_mbps": 397.32,
+"decompress_mbps": 801.98
 },
 {
 "compressor": "libdeflate",
@@ -3274,8 +3274,8 @@
 "level": 3,
 "out_size": 3242,
 "ratio": 0.2908,
-"compress_mbps": 369.13,
-"decompress_mbps": 800.47
+"compress_mbps": 371.22,
+"decompress_mbps": 817.83
 },
 {
 "compressor": "libdeflate",
@@ -3284,8 +3284,8 @@
 "level": 4,
 "out_size": 3205,
 "ratio": 0.2874,
-"compress_mbps": 348.83,
-"decompress_mbps": 805.69
+"compress_mbps": 348.32,
+"decompress_mbps": 830.74
 },
 {
 "compressor": "libdeflate",
@@ -3294,8 +3294,8 @@
 "level": 5,
 "out_size": 3150,
 "ratio": 0.2825,
-"compress_mbps": 312.41,
-"decompress_mbps": 826.54
+"compress_mbps": 314.09,
+"decompress_mbps": 837.54
 },
 {
 "compressor": "libdeflate",
@@ -3304,8 +3304,8 @@
 "level": 6,
 "out_size": 3126,
 "ratio": 0.2804,
-"compress_mbps": 265.24,
-"decompress_mbps": 832.56
+"compress_mbps": 267.64,
+"decompress_mbps": 841.85
 },
 {
 "compressor": "libdeflate",
@@ -3314,8 +3314,8 @@
 "level": 7,
 "out_size": 3106,
 "ratio": 0.2786,
-"compress_mbps": 206.29,
-"decompress_mbps": 833.47
+"compress_mbps": 207.41,
+"decompress_mbps": 839.73
 },
 {
 "compressor": "libdeflate",
@@ -3324,8 +3324,8 @@
 "level": 8,
 "out_size": 3102,
 "ratio": 0.2782,
-"compress_mbps": 147.31,
-"decompress_mbps": 832.63
+"compress_mbps": 147.79,
+"decompress_mbps": 843.39
 },
 {
 "compressor": "libdeflate",
@@ -3334,8 +3334,8 @@
 "level": 9,
 "out_size": 3102,
 "ratio": 0.2782,
-"compress_mbps": 140.03,
-"decompress_mbps": 835.11
+"compress_mbps": 140.13,
+"decompress_mbps": 844.66
 },
 {
 "compressor": "libdeflate",
@@ -3344,8 +3344,8 @@
 "level": 1,
 "out_size": 1251,
 "ratio": 0.3362,
-"compress_mbps": 379.25,
-"decompress_mbps": 553.95
+"compress_mbps": 381.82,
+"decompress_mbps": 434.24
 },
 {
 "compressor": "libdeflate",
@@ -3354,8 +3354,8 @@
 "level": 2,
 "out_size": 1228,
 "ratio": 0.33,
-"compress_mbps": 267.18,
-"decompress_mbps": 565.34
+"compress_mbps": 267.74,
+"decompress_mbps": 434.72
 },
 {
 "compressor": "libdeflate",
@@ -3364,8 +3364,8 @@
 "level": 3,
 "out_size": 1219,
 "ratio": 0.3276,
-"compress_mbps": 260.81,
-"decompress_mbps": 561.76
+"compress_mbps": 259.59,
+"decompress_mbps": 436.59
 },
 {
 "compressor": "libdeflate",
@@ -3374,8 +3374,8 @@
 "level": 4,
 "out_size": 1220,
 "ratio": 0.3279,
-"compress_mbps": 253.67,
-"decompress_mbps": 558.75
+"compress_mbps": 252.97,
+"decompress_mbps": 444.24
 },
 {
 "compressor": "libdeflate",
@@ -3384,8 +3384,8 @@
 "level": 5,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 239.32,
-"decompress_mbps": 577.29
+"compress_mbps": 240.0,
+"decompress_mbps": 447.1
 },
 {
 "compressor": "libdeflate",
@@ -3394,8 +3394,8 @@
 "level": 6,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 221.72,
-"decompress_mbps": 540.78
+"compress_mbps": 222.53,
+"decompress_mbps": 448.06
 },
 {
 "compressor": "libdeflate",
@@ -3404,8 +3404,8 @@
 "level": 7,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 202.26,
-"decompress_mbps": 576.26
+"compress_mbps": 202.55,
+"decompress_mbps": 443.58
 },
 {
 "compressor": "libdeflate",
@@ -3414,8 +3414,8 @@
 "level": 8,
 "out_size": 1204,
 "ratio": 0.3236,
-"compress_mbps": 168.42,
-"decompress_mbps": 578.33
+"compress_mbps": 169.05,
+"decompress_mbps": 445.64
 },
 {
 "compressor": "libdeflate",
@@ -3424,8 +3424,8 @@
 "level": 9,
 "out_size": 1204,
 "ratio": 0.3236,
-"compress_mbps": 168.27,
-"decompress_mbps": 576.92
+"compress_mbps": 168.91,
+"decompress_mbps": 446.03
 },
 {
 "compressor": "libdeflate",
@@ -3434,8 +3434,8 @@
 "level": 1,
 "out_size": 221813,
 "ratio": 0.2154,
-"compress_mbps": 576.64,
-"decompress_mbps": 1008.19
+"compress_mbps": 590.09,
+"decompress_mbps": 1015.78
 },
 {
 "compressor": "libdeflate",
@@ -3444,8 +3444,8 @@
 "level": 2,
 "out_size": 199825,
 "ratio": 0.1941,
-"compress_mbps": 407.46,
-"decompress_mbps": 1449.67
+"compress_mbps": 408.04,
+"decompress_mbps": 1466.99
 },
 {
 "compressor": "libdeflate",
@@ -3454,8 +3454,8 @@
 "level": 3,
 "out_size": 195675,
 "ratio": 0.19,
-"compress_mbps": 280.26,
-"decompress_mbps": 1518.73
+"compress_mbps": 282.42,
+"decompress_mbps": 1537.07
 },
 {
 "compressor": "libdeflate",
@@ -3464,8 +3464,8 @@
 "level": 4,
 "out_size": 195664,
 "ratio": 0.19,
-"compress_mbps": 277.16,
-"decompress_mbps": 1526.06
+"compress_mbps": 278.75,
+"decompress_mbps": 1547.12
 },
 {
 "compressor": "libdeflate",
@@ -3474,8 +3474,8 @@
 "level": 5,
 "out_size": 198900,
 "ratio": 0.1932,
-"compress_mbps": 237.39,
-"decompress_mbps": 1123.39
+"compress_mbps": 239.32,
+"decompress_mbps": 1132.89
 },
 {
 "compressor": "libdeflate",
@@ -3484,8 +3484,8 @@
 "level": 6,
 "out_size": 199347,
 "ratio": 0.1936,
-"compress_mbps": 202.94,
-"decompress_mbps": 1122.55
+"compress_mbps": 204.7,
+"decompress_mbps": 1134.87
 },
 {
 "compressor": "libdeflate",
@@ -3494,8 +3494,8 @@
 "level": 7,
 "out_size": 199777,
 "ratio": 0.194,
-"compress_mbps": 122.8,
-"decompress_mbps": 1182.17
+"compress_mbps": 123.64,
+"decompress_mbps": 1191.65
 },
 {
 "compressor": "libdeflate",
@@ -3504,8 +3504,8 @@
 "level": 8,
 "out_size": 182094,
 "ratio": 0.1768,
-"compress_mbps": 25.47,
-"decompress_mbps": 1165.56
+"compress_mbps": 25.59,
+"decompress_mbps": 1168.99
 },
 {
 "compressor": "libdeflate",
@@ -3514,8 +3514,8 @@
 "level": 9,
 "out_size": 181451,
 "ratio": 0.1762,
-"compress_mbps": 13.55,
-"decompress_mbps": 1160.77
+"compress_mbps": 13.6,
+"decompress_mbps": 1181.11
 },
 {
 "compressor": "libdeflate",
@@ -3524,8 +3524,8 @@
 "level": 1,
 "out_size": 159063,
 "ratio": 0.3727,
-"compress_mbps": 264.54,
-"decompress_mbps": 1021.24
+"compress_mbps": 266.79,
+"decompress_mbps": 1023.62
 },
 {
 "compressor": "libdeflate",
@@ -3534,8 +3534,8 @@
 "level": 2,
 "out_size": 152115,
 "ratio": 0.3564,
-"compress_mbps": 186.8,
-"decompress_mbps": 1098.04
+"compress_mbps": 187.13,
+"decompress_mbps": 1099.94
 },
 {
 "compressor": "libdeflate",
@@ -3544,8 +3544,8 @@
 "level": 3,
 "out_size": 149162,
 "ratio": 0.3495,
-"compress_mbps": 155.85,
-"decompress_mbps": 1182.6
+"compress_mbps": 157.38,
+"decompress_mbps": 1192.84
 },
 {
 "compressor": "libdeflate",
@@ -3554,8 +3554,8 @@
 "level": 4,
 "out_size": 148359,
 "ratio": 0.3476,
-"compress_mbps": 142.21,
-"decompress_mbps": 1041.87
+"compress_mbps": 143.1,
+"decompress_mbps": 1047.97
 },
 {
 "compressor": "libdeflate",
@@ -3564,8 +3564,8 @@
 "level": 5,
 "out_size": 145353,
 "ratio": 0.3406,
-"compress_mbps": 112.99,
-"decompress_mbps": 1011.31
+"compress_mbps": 113.72,
+"decompress_mbps": 1009.92
 },
 {
 "compressor": "libdeflate",
@@ -3574,8 +3574,8 @@
 "level": 6,
 "out_size": 144209,
 "ratio": 0.3379,
-"compress_mbps": 86.93,
-"decompress_mbps": 1049.43
+"compress_mbps": 88.45,
+"decompress_mbps": 1054.42
 },
 {
 "compressor": "libdeflate",
@@ -3584,8 +3584,8 @@
 "level": 7,
 "out_size": 143604,
 "ratio": 0.3365,
-"compress_mbps": 66.46,
-"decompress_mbps": 1063.62
+"compress_mbps": 66.76,
+"decompress_mbps": 1058.64
 },
 {
 "compressor": "libdeflate",
@@ -3594,8 +3594,8 @@
 "level": 8,
 "out_size": 142086,
 "ratio": 0.3329,
-"compress_mbps": 44.09,
-"decompress_mbps": 1060.67
+"compress_mbps": 44.23,
+"decompress_mbps": 1053.59
 },
 {
 "compressor": "libdeflate",
@@ -3604,8 +3604,8 @@
 "level": 9,
 "out_size": 142027,
 "ratio": 0.3328,
-"compress_mbps": 40.29,
-"decompress_mbps": 1056.76
+"compress_mbps": 40.46,
+"decompress_mbps": 1052.52
 },
 {
 "compressor": "libdeflate",
@@ -3614,8 +3614,8 @@
 "level": 1,
 "out_size": 210662,
 "ratio": 0.4372,
-"compress_mbps": 230.18,
-"decompress_mbps": 864.86
+"compress_mbps": 232.01,
+"decompress_mbps": 866.32
 },
 {
 "compressor": "libdeflate",
@@ -3624,8 +3624,8 @@
 "level": 2,
 "out_size": 202881,
 "ratio": 0.421,
-"compress_mbps": 158.04,
-"decompress_mbps": 933.13
+"compress_mbps": 159.23,
+"decompress_mbps": 937.1
 },
 {
 "compressor": "libdeflate",
@@ -3634,8 +3634,8 @@
 "level": 3,
 "out_size": 200409,
 "ratio": 0.4159,
-"compress_mbps": 132.69,
-"decompress_mbps": 1014.92
+"compress_mbps": 133.69,
+"decompress_mbps": 1020.91
 },
 {
 "compressor": "libdeflate",
@@ -3644,8 +3644,8 @@
 "level": 4,
 "out_size": 199678,
 "ratio": 0.4144,
-"compress_mbps": 122.81,
-"decompress_mbps": 853.48
+"compress_mbps": 123.38,
+"decompress_mbps": 850.18
 },
 {
 "compressor": "libdeflate",
@@ -3654,8 +3654,8 @@
 "level": 5,
 "out_size": 195798,
 "ratio": 0.4063,
-"compress_mbps": 93.09,
-"decompress_mbps": 807.11
+"compress_mbps": 93.3,
+"decompress_mbps": 804.08
 },
 {
 "compressor": "libdeflate",
@@ -3664,8 +3664,8 @@
 "level": 6,
 "out_size": 194029,
 "ratio": 0.4027,
-"compress_mbps": 71.72,
-"decompress_mbps": 827.42
+"compress_mbps": 71.98,
+"decompress_mbps": 826.97
 },
 {
 "compressor": "libdeflate",
@@ -3674,8 +3674,8 @@
 "level": 7,
 "out_size": 192773,
 "ratio": 0.4001,
-"compress_mbps": 51.16,
-"decompress_mbps": 833.35
+"compress_mbps": 50.8,
+"decompress_mbps": 830.48
 },
 {
 "compressor": "libdeflate",
@@ -3684,8 +3684,8 @@
 "level": 8,
 "out_size": 191739,
 "ratio": 0.3979,
-"compress_mbps": 33.53,
-"decompress_mbps": 837.14
+"compress_mbps": 33.69,
+"decompress_mbps": 834.44
 },
 {
 "compressor": "libdeflate",
@@ -3694,8 +3694,8 @@
 "level": 9,
 "out_size": 191676,
 "ratio": 0.3978,
-"compress_mbps": 30.94,
-"decompress_mbps": 838.25
+"compress_mbps": 31.07,
+"decompress_mbps": 831.22
 },
 {
 "compressor": "libdeflate",
@@ -3704,8 +3704,8 @@
 "level": 1,
 "out_size": 58079,
 "ratio": 0.1132,
-"compress_mbps": 372.62,
-"decompress_mbps": 1684.31
+"compress_mbps": 373.57,
+"decompress_mbps": 1656.1
 },
 {
 "compressor": "libdeflate",
@@ -3714,8 +3714,8 @@
 "level": 2,
 "out_size": 57838,
 "ratio": 0.1127,
-"compress_mbps": 412.04,
-"decompress_mbps": 1784.89
+"compress_mbps": 413.43,
+"decompress_mbps": 1804.88
 },
 {
 "compressor": "libdeflate",
@@ -3724,8 +3724,8 @@
 "level": 3,
 "out_size": 57554,
 "ratio": 0.1121,
-"compress_mbps": 393.18,
-"decompress_mbps": 1896.59
+"compress_mbps": 393.37,
+"decompress_mbps": 1909.86
 },
 {
 "compressor": "libdeflate",
@@ -3734,8 +3734,8 @@
 "level": 4,
 "out_size": 57064,
 "ratio": 0.1112,
-"compress_mbps": 372.73,
-"decompress_mbps": 1727.72
+"compress_mbps": 372.52,
+"decompress_mbps": 1746.78
 },
 {
 "compressor": "libdeflate",
@@ -3744,8 +3744,8 @@
 "level": 5,
 "out_size": 55743,
 "ratio": 0.1086,
-"compress_mbps": 341.79,
-"decompress_mbps": 1781.44
+"compress_mbps": 344.08,
+"decompress_mbps": 1804.0
 },
 {
 "compressor": "libdeflate",
@@ -3754,8 +3754,8 @@
 "level": 6,
 "out_size": 55102,
 "ratio": 0.1074,
-"compress_mbps": 282.49,
-"decompress_mbps": 1880.32
+"compress_mbps": 279.88,
+"decompress_mbps": 1883.59
 },
 {
 "compressor": "libdeflate",
@@ -3764,8 +3764,8 @@
 "level": 7,
 "out_size": 54742,
 "ratio": 0.1067,
-"compress_mbps": 186.82,
-"decompress_mbps": 1929.62
+"compress_mbps": 188.48,
+"decompress_mbps": 1935.81
 },
 {
 "compressor": "libdeflate",
@@ -3774,8 +3774,8 @@
 "level": 8,
 "out_size": 53133,
 "ratio": 0.1035,
-"compress_mbps": 102.71,
-"decompress_mbps": 1956.97
+"compress_mbps": 102.97,
+"decompress_mbps": 1989.78
 },
 {
 "compressor": "libdeflate",
@@ -3784,8 +3784,8 @@
 "level": 9,
 "out_size": 52186,
 "ratio": 0.1017,
-"compress_mbps": 72.24,
-"decompress_mbps": 2014.54
+"compress_mbps": 72.32,
+"decompress_mbps": 2042.35
 },
 {
 "compressor": "libdeflate",
@@ -3794,8 +3794,8 @@
 "level": 1,
 "out_size": 14122,
 "ratio": 0.3693,
-"compress_mbps": 648.55,
-"decompress_mbps": 821.07
+"compress_mbps": 644.89,
+"decompress_mbps": 827.7
 },
 {
 "compressor": "libdeflate",
@@ -3804,8 +3804,8 @@
 "level": 2,
 "out_size": 13374,
 "ratio": 0.3497,
-"compress_mbps": 365.06,
-"decompress_mbps": 875.59
+"compress_mbps": 332.44,
+"decompress_mbps": 888.7
 },
 {
 "compressor": "libdeflate",
@@ -3814,8 +3814,8 @@
 "level": 3,
 "out_size": 13293,
 "ratio": 0.3476,
-"compress_mbps": 306.06,
-"decompress_mbps": 955.02
+"compress_mbps": 277.6,
+"decompress_mbps": 960.38
 },
 {
 "compressor": "libdeflate",
@@ -3824,8 +3824,8 @@
 "level": 4,
 "out_size": 13259,
 "ratio": 0.3467,
-"compress_mbps": 276.52,
-"decompress_mbps": 953.77
+"compress_mbps": 262.14,
+"decompress_mbps": 960.33
 },
 {
 "compressor": "libdeflate",
@@ -3834,8 +3834,8 @@
 "level": 5,
 "out_size": 12641,
 "ratio": 0.3306,
-"compress_mbps": 187.17,
-"decompress_mbps": 973.14
+"compress_mbps": 186.71,
+"decompress_mbps": 947.5
 },
 {
 "compressor": "libdeflate",
@@ -3844,8 +3844,8 @@
 "level": 6,
 "out_size": 12432,
 "ratio": 0.3251,
-"compress_mbps": 164.66,
-"decompress_mbps": 1006.92
+"compress_mbps": 160.33,
+"decompress_mbps": 1005.94
 },
 {
 "compressor": "libdeflate",
@@ -3854,8 +3854,8 @@
 "level": 7,
 "out_size": 12439,
 "ratio": 0.3253,
-"compress_mbps": 114.94,
-"decompress_mbps": 1015.21
+"compress_mbps": 115.01,
+"decompress_mbps": 1010.38
 },
 {
 "compressor": "libdeflate",
@@ -3864,8 +3864,8 @@
 "level": 8,
 "out_size": 12579,
 "ratio": 0.3289,
-"compress_mbps": 67.44,
-"decompress_mbps": 1024.74
+"compress_mbps": 67.0,
+"decompress_mbps": 1028.38
 },
 {
 "compressor": "libdeflate",
@@ -3874,8 +3874,8 @@
 "level": 9,
 "out_size": 12574,
 "ratio": 0.3288,
-"compress_mbps": 47.24,
-"decompress_mbps": 1023.22
+"compress_mbps": 47.33,
+"decompress_mbps": 1038.57
 },
 {
 "compressor": "libdeflate",
@@ -3884,8 +3884,8 @@
 "level": 1,
 "out_size": 1777,
 "ratio": 0.4204,
-"compress_mbps": 384.47,
-"decompress_mbps": 398.06
+"compress_mbps": 386.8,
+"decompress_mbps": 405.67
 },
 {
 "compressor": "libdeflate",
@@ -3894,8 +3894,8 @@
 "level": 2,
 "out_size": 1756,
 "ratio": 0.4154,
-"compress_mbps": 256.45,
-"decompress_mbps": 401.59
+"compress_mbps": 259.36,
+"decompress_mbps": 406.0
 },
 {
 "compressor": "libdeflate",
@@ -3904,8 +3904,8 @@
 "level": 3,
 "out_size": 1746,
 "ratio": 0.4131,
-"compress_mbps": 254.8,
-"decompress_mbps": 404.01
+"compress_mbps": 255.77,
+"decompress_mbps": 408.59
 },
 {
 "compressor": "libdeflate",
@@ -3914,8 +3914,8 @@
 "level": 4,
 "out_size": 1740,
 "ratio": 0.4116,
-"compress_mbps": 251.62,
-"decompress_mbps": 408.76
+"compress_mbps": 253.88,
+"decompress_mbps": 415.29
 },
 {
 "compressor": "libdeflate",
@@ -3924,8 +3924,8 @@
 "level": 5,
 "out_size": 1722,
 "ratio": 0.4074,
-"compress_mbps": 238.72,
-"decompress_mbps": 414.01
+"compress_mbps": 237.59,
+"decompress_mbps": 418.48
 },
 {
 "compressor": "libdeflate",
@@ -3934,8 +3934,8 @@
 "level": 6,
 "out_size": 1721,
 "ratio": 0.4071,
-"compress_mbps": 234.67,
-"decompress_mbps": 417.31
+"compress_mbps": 235.41,
+"decompress_mbps": 416.96
 },
 {
 "compressor": "libdeflate",
@@ -3944,8 +3944,8 @@
 "level": 7,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 232.47,
-"decompress_mbps": 419.13
+"compress_mbps": 233.87,
+"decompress_mbps": 419.78
 },
 {
 "compressor": "libdeflate",
@@ -3954,8 +3954,8 @@
 "level": 8,
 "out_size": 1717,
 "ratio": 0.4062,
-"compress_mbps": 216.79,
-"decompress_mbps": 419.13
+"compress_mbps": 216.99,
+"decompress_mbps": 415.29
 },
 {
 "compressor": "libdeflate",
@@ -3964,8 +3964,8 @@
 "level": 9,
 "out_size": 1717,
 "ratio": 0.4062,
-"compress_mbps": 216.06,
-"decompress_mbps": 419.22
+"compress_mbps": 217.77,
+"decompress_mbps": 415.71
 },
 {
 "compressor": "native",
@@ -3974,8 +3974,8 @@
 "level": 1,
 "out_size": 4231315,
 "ratio": 0.4151,
-"compress_mbps": 26.23,
-"decompress_mbps": 79.17
+"compress_mbps": 29.05,
+"decompress_mbps": 78.62
 },
 {
 "compressor": "native",
@@ -3984,8 +3984,8 @@
 "level": 2,
 "out_size": 4120658,
 "ratio": 0.4043,
-"compress_mbps": 22.46,
-"decompress_mbps": 84.35
+"compress_mbps": 25.7,
+"decompress_mbps": 84.9
 },
 {
 "compressor": "native",
@@ -3994,8 +3994,8 @@
 "level": 3,
 "out_size": 4037988,
 "ratio": 0.3962,
-"compress_mbps": 19.87,
-"decompress_mbps": 91.31
+"compress_mbps": 22.57,
+"decompress_mbps": 89.97
 },
 {
 "compressor": "native",
@@ -4004,8 +4004,8 @@
 "level": 4,
 "out_size": 3959738,
 "ratio": 0.3885,
-"compress_mbps": 12.02,
-"decompress_mbps": 91.65
+"compress_mbps": 14.54,
+"decompress_mbps": 88.84
 },
 {
 "compressor": "native",
@@ -4014,8 +4014,8 @@
 "level": 5,
 "out_size": 3941691,
 "ratio": 0.3867,
-"compress_mbps": 11.18,
-"decompress_mbps": 92.5
+"compress_mbps": 13.9,
+"decompress_mbps": 92.0
 },
 {
 "compressor": "native",
@@ -4024,8 +4024,8 @@
 "level": 6,
 "out_size": 3913931,
 "ratio": 0.384,
-"compress_mbps": 9.41,
-"decompress_mbps": 95.78
+"compress_mbps": 11.8,
+"decompress_mbps": 94.64
 },
 {
 "compressor": "native",
@@ -4034,8 +4034,8 @@
 "level": 7,
 "out_size": 3902484,
 "ratio": 0.3829,
-"compress_mbps": 5.52,
-"decompress_mbps": 98.67
+"compress_mbps": 6.44,
+"decompress_mbps": 99.64
 },
 {
 "compressor": "native",
@@ -4044,8 +4044,8 @@
 "level": 8,
 "out_size": 3899047,
 "ratio": 0.3825,
-"compress_mbps": 5.4,
-"decompress_mbps": 100.37
+"compress_mbps": 6.29,
+"decompress_mbps": 99.05
 },
 {
 "compressor": "native",
@@ -4054,8 +4054,8 @@
 "level": 9,
 "out_size": 3712344,
 "ratio": 0.3642,
-"compress_mbps": 0.97,
-"decompress_mbps": 101.66
+"compress_mbps": 1.0,
+"decompress_mbps": 101.67
 },
 {
 "compressor": "native",
@@ -4064,8 +4064,8 @@
 "level": 1,
 "out_size": 20729473,
 "ratio": 0.4047,
-"compress_mbps": 37.09,
-"decompress_mbps": 72.96
+"compress_mbps": 40.35,
+"decompress_mbps": 71.27
 },
 {
 "compressor": "native",
@@ -4074,8 +4074,8 @@
 "level": 2,
 "out_size": 20500337,
 "ratio": 0.4002,
-"compress_mbps": 33.39,
-"decompress_mbps": 74.99
+"compress_mbps": 37.43,
+"decompress_mbps": 75.56
 },
 {
 "compressor": "native",
@@ -4084,8 +4084,8 @@
 "level": 3,
 "out_size": 20349978,
 "ratio": 0.3973,
-"compress_mbps": 30.26,
-"decompress_mbps": 77.93
+"compress_mbps": 34.25,
+"decompress_mbps": 78.14
 },
 {
 "compressor": "native",
@@ -4094,8 +4094,8 @@
 "level": 4,
 "out_size": 19952001,
 "ratio": 0.3895,
-"compress_mbps": 19.24,
-"decompress_mbps": 79.34
+"compress_mbps": 23.84,
+"decompress_mbps": 78.7
 },
 {
 "compressor": "native",
@@ -4104,8 +4104,8 @@
 "level": 5,
 "out_size": 19925043,
 "ratio": 0.389,
-"compress_mbps": 17.61,
-"decompress_mbps": 82.34
+"compress_mbps": 22.08,
+"decompress_mbps": 82.04
 },
 {
 "compressor": "native",
@@ -4114,8 +4114,8 @@
 "level": 6,
 "out_size": 19882104,
 "ratio": 0.3882,
-"compress_mbps": 14.18,
-"decompress_mbps": 83.72
+"compress_mbps": 18.24,
+"decompress_mbps": 84.17
 },
 {
 "compressor": "native",
@@ -4124,8 +4124,8 @@
 "level": 7,
 "out_size": 18841079,
 "ratio": 0.3678,
-"compress_mbps": 5.8,
-"decompress_mbps": 84.39
+"compress_mbps": 6.58,
+"decompress_mbps": 83.3
 },
 {
 "compressor": "native",
@@ -4134,8 +4134,8 @@
 "level": 8,
 "out_size": 18833163,
 "ratio": 0.3677,
-"compress_mbps": 5.1,
-"decompress_mbps": 83.89
+"compress_mbps": 5.98,
+"decompress_mbps": 84.12
 },
 {
 "compressor": "native",
@@ -4144,8 +4144,8 @@
 "level": 9,
 "out_size": 18518350,
 "ratio": 0.3615,
-"compress_mbps": 0.84,
-"decompress_mbps": 84.47
+"compress_mbps": 0.86,
+"decompress_mbps": 84.41
 },
 {
 "compressor": "native",
@@ -4154,8 +4154,8 @@
 "level": 1,
 "out_size": 3773613,
 "ratio": 0.3785,
-"compress_mbps": 38.58,
-"decompress_mbps": 64.32
+"compress_mbps": 43.0,
+"decompress_mbps": 74.69
 },
 {
 "compressor": "native",
@@ -4164,8 +4164,8 @@
 "level": 2,
 "out_size": 3728325,
 "ratio": 0.3739,
-"compress_mbps": 34.1,
-"decompress_mbps": 67.89
+"compress_mbps": 38.4,
+"decompress_mbps": 77.17
 },
 {
 "compressor": "native",
@@ -4174,8 +4174,8 @@
 "level": 3,
 "out_size": 3701126,
 "ratio": 0.3712,
-"compress_mbps": 30.44,
-"decompress_mbps": 71.33
+"compress_mbps": 33.51,
+"decompress_mbps": 79.16
 },
 {
 "compressor": "native",
@@ -4184,8 +4184,8 @@
 "level": 4,
 "out_size": 3718920,
 "ratio": 0.373,
-"compress_mbps": 19.42,
-"decompress_mbps": 66.99
+"compress_mbps": 21.28,
+"decompress_mbps": 73.67
 },
 {
 "compressor": "native",
@@ -4194,8 +4194,8 @@
 "level": 5,
 "out_size": 3715907,
 "ratio": 0.3727,
-"compress_mbps": 17.58,
-"decompress_mbps": 75.52
+"compress_mbps": 19.14,
+"decompress_mbps": 75.79
 },
 {
 "compressor": "native",
@@ -4204,8 +4204,8 @@
 "level": 6,
 "out_size": 3715635,
 "ratio": 0.3727,
-"compress_mbps": 13.34,
-"decompress_mbps": 77.3
+"compress_mbps": 14.63,
+"decompress_mbps": 77.97
 },
 {
 "compressor": "native",
@@ -4214,8 +4214,8 @@
 "level": 7,
 "out_size": 3649251,
 "ratio": 0.366,
-"compress_mbps": 5.98,
-"decompress_mbps": 76.01
+"compress_mbps": 6.36,
+"decompress_mbps": 75.79
 },
 {
 "compressor": "native",
@@ -4224,8 +4224,8 @@
 "level": 8,
 "out_size": 3648922,
 "ratio": 0.366,
-"compress_mbps": 4.94,
-"decompress_mbps": 78.0
+"compress_mbps": 5.29,
+"decompress_mbps": 78.31
 },
 {
 "compressor": "native",
@@ -4234,8 +4234,8 @@
 "level": 9,
 "out_size": 3520112,
 "ratio": 0.3531,
-"compress_mbps": 0.34,
-"decompress_mbps": 78.15
+"compress_mbps": 0.36,
+"decompress_mbps": 79.14
 },
 {
 "compressor": "native",
@@ -4244,8 +4244,8 @@
 "level": 1,
 "out_size": 3957304,
 "ratio": 0.1179,
-"compress_mbps": 87.92,
-"decompress_mbps": 266.64
+"compress_mbps": 100.59,
+"decompress_mbps": 270.43
 },
 {
 "compressor": "native",
@@ -4254,8 +4254,8 @@
 "level": 2,
 "out_size": 3769595,
 "ratio": 0.1123,
-"compress_mbps": 78.16,
-"decompress_mbps": 295.8
+"compress_mbps": 89.69,
+"decompress_mbps": 297.96
 },
 {
 "compressor": "native",
@@ -4264,8 +4264,8 @@
 "level": 3,
 "out_size": 3594567,
 "ratio": 0.1071,
-"compress_mbps": 65.9,
-"decompress_mbps": 325.47
+"compress_mbps": 78.45,
+"decompress_mbps": 326.65
 },
 {
 "compressor": "native",
@@ -4274,8 +4274,8 @@
 "level": 4,
 "out_size": 3339928,
 "ratio": 0.0995,
-"compress_mbps": 42.2,
-"decompress_mbps": 323.53
+"compress_mbps": 55.26,
+"decompress_mbps": 326.77
 },
 {
 "compressor": "native",
@@ -4284,8 +4284,8 @@
 "level": 5,
 "out_size": 3315513,
 "ratio": 0.0988,
-"compress_mbps": 38.78,
-"decompress_mbps": 355.09
+"compress_mbps": 51.58,
+"decompress_mbps": 358.58
 },
 {
 "compressor": "native",
@@ -4294,8 +4294,8 @@
 "level": 6,
 "out_size": 3275531,
 "ratio": 0.0976,
-"compress_mbps": 31.07,
-"decompress_mbps": 378.85
+"compress_mbps": 42.92,
+"decompress_mbps": 378.77
 },
 {
 "compressor": "native",
@@ -4304,8 +4304,8 @@
 "level": 7,
 "out_size": 3249135,
 "ratio": 0.0968,
-"compress_mbps": 17.6,
-"decompress_mbps": 384.26
+"compress_mbps": 22.02,
+"decompress_mbps": 387.34
 },
 {
 "compressor": "native",
@@ -4314,8 +4314,8 @@
 "level": 8,
 "out_size": 3225205,
 "ratio": 0.0961,
-"compress_mbps": 14.07,
-"decompress_mbps": 386.44
+"compress_mbps": 18.36,
+"decompress_mbps": 389.77
 },
 {
 "compressor": "native",
@@ -4324,8 +4324,8 @@
 "level": 9,
 "out_size": 2868751,
 "ratio": 0.0855,
-"compress_mbps": 0.52,
-"decompress_mbps": 376.15
+"compress_mbps": 0.53,
+"decompress_mbps": 374.8
 },
 {
 "compressor": "native",
@@ -4334,8 +4334,8 @@
 "level": 1,
 "out_size": 3218639,
 "ratio": 0.5232,
-"compress_mbps": 26.01,
-"decompress_mbps": 49.1
+"compress_mbps": 28.21,
+"decompress_mbps": 47.64
 },
 {
 "compressor": "native",
@@ -4344,8 +4344,8 @@
 "level": 2,
 "out_size": 3192732,
 "ratio": 0.519,
-"compress_mbps": 24.41,
-"decompress_mbps": 50.59
+"compress_mbps": 26.13,
+"decompress_mbps": 49.72
 },
 {
 "compressor": "native",
@@ -4354,8 +4354,8 @@
 "level": 3,
 "out_size": 3174297,
 "ratio": 0.516,
-"compress_mbps": 22.4,
-"decompress_mbps": 53.48
+"compress_mbps": 24.48,
+"decompress_mbps": 54.67
 },
 {
 "compressor": "native",
@@ -4364,8 +4364,8 @@
 "level": 4,
 "out_size": 3121308,
 "ratio": 0.5073,
-"compress_mbps": 15.74,
-"decompress_mbps": 53.56
+"compress_mbps": 18.25,
+"decompress_mbps": 53.86
 },
 {
 "compressor": "native",
@@ -4374,8 +4374,8 @@
 "level": 5,
 "out_size": 3117864,
 "ratio": 0.5068,
-"compress_mbps": 14.92,
-"decompress_mbps": 54.37
+"compress_mbps": 17.31,
+"decompress_mbps": 55.84
 },
 {
 "compressor": "native",
@@ -4384,8 +4384,8 @@
 "level": 6,
 "out_size": 3112351,
 "ratio": 0.5059,
-"compress_mbps": 12.98,
-"decompress_mbps": 55.87
+"compress_mbps": 15.22,
+"decompress_mbps": 57.08
 },
 {
 "compressor": "native",
@@ -4394,8 +4394,8 @@
 "level": 7,
 "out_size": 3072891,
 "ratio": 0.4995,
-"compress_mbps": 5.27,
-"decompress_mbps": 56.86
+"compress_mbps": 5.65,
+"decompress_mbps": 57.59
 },
 {
 "compressor": "native",
@@ -4404,8 +4404,8 @@
 "level": 8,
 "out_size": 3071839,
 "ratio": 0.4993,
-"compress_mbps": 4.96,
-"decompress_mbps": 57.08
+"compress_mbps": 5.34,
+"decompress_mbps": 57.97
 },
 {
 "compressor": "native",
@@ -4414,8 +4414,8 @@
 "level": 9,
 "out_size": 3017696,
 "ratio": 0.4905,
-"compress_mbps": 1.16,
-"decompress_mbps": 57.07
+"compress_mbps": 1.21,
+"decompress_mbps": 57.41
 },
 {
 "compressor": "native",
@@ -4424,8 +4424,8 @@
 "level": 1,
 "out_size": 3889230,
 "ratio": 0.3856,
-"compress_mbps": 37.84,
-"decompress_mbps": 68.32
+"compress_mbps": 41.29,
+"decompress_mbps": 68.95
 },
 {
 "compressor": "native",
@@ -4434,8 +4434,8 @@
 "level": 2,
 "out_size": 3811489,
 "ratio": 0.3779,
-"compress_mbps": 34.61,
-"decompress_mbps": 68.46
+"compress_mbps": 37.76,
+"decompress_mbps": 71.82
 },
 {
 "compressor": "native",
@@ -4444,8 +4444,8 @@
 "level": 3,
 "out_size": 3789217,
 "ratio": 0.3757,
-"compress_mbps": 33.19,
-"decompress_mbps": 72.31
+"compress_mbps": 36.64,
+"decompress_mbps": 73.35
 },
 {
 "compressor": "native",
@@ -4454,8 +4454,8 @@
 "level": 4,
 "out_size": 3742155,
 "ratio": 0.371,
-"compress_mbps": 25.9,
-"decompress_mbps": 72.83
+"compress_mbps": 29.2,
+"decompress_mbps": 74.01
 },
 {
 "compressor": "native",
@@ -4464,8 +4464,8 @@
 "level": 5,
 "out_size": 3734147,
 "ratio": 0.3702,
-"compress_mbps": 24.95,
-"decompress_mbps": 72.35
+"compress_mbps": 28.22,
+"decompress_mbps": 73.04
 },
 {
 "compressor": "native",
@@ -4474,8 +4474,8 @@
 "level": 6,
 "out_size": 3723457,
 "ratio": 0.3692,
-"compress_mbps": 22.48,
-"decompress_mbps": 72.24
+"compress_mbps": 25.31,
+"decompress_mbps": 73.29
 },
 {
 "compressor": "native",
@@ -4484,8 +4484,8 @@
 "level": 7,
 "out_size": 3723087,
 "ratio": 0.3691,
-"compress_mbps": 9.03,
-"decompress_mbps": 71.47
+"compress_mbps": 9.38,
+"decompress_mbps": 72.3
 },
 {
 "compressor": "native",
@@ -4494,8 +4494,8 @@
 "level": 8,
 "out_size": 3723909,
 "ratio": 0.3692,
-"compress_mbps": 8.56,
-"decompress_mbps": 71.52
+"compress_mbps": 8.87,
+"decompress_mbps": 72.47
 },
 {
 "compressor": "native",
@@ -4504,8 +4504,8 @@
 "level": 9,
 "out_size": 3647083,
 "ratio": 0.3616,
-"compress_mbps": 1.5,
-"decompress_mbps": 71.54
+"compress_mbps": 1.52,
+"decompress_mbps": 71.78
 },
 {
 "compressor": "native",
@@ -4514,8 +4514,8 @@
 "level": 1,
 "out_size": 2146953,
 "ratio": 0.324,
-"compress_mbps": 33.16,
-"decompress_mbps": 96.14
+"compress_mbps": 37.5,
+"decompress_mbps": 96.78
 },
 {
 "compressor": "native",
@@ -4524,8 +4524,8 @@
 "level": 2,
 "out_size": 2072169,
 "ratio": 0.3127,
-"compress_mbps": 27.7,
-"decompress_mbps": 107.85
+"compress_mbps": 32.44,
+"decompress_mbps": 108.45
 },
 {
 "compressor": "native",
@@ -4534,8 +4534,8 @@
 "level": 3,
 "out_size": 2021398,
 "ratio": 0.305,
-"compress_mbps": 23.12,
-"decompress_mbps": 117.53
+"compress_mbps": 28.5,
+"decompress_mbps": 117.75
 },
 {
 "compressor": "native",
@@ -4544,8 +4544,8 @@
 "level": 4,
 "out_size": 1934888,
 "ratio": 0.292,
-"compress_mbps": 13.13,
-"decompress_mbps": 117.04
+"compress_mbps": 17.78,
+"decompress_mbps": 117.48
 },
 {
 "compressor": "native",
@@ -4554,8 +4554,8 @@
 "level": 5,
 "out_size": 1920522,
 "ratio": 0.2898,
-"compress_mbps": 11.42,
-"decompress_mbps": 121.22
+"compress_mbps": 15.78,
+"decompress_mbps": 121.77
 },
 {
 "compressor": "native",
@@ -4564,8 +4564,8 @@
 "level": 6,
 "out_size": 1893334,
 "ratio": 0.2857,
-"compress_mbps": 8.05,
-"decompress_mbps": 126.71
+"compress_mbps": 11.42,
+"decompress_mbps": 126.59
 },
 {
 "compressor": "native",
@@ -4574,8 +4574,8 @@
 "level": 7,
 "out_size": 1854694,
 "ratio": 0.2799,
-"compress_mbps": 4.74,
-"decompress_mbps": 130.68
+"compress_mbps": 6.15,
+"decompress_mbps": 131.5
 },
 {
 "compressor": "native",
@@ -4584,8 +4584,8 @@
 "level": 8,
 "out_size": 1849481,
 "ratio": 0.2791,
-"compress_mbps": 3.95,
-"decompress_mbps": 128.62
+"compress_mbps": 5.05,
+"decompress_mbps": 130.96
 },
 {
 "compressor": "native",
@@ -4594,8 +4594,8 @@
 "level": 9,
 "out_size": 1724560,
 "ratio": 0.2602,
-"compress_mbps": 0.63,
-"decompress_mbps": 136.96
+"compress_mbps": 0.65,
+"decompress_mbps": 137.33
 },
 {
 "compressor": "native",
@@ -4604,8 +4604,8 @@
 "level": 1,
 "out_size": 6185865,
 "ratio": 0.2863,
-"compress_mbps": 49.02,
-"decompress_mbps": 127.56
+"compress_mbps": 53.89,
+"decompress_mbps": 128.05
 },
 {
 "compressor": "native",
@@ -4614,8 +4614,8 @@
 "level": 2,
 "out_size": 6066146,
 "ratio": 0.2808,
-"compress_mbps": 43.4,
-"decompress_mbps": 133.77
+"compress_mbps": 48.76,
+"decompress_mbps": 134.56
 },
 {
 "compressor": "native",
@@ -4624,8 +4624,8 @@
 "level": 3,
 "out_size": 5993070,
 "ratio": 0.2774,
-"compress_mbps": 38.71,
-"decompress_mbps": 139.01
+"compress_mbps": 44.31,
+"decompress_mbps": 139.93
 },
 {
 "compressor": "native",
@@ -4634,8 +4634,8 @@
 "level": 4,
 "out_size": 5847650,
 "ratio": 0.2706,
-"compress_mbps": 25.19,
-"decompress_mbps": 142.12
+"compress_mbps": 31.63,
+"decompress_mbps": 143.39
 },
 {
 "compressor": "native",
@@ -4644,8 +4644,8 @@
 "level": 5,
 "out_size": 5837234,
 "ratio": 0.2702,
-"compress_mbps": 23.33,
-"decompress_mbps": 145.86
+"compress_mbps": 29.94,
+"decompress_mbps": 147.02
 },
 {
 "compressor": "native",
@@ -4654,8 +4654,8 @@
 "level": 6,
 "out_size": 5823141,
 "ratio": 0.2695,
-"compress_mbps": 20.14,
-"decompress_mbps": 148.37
+"compress_mbps": 26.58,
+"decompress_mbps": 149.46
 },
 {
 "compressor": "native",
@@ -4664,8 +4664,8 @@
 "level": 7,
 "out_size": 5422105,
 "ratio": 0.2509,
-"compress_mbps": 9.79,
-"decompress_mbps": 143.03
+"compress_mbps": 11.28,
+"decompress_mbps": 141.67
 },
 {
 "compressor": "native",
@@ -4674,8 +4674,8 @@
 "level": 8,
 "out_size": 5419419,
 "ratio": 0.2508,
-"compress_mbps": 9.11,
-"decompress_mbps": 146.0
+"compress_mbps": 10.87,
+"decompress_mbps": 146.48
 },
 {
 "compressor": "native",
@@ -4684,8 +4684,8 @@
 "level": 9,
 "out_size": 5169629,
 "ratio": 0.2393,
-"compress_mbps": 0.8,
-"decompress_mbps": 150.8
+"compress_mbps": 0.82,
+"decompress_mbps": 151.21
 },
 {
 "compressor": "native",
@@ -4694,8 +4694,8 @@
 "level": 1,
 "out_size": 5514155,
 "ratio": 0.7604,
-"compress_mbps": 23.8,
-"decompress_mbps": 51.5
+"compress_mbps": 25.35,
+"decompress_mbps": 51.81
 },
 {
 "compressor": "native",
@@ -4704,8 +4704,8 @@
 "level": 2,
 "out_size": 5472540,
 "ratio": 0.7546,
-"compress_mbps": 21.9,
-"decompress_mbps": 53.28
+"compress_mbps": 24.08,
+"decompress_mbps": 53.35
 },
 {
 "compressor": "native",
@@ -4714,8 +4714,8 @@
 "level": 3,
 "out_size": 5448811,
 "ratio": 0.7514,
-"compress_mbps": 19.72,
-"decompress_mbps": 54.5
+"compress_mbps": 22.46,
+"decompress_mbps": 54.36
 },
 {
 "compressor": "native",
@@ -4724,8 +4724,8 @@
 "level": 4,
 "out_size": 5375802,
 "ratio": 0.7413,
-"compress_mbps": 13.22,
-"decompress_mbps": 55.15
+"compress_mbps": 16.07,
+"decompress_mbps": 55.08
 },
 {
 "compressor": "native",
@@ -4734,8 +4734,8 @@
 "level": 5,
 "out_size": 5370794,
 "ratio": 0.7406,
-"compress_mbps": 12.25,
-"decompress_mbps": 55.34
+"compress_mbps": 15.2,
+"decompress_mbps": 55.31
 },
 {
 "compressor": "native",
@@ -4744,8 +4744,8 @@
 "level": 6,
 "out_size": 5362339,
 "ratio": 0.7394,
-"compress_mbps": 10.47,
-"decompress_mbps": 56.08
+"compress_mbps": 13.27,
+"decompress_mbps": 55.95
 },
 {
 "compressor": "native",
@@ -4754,8 +4754,8 @@
 "level": 7,
 "out_size": 5349148,
 "ratio": 0.7376,
-"compress_mbps": 4.49,
-"decompress_mbps": 55.46
+"compress_mbps": 4.98,
+"decompress_mbps": 55.76
 },
 {
 "compressor": "native",
@@ -4764,8 +4764,8 @@
 "level": 8,
 "out_size": 5348874,
 "ratio": 0.7376,
-"compress_mbps": 4.44,
-"decompress_mbps": 55.87
+"compress_mbps": 5.01,
+"decompress_mbps": 55.29
 },
 {
 "compressor": "native",
@@ -4774,8 +4774,8 @@
 "level": 9,
 "out_size": 5261135,
 "ratio": 0.7255,
-"compress_mbps": 1.22,
-"decompress_mbps": 55.65
+"compress_mbps": 1.28,
+"decompress_mbps": 55.55
 },
 {
 "compressor": "native",
@@ -4784,8 +4784,8 @@
 "level": 1,
 "out_size": 13389198,
 "ratio": 0.323,
-"compress_mbps": 34.63,
-"decompress_mbps": 102.73
+"compress_mbps": 38.35,
+"decompress_mbps": 103.49
 },
 {
 "compressor": "native",
@@ -4794,8 +4794,8 @@
 "level": 2,
 "out_size": 12991470,
 "ratio": 0.3134,
-"compress_mbps": 29.39,
-"decompress_mbps": 109.57
+"compress_mbps": 34.63,
+"decompress_mbps": 109.66
 },
 {
 "compressor": "native",
@@ -4804,8 +4804,8 @@
 "level": 3,
 "out_size": 12756198,
 "ratio": 0.3077,
-"compress_mbps": 26.57,
-"decompress_mbps": 117.11
+"compress_mbps": 31.27,
+"decompress_mbps": 117.59
 },
 {
 "compressor": "native",
@@ -4814,8 +4814,8 @@
 "level": 4,
 "out_size": 12441121,
 "ratio": 0.3001,
-"compress_mbps": 17.05,
-"decompress_mbps": 118.76
+"compress_mbps": 21.83,
+"decompress_mbps": 116.79
 },
 {
 "compressor": "native",
@@ -4824,8 +4824,8 @@
 "level": 5,
 "out_size": 12392694,
 "ratio": 0.2989,
-"compress_mbps": 15.73,
-"decompress_mbps": 121.9
+"compress_mbps": 20.52,
+"decompress_mbps": 121.48
 },
 {
 "compressor": "native",
@@ -4834,8 +4834,8 @@
 "level": 6,
 "out_size": 12309254,
 "ratio": 0.2969,
-"compress_mbps": 13.07,
-"decompress_mbps": 125.1
+"compress_mbps": 17.6,
+"decompress_mbps": 124.46
 },
 {
 "compressor": "native",
@@ -4844,8 +4844,8 @@
 "level": 7,
 "out_size": 12265937,
 "ratio": 0.2959,
-"compress_mbps": 7.45,
-"decompress_mbps": 125.02
+"compress_mbps": 9.03,
+"decompress_mbps": 125.62
 },
 {
 "compressor": "native",
@@ -4854,8 +4854,8 @@
 "level": 8,
 "out_size": 12249548,
 "ratio": 0.2955,
-"compress_mbps": 6.93,
-"decompress_mbps": 124.41
+"compress_mbps": 8.5,
+"decompress_mbps": 125.69
 },
 {
 "compressor": "native",
@@ -4864,8 +4864,8 @@
 "level": 9,
 "out_size": 11638957,
 "ratio": 0.2807,
-"compress_mbps": 0.82,
-"decompress_mbps": 125.82
+"compress_mbps": 0.85,
+"decompress_mbps": 125.17
 },
 {
 "compressor": "native",
@@ -4874,8 +4874,8 @@
 "level": 1,
 "out_size": 6018712,
 "ratio": 0.7102,
-"compress_mbps": 24.3,
-"decompress_mbps": 39.86
+"compress_mbps": 25.69,
+"decompress_mbps": 39.99
 },
 {
 "compressor": "native",
@@ -4884,8 +4884,8 @@
 "level": 2,
 "out_size": 5998688,
 "ratio": 0.7079,
-"compress_mbps": 22.56,
-"decompress_mbps": 42.55
+"compress_mbps": 24.01,
+"decompress_mbps": 42.86
 },
 {
 "compressor": "native",
@@ -4894,8 +4894,8 @@
 "level": 3,
 "out_size": 5983501,
 "ratio": 0.7061,
-"compress_mbps": 21.54,
-"decompress_mbps": 44.96
+"compress_mbps": 23.12,
+"decompress_mbps": 45.47
 },
 {
 "compressor": "native",
@@ -4904,8 +4904,8 @@
 "level": 4,
 "out_size": 5965382,
 "ratio": 0.7039,
-"compress_mbps": 17.66,
-"decompress_mbps": 42.54
+"compress_mbps": 19.21,
+"decompress_mbps": 42.41
 },
 {
 "compressor": "native",
@@ -4914,8 +4914,8 @@
 "level": 5,
 "out_size": 5964821,
 "ratio": 0.7039,
-"compress_mbps": 16.97,
-"decompress_mbps": 38.57
+"compress_mbps": 18.96,
+"decompress_mbps": 43.25
 },
 {
 "compressor": "native",
@@ -4924,8 +4924,8 @@
 "level": 6,
 "out_size": 5964654,
 "ratio": 0.7039,
-"compress_mbps": 16.8,
-"decompress_mbps": 39.03
+"compress_mbps": 18.66,
+"decompress_mbps": 43.82
 },
 {
 "compressor": "native",
@@ -4934,8 +4934,8 @@
 "level": 7,
 "out_size": 5937524,
 "ratio": 0.7007,
-"compress_mbps": 5.63,
-"decompress_mbps": 43.16
+"compress_mbps": 5.81,
+"decompress_mbps": 44.2
 },
 {
 "compressor": "native",
@@ -4944,8 +4944,8 @@
 "level": 8,
 "out_size": 5937524,
 "ratio": 0.7007,
-"compress_mbps": 5.47,
-"decompress_mbps": 43.72
+"compress_mbps": 5.84,
+"decompress_mbps": 43.82
 },
 {
 "compressor": "native",
@@ -4955,7 +4955,7 @@
 "out_size": 5825680,
 "ratio": 0.6875,
 "compress_mbps": 1.64,
-"decompress_mbps": 43.34
+"decompress_mbps": 43.95
 },
 {
 "compressor": "native",
@@ -4964,8 +4964,8 @@
 "level": 1,
 "out_size": 841047,
 "ratio": 0.1573,
-"compress_mbps": 69.84,
-"decompress_mbps": 200.44
+"compress_mbps": 76.81,
+"decompress_mbps": 202.74
 },
 {
 "compressor": "native",
@@ -4974,8 +4974,8 @@
 "level": 2,
 "out_size": 796222,
 "ratio": 0.149,
-"compress_mbps": 59.99,
-"decompress_mbps": 226.88
+"compress_mbps": 69.88,
+"decompress_mbps": 227.86
 },
 {
 "compressor": "native",
@@ -4984,8 +4984,8 @@
 "level": 3,
 "out_size": 765435,
 "ratio": 0.1432,
-"compress_mbps": 51.09,
-"decompress_mbps": 249.46
+"compress_mbps": 61.3,
+"decompress_mbps": 251.28
 },
 {
 "compressor": "native",
@@ -4994,8 +4994,8 @@
 "level": 4,
 "out_size": 730001,
 "ratio": 0.1366,
-"compress_mbps": 31.99,
-"decompress_mbps": 241.42
+"compress_mbps": 41.75,
+"decompress_mbps": 244.77
 },
 {
 "compressor": "native",
@@ -5004,8 +5004,8 @@
 "level": 5,
 "out_size": 722548,
 "ratio": 0.1352,
-"compress_mbps": 29.6,
-"decompress_mbps": 269.76
+"compress_mbps": 39.09,
+"decompress_mbps": 272.02
 },
 {
 "compressor": "native",
@@ -5014,8 +5014,8 @@
 "level": 6,
 "out_size": 711223,
 "ratio": 0.1331,
-"compress_mbps": 24.6,
-"decompress_mbps": 281.73
+"compress_mbps": 33.38,
+"decompress_mbps": 282.41
 },
 {
 "compressor": "native",
@@ -5024,8 +5024,8 @@
 "level": 7,
 "out_size": 682684,
 "ratio": 0.1277,
-"compress_mbps": 14.38,
-"decompress_mbps": 278.79
+"compress_mbps": 17.81,
+"decompress_mbps": 282.05
 },
 {
 "compressor": "native",
@@ -5034,8 +5034,8 @@
 "level": 8,
 "out_size": 681103,
 "ratio": 0.1274,
-"compress_mbps": 13.12,
-"decompress_mbps": 279.21
+"compress_mbps": 16.52,
+"decompress_mbps": 286.26
 },
 {
 "compressor": "native",
@@ -5044,8 +5044,8 @@
 "level": 9,
 "out_size": 637424,
 "ratio": 0.1192,
-"compress_mbps": 0.66,
-"decompress_mbps": 303.45
+"compress_mbps": 0.67,
+"decompress_mbps": 305.7
 },
 {
 "compressor": "zlib",
@@ -5054,8 +5054,8 @@
 "level": 1,
 "out_size": 4585612,
 "ratio": 0.4499,
-"compress_mbps": 113.23,
-"decompress_mbps": 335.83
+"compress_mbps": 113.4,
+"decompress_mbps": 336.89
 },
 {
 "compressor": "zlib",
@@ -5064,8 +5064,8 @@
 "level": 2,
 "out_size": 4389474,
 "ratio": 0.4307,
-"compress_mbps": 95.59,
-"decompress_mbps": 351.39
+"compress_mbps": 95.9,
+"decompress_mbps": 352.16
 },
 {
 "compressor": "zlib",
@@ -5074,8 +5074,8 @@
 "level": 3,
 "out_size": 4192079,
 "ratio": 0.4113,
-"compress_mbps": 59.42,
-"decompress_mbps": 380.52
+"compress_mbps": 59.59,
+"decompress_mbps": 381.32
 },
 {
 "compressor": "zlib",
@@ -5084,8 +5084,8 @@
 "level": 4,
 "out_size": 4095021,
 "ratio": 0.4018,
-"compress_mbps": 65.91,
-"decompress_mbps": 364.75
+"compress_mbps": 66.05,
+"decompress_mbps": 364.33
 },
 {
 "compressor": "zlib",
@@ -5094,8 +5094,8 @@
 "level": 5,
 "out_size": 3949169,
 "ratio": 0.3875,
-"compress_mbps": 35.46,
-"decompress_mbps": 351.11
+"compress_mbps": 36.0,
+"decompress_mbps": 351.66
 },
 {
 "compressor": "zlib",
@@ -5104,8 +5104,8 @@
 "level": 6,
 "out_size": 3871628,
 "ratio": 0.3799,
-"compress_mbps": 21.25,
-"decompress_mbps": 362.41
+"compress_mbps": 21.31,
+"decompress_mbps": 361.68
 },
 {
 "compressor": "zlib",
@@ -5114,8 +5114,8 @@
 "level": 7,
 "out_size": 3858876,
 "ratio": 0.3786,
-"compress_mbps": 17.73,
-"decompress_mbps": 360.99
+"compress_mbps": 17.8,
+"decompress_mbps": 361.95
 },
 {
 "compressor": "zlib",
@@ -5124,8 +5124,8 @@
 "level": 8,
 "out_size": 3854729,
 "ratio": 0.3782,
-"compress_mbps": 14.97,
-"decompress_mbps": 361.22
+"compress_mbps": 15.13,
+"decompress_mbps": 363.88
 },
 {
 "compressor": "zlib",
@@ -5134,8 +5134,8 @@
 "level": 9,
 "out_size": 3854729,
 "ratio": 0.3782,
-"compress_mbps": 14.95,
-"decompress_mbps": 348.59
+"compress_mbps": 15.14,
+"decompress_mbps": 364.43
 },
 {
 "compressor": "zlib",
@@ -5144,8 +5144,8 @@
 "level": 1,
 "out_size": 20577220,
 "ratio": 0.4017,
-"compress_mbps": 111.81,
-"decompress_mbps": 357.82
+"compress_mbps": 113.62,
+"decompress_mbps": 365.07
 },
 {
 "compressor": "zlib",
@@ -5154,8 +5154,8 @@
 "level": 2,
 "out_size": 20247697,
 "ratio": 0.3953,
-"compress_mbps": 100.15,
-"decompress_mbps": 366.61
+"compress_mbps": 101.71,
+"decompress_mbps": 373.08
 },
 {
 "compressor": "zlib",
@@ -5164,8 +5164,8 @@
 "level": 3,
 "out_size": 19987880,
 "ratio": 0.3902,
-"compress_mbps": 76.7,
-"decompress_mbps": 377.43
+"compress_mbps": 77.06,
+"decompress_mbps": 382.29
 },
 {
 "compressor": "zlib",
@@ -5174,8 +5174,8 @@
 "level": 4,
 "out_size": 19512665,
 "ratio": 0.381,
-"compress_mbps": 75.92,
-"decompress_mbps": 367.79
+"compress_mbps": 76.34,
+"decompress_mbps": 370.33
 },
 {
 "compressor": "zlib",
@@ -5184,8 +5184,8 @@
 "level": 5,
 "out_size": 19213507,
 "ratio": 0.3751,
-"compress_mbps": 53.39,
-"decompress_mbps": 369.5
+"compress_mbps": 53.71,
+"decompress_mbps": 377.3
 },
 {
 "compressor": "zlib",
@@ -5194,8 +5194,8 @@
 "level": 6,
 "out_size": 19089118,
 "ratio": 0.3727,
-"compress_mbps": 34.2,
-"decompress_mbps": 379.5
+"compress_mbps": 34.53,
+"decompress_mbps": 381.73
 },
 {
 "compressor": "zlib",
@@ -5204,8 +5204,8 @@
 "level": 7,
 "out_size": 19061204,
 "ratio": 0.3721,
-"compress_mbps": 27.36,
-"decompress_mbps": 381.53
+"compress_mbps": 27.47,
+"decompress_mbps": 380.43
 },
 {
 "compressor": "zlib",
@@ -5214,8 +5214,8 @@
 "level": 8,
 "out_size": 19040998,
 "ratio": 0.3717,
-"compress_mbps": 15.4,
-"decompress_mbps": 380.59
+"compress_mbps": 15.42,
+"decompress_mbps": 359.03
 },
 {
 "compressor": "zlib",
@@ -5224,8 +5224,8 @@
 "level": 9,
 "out_size": 19044390,
 "ratio": 0.3718,
-"compress_mbps": 9.49,
-"decompress_mbps": 380.45
+"compress_mbps": 9.54,
+"decompress_mbps": 359.57
 },
 {
 "compressor": "zlib",
@@ -5234,8 +5234,8 @@
 "level": 1,
 "out_size": 3828360,
 "ratio": 0.384,
-"compress_mbps": 142.58,
-"decompress_mbps": 447.95
+"compress_mbps": 143.44,
+"decompress_mbps": 446.1
 },
 {
 "compressor": "zlib",
@@ -5244,8 +5244,8 @@
 "level": 2,
 "out_size": 3798539,
 "ratio": 0.381,
-"compress_mbps": 126.59,
-"decompress_mbps": 459.09
+"compress_mbps": 127.72,
+"decompress_mbps": 459.65
 },
 {
 "compressor": "zlib",
@@ -5254,8 +5254,8 @@
 "level": 3,
 "out_size": 3674568,
 "ratio": 0.3685,
-"compress_mbps": 79.25,
-"decompress_mbps": 476.64
+"compress_mbps": 79.64,
+"decompress_mbps": 473.62
 },
 {
 "compressor": "zlib",
@@ -5264,8 +5264,8 @@
 "level": 4,
 "out_size": 3680923,
 "ratio": 0.3692,
-"compress_mbps": 88.38,
-"decompress_mbps": 425.15
+"compress_mbps": 89.42,
+"decompress_mbps": 421.88
 },
 {
 "compressor": "zlib",
@@ -5274,8 +5274,8 @@
 "level": 5,
 "out_size": 3698707,
 "ratio": 0.371,
-"compress_mbps": 47.35,
-"decompress_mbps": 398.79
+"compress_mbps": 47.89,
+"decompress_mbps": 398.05
 },
 {
 "compressor": "zlib",
@@ -5284,8 +5284,8 @@
 "level": 6,
 "out_size": 3675935,
 "ratio": 0.3687,
-"compress_mbps": 26.19,
-"decompress_mbps": 409.42
+"compress_mbps": 26.38,
+"decompress_mbps": 412.8
 },
 {
 "compressor": "zlib",
@@ -5294,8 +5294,8 @@
 "level": 7,
 "out_size": 3670281,
 "ratio": 0.3681,
-"compress_mbps": 20.67,
-"decompress_mbps": 411.24
+"compress_mbps": 20.76,
+"decompress_mbps": 413.76
 },
 {
 "compressor": "zlib",
@@ -5304,8 +5304,8 @@
 "level": 8,
 "out_size": 3661103,
 "ratio": 0.3672,
-"compress_mbps": 10.94,
-"decompress_mbps": 421.25
+"compress_mbps": 11.01,
+"decompress_mbps": 417.83
 },
 {
 "compressor": "zlib",
@@ -5314,8 +5314,8 @@
 "level": 9,
 "out_size": 3660788,
 "ratio": 0.3672,
-"compress_mbps": 9.47,
-"decompress_mbps": 421.34
+"compress_mbps": 9.54,
+"decompress_mbps": 426.32
 },
 {
 "compressor": "zlib",
@@ -5324,8 +5324,8 @@
 "level": 1,
 "out_size": 4624591,
 "ratio": 0.1378,
-"compress_mbps": 331.46,
-"decompress_mbps": 809.35
+"compress_mbps": 335.61,
+"decompress_mbps": 818.92
 },
 {
 "compressor": "zlib",
@@ -5334,8 +5334,8 @@
 "level": 2,
 "out_size": 4303176,
 "ratio": 0.1282,
-"compress_mbps": 307.4,
-"decompress_mbps": 834.61
+"compress_mbps": 301.15,
+"decompress_mbps": 843.73
 },
 {
 "compressor": "zlib",
@@ -5344,8 +5344,8 @@
 "level": 3,
 "out_size": 4010156,
 "ratio": 0.1195,
-"compress_mbps": 256.31,
-"decompress_mbps": 909.69
+"compress_mbps": 259.16,
+"decompress_mbps": 920.46
 },
 {
 "compressor": "zlib",
@@ -5354,8 +5354,8 @@
 "level": 4,
 "out_size": 3713866,
 "ratio": 0.1107,
-"compress_mbps": 211.34,
-"decompress_mbps": 892.52
+"compress_mbps": 214.16,
+"decompress_mbps": 903.31
 },
 {
 "compressor": "zlib",
@@ -5364,8 +5364,8 @@
 "level": 5,
 "out_size": 3378136,
 "ratio": 0.1007,
-"compress_mbps": 164.32,
-"decompress_mbps": 961.38
+"compress_mbps": 166.92,
+"decompress_mbps": 969.86
 },
 {
 "compressor": "zlib",
@@ -5374,8 +5374,8 @@
 "level": 6,
 "out_size": 3200182,
 "ratio": 0.0954,
-"compress_mbps": 113.1,
-"decompress_mbps": 990.6
+"compress_mbps": 114.5,
+"decompress_mbps": 1002.33
 },
 {
 "compressor": "zlib",
@@ -5384,8 +5384,8 @@
 "level": 7,
 "out_size": 3141278,
 "ratio": 0.0936,
-"compress_mbps": 90.09,
-"decompress_mbps": 995.47
+"compress_mbps": 90.7,
+"decompress_mbps": 1010.13
 },
 {
 "compressor": "zlib",
@@ -5394,8 +5394,8 @@
 "level": 8,
 "out_size": 3031199,
 "ratio": 0.0903,
-"compress_mbps": 39.11,
-"decompress_mbps": 1010.76
+"compress_mbps": 39.5,
+"decompress_mbps": 1021.96
 },
 {
 "compressor": "zlib",
@@ -5404,8 +5404,8 @@
 "level": 9,
 "out_size": 2987995,
 "ratio": 0.0891,
-"compress_mbps": 21.38,
-"decompress_mbps": 1019.0
+"compress_mbps": 21.46,
+"decompress_mbps": 1047.14
 },
 {
 "compressor": "zlib",
@@ -5414,8 +5414,8 @@
 "level": 1,
 "out_size": 3290526,
 "ratio": 0.5349,
-"compress_mbps": 78.14,
-"decompress_mbps": 252.22
+"compress_mbps": 79.38,
+"decompress_mbps": 255.92
 },
 {
 "compressor": "zlib",
@@ -5424,8 +5424,8 @@
 "level": 2,
 "out_size": 3238282,
 "ratio": 0.5264,
-"compress_mbps": 71.3,
-"decompress_mbps": 257.39
+"compress_mbps": 72.55,
+"decompress_mbps": 259.73
 },
 {
 "compressor": "zlib",
@@ -5434,8 +5434,8 @@
 "level": 3,
 "out_size": 3193366,
 "ratio": 0.5191,
-"compress_mbps": 56.42,
-"decompress_mbps": 263.55
+"compress_mbps": 57.11,
+"decompress_mbps": 266.63
 },
 {
 "compressor": "zlib",
@@ -5444,8 +5444,8 @@
 "level": 4,
 "out_size": 3158012,
 "ratio": 0.5133,
-"compress_mbps": 54.84,
-"decompress_mbps": 264.04
+"compress_mbps": 55.9,
+"decompress_mbps": 269.78
 },
 {
 "compressor": "zlib",
@@ -5454,8 +5454,8 @@
 "level": 5,
 "out_size": 3115309,
 "ratio": 0.5064,
-"compress_mbps": 38.79,
-"decompress_mbps": 268.01
+"compress_mbps": 39.36,
+"decompress_mbps": 274.06
 },
 {
 "compressor": "zlib",
@@ -5464,8 +5464,8 @@
 "level": 6,
 "out_size": 3097288,
 "ratio": 0.5034,
-"compress_mbps": 26.25,
-"decompress_mbps": 269.7
+"compress_mbps": 26.56,
+"decompress_mbps": 273.04
 },
 {
 "compressor": "zlib",
@@ -5474,8 +5474,8 @@
 "level": 7,
 "out_size": 3094363,
 "ratio": 0.503,
-"compress_mbps": 21.86,
-"decompress_mbps": 270.92
+"compress_mbps": 22.11,
+"decompress_mbps": 273.38
 },
 {
 "compressor": "zlib",
@@ -5484,8 +5484,8 @@
 "level": 8,
 "out_size": 3093026,
 "ratio": 0.5028,
-"compress_mbps": 17.09,
-"decompress_mbps": 269.83
+"compress_mbps": 17.26,
+"decompress_mbps": 273.77
 },
 {
 "compressor": "zlib",
@@ -5494,8 +5494,8 @@
 "level": 9,
 "out_size": 3092920,
 "ratio": 0.5027,
-"compress_mbps": 15.52,
-"decompress_mbps": 269.75
+"compress_mbps": 15.63,
+"decompress_mbps": 272.23
 },
 {
 "compressor": "zlib",
@@ -5504,8 +5504,8 @@
 "level": 1,
 "out_size": 4076385,
 "ratio": 0.4042,
-"compress_mbps": 126.22,
-"decompress_mbps": 442.08
+"compress_mbps": 128.32,
+"decompress_mbps": 445.83
 },
 {
 "compressor": "zlib",
@@ -5514,8 +5514,8 @@
 "level": 2,
 "out_size": 3991014,
 "ratio": 0.3957,
-"compress_mbps": 116.73,
-"decompress_mbps": 462.07
+"compress_mbps": 118.47,
+"decompress_mbps": 460.7
 },
 {
 "compressor": "zlib",
@@ -5524,8 +5524,8 @@
 "level": 3,
 "out_size": 3934055,
 "ratio": 0.3901,
-"compress_mbps": 93.31,
-"decompress_mbps": 475.07
+"compress_mbps": 94.37,
+"decompress_mbps": 474.51
 },
 {
 "compressor": "zlib",
@@ -5534,8 +5534,8 @@
 "level": 4,
 "out_size": 3825092,
 "ratio": 0.3793,
-"compress_mbps": 84.13,
-"decompress_mbps": 471.19
+"compress_mbps": 85.67,
+"decompress_mbps": 475.21
 },
 {
 "compressor": "zlib",
@@ -5544,8 +5544,8 @@
 "level": 5,
 "out_size": 3752932,
 "ratio": 0.3721,
-"compress_mbps": 64.3,
-"decompress_mbps": 463.51
+"compress_mbps": 65.24,
+"decompress_mbps": 465.59
 },
 {
 "compressor": "zlib",
@@ -5554,8 +5554,8 @@
 "level": 6,
 "out_size": 3695164,
 "ratio": 0.3664,
-"compress_mbps": 49.16,
-"decompress_mbps": 471.26
+"compress_mbps": 49.86,
+"decompress_mbps": 474.34
 },
 {
 "compressor": "zlib",
@@ -5564,8 +5564,8 @@
 "level": 7,
 "out_size": 3676881,
 "ratio": 0.3646,
-"compress_mbps": 38.01,
-"decompress_mbps": 478.43
+"compress_mbps": 38.39,
+"decompress_mbps": 484.05
 },
 {
 "compressor": "zlib",
@@ -5574,8 +5574,8 @@
 "level": 8,
 "out_size": 3673171,
 "ratio": 0.3642,
-"compress_mbps": 31.84,
-"decompress_mbps": 480.1
+"compress_mbps": 32.12,
+"decompress_mbps": 488.13
 },
 {
 "compressor": "zlib",
@@ -5584,8 +5584,8 @@
 "level": 9,
 "out_size": 3673171,
 "ratio": 0.3642,
-"compress_mbps": 31.69,
-"decompress_mbps": 481.45
+"compress_mbps": 31.47,
+"decompress_mbps": 485.26
 },
 {
 "compressor": "zlib",
@@ -5594,8 +5594,8 @@
 "level": 1,
 "out_size": 2376424,
 "ratio": 0.3586,
-"compress_mbps": 130.68,
-"decompress_mbps": 395.47
+"compress_mbps": 131.07,
+"decompress_mbps": 389.44
 },
 {
 "compressor": "zlib",
@@ -5604,8 +5604,8 @@
 "level": 2,
 "out_size": 2259060,
 "ratio": 0.3409,
-"compress_mbps": 112.24,
-"decompress_mbps": 405.92
+"compress_mbps": 113.6,
+"decompress_mbps": 407.41
 },
 {
 "compressor": "zlib",
@@ -5614,8 +5614,8 @@
 "level": 3,
 "out_size": 2135664,
 "ratio": 0.3223,
-"compress_mbps": 72.91,
-"decompress_mbps": 425.81
+"compress_mbps": 73.12,
+"decompress_mbps": 424.09
 },
 {
 "compressor": "zlib",
@@ -5624,8 +5624,8 @@
 "level": 4,
 "out_size": 2052793,
 "ratio": 0.3098,
-"compress_mbps": 82.22,
-"decompress_mbps": 423.64
+"compress_mbps": 82.63,
+"decompress_mbps": 419.74
 },
 {
 "compressor": "zlib",
@@ -5634,8 +5634,8 @@
 "level": 5,
 "out_size": 1932127,
 "ratio": 0.2915,
-"compress_mbps": 45.61,
-"decompress_mbps": 422.63
+"compress_mbps": 45.95,
+"decompress_mbps": 427.23
 },
 {
 "compressor": "zlib",
@@ -5644,8 +5644,8 @@
 "level": 6,
 "out_size": 1860865,
 "ratio": 0.2808,
-"compress_mbps": 22.95,
-"decompress_mbps": 434.49
+"compress_mbps": 23.07,
+"decompress_mbps": 435.0
 },
 {
 "compressor": "zlib",
@@ -5654,8 +5654,8 @@
 "level": 7,
 "out_size": 1838671,
 "ratio": 0.2774,
-"compress_mbps": 15.96,
-"decompress_mbps": 437.43
+"compress_mbps": 16.08,
+"decompress_mbps": 435.89
 },
 {
 "compressor": "zlib",
@@ -5664,8 +5664,8 @@
 "level": 8,
 "out_size": 1823235,
 "ratio": 0.2751,
-"compress_mbps": 8.13,
-"decompress_mbps": 432.62
+"compress_mbps": 8.19,
+"decompress_mbps": 431.26
 },
 {
 "compressor": "zlib",
@@ -5674,8 +5674,8 @@
 "level": 9,
 "out_size": 1823190,
 "ratio": 0.2751,
-"compress_mbps": 8.07,
-"decompress_mbps": 432.03
+"compress_mbps": 8.14,
+"decompress_mbps": 410.97
 },
 {
 "compressor": "zlib",
@@ -5684,8 +5684,8 @@
 "level": 1,
 "out_size": 6329449,
 "ratio": 0.2929,
-"compress_mbps": 169.76,
-"decompress_mbps": 487.59
+"compress_mbps": 170.41,
+"decompress_mbps": 460.75
 },
 {
 "compressor": "zlib",
@@ -5694,8 +5694,8 @@
 "level": 2,
 "out_size": 6128866,
 "ratio": 0.2837,
-"compress_mbps": 156.28,
-"decompress_mbps": 550.67
+"compress_mbps": 156.81,
+"decompress_mbps": 531.63
 },
 {
 "compressor": "zlib",
@@ -5704,8 +5704,8 @@
 "level": 3,
 "out_size": 5982546,
 "ratio": 0.2769,
-"compress_mbps": 125.47,
-"decompress_mbps": 576.15
+"compress_mbps": 125.92,
+"decompress_mbps": 571.65
 },
 {
 "compressor": "zlib",
@@ -5714,8 +5714,8 @@
 "level": 4,
 "out_size": 5656400,
 "ratio": 0.2618,
-"compress_mbps": 117.05,
-"decompress_mbps": 573.12
+"compress_mbps": 117.46,
+"decompress_mbps": 570.94
 },
 {
 "compressor": "zlib",
@@ -5724,8 +5724,8 @@
 "level": 5,
 "out_size": 5511352,
 "ratio": 0.2551,
-"compress_mbps": 82.26,
-"decompress_mbps": 579.4
+"compress_mbps": 82.67,
+"decompress_mbps": 578.92
 },
 {
 "compressor": "zlib",
@@ -5734,8 +5734,8 @@
 "level": 6,
 "out_size": 5451399,
 "ratio": 0.2523,
-"compress_mbps": 56.64,
-"decompress_mbps": 592.09
+"compress_mbps": 56.89,
+"decompress_mbps": 591.12
 },
 {
 "compressor": "zlib",
@@ -5744,8 +5744,8 @@
 "level": 7,
 "out_size": 5417123,
 "ratio": 0.2507,
-"compress_mbps": 46.72,
-"decompress_mbps": 594.93
+"compress_mbps": 46.85,
+"decompress_mbps": 593.57
 },
 {
 "compressor": "zlib",
@@ -5754,8 +5754,8 @@
 "level": 8,
 "out_size": 5404364,
 "ratio": 0.2501,
-"compress_mbps": 32.73,
-"decompress_mbps": 602.28
+"compress_mbps": 32.81,
+"decompress_mbps": 597.41
 },
 {
 "compressor": "zlib",
@@ -5764,8 +5764,8 @@
 "level": 9,
 "out_size": 5402704,
 "ratio": 0.2501,
-"compress_mbps": 29.78,
-"decompress_mbps": 601.75
+"compress_mbps": 29.92,
+"decompress_mbps": 599.18
 },
 {
 "compressor": "zlib",
@@ -5774,8 +5774,8 @@
 "level": 1,
 "out_size": 5567768,
 "ratio": 0.7678,
-"compress_mbps": 64.73,
-"decompress_mbps": 315.8
+"compress_mbps": 65.43,
+"decompress_mbps": 314.61
 },
 {
 "compressor": "zlib",
@@ -5784,8 +5784,8 @@
 "level": 2,
 "out_size": 5504009,
 "ratio": 0.759,
-"compress_mbps": 58.71,
-"decompress_mbps": 324.71
+"compress_mbps": 59.08,
+"decompress_mbps": 324.77
 },
 {
 "compressor": "zlib",
@@ -5794,8 +5794,8 @@
 "level": 3,
 "out_size": 5439339,
 "ratio": 0.7501,
-"compress_mbps": 46.64,
-"decompress_mbps": 333.28
+"compress_mbps": 46.86,
+"decompress_mbps": 332.26
 },
 {
 "compressor": "zlib",
@@ -5804,8 +5804,8 @@
 "level": 4,
 "out_size": 5394604,
 "ratio": 0.7439,
-"compress_mbps": 48.31,
-"decompress_mbps": 343.31
+"compress_mbps": 48.62,
+"decompress_mbps": 342.95
 },
 {
 "compressor": "zlib",
@@ -5814,8 +5814,8 @@
 "level": 5,
 "out_size": 5370116,
 "ratio": 0.7405,
-"compress_mbps": 33.21,
-"decompress_mbps": 336.89
+"compress_mbps": 33.37,
+"decompress_mbps": 333.72
 },
 {
 "compressor": "zlib",
@@ -5824,8 +5824,8 @@
 "level": 6,
 "out_size": 5331793,
 "ratio": 0.7352,
-"compress_mbps": 23.09,
-"decompress_mbps": 337.03
+"compress_mbps": 23.2,
+"decompress_mbps": 343.29
 },
 {
 "compressor": "zlib",
@@ -5834,8 +5834,8 @@
 "level": 7,
 "out_size": 5327677,
 "ratio": 0.7347,
-"compress_mbps": 21.17,
-"decompress_mbps": 346.36
+"compress_mbps": 21.23,
+"decompress_mbps": 340.21
 },
 {
 "compressor": "zlib",
@@ -5844,8 +5844,8 @@
 "level": 8,
 "out_size": 5325914,
 "ratio": 0.7344,
-"compress_mbps": 18.94,
-"decompress_mbps": 345.86
+"compress_mbps": 18.84,
+"decompress_mbps": 340.82
 },
 {
 "compressor": "zlib",
@@ -5854,8 +5854,8 @@
 "level": 9,
 "out_size": 5325914,
 "ratio": 0.7344,
-"compress_mbps": 18.95,
-"decompress_mbps": 345.78
+"compress_mbps": 18.87,
+"decompress_mbps": 343.3
 },
 {
 "compressor": "zlib",
@@ -5864,8 +5864,8 @@
 "level": 1,
 "out_size": 14991236,
 "ratio": 0.3616,
-"compress_mbps": 136.75,
-"decompress_mbps": 377.06
+"compress_mbps": 136.7,
+"decompress_mbps": 375.33
 },
 {
 "compressor": "zlib",
@@ -5874,8 +5874,8 @@
 "level": 2,
 "out_size": 14249692,
 "ratio": 0.3437,
-"compress_mbps": 120.65,
-"decompress_mbps": 394.34
+"compress_mbps": 120.32,
+"decompress_mbps": 391.4
 },
 {
 "compressor": "zlib",
@@ -5884,8 +5884,8 @@
 "level": 3,
 "out_size": 13627761,
 "ratio": 0.3287,
-"compress_mbps": 87.67,
-"decompress_mbps": 409.13
+"compress_mbps": 87.82,
+"decompress_mbps": 403.94
 },
 {
 "compressor": "zlib",
@@ -5894,8 +5894,8 @@
 "level": 4,
 "out_size": 13001990,
 "ratio": 0.3136,
-"compress_mbps": 85.14,
-"decompress_mbps": 392.58
+"compress_mbps": 85.74,
+"decompress_mbps": 388.77
 },
 {
 "compressor": "zlib",
@@ -5904,8 +5904,8 @@
 "level": 5,
 "out_size": 12445991,
 "ratio": 0.3002,
-"compress_mbps": 54.25,
-"decompress_mbps": 372.51
+"compress_mbps": 55.1,
+"decompress_mbps": 387.91
 },
 {
 "compressor": "zlib",
@@ -5914,8 +5914,8 @@
 "level": 6,
 "out_size": 12213941,
 "ratio": 0.2946,
-"compress_mbps": 36.46,
-"decompress_mbps": 395.28
+"compress_mbps": 36.43,
+"decompress_mbps": 395.97
 },
 {
 "compressor": "zlib",
@@ -5924,8 +5924,8 @@
 "level": 7,
 "out_size": 12130416,
 "ratio": 0.2926,
-"compress_mbps": 29.64,
-"decompress_mbps": 396.96
+"compress_mbps": 29.72,
+"decompress_mbps": 396.24
 },
 {
 "compressor": "zlib",
@@ -5934,8 +5934,8 @@
 "level": 8,
 "out_size": 12073697,
 "ratio": 0.2912,
-"compress_mbps": 21.44,
-"decompress_mbps": 398.29
+"compress_mbps": 21.51,
+"decompress_mbps": 399.04
 },
 {
 "compressor": "zlib",
@@ -5944,8 +5944,8 @@
 "level": 9,
 "out_size": 12073469,
 "ratio": 0.2912,
-"compress_mbps": 21.27,
-"decompress_mbps": 400.83
+"compress_mbps": 21.31,
+"decompress_mbps": 398.38
 },
 {
 "compressor": "zlib",
@@ -5954,8 +5954,8 @@
 "level": 1,
 "out_size": 6033926,
 "ratio": 0.712,
-"compress_mbps": 75.16,
-"decompress_mbps": 281.92
+"compress_mbps": 75.61,
+"decompress_mbps": 281.72
 },
 {
 "compressor": "zlib",
@@ -5964,8 +5964,8 @@
 "level": 2,
 "out_size": 5997474,
 "ratio": 0.7077,
-"compress_mbps": 68.12,
-"decompress_mbps": 290.48
+"compress_mbps": 68.71,
+"decompress_mbps": 290.03
 },
 {
 "compressor": "zlib",
@@ -5974,8 +5974,8 @@
 "level": 3,
 "out_size": 5966621,
 "ratio": 0.7041,
-"compress_mbps": 55.16,
-"decompress_mbps": 293.04
+"compress_mbps": 55.65,
+"decompress_mbps": 291.1
 },
 {
 "compressor": "zlib",
@@ -5984,8 +5984,8 @@
 "level": 4,
 "out_size": 6091108,
 "ratio": 0.7188,
-"compress_mbps": 45.75,
-"decompress_mbps": 255.74
+"compress_mbps": 46.17,
+"decompress_mbps": 255.79
 },
 {
 "compressor": "zlib",
@@ -5994,8 +5994,8 @@
 "level": 5,
 "out_size": 6053566,
 "ratio": 0.7143,
-"compress_mbps": 37.05,
-"decompress_mbps": 261.39
+"compress_mbps": 37.29,
+"decompress_mbps": 261.92
 },
 {
 "compressor": "zlib",
@@ -6004,8 +6004,8 @@
 "level": 6,
 "out_size": 6045111,
 "ratio": 0.7134,
-"compress_mbps": 34.84,
-"decompress_mbps": 265.98
+"compress_mbps": 35.03,
+"decompress_mbps": 265.89
 },
 {
 "compressor": "zlib",
@@ -6014,8 +6014,8 @@
 "level": 7,
 "out_size": 6045034,
 "ratio": 0.7133,
-"compress_mbps": 34.79,
-"decompress_mbps": 266.45
+"compress_mbps": 34.93,
+"decompress_mbps": 266.42
 },
 {
 "compressor": "zlib",
@@ -6024,8 +6024,8 @@
 "level": 8,
 "out_size": 6045032,
 "ratio": 0.7133,
-"compress_mbps": 34.76,
-"decompress_mbps": 266.12
+"compress_mbps": 34.86,
+"decompress_mbps": 266.11
 },
 {
 "compressor": "zlib",
@@ -6034,8 +6034,8 @@
 "level": 9,
 "out_size": 6045032,
 "ratio": 0.7133,
-"compress_mbps": 34.77,
-"decompress_mbps": 265.14
+"compress_mbps": 34.89,
+"decompress_mbps": 266.04
 },
 {
 "compressor": "zlib",
@@ -6044,8 +6044,8 @@
 "level": 1,
 "out_size": 965242,
 "ratio": 0.1806,
-"compress_mbps": 261.17,
-"decompress_mbps": 678.68
+"compress_mbps": 263.73,
+"decompress_mbps": 686.79
 },
 {
 "compressor": "zlib",
@@ -6054,8 +6054,8 @@
 "level": 2,
 "out_size": 887265,
 "ratio": 0.166,
-"compress_mbps": 245.37,
-"decompress_mbps": 733.92
+"compress_mbps": 247.17,
+"decompress_mbps": 752.09
 },
 {
 "compressor": "zlib",
@@ -6064,8 +6064,8 @@
 "level": 3,
 "out_size": 822167,
 "ratio": 0.1538,
-"compress_mbps": 190.48,
-"decompress_mbps": 788.03
+"compress_mbps": 191.77,
+"decompress_mbps": 802.69
 },
 {
 "compressor": "zlib",
@@ -6074,8 +6074,8 @@
 "level": 4,
 "out_size": 807518,
 "ratio": 0.1511,
-"compress_mbps": 168.34,
-"decompress_mbps": 753.74
+"compress_mbps": 169.62,
+"decompress_mbps": 767.49
 },
 {
 "compressor": "zlib",
@@ -6084,8 +6084,8 @@
 "level": 5,
 "out_size": 730574,
 "ratio": 0.1367,
-"compress_mbps": 121.58,
-"decompress_mbps": 811.42
+"compress_mbps": 122.12,
+"decompress_mbps": 813.74
 },
 {
 "compressor": "zlib",
@@ -6094,8 +6094,8 @@
 "level": 6,
 "out_size": 687991,
 "ratio": 0.1287,
-"compress_mbps": 79.21,
-"decompress_mbps": 859.24
+"compress_mbps": 79.52,
+"decompress_mbps": 874.65
 },
 {
 "compressor": "zlib",
@@ -6104,8 +6104,8 @@
 "level": 7,
 "out_size": 673933,
 "ratio": 0.1261,
-"compress_mbps": 64.95,
-"decompress_mbps": 873.58
+"compress_mbps": 65.16,
+"decompress_mbps": 846.85
 },
 {
 "compressor": "zlib",
@@ -6114,8 +6114,8 @@
 "level": 8,
 "out_size": 659518,
 "ratio": 0.1234,
-"compress_mbps": 43.05,
-"decompress_mbps": 901.08
+"compress_mbps": 43.21,
+"decompress_mbps": 888.65
 },
 {
 "compressor": "zlib",
@@ -6124,8 +6124,8 @@
 "level": 9,
 "out_size": 658899,
 "ratio": 0.1233,
-"compress_mbps": 39.58,
-"decompress_mbps": 894.67
+"compress_mbps": 39.95,
+"decompress_mbps": 901.4
 },
 {
 "compressor": "miniz_oxide",
@@ -6134,8 +6134,8 @@
 "level": 1,
 "out_size": 5363862,
 "ratio": 0.5263,
-"compress_mbps": 138.84,
-"decompress_mbps": 367.81
+"compress_mbps": 139.37,
+"decompress_mbps": 375.2
 },
 {
 "compressor": "miniz_oxide",
@@ -6144,8 +6144,8 @@
 "level": 2,
 "out_size": 4438205,
 "ratio": 0.4354,
-"compress_mbps": 128.37,
-"decompress_mbps": 428.06
+"compress_mbps": 128.31,
+"decompress_mbps": 444.07
 },
 {
 "compressor": "miniz_oxide",
@@ -6154,8 +6154,8 @@
 "level": 3,
 "out_size": 4054333,
 "ratio": 0.3978,
-"compress_mbps": 63.93,
-"decompress_mbps": 476.26
+"compress_mbps": 63.98,
+"decompress_mbps": 490.49
 },
 {
 "compressor": "miniz_oxide",
@@ -6164,8 +6164,8 @@
 "level": 4,
 "out_size": 4038550,
 "ratio": 0.3962,
-"compress_mbps": 57.49,
-"decompress_mbps": 470.47
+"compress_mbps": 57.8,
+"decompress_mbps": 480.43
 },
 {
 "compressor": "miniz_oxide",
@@ -6174,8 +6174,8 @@
 "level": 5,
 "out_size": 3954920,
 "ratio": 0.388,
-"compress_mbps": 40.17,
-"decompress_mbps": 457.45
+"compress_mbps": 40.33,
+"decompress_mbps": 471.13
 },
 {
 "compressor": "miniz_oxide",
@@ -6184,8 +6184,8 @@
 "level": 6,
 "out_size": 3872874,
 "ratio": 0.38,
-"compress_mbps": 22.55,
-"decompress_mbps": 469.75
+"compress_mbps": 22.62,
+"decompress_mbps": 480.64
 },
 {
 "compressor": "miniz_oxide",
@@ -6194,8 +6194,8 @@
 "level": 7,
 "out_size": 3859937,
 "ratio": 0.3787,
-"compress_mbps": 18.81,
-"decompress_mbps": 471.16
+"compress_mbps": 18.87,
+"decompress_mbps": 480.93
 },
 {
 "compressor": "miniz_oxide",
@@ -6204,8 +6204,8 @@
 "level": 8,
 "out_size": 3855935,
 "ratio": 0.3783,
-"compress_mbps": 17.06,
-"decompress_mbps": 469.53
+"compress_mbps": 17.1,
+"decompress_mbps": 480.84
 },
 {
 "compressor": "miniz_oxide",
@@ -6214,8 +6214,8 @@
 "level": 9,
 "out_size": 3855791,
 "ratio": 0.3783,
-"compress_mbps": 16.99,
-"decompress_mbps": 469.82
+"compress_mbps": 17.04,
+"decompress_mbps": 480.82
 },
 {
 "compressor": "miniz_oxide",
@@ -6224,8 +6224,8 @@
 "level": 1,
 "out_size": 22334882,
 "ratio": 0.4361,
-"compress_mbps": 230.39,
-"decompress_mbps": 363.79
+"compress_mbps": 232.08,
+"decompress_mbps": 374.31
 },
 {
 "compressor": "miniz_oxide",
@@ -6234,8 +6234,8 @@
 "level": 2,
 "out_size": 20150366,
 "ratio": 0.3934,
-"compress_mbps": 118.85,
-"decompress_mbps": 374.49
+"compress_mbps": 119.26,
+"decompress_mbps": 381.57
 },
 {
 "compressor": "miniz_oxide",
@@ -6244,8 +6244,8 @@
 "level": 3,
 "out_size": 19495014,
 "ratio": 0.3806,
-"compress_mbps": 69.8,
-"decompress_mbps": 382.14
+"compress_mbps": 70.01,
+"decompress_mbps": 393.35
 },
 {
 "compressor": "miniz_oxide",
@@ -6254,8 +6254,8 @@
 "level": 4,
 "out_size": 19424978,
 "ratio": 0.3792,
-"compress_mbps": 70.86,
-"decompress_mbps": 396.9
+"compress_mbps": 71.42,
+"decompress_mbps": 407.0
 },
 {
 "compressor": "miniz_oxide",
@@ -6264,8 +6264,8 @@
 "level": 5,
 "out_size": 19298736,
 "ratio": 0.3768,
-"compress_mbps": 53.9,
-"decompress_mbps": 410.98
+"compress_mbps": 54.07,
+"decompress_mbps": 419.71
 },
 {
 "compressor": "miniz_oxide",
@@ -6274,8 +6274,8 @@
 "level": 6,
 "out_size": 19179167,
 "ratio": 0.3744,
-"compress_mbps": 29.61,
-"decompress_mbps": 417.74
+"compress_mbps": 29.67,
+"decompress_mbps": 429.37
 },
 {
 "compressor": "miniz_oxide",
@@ -6284,8 +6284,8 @@
 "level": 7,
 "out_size": 19151324,
 "ratio": 0.3739,
-"compress_mbps": 21.88,
-"decompress_mbps": 411.94
+"compress_mbps": 21.89,
+"decompress_mbps": 428.97
 },
 {
 "compressor": "miniz_oxide",
@@ -6294,8 +6294,8 @@
 "level": 8,
 "out_size": 19144373,
 "ratio": 0.3738,
-"compress_mbps": 16.54,
-"decompress_mbps": 418.45
+"compress_mbps": 16.6,
+"decompress_mbps": 430.62
 },
 {
 "compressor": "miniz_oxide",
@@ -6304,8 +6304,8 @@
 "level": 9,
 "out_size": 19141383,
 "ratio": 0.3737,
-"compress_mbps": 14.14,
-"decompress_mbps": 417.68
+"compress_mbps": 14.2,
+"decompress_mbps": 432.22
 },
 {
 "compressor": "miniz_oxide",
@@ -6314,8 +6314,8 @@
 "level": 1,
 "out_size": 4249731,
 "ratio": 0.4262,
-"compress_mbps": 309.05,
-"decompress_mbps": 495.59
+"compress_mbps": 308.92,
+"decompress_mbps": 537.71
 },
 {
 "compressor": "miniz_oxide",
@@ -6324,8 +6324,8 @@
 "level": 2,
 "out_size": 3775479,
 "ratio": 0.3787,
-"compress_mbps": 156.4,
-"decompress_mbps": 553.56
+"compress_mbps": 158.58,
+"decompress_mbps": 565.35
 },
 {
 "compressor": "miniz_oxide",
@@ -6334,8 +6334,8 @@
 "level": 3,
 "out_size": 3656966,
 "ratio": 0.3668,
-"compress_mbps": 79.69,
-"decompress_mbps": 573.29
+"compress_mbps": 80.3,
+"decompress_mbps": 587.01
 },
 {
 "compressor": "miniz_oxide",
@@ -6344,8 +6344,8 @@
 "level": 4,
 "out_size": 3740378,
 "ratio": 0.3751,
-"compress_mbps": 67.29,
-"decompress_mbps": 532.55
+"compress_mbps": 68.2,
+"decompress_mbps": 548.54
 },
 {
 "compressor": "miniz_oxide",
@@ -6354,8 +6354,8 @@
 "level": 5,
 "out_size": 3713604,
 "ratio": 0.3725,
-"compress_mbps": 48.5,
-"decompress_mbps": 496.36
+"compress_mbps": 48.92,
+"decompress_mbps": 514.64
 },
 {
 "compressor": "miniz_oxide",
@@ -6364,8 +6364,8 @@
 "level": 6,
 "out_size": 3683556,
 "ratio": 0.3694,
-"compress_mbps": 25.11,
-"decompress_mbps": 512.39
+"compress_mbps": 25.27,
+"decompress_mbps": 532.35
 },
 {
 "compressor": "miniz_oxide",
@@ -6374,8 +6374,8 @@
 "level": 7,
 "out_size": 3683797,
 "ratio": 0.3695,
-"compress_mbps": 19.09,
-"decompress_mbps": 524.17
+"compress_mbps": 19.22,
+"decompress_mbps": 539.74
 },
 {
 "compressor": "miniz_oxide",
@@ -6384,8 +6384,8 @@
 "level": 8,
 "out_size": 3684477,
 "ratio": 0.3695,
-"compress_mbps": 14.43,
-"decompress_mbps": 535.45
+"compress_mbps": 14.5,
+"decompress_mbps": 513.45
 },
 {
 "compressor": "miniz_oxide",
@@ -6394,8 +6394,8 @@
 "level": 9,
 "out_size": 3679414,
 "ratio": 0.369,
-"compress_mbps": 12.41,
-"decompress_mbps": 536.55
+"compress_mbps": 12.49,
+"decompress_mbps": 545.83
 },
 {
 "compressor": "miniz_oxide",
@@ -6404,8 +6404,8 @@
 "level": 1,
 "out_size": 5594622,
 "ratio": 0.1667,
-"compress_mbps": 430.78,
-"decompress_mbps": 829.99
+"compress_mbps": 428.92,
+"decompress_mbps": 793.28
 },
 {
 "compressor": "miniz_oxide",
@@ -6414,8 +6414,8 @@
 "level": 2,
 "out_size": 4179532,
 "ratio": 0.1246,
-"compress_mbps": 326.57,
-"decompress_mbps": 941.63
+"compress_mbps": 329.24,
+"decompress_mbps": 963.61
 },
 {
 "compressor": "miniz_oxide",
@@ -6424,8 +6424,8 @@
 "level": 3,
 "out_size": 3542329,
 "ratio": 0.1056,
-"compress_mbps": 211.22,
-"decompress_mbps": 836.64
+"compress_mbps": 213.19,
+"decompress_mbps": 884.15
 },
 {
 "compressor": "miniz_oxide",
@@ -6434,8 +6434,8 @@
 "level": 4,
 "out_size": 3323363,
 "ratio": 0.099,
-"compress_mbps": 198.39,
-"decompress_mbps": 870.64
+"compress_mbps": 199.57,
+"decompress_mbps": 921.44
 },
 {
 "compressor": "miniz_oxide",
@@ -6444,8 +6444,8 @@
 "level": 5,
 "out_size": 3230343,
 "ratio": 0.0963,
-"compress_mbps": 161.96,
-"decompress_mbps": 952.9
+"compress_mbps": 163.68,
+"decompress_mbps": 980.95
 },
 {
 "compressor": "miniz_oxide",
@@ -6454,8 +6454,8 @@
 "level": 6,
 "out_size": 3123421,
 "ratio": 0.0931,
-"compress_mbps": 95.56,
-"decompress_mbps": 999.0
+"compress_mbps": 96.44,
+"decompress_mbps": 1031.3
 },
 {
 "compressor": "miniz_oxide",
@@ -6464,8 +6464,8 @@
 "level": 7,
 "out_size": 3093778,
 "ratio": 0.0922,
-"compress_mbps": 70.47,
-"decompress_mbps": 971.07
+"compress_mbps": 70.89,
+"decompress_mbps": 1007.71
 },
 {
 "compressor": "miniz_oxide",
@@ -6474,8 +6474,8 @@
 "level": 8,
 "out_size": 3067318,
 "ratio": 0.0914,
-"compress_mbps": 50.0,
-"decompress_mbps": 1028.45
+"compress_mbps": 50.2,
+"decompress_mbps": 1045.13
 },
 {
 "compressor": "miniz_oxide",
@@ -6484,8 +6484,8 @@
 "level": 9,
 "out_size": 3050695,
 "ratio": 0.0909,
-"compress_mbps": 41.95,
-"decompress_mbps": 1034.29
+"compress_mbps": 42.16,
+"decompress_mbps": 1088.3
 },
 {
 "compressor": "miniz_oxide",
@@ -6494,8 +6494,8 @@
 "level": 1,
 "out_size": 3543611,
 "ratio": 0.576,
-"compress_mbps": 165.65,
-"decompress_mbps": 278.91
+"compress_mbps": 168.15,
+"decompress_mbps": 280.16
 },
 {
 "compressor": "miniz_oxide",
@@ -6504,8 +6504,8 @@
 "level": 2,
 "out_size": 3226818,
 "ratio": 0.5245,
-"compress_mbps": 86.5,
-"decompress_mbps": 286.55
+"compress_mbps": 86.2,
+"decompress_mbps": 294.03
 },
 {
 "compressor": "miniz_oxide",
@@ -6514,8 +6514,8 @@
 "level": 3,
 "out_size": 3144140,
 "ratio": 0.5111,
-"compress_mbps": 52.82,
-"decompress_mbps": 294.54
+"compress_mbps": 52.64,
+"decompress_mbps": 304.6
 },
 {
 "compressor": "miniz_oxide",
@@ -6524,8 +6524,8 @@
 "level": 4,
 "out_size": 3129833,
 "ratio": 0.5087,
-"compress_mbps": 51.57,
-"decompress_mbps": 323.92
+"compress_mbps": 51.69,
+"decompress_mbps": 333.32
 },
 {
 "compressor": "miniz_oxide",
@@ -6534,8 +6534,8 @@
 "level": 5,
 "out_size": 3114809,
 "ratio": 0.5063,
-"compress_mbps": 40.42,
-"decompress_mbps": 335.9
+"compress_mbps": 40.37,
+"decompress_mbps": 345.37
 },
 {
 "compressor": "miniz_oxide",
@@ -6544,8 +6544,8 @@
 "level": 6,
 "out_size": 3095705,
 "ratio": 0.5032,
-"compress_mbps": 25.14,
-"decompress_mbps": 341.7
+"compress_mbps": 25.12,
+"decompress_mbps": 350.62
 },
 {
 "compressor": "miniz_oxide",
@@ -6554,8 +6554,8 @@
 "level": 7,
 "out_size": 3090055,
 "ratio": 0.5023,
-"compress_mbps": 20.41,
-"decompress_mbps": 340.84
+"compress_mbps": 20.44,
+"decompress_mbps": 350.77
 },
 {
 "compressor": "miniz_oxide",
@@ -6565,7 +6565,7 @@
 "out_size": 3087665,
 "ratio": 0.5019,
 "compress_mbps": 17.39,
-"decompress_mbps": 346.63
+"decompress_mbps": 353.6
 },
 {
 "compressor": "miniz_oxide",
@@ -6574,8 +6574,8 @@
 "level": 9,
 "out_size": 3087158,
 "ratio": 0.5018,
-"compress_mbps": 16.31,
-"decompress_mbps": 345.97
+"compress_mbps": 16.34,
+"decompress_mbps": 354.26
 },
 {
 "compressor": "miniz_oxide",
@@ -6584,8 +6584,8 @@
 "level": 1,
 "out_size": 5419510,
 "ratio": 0.5373,
-"compress_mbps": 238.52,
-"decompress_mbps": 530.68
+"compress_mbps": 242.39,
+"decompress_mbps": 543.15
 },
 {
 "compressor": "miniz_oxide",
@@ -6594,8 +6594,8 @@
 "level": 2,
 "out_size": 3982547,
 "ratio": 0.3949,
-"compress_mbps": 122.93,
-"decompress_mbps": 547.08
+"compress_mbps": 122.94,
+"decompress_mbps": 563.6
 },
 {
 "compressor": "miniz_oxide",
@@ -6604,8 +6604,8 @@
 "level": 3,
 "out_size": 3806102,
 "ratio": 0.3774,
-"compress_mbps": 81.72,
-"decompress_mbps": 561.82
+"compress_mbps": 82.15,
+"decompress_mbps": 582.18
 },
 {
 "compressor": "miniz_oxide",
@@ -6614,8 +6614,8 @@
 "level": 4,
 "out_size": 3761477,
 "ratio": 0.373,
-"compress_mbps": 78.43,
-"decompress_mbps": 597.71
+"compress_mbps": 78.93,
+"decompress_mbps": 620.26
 },
 {
 "compressor": "miniz_oxide",
@@ -6624,8 +6624,8 @@
 "level": 5,
 "out_size": 3740298,
 "ratio": 0.3709,
-"compress_mbps": 67.35,
-"decompress_mbps": 596.99
+"compress_mbps": 67.42,
+"decompress_mbps": 622.75
 },
 {
 "compressor": "miniz_oxide",
@@ -6634,8 +6634,8 @@
 "level": 6,
 "out_size": 3686116,
 "ratio": 0.3655,
-"compress_mbps": 49.33,
-"decompress_mbps": 634.77
+"compress_mbps": 49.55,
+"decompress_mbps": 654.14
 },
 {
 "compressor": "miniz_oxide",
@@ -6644,8 +6644,8 @@
 "level": 7,
 "out_size": 3668442,
 "ratio": 0.3637,
-"compress_mbps": 38.67,
-"decompress_mbps": 648.55
+"compress_mbps": 38.83,
+"decompress_mbps": 665.71
 },
 {
 "compressor": "miniz_oxide",
@@ -6654,8 +6654,8 @@
 "level": 8,
 "out_size": 3665072,
 "ratio": 0.3634,
-"compress_mbps": 33.07,
-"decompress_mbps": 641.74
+"compress_mbps": 33.2,
+"decompress_mbps": 662.29
 },
 {
 "compressor": "miniz_oxide",
@@ -6664,8 +6664,8 @@
 "level": 9,
 "out_size": 3665057,
 "ratio": 0.3634,
-"compress_mbps": 32.97,
-"decompress_mbps": 644.3
+"compress_mbps": 33.11,
+"decompress_mbps": 660.9
 },
 {
 "compressor": "miniz_oxide",
@@ -6674,8 +6674,8 @@
 "level": 1,
 "out_size": 2842321,
 "ratio": 0.4289,
-"compress_mbps": 186.85,
-"decompress_mbps": 475.6
+"compress_mbps": 188.8,
+"decompress_mbps": 492.72
 },
 {
 "compressor": "miniz_oxide",
@@ -6684,8 +6684,8 @@
 "level": 2,
 "out_size": 2232180,
 "ratio": 0.3368,
-"compress_mbps": 151.74,
-"decompress_mbps": 514.0
+"compress_mbps": 152.31,
+"decompress_mbps": 532.97
 },
 {
 "compressor": "miniz_oxide",
@@ -6694,8 +6694,8 @@
 "level": 3,
 "out_size": 2003056,
 "ratio": 0.3022,
-"compress_mbps": 81.96,
-"decompress_mbps": 551.23
+"compress_mbps": 82.28,
+"decompress_mbps": 572.07
 },
 {
 "compressor": "miniz_oxide",
@@ -6704,8 +6704,8 @@
 "level": 4,
 "out_size": 1985375,
 "ratio": 0.2996,
-"compress_mbps": 74.08,
-"decompress_mbps": 565.83
+"compress_mbps": 74.23,
+"decompress_mbps": 575.99
 },
 {
 "compressor": "miniz_oxide",
@@ -6714,8 +6714,8 @@
 "level": 5,
 "out_size": 1933775,
 "ratio": 0.2918,
-"compress_mbps": 51.9,
-"decompress_mbps": 540.96
+"compress_mbps": 52.06,
+"decompress_mbps": 551.2
 },
 {
 "compressor": "miniz_oxide",
@@ -6724,8 +6724,8 @@
 "level": 6,
 "out_size": 1858103,
 "ratio": 0.2804,
-"compress_mbps": 21.98,
-"decompress_mbps": 546.37
+"compress_mbps": 22.05,
+"decompress_mbps": 556.66
 },
 {
 "compressor": "miniz_oxide",
@@ -6734,8 +6734,8 @@
 "level": 7,
 "out_size": 1840414,
 "ratio": 0.2777,
-"compress_mbps": 15.08,
-"decompress_mbps": 541.87
+"compress_mbps": 15.14,
+"decompress_mbps": 559.48
 },
 {
 "compressor": "miniz_oxide",
@@ -6744,8 +6744,8 @@
 "level": 8,
 "out_size": 1831679,
 "ratio": 0.2764,
-"compress_mbps": 11.65,
-"decompress_mbps": 534.0
+"compress_mbps": 11.73,
+"decompress_mbps": 529.05
 },
 {
 "compressor": "miniz_oxide",
@@ -6754,8 +6754,8 @@
 "level": 9,
 "out_size": 1827137,
 "ratio": 0.2757,
-"compress_mbps": 10.13,
-"decompress_mbps": 543.76
+"compress_mbps": 10.16,
+"decompress_mbps": 556.73
 },
 {
 "compressor": "miniz_oxide",
@@ -6764,8 +6764,8 @@
 "level": 1,
 "out_size": 7089759,
 "ratio": 0.3281,
-"compress_mbps": 286.42,
-"decompress_mbps": 555.98
+"compress_mbps": 287.53,
+"decompress_mbps": 549.07
 },
 {
 "compressor": "miniz_oxide",
@@ -6774,8 +6774,8 @@
 "level": 2,
 "out_size": 5966231,
 "ratio": 0.2761,
-"compress_mbps": 173.68,
-"decompress_mbps": 620.8
+"compress_mbps": 173.93,
+"decompress_mbps": 644.51
 },
 {
 "compressor": "miniz_oxide",
@@ -6784,8 +6784,8 @@
 "level": 3,
 "out_size": 5611838,
 "ratio": 0.2597,
-"compress_mbps": 111.31,
-"decompress_mbps": 648.6
+"compress_mbps": 111.63,
+"decompress_mbps": 669.29
 },
 {
 "compressor": "miniz_oxide",
@@ -6794,8 +6794,8 @@
 "level": 4,
 "out_size": 5535436,
 "ratio": 0.2562,
-"compress_mbps": 105.34,
-"decompress_mbps": 670.88
+"compress_mbps": 105.67,
+"decompress_mbps": 690.05
 },
 {
 "compressor": "miniz_oxide",
@@ -6804,8 +6804,8 @@
 "level": 5,
 "out_size": 5480971,
 "ratio": 0.2537,
-"compress_mbps": 81.31,
-"decompress_mbps": 679.9
+"compress_mbps": 81.48,
+"decompress_mbps": 698.94
 },
 {
 "compressor": "miniz_oxide",
@@ -6814,8 +6814,8 @@
 "level": 6,
 "out_size": 5437556,
 "ratio": 0.2517,
-"compress_mbps": 49.49,
-"decompress_mbps": 695.34
+"compress_mbps": 49.59,
+"decompress_mbps": 712.63
 },
 {
 "compressor": "miniz_oxide",
@@ -6824,8 +6824,8 @@
 "level": 7,
 "out_size": 5432108,
 "ratio": 0.2514,
-"compress_mbps": 40.43,
-"decompress_mbps": 698.02
+"compress_mbps": 40.49,
+"decompress_mbps": 711.25
 },
 {
 "compressor": "miniz_oxide",
@@ -6834,8 +6834,8 @@
 "level": 8,
 "out_size": 5428571,
 "ratio": 0.2512,
-"compress_mbps": 33.63,
-"decompress_mbps": 704.91
+"compress_mbps": 33.69,
+"decompress_mbps": 720.29
 },
 {
 "compressor": "miniz_oxide",
@@ -6844,8 +6844,8 @@
 "level": 9,
 "out_size": 5425526,
 "ratio": 0.2511,
-"compress_mbps": 30.46,
-"decompress_mbps": 702.22
+"compress_mbps": 30.54,
+"decompress_mbps": 719.41
 },
 {
 "compressor": "miniz_oxide",
@@ -6854,8 +6854,8 @@
 "level": 1,
 "out_size": 5900800,
 "ratio": 0.8137,
-"compress_mbps": 185.19,
-"decompress_mbps": 325.47
+"compress_mbps": 187.0,
+"decompress_mbps": 333.33
 },
 {
 "compressor": "miniz_oxide",
@@ -6864,8 +6864,8 @@
 "level": 2,
 "out_size": 5523611,
 "ratio": 0.7617,
-"compress_mbps": 68.99,
-"decompress_mbps": 338.67
+"compress_mbps": 69.17,
+"decompress_mbps": 346.67
 },
 {
 "compressor": "miniz_oxide",
@@ -6874,8 +6874,8 @@
 "level": 3,
 "out_size": 5393086,
 "ratio": 0.7437,
-"compress_mbps": 40.2,
-"decompress_mbps": 347.87
+"compress_mbps": 40.35,
+"decompress_mbps": 356.58
 },
 {
 "compressor": "miniz_oxide",
@@ -6884,8 +6884,8 @@
 "level": 4,
 "out_size": 5401582,
 "ratio": 0.7448,
-"compress_mbps": 40.52,
-"decompress_mbps": 365.57
+"compress_mbps": 40.67,
+"decompress_mbps": 372.41
 },
 {
 "compressor": "miniz_oxide",
@@ -6894,8 +6894,8 @@
 "level": 5,
 "out_size": 5371274,
 "ratio": 0.7407,
-"compress_mbps": 31.11,
-"decompress_mbps": 356.55
+"compress_mbps": 31.28,
+"decompress_mbps": 363.5
 },
 {
 "compressor": "miniz_oxide",
@@ -6904,8 +6904,8 @@
 "level": 6,
 "out_size": 5330096,
 "ratio": 0.735,
-"compress_mbps": 20.76,
-"decompress_mbps": 363.28
+"compress_mbps": 20.81,
+"decompress_mbps": 369.42
 },
 {
 "compressor": "miniz_oxide",
@@ -6914,8 +6914,8 @@
 "level": 7,
 "out_size": 5325437,
 "ratio": 0.7343,
-"compress_mbps": 18.98,
-"decompress_mbps": 363.74
+"compress_mbps": 19.02,
+"decompress_mbps": 372.35
 },
 {
 "compressor": "miniz_oxide",
@@ -6924,8 +6924,8 @@
 "level": 8,
 "out_size": 5323934,
 "ratio": 0.7341,
-"compress_mbps": 18.03,
-"decompress_mbps": 363.6
+"compress_mbps": 18.08,
+"decompress_mbps": 369.5
 },
 {
 "compressor": "miniz_oxide",
@@ -6934,8 +6934,8 @@
 "level": 9,
 "out_size": 5323621,
 "ratio": 0.7341,
-"compress_mbps": 17.73,
-"decompress_mbps": 363.45
+"compress_mbps": 17.77,
+"decompress_mbps": 370.97
 },
 {
 "compressor": "miniz_oxide",
@@ -6944,8 +6944,8 @@
 "level": 1,
 "out_size": 17587173,
 "ratio": 0.4242,
-"compress_mbps": 180.5,
-"decompress_mbps": 373.84
+"compress_mbps": 182.23,
+"decompress_mbps": 386.88
 },
 {
 "compressor": "miniz_oxide",
@@ -6954,8 +6954,8 @@
 "level": 2,
 "out_size": 14171707,
 "ratio": 0.3418,
-"compress_mbps": 148.44,
-"decompress_mbps": 406.39
+"compress_mbps": 149.07,
+"decompress_mbps": 423.73
 },
 {
 "compressor": "miniz_oxide",
@@ -6964,8 +6964,8 @@
 "level": 3,
 "out_size": 12774851,
 "ratio": 0.3081,
-"compress_mbps": 85.79,
-"decompress_mbps": 436.74
+"compress_mbps": 85.97,
+"decompress_mbps": 455.08
 },
 {
 "compressor": "miniz_oxide",
@@ -6974,8 +6974,8 @@
 "level": 4,
 "out_size": 12612554,
 "ratio": 0.3042,
-"compress_mbps": 75.9,
-"decompress_mbps": 434.06
+"compress_mbps": 76.45,
+"decompress_mbps": 450.29
 },
 {
 "compressor": "miniz_oxide",
@@ -6984,8 +6984,8 @@
 "level": 5,
 "out_size": 12392339,
 "ratio": 0.2989,
-"compress_mbps": 57.89,
-"decompress_mbps": 442.61
+"compress_mbps": 58.11,
+"decompress_mbps": 463.39
 },
 {
 "compressor": "miniz_oxide",
@@ -6994,8 +6994,8 @@
 "level": 6,
 "out_size": 12158314,
 "ratio": 0.2933,
-"compress_mbps": 34.34,
-"decompress_mbps": 455.97
+"compress_mbps": 34.38,
+"decompress_mbps": 469.88
 },
 {
 "compressor": "miniz_oxide",
@@ -7004,8 +7004,8 @@
 "level": 7,
 "out_size": 12107840,
 "ratio": 0.292,
-"compress_mbps": 27.55,
-"decompress_mbps": 455.69
+"compress_mbps": 27.64,
+"decompress_mbps": 468.69
 },
 {
 "compressor": "miniz_oxide",
@@ -7014,8 +7014,8 @@
 "level": 8,
 "out_size": 12081311,
 "ratio": 0.2914,
-"compress_mbps": 22.79,
-"decompress_mbps": 458.8
+"compress_mbps": 22.87,
+"decompress_mbps": 476.84
 },
 {
 "compressor": "miniz_oxide",
@@ -7024,8 +7024,8 @@
 "level": 9,
 "out_size": 12081011,
 "ratio": 0.2914,
-"compress_mbps": 22.7,
-"decompress_mbps": 457.58
+"compress_mbps": 22.79,
+"decompress_mbps": 477.79
 },
 {
 "compressor": "miniz_oxide",
@@ -7034,8 +7034,8 @@
 "level": 1,
 "out_size": 6527324,
 "ratio": 0.7703,
-"compress_mbps": 236.69,
-"decompress_mbps": 324.88
+"compress_mbps": 237.95,
+"decompress_mbps": 330.9
 },
 {
 "compressor": "miniz_oxide",
@@ -7044,8 +7044,8 @@
 "level": 2,
 "out_size": 6051483,
 "ratio": 0.7141,
-"compress_mbps": 74.25,
-"decompress_mbps": 320.63
+"compress_mbps": 75.21,
+"decompress_mbps": 334.18
 },
 {
 "compressor": "miniz_oxide",
@@ -7054,8 +7054,8 @@
 "level": 3,
 "out_size": 6010123,
 "ratio": 0.7092,
-"compress_mbps": 51.61,
-"decompress_mbps": 326.32
+"compress_mbps": 52.11,
+"decompress_mbps": 335.05
 },
 {
 "compressor": "miniz_oxide",
@@ -7064,8 +7064,8 @@
 "level": 4,
 "out_size": 6024815,
 "ratio": 0.711,
-"compress_mbps": 44.14,
-"decompress_mbps": 277.6
+"compress_mbps": 44.4,
+"decompress_mbps": 287.65
 },
 {
 "compressor": "miniz_oxide",
@@ -7074,8 +7074,8 @@
 "level": 5,
 "out_size": 6005181,
 "ratio": 0.7086,
-"compress_mbps": 40.04,
-"decompress_mbps": 283.6
+"compress_mbps": 40.36,
+"decompress_mbps": 294.61
 },
 {
 "compressor": "miniz_oxide",
@@ -7084,8 +7084,8 @@
 "level": 6,
 "out_size": 5997508,
 "ratio": 0.7077,
-"compress_mbps": 37.63,
-"decompress_mbps": 289.26
+"compress_mbps": 37.82,
+"decompress_mbps": 299.96
 },
 {
 "compressor": "miniz_oxide",
@@ -7094,8 +7094,8 @@
 "level": 7,
 "out_size": 5997403,
 "ratio": 0.7077,
-"compress_mbps": 37.54,
-"decompress_mbps": 288.85
+"compress_mbps": 37.83,
+"decompress_mbps": 299.11
 },
 {
 "compressor": "miniz_oxide",
@@ -7104,8 +7104,8 @@
 "level": 8,
 "out_size": 5997403,
 "ratio": 0.7077,
-"compress_mbps": 37.53,
-"decompress_mbps": 288.55
+"compress_mbps": 37.88,
+"decompress_mbps": 298.22
 },
 {
 "compressor": "miniz_oxide",
@@ -7114,8 +7114,8 @@
 "level": 9,
 "out_size": 5997403,
 "ratio": 0.7077,
-"compress_mbps": 37.49,
-"decompress_mbps": 288.95
+"compress_mbps": 37.82,
+"decompress_mbps": 299.23
 },
 {
 "compressor": "miniz_oxide",
@@ -7124,8 +7124,8 @@
 "level": 1,
 "out_size": 1147652,
 "ratio": 0.2147,
-"compress_mbps": 385.07,
-"decompress_mbps": 825.7
+"compress_mbps": 384.13,
+"decompress_mbps": 862.85
 },
 {
 "compressor": "miniz_oxide",
@@ -7134,8 +7134,8 @@
 "level": 2,
 "out_size": 919639,
 "ratio": 0.172,
-"compress_mbps": 260.1,
-"decompress_mbps": 944.21
+"compress_mbps": 261.19,
+"decompress_mbps": 982.74
 },
 {
 "compressor": "miniz_oxide",
@@ -7144,8 +7144,8 @@
 "level": 3,
 "out_size": 752341,
 "ratio": 0.1407,
-"compress_mbps": 166.29,
-"decompress_mbps": 1046.71
+"compress_mbps": 167.42,
+"decompress_mbps": 1085.11
 },
 {
 "compressor": "miniz_oxide",
@@ -7154,8 +7154,8 @@
 "level": 4,
 "out_size": 735537,
 "ratio": 0.1376,
-"compress_mbps": 160.33,
-"decompress_mbps": 1027.47
+"compress_mbps": 161.73,
+"decompress_mbps": 1053.95
 },
 {
 "compressor": "miniz_oxide",
@@ -7164,8 +7164,8 @@
 "level": 5,
 "out_size": 706789,
 "ratio": 0.1322,
-"compress_mbps": 122.95,
-"decompress_mbps": 1102.42
+"compress_mbps": 123.69,
+"decompress_mbps": 1149.26
 },
 {
 "compressor": "miniz_oxide",
@@ -7174,8 +7174,8 @@
 "level": 6,
 "out_size": 676279,
 "ratio": 0.1265,
-"compress_mbps": 69.28,
-"decompress_mbps": 1203.23
+"compress_mbps": 69.66,
+"decompress_mbps": 1240.08
 },
 {
 "compressor": "miniz_oxide",
@@ -7184,8 +7184,8 @@
 "level": 7,
 "out_size": 668772,
 "ratio": 0.1251,
-"compress_mbps": 55.86,
-"decompress_mbps": 1203.45
+"compress_mbps": 56.09,
+"decompress_mbps": 1249.6
 },
 {
 "compressor": "miniz_oxide",
@@ -7194,8 +7194,8 @@
 "level": 8,
 "out_size": 665340,
 "ratio": 0.1245,
-"compress_mbps": 47.32,
-"decompress_mbps": 1169.03
+"compress_mbps": 47.65,
+"decompress_mbps": 1211.14
 },
 {
 "compressor": "miniz_oxide",
@@ -7204,8 +7204,8 @@
 "level": 9,
 "out_size": 664273,
 "ratio": 0.1243,
-"compress_mbps": 45.74,
-"decompress_mbps": 1182.28
+"compress_mbps": 45.9,
+"decompress_mbps": 1247.51
 },
 {
 "compressor": "libdeflate",
@@ -7214,8 +7214,8 @@
 "level": 1,
 "out_size": 4217525,
 "ratio": 0.4138,
-"compress_mbps": 238.58,
-"decompress_mbps": 774.63
+"compress_mbps": 243.59,
+"decompress_mbps": 795.98
 },
 {
 "compressor": "libdeflate",
@@ -7224,8 +7224,8 @@
 "level": 2,
 "out_size": 4053259,
 "ratio": 0.3977,
-"compress_mbps": 168.47,
-"decompress_mbps": 858.34
+"compress_mbps": 170.2,
+"decompress_mbps": 895.08
 },
 {
 "compressor": "libdeflate",
@@ -7234,8 +7234,8 @@
 "level": 3,
 "out_size": 3989875,
 "ratio": 0.3915,
-"compress_mbps": 138.74,
-"decompress_mbps": 909.13
+"compress_mbps": 139.88,
+"decompress_mbps": 935.58
 },
 {
 "compressor": "libdeflate",
@@ -7244,8 +7244,8 @@
 "level": 4,
 "out_size": 3972869,
 "ratio": 0.3898,
-"compress_mbps": 126.8,
-"decompress_mbps": 812.77
+"compress_mbps": 127.92,
+"decompress_mbps": 847.71
 },
 {
 "compressor": "libdeflate",
@@ -7254,8 +7254,8 @@
 "level": 5,
 "out_size": 3894026,
 "ratio": 0.3821,
-"compress_mbps": 98.53,
-"decompress_mbps": 765.78
+"compress_mbps": 99.07,
+"decompress_mbps": 807.23
 },
 {
 "compressor": "libdeflate",
@@ -7264,8 +7264,8 @@
 "level": 6,
 "out_size": 3859436,
 "ratio": 0.3787,
-"compress_mbps": 74.9,
-"decompress_mbps": 789.64
+"compress_mbps": 75.61,
+"decompress_mbps": 836.86
 },
 {
 "compressor": "libdeflate",
@@ -7274,8 +7274,8 @@
 "level": 7,
 "out_size": 3837515,
 "ratio": 0.3765,
-"compress_mbps": 55.3,
-"decompress_mbps": 794.86
+"compress_mbps": 55.76,
+"decompress_mbps": 818.1
 },
 {
 "compressor": "libdeflate",
@@ -7284,8 +7284,8 @@
 "level": 8,
 "out_size": 3811467,
 "ratio": 0.374,
-"compress_mbps": 35.91,
-"decompress_mbps": 775.79
+"compress_mbps": 36.01,
+"decompress_mbps": 819.21
 },
 {
 "compressor": "libdeflate",
@@ -7294,8 +7294,8 @@
 "level": 9,
 "out_size": 3810354,
 "ratio": 0.3738,
-"compress_mbps": 32.38,
-"decompress_mbps": 808.76
+"compress_mbps": 32.78,
+"decompress_mbps": 811.67
 },
 {
 "compressor": "libdeflate",
@@ -7304,8 +7304,8 @@
 "level": 1,
 "out_size": 20192961,
 "ratio": 0.3942,
-"compress_mbps": 240.89,
-"decompress_mbps": 691.3
+"compress_mbps": 241.63,
+"decompress_mbps": 691.88
 },
 {
 "compressor": "libdeflate",
@@ -7314,8 +7314,8 @@
 "level": 2,
 "out_size": 19374226,
 "ratio": 0.3783,
-"compress_mbps": 186.23,
-"decompress_mbps": 713.89
+"compress_mbps": 186.41,
+"decompress_mbps": 728.31
 },
 {
 "compressor": "libdeflate",
@@ -7324,8 +7324,8 @@
 "level": 3,
 "out_size": 19234937,
 "ratio": 0.3755,
-"compress_mbps": 173.43,
-"decompress_mbps": 732.81
+"compress_mbps": 173.63,
+"decompress_mbps": 741.76
 },
 {
 "compressor": "libdeflate",
@@ -7334,8 +7334,8 @@
 "level": 4,
 "out_size": 19145385,
 "ratio": 0.3738,
-"compress_mbps": 162.58,
-"decompress_mbps": 727.13
+"compress_mbps": 161.79,
+"decompress_mbps": 736.97
 },
 {
 "compressor": "libdeflate",
@@ -7344,8 +7344,8 @@
 "level": 5,
 "out_size": 18878875,
 "ratio": 0.3686,
-"compress_mbps": 143.22,
-"decompress_mbps": 677.53
+"compress_mbps": 144.12,
+"decompress_mbps": 756.99
 },
 {
 "compressor": "libdeflate",
@@ -7354,8 +7354,8 @@
 "level": 6,
 "out_size": 18805391,
 "ratio": 0.3671,
-"compress_mbps": 120.24,
-"decompress_mbps": 757.33
+"compress_mbps": 119.2,
+"decompress_mbps": 768.38
 },
 {
 "compressor": "libdeflate",
@@ -7364,8 +7364,8 @@
 "level": 7,
 "out_size": 18749947,
 "ratio": 0.3661,
-"compress_mbps": 87.78,
-"decompress_mbps": 757.25
+"compress_mbps": 88.03,
+"decompress_mbps": 774.18
 },
 {
 "compressor": "libdeflate",
@@ -7374,8 +7374,8 @@
 "level": 8,
 "out_size": 18718540,
 "ratio": 0.3655,
-"compress_mbps": 47.41,
-"decompress_mbps": 758.49
+"compress_mbps": 47.56,
+"decompress_mbps": 776.25
 },
 {
 "compressor": "libdeflate",
@@ -7384,8 +7384,8 @@
 "level": 9,
 "out_size": 18713659,
 "ratio": 0.3654,
-"compress_mbps": 33.56,
-"decompress_mbps": 757.57
+"compress_mbps": 33.69,
+"decompress_mbps": 771.26
 },
 {
 "compressor": "libdeflate",
@@ -7394,8 +7394,8 @@
 "level": 1,
 "out_size": 3740775,
 "ratio": 0.3752,
-"compress_mbps": 292.24,
-"decompress_mbps": 768.0
+"compress_mbps": 293.48,
+"decompress_mbps": 868.65
 },
 {
 "compressor": "libdeflate",
@@ -7404,8 +7404,8 @@
 "level": 2,
 "out_size": 3707407,
 "ratio": 0.3718,
-"compress_mbps": 213.07,
-"decompress_mbps": 864.07
+"compress_mbps": 214.93,
+"decompress_mbps": 895.66
 },
 {
 "compressor": "libdeflate",
@@ -7414,8 +7414,8 @@
 "level": 3,
 "out_size": 3672389,
 "ratio": 0.3683,
-"compress_mbps": 182.86,
-"decompress_mbps": 916.57
+"compress_mbps": 184.55,
+"decompress_mbps": 948.09
 },
 {
 "compressor": "libdeflate",
@@ -7424,8 +7424,8 @@
 "level": 4,
 "out_size": 3660011,
 "ratio": 0.3671,
-"compress_mbps": 169.9,
-"decompress_mbps": 832.61
+"compress_mbps": 170.49,
+"decompress_mbps": 863.62
 },
 {
 "compressor": "libdeflate",
@@ -7434,8 +7434,8 @@
 "level": 5,
 "out_size": 3664245,
 "ratio": 0.3675,
-"compress_mbps": 140.03,
-"decompress_mbps": 793.62
+"compress_mbps": 141.76,
+"decompress_mbps": 824.31
 },
 {
 "compressor": "libdeflate",
@@ -7444,8 +7444,8 @@
 "level": 6,
 "out_size": 3648644,
 "ratio": 0.3659,
-"compress_mbps": 106.18,
-"decompress_mbps": 830.91
+"compress_mbps": 106.97,
+"decompress_mbps": 840.68
 },
 {
 "compressor": "libdeflate",
@@ -7454,8 +7454,8 @@
 "level": 7,
 "out_size": 3635323,
 "ratio": 0.3646,
-"compress_mbps": 68.18,
-"decompress_mbps": 828.28
+"compress_mbps": 68.77,
+"decompress_mbps": 857.87
 },
 {
 "compressor": "libdeflate",
@@ -7464,8 +7464,8 @@
 "level": 8,
 "out_size": 3624778,
 "ratio": 0.3635,
-"compress_mbps": 42.91,
-"decompress_mbps": 849.49
+"compress_mbps": 43.07,
+"decompress_mbps": 879.58
 },
 {
 "compressor": "libdeflate",
@@ -7474,8 +7474,8 @@
 "level": 9,
 "out_size": 3625176,
 "ratio": 0.3636,
-"compress_mbps": 38.73,
-"decompress_mbps": 845.04
+"compress_mbps": 38.9,
+"decompress_mbps": 873.25
 },
 {
 "compressor": "libdeflate",
@@ -7484,8 +7484,8 @@
 "level": 1,
 "out_size": 3837577,
 "ratio": 0.1144,
-"compress_mbps": 605.41,
-"decompress_mbps": 1496.72
+"compress_mbps": 608.67,
+"decompress_mbps": 1536.6
 },
 {
 "compressor": "libdeflate",
@@ -7494,8 +7494,8 @@
 "level": 2,
 "out_size": 3714632,
 "ratio": 0.1107,
-"compress_mbps": 462.56,
-"decompress_mbps": 1680.7
+"compress_mbps": 465.03,
+"decompress_mbps": 1786.1
 },
 {
 "compressor": "libdeflate",
@@ -7504,8 +7504,8 @@
 "level": 3,
 "out_size": 3599455,
 "ratio": 0.1073,
-"compress_mbps": 424.96,
-"decompress_mbps": 1767.64
+"compress_mbps": 428.65,
+"decompress_mbps": 1912.87
 },
 {
 "compressor": "libdeflate",
@@ -7514,8 +7514,8 @@
 "level": 4,
 "out_size": 3431843,
 "ratio": 0.1023,
-"compress_mbps": 388.55,
-"decompress_mbps": 1760.65
+"compress_mbps": 391.23,
+"decompress_mbps": 1786.35
 },
 {
 "compressor": "libdeflate",
@@ -7524,8 +7524,8 @@
 "level": 5,
 "out_size": 3268188,
 "ratio": 0.0974,
-"compress_mbps": 346.98,
-"decompress_mbps": 1769.52
+"compress_mbps": 348.92,
+"decompress_mbps": 1799.16
 },
 {
 "compressor": "libdeflate",
@@ -7534,8 +7534,8 @@
 "level": 6,
 "out_size": 3091741,
 "ratio": 0.0921,
-"compress_mbps": 263.29,
-"decompress_mbps": 1828.71
+"compress_mbps": 264.09,
+"decompress_mbps": 1862.61
 },
 {
 "compressor": "libdeflate",
@@ -7544,8 +7544,8 @@
 "level": 7,
 "out_size": 3032499,
 "ratio": 0.0904,
-"compress_mbps": 185.39,
-"decompress_mbps": 1771.44
+"compress_mbps": 178.34,
+"decompress_mbps": 1805.59
 },
 {
 "compressor": "libdeflate",
@@ -7554,8 +7554,8 @@
 "level": 8,
 "out_size": 2949097,
 "ratio": 0.0879,
-"compress_mbps": 96.6,
-"decompress_mbps": 1753.7
+"compress_mbps": 97.6,
+"decompress_mbps": 1783.61
 },
 {
 "compressor": "libdeflate",
@@ -7564,8 +7564,8 @@
 "level": 9,
 "out_size": 2925243,
 "ratio": 0.0872,
-"compress_mbps": 68.93,
-"decompress_mbps": 1729.85
+"compress_mbps": 69.36,
+"decompress_mbps": 1808.56
 },
 {
 "compressor": "libdeflate",
@@ -7574,8 +7574,8 @@
 "level": 1,
 "out_size": 3275124,
 "ratio": 0.5324,
-"compress_mbps": 164.9,
-"decompress_mbps": 468.52
+"compress_mbps": 166.47,
+"decompress_mbps": 473.56
 },
 {
 "compressor": "libdeflate",
@@ -7584,8 +7584,8 @@
 "level": 2,
 "out_size": 3150806,
 "ratio": 0.5121,
-"compress_mbps": 129.44,
-"decompress_mbps": 506.38
+"compress_mbps": 128.41,
+"decompress_mbps": 517.64
 },
 {
 "compressor": "libdeflate",
@@ -7594,8 +7594,8 @@
 "level": 3,
 "out_size": 3137061,
 "ratio": 0.5099,
-"compress_mbps": 121.5,
-"decompress_mbps": 531.06
+"compress_mbps": 120.42,
+"decompress_mbps": 528.41
 },
 {
 "compressor": "libdeflate",
@@ -7604,8 +7604,8 @@
 "level": 4,
 "out_size": 3129676,
 "ratio": 0.5087,
-"compress_mbps": 117.38,
-"decompress_mbps": 542.86
+"compress_mbps": 116.91,
+"decompress_mbps": 553.18
 },
 {
 "compressor": "libdeflate",
@@ -7614,8 +7614,8 @@
 "level": 5,
 "out_size": 3079277,
 "ratio": 0.5005,
-"compress_mbps": 98.94,
-"decompress_mbps": 558.82
+"compress_mbps": 99.65,
+"decompress_mbps": 571.01
 },
 {
 "compressor": "libdeflate",
@@ -7624,8 +7624,8 @@
 "level": 6,
 "out_size": 3072378,
 "ratio": 0.4994,
-"compress_mbps": 88.55,
-"decompress_mbps": 566.02
+"compress_mbps": 88.89,
+"decompress_mbps": 573.8
 },
 {
 "compressor": "libdeflate",
@@ -7634,8 +7634,8 @@
 "level": 7,
 "out_size": 3068123,
 "ratio": 0.4987,
-"compress_mbps": 75.68,
-"decompress_mbps": 563.14
+"compress_mbps": 76.0,
+"decompress_mbps": 573.65
 },
 {
 "compressor": "libdeflate",
@@ -7644,8 +7644,8 @@
 "level": 8,
 "out_size": 3067299,
 "ratio": 0.4986,
-"compress_mbps": 55.26,
-"decompress_mbps": 570.84
+"compress_mbps": 55.42,
+"decompress_mbps": 554.03
 },
 {
 "compressor": "libdeflate",
@@ -7654,8 +7654,8 @@
 "level": 9,
 "out_size": 3066968,
 "ratio": 0.4985,
-"compress_mbps": 49.89,
-"decompress_mbps": 555.16
+"compress_mbps": 49.99,
+"decompress_mbps": 569.15
 },
 {
 "compressor": "libdeflate",
@@ -7664,8 +7664,8 @@
 "level": 1,
 "out_size": 3868663,
 "ratio": 0.3836,
-"compress_mbps": 285.17,
-"decompress_mbps": 798.37
+"compress_mbps": 288.08,
+"decompress_mbps": 892.74
 },
 {
 "compressor": "libdeflate",
@@ -7674,8 +7674,8 @@
 "level": 2,
 "out_size": 3839158,
 "ratio": 0.3807,
-"compress_mbps": 210.87,
-"decompress_mbps": 896.26
+"compress_mbps": 213.72,
+"decompress_mbps": 914.92
 },
 {
 "compressor": "libdeflate",
@@ -7684,8 +7684,8 @@
 "level": 3,
 "out_size": 3818964,
 "ratio": 0.3787,
-"compress_mbps": 195.03,
-"decompress_mbps": 938.21
+"compress_mbps": 197.09,
+"decompress_mbps": 930.83
 },
 {
 "compressor": "libdeflate",
@@ -7694,8 +7694,8 @@
 "level": 4,
 "out_size": 3789325,
 "ratio": 0.3757,
-"compress_mbps": 177.54,
-"decompress_mbps": 954.54
+"compress_mbps": 180.61,
+"decompress_mbps": 979.71
 },
 {
 "compressor": "libdeflate",
@@ -7704,8 +7704,8 @@
 "level": 5,
 "out_size": 3666476,
 "ratio": 0.3635,
-"compress_mbps": 157.06,
-"decompress_mbps": 945.45
+"compress_mbps": 158.45,
+"decompress_mbps": 982.55
 },
 {
 "compressor": "libdeflate",
@@ -7714,8 +7714,8 @@
 "level": 6,
 "out_size": 3660266,
 "ratio": 0.3629,
-"compress_mbps": 141.81,
-"decompress_mbps": 988.06
+"compress_mbps": 142.58,
+"decompress_mbps": 1018.98
 },
 {
 "compressor": "libdeflate",
@@ -7724,8 +7724,8 @@
 "level": 7,
 "out_size": 3659491,
 "ratio": 0.3628,
-"compress_mbps": 134.57,
-"decompress_mbps": 956.62
+"compress_mbps": 135.2,
+"decompress_mbps": 1024.5
 },
 {
 "compressor": "libdeflate",
@@ -7734,8 +7734,8 @@
 "level": 8,
 "out_size": 3654863,
 "ratio": 0.3624,
-"compress_mbps": 114.01,
-"decompress_mbps": 974.24
+"compress_mbps": 115.43,
+"decompress_mbps": 1033.18
 },
 {
 "compressor": "libdeflate",
@@ -7744,8 +7744,8 @@
 "level": 9,
 "out_size": 3654860,
 "ratio": 0.3624,
-"compress_mbps": 114.46,
-"decompress_mbps": 976.58
+"compress_mbps": 115.4,
+"decompress_mbps": 1013.57
 },
 {
 "compressor": "libdeflate",
@@ -7754,8 +7754,8 @@
 "level": 1,
 "out_size": 2197055,
 "ratio": 0.3315,
-"compress_mbps": 299.67,
-"decompress_mbps": 998.3
+"compress_mbps": 301.03,
+"decompress_mbps": 1002.39
 },
 {
 "compressor": "libdeflate",
@@ -7764,8 +7764,8 @@
 "level": 2,
 "out_size": 2082309,
 "ratio": 0.3142,
-"compress_mbps": 212.41,
-"decompress_mbps": 1074.09
+"compress_mbps": 214.55,
+"decompress_mbps": 1136.41
 },
 {
 "compressor": "libdeflate",
@@ -7774,8 +7774,8 @@
 "level": 3,
 "out_size": 2021047,
 "ratio": 0.305,
-"compress_mbps": 177.45,
-"decompress_mbps": 1202.29
+"compress_mbps": 178.28,
+"decompress_mbps": 1246.32
 },
 {
 "compressor": "libdeflate",
@@ -7784,8 +7784,8 @@
 "level": 4,
 "out_size": 1990952,
 "ratio": 0.3004,
-"compress_mbps": 157.71,
-"decompress_mbps": 1103.11
+"compress_mbps": 158.76,
+"decompress_mbps": 1159.7
 },
 {
 "compressor": "libdeflate",
@@ -7794,8 +7794,8 @@
 "level": 5,
 "out_size": 1921113,
 "ratio": 0.2899,
-"compress_mbps": 126.82,
-"decompress_mbps": 1027.98
+"compress_mbps": 128.12,
+"decompress_mbps": 1065.36
 },
 {
 "compressor": "libdeflate",
@@ -7804,8 +7804,8 @@
 "level": 6,
 "out_size": 1876257,
 "ratio": 0.2831,
-"compress_mbps": 86.63,
-"decompress_mbps": 1056.64
+"compress_mbps": 87.45,
+"decompress_mbps": 1089.6
 },
 {
 "compressor": "libdeflate",
@@ -7814,8 +7814,8 @@
 "level": 7,
 "out_size": 1832695,
 "ratio": 0.2765,
-"compress_mbps": 46.52,
-"decompress_mbps": 1064.64
+"compress_mbps": 46.82,
+"decompress_mbps": 1106.58
 },
 {
 "compressor": "libdeflate",
@@ -7824,8 +7824,8 @@
 "level": 8,
 "out_size": 1809967,
 "ratio": 0.2731,
-"compress_mbps": 24.23,
-"decompress_mbps": 1054.03
+"compress_mbps": 24.36,
+"decompress_mbps": 1089.68
 },
 {
 "compressor": "libdeflate",
@@ -7834,8 +7834,8 @@
 "level": 9,
 "out_size": 1806374,
 "ratio": 0.2726,
-"compress_mbps": 19.85,
-"decompress_mbps": 1027.55
+"compress_mbps": 19.91,
+"decompress_mbps": 1040.19
 },
 {
 "compressor": "libdeflate",
@@ -7844,8 +7844,8 @@
 "level": 1,
 "out_size": 5866517,
 "ratio": 0.2715,
-"compress_mbps": 337.5,
-"decompress_mbps": 987.53
+"compress_mbps": 339.5,
+"decompress_mbps": 918.88
 },
 {
 "compressor": "libdeflate",
@@ -7854,8 +7854,8 @@
 "level": 2,
 "out_size": 5695942,
 "ratio": 0.2636,
-"compress_mbps": 256.94,
-"decompress_mbps": 1071.13
+"compress_mbps": 258.44,
+"decompress_mbps": 1072.83
 },
 {
 "compressor": "libdeflate",
@@ -7864,8 +7864,8 @@
 "level": 3,
 "out_size": 5605878,
 "ratio": 0.2595,
-"compress_mbps": 234.56,
-"decompress_mbps": 1101.26
+"compress_mbps": 236.1,
+"decompress_mbps": 1118.68
 },
 {
 "compressor": "libdeflate",
@@ -7874,8 +7874,8 @@
 "level": 4,
 "out_size": 5553432,
 "ratio": 0.257,
-"compress_mbps": 217.52,
-"decompress_mbps": 1087.45
+"compress_mbps": 218.73,
+"decompress_mbps": 1090.01
 },
 {
 "compressor": "libdeflate",
@@ -7884,8 +7884,8 @@
 "level": 5,
 "out_size": 5416713,
 "ratio": 0.2507,
-"compress_mbps": 187.45,
-"decompress_mbps": 1085.0
+"compress_mbps": 188.8,
+"decompress_mbps": 1084.04
 },
 {
 "compressor": "libdeflate",
@@ -7894,8 +7894,8 @@
 "level": 6,
 "out_size": 5337149,
 "ratio": 0.247,
-"compress_mbps": 144.12,
-"decompress_mbps": 1092.33
+"compress_mbps": 144.82,
+"decompress_mbps": 1100.67
 },
 {
 "compressor": "libdeflate",
@@ -7904,8 +7904,8 @@
 "level": 7,
 "out_size": 5310181,
 "ratio": 0.2458,
-"compress_mbps": 100.2,
-"decompress_mbps": 1043.71
+"compress_mbps": 100.81,
+"decompress_mbps": 1090.5
 },
 {
 "compressor": "libdeflate",
@@ -7914,8 +7914,8 @@
 "level": 8,
 "out_size": 5272761,
 "ratio": 0.244,
-"compress_mbps": 62.12,
-"decompress_mbps": 1077.99
+"compress_mbps": 62.66,
+"decompress_mbps": 1096.01
 },
 {
 "compressor": "libdeflate",
@@ -7924,8 +7924,8 @@
 "level": 9,
 "out_size": 5270405,
 "ratio": 0.2439,
-"compress_mbps": 50.08,
-"decompress_mbps": 634.63
+"compress_mbps": 50.38,
+"decompress_mbps": 1088.65
 },
 {
 "compressor": "libdeflate",
@@ -7934,8 +7934,8 @@
 "level": 1,
 "out_size": 5575128,
 "ratio": 0.7688,
-"compress_mbps": 161.1,
-"decompress_mbps": 419.63
+"compress_mbps": 162.96,
+"decompress_mbps": 493.08
 },
 {
 "compressor": "libdeflate",
@@ -7944,8 +7944,8 @@
 "level": 2,
 "out_size": 5417142,
 "ratio": 0.747,
-"compress_mbps": 116.31,
-"decompress_mbps": 390.97
+"compress_mbps": 117.3,
+"decompress_mbps": 523.32
 },
 {
 "compressor": "libdeflate",
@@ -7954,8 +7954,8 @@
 "level": 3,
 "out_size": 5397999,
 "ratio": 0.7444,
-"compress_mbps": 105.09,
-"decompress_mbps": 278.73
+"compress_mbps": 105.62,
+"decompress_mbps": 531.88
 },
 {
 "compressor": "libdeflate",
@@ -7964,8 +7964,8 @@
 "level": 4,
 "out_size": 5391125,
 "ratio": 0.7434,
-"compress_mbps": 99.15,
-"decompress_mbps": 400.63
+"compress_mbps": 99.83,
+"decompress_mbps": 535.9
 },
 {
 "compressor": "libdeflate",
@@ -7974,8 +7974,8 @@
 "level": 5,
 "out_size": 5352212,
 "ratio": 0.738,
-"compress_mbps": 83.53,
-"decompress_mbps": 497.88
+"compress_mbps": 88.53,
+"decompress_mbps": 525.52
 },
 {
 "compressor": "libdeflate",
@@ -7984,8 +7984,8 @@
 "level": 6,
 "out_size": 5335405,
 "ratio": 0.7357,
-"compress_mbps": 72.15,
-"decompress_mbps": 517.65
+"compress_mbps": 74.27,
+"decompress_mbps": 536.9
 },
 {
 "compressor": "libdeflate",
@@ -7994,8 +7994,8 @@
 "level": 7,
 "out_size": 5325697,
 "ratio": 0.7344,
-"compress_mbps": 61.33,
-"decompress_mbps": 462.7
+"compress_mbps": 63.91,
+"decompress_mbps": 533.34
 },
 {
 "compressor": "libdeflate",
@@ -8004,8 +8004,8 @@
 "level": 8,
 "out_size": 5324004,
 "ratio": 0.7341,
-"compress_mbps": 51.85,
-"decompress_mbps": 519.59
+"compress_mbps": 52.63,
+"decompress_mbps": 522.59
 },
 {
 "compressor": "libdeflate",
@@ -8014,8 +8014,8 @@
 "level": 9,
 "out_size": 5323197,
 "ratio": 0.734,
-"compress_mbps": 50.8,
-"decompress_mbps": 519.09
+"compress_mbps": 51.23,
+"decompress_mbps": 533.61
 },
 {
 "compressor": "libdeflate",
@@ -8024,8 +8024,8 @@
 "level": 1,
 "out_size": 13550569,
 "ratio": 0.3268,
-"compress_mbps": 265.58,
-"decompress_mbps": 859.69
+"compress_mbps": 267.72,
+"decompress_mbps": 838.35
 },
 {
 "compressor": "libdeflate",
@@ -8034,8 +8034,8 @@
 "level": 2,
 "out_size": 13130705,
 "ratio": 0.3167,
-"compress_mbps": 198.44,
-"decompress_mbps": 951.75
+"compress_mbps": 202.6,
+"decompress_mbps": 980.86
 },
 {
 "compressor": "libdeflate",
@@ -8044,8 +8044,8 @@
 "level": 3,
 "out_size": 12839361,
 "ratio": 0.3097,
-"compress_mbps": 176.28,
-"decompress_mbps": 880.28
+"compress_mbps": 179.37,
+"decompress_mbps": 1035.45
 },
 {
 "compressor": "libdeflate",
@@ -8054,8 +8054,8 @@
 "level": 4,
 "out_size": 12601933,
 "ratio": 0.304,
-"compress_mbps": 161.52,
-"decompress_mbps": 884.3
+"compress_mbps": 164.03,
+"decompress_mbps": 925.96
 },
 {
 "compressor": "libdeflate",
@@ -8064,8 +8064,8 @@
 "level": 5,
 "out_size": 12310776,
 "ratio": 0.2969,
-"compress_mbps": 131.44,
-"decompress_mbps": 870.48
+"compress_mbps": 133.37,
+"decompress_mbps": 905.44
 },
 {
 "compressor": "libdeflate",
@@ -8074,8 +8074,8 @@
 "level": 6,
 "out_size": 12140474,
 "ratio": 0.2928,
-"compress_mbps": 104.64,
-"decompress_mbps": 879.58
+"compress_mbps": 105.86,
+"decompress_mbps": 913.37
 },
 {
 "compressor": "libdeflate",
@@ -8084,8 +8084,8 @@
 "level": 7,
 "out_size": 12025296,
 "ratio": 0.2901,
-"compress_mbps": 75.02,
-"decompress_mbps": 862.76
+"compress_mbps": 75.68,
+"decompress_mbps": 912.07
 },
 {
 "compressor": "libdeflate",
@@ -8094,8 +8094,8 @@
 "level": 8,
 "out_size": 11893824,
 "ratio": 0.2869,
-"compress_mbps": 46.04,
-"decompress_mbps": 889.34
+"compress_mbps": 46.17,
+"decompress_mbps": 908.69
 },
 {
 "compressor": "libdeflate",
@@ -8104,8 +8104,8 @@
 "level": 9,
 "out_size": 11882496,
 "ratio": 0.2866,
-"compress_mbps": 39.54,
-"decompress_mbps": 895.98
+"compress_mbps": 39.76,
+"decompress_mbps": 909.14
 },
 {
 "compressor": "libdeflate",
@@ -8114,8 +8114,8 @@
 "level": 1,
 "out_size": 6293390,
 "ratio": 0.7426,
-"compress_mbps": 144.69,
-"decompress_mbps": 508.14
+"compress_mbps": 145.14,
+"decompress_mbps": 524.63
 },
 {
 "compressor": "libdeflate",
@@ -8124,8 +8124,8 @@
 "level": 2,
 "out_size": 6058412,
 "ratio": 0.7149,
-"compress_mbps": 120.48,
-"decompress_mbps": 534.42
+"compress_mbps": 120.91,
+"decompress_mbps": 535.34
 },
 {
 "compressor": "libdeflate",
@@ -8134,8 +8134,8 @@
 "level": 3,
 "out_size": 6058381,
 "ratio": 0.7149,
-"compress_mbps": 120.15,
-"decompress_mbps": 541.13
+"compress_mbps": 121.18,
+"decompress_mbps": 539.59
 },
 {
 "compressor": "libdeflate",
@@ -8144,8 +8144,8 @@
 "level": 4,
 "out_size": 6058363,
 "ratio": 0.7149,
-"compress_mbps": 120.27,
-"decompress_mbps": 432.5
+"compress_mbps": 121.22,
+"decompress_mbps": 437.28
 },
 {
 "compressor": "libdeflate",
@@ -8154,8 +8154,8 @@
 "level": 5,
 "out_size": 5998400,
 "ratio": 0.7078,
-"compress_mbps": 107.62,
-"decompress_mbps": 455.93
+"compress_mbps": 108.85,
+"decompress_mbps": 460.99
 },
 {
 "compressor": "libdeflate",
@@ -8164,8 +8164,8 @@
 "level": 6,
 "out_size": 5998438,
 "ratio": 0.7078,
-"compress_mbps": 107.71,
-"decompress_mbps": 451.42
+"compress_mbps": 108.81,
+"decompress_mbps": 452.16
 },
 {
 "compressor": "libdeflate",
@@ -8174,8 +8174,8 @@
 "level": 7,
 "out_size": 5998439,
 "ratio": 0.7078,
-"compress_mbps": 107.99,
-"decompress_mbps": 461.39
+"compress_mbps": 108.73,
+"decompress_mbps": 459.69
 },
 {
 "compressor": "libdeflate",
@@ -8184,8 +8184,8 @@
 "level": 8,
 "out_size": 5986859,
 "ratio": 0.7065,
-"compress_mbps": 90.1,
-"decompress_mbps": 456.45
+"compress_mbps": 90.17,
+"decompress_mbps": 462.01
 },
 {
 "compressor": "libdeflate",
@@ -8194,8 +8194,8 @@
 "level": 9,
 "out_size": 5986859,
 "ratio": 0.7065,
-"compress_mbps": 89.87,
-"decompress_mbps": 458.45
+"compress_mbps": 90.43,
+"decompress_mbps": 457.91
 },
 {
 "compressor": "libdeflate",
@@ -8204,8 +8204,8 @@
 "level": 1,
 "out_size": 887708,
 "ratio": 0.1661,
-"compress_mbps": 488.6,
-"decompress_mbps": 1315.83
+"compress_mbps": 492.13,
+"decompress_mbps": 1317.2
 },
 {
 "compressor": "libdeflate",
@@ -8214,8 +8214,8 @@
 "level": 2,
 "out_size": 843475,
 "ratio": 0.1578,
-"compress_mbps": 363.67,
-"decompress_mbps": 1445.93
+"compress_mbps": 364.82,
+"decompress_mbps": 1479.99
 },
 {
 "compressor": "libdeflate",
@@ -8224,8 +8224,8 @@
 "level": 3,
 "out_size": 793388,
 "ratio": 0.1484,
-"compress_mbps": 336.94,
-"decompress_mbps": 1567.54
+"compress_mbps": 336.39,
+"decompress_mbps": 1592.52
 },
 {
 "compressor": "libdeflate",
@@ -8234,8 +8234,8 @@
 "level": 4,
 "out_size": 747602,
 "ratio": 0.1399,
-"compress_mbps": 302.89,
-"decompress_mbps": 1487.72
+"compress_mbps": 304.97,
+"decompress_mbps": 1536.28
 },
 {
 "compressor": "libdeflate",
@@ -8244,8 +8244,8 @@
 "level": 5,
 "out_size": 718615,
 "ratio": 0.1344,
-"compress_mbps": 261.62,
-"decompress_mbps": 1521.98
+"compress_mbps": 263.04,
+"decompress_mbps": 1550.47
 },
 {
 "compressor": "libdeflate",
@@ -8254,8 +8254,8 @@
 "level": 6,
 "out_size": 684405,
 "ratio": 0.128,
-"compress_mbps": 205.52,
-"decompress_mbps": 1584.25
+"compress_mbps": 206.69,
+"decompress_mbps": 1606.06
 },
 {
 "compressor": "libdeflate",
@@ -8264,8 +8264,8 @@
 "level": 7,
 "out_size": 664859,
 "ratio": 0.1244,
-"compress_mbps": 142.64,
-"decompress_mbps": 1541.27
+"compress_mbps": 143.05,
+"decompress_mbps": 1601.48
 },
 {
 "compressor": "libdeflate",
@@ -8274,8 +8274,8 @@
 "level": 8,
 "out_size": 650835,
 "ratio": 0.1218,
-"compress_mbps": 84.4,
-"decompress_mbps": 1506.86
+"compress_mbps": 84.78,
+"decompress_mbps": 1326.69
 },
 {
 "compressor": "libdeflate",
@@ -8284,8 +8284,8 @@
 "level": 9,
 "out_size": 649494,
 "ratio": 0.1215,
-"compress_mbps": 68.24,
-"decompress_mbps": 1540.82
+"compress_mbps": 68.16,
+"decompress_mbps": 1227.38
 },
 {
 "compressor": "go",
@@ -8294,8 +8294,8 @@
 "level": 1,
 "out_size": 65708,
 "ratio": 0.432,
-"compress_mbps": 33.78,
-"decompress_mbps": 60.3
+"compress_mbps": 42.56,
+"decompress_mbps": 61.17
 },
 {
 "compressor": "go",
@@ -8304,8 +8304,8 @@
 "level": 2,
 "out_size": 60259,
 "ratio": 0.3962,
-"compress_mbps": 25.56,
-"decompress_mbps": 67.24
+"compress_mbps": 26.21,
+"decompress_mbps": 68.33
 },
 {
 "compressor": "go",
@@ -8314,8 +8314,8 @@
 "level": 3,
 "out_size": 58544,
 "ratio": 0.3849,
-"compress_mbps": 21.29,
-"decompress_mbps": 69.5
+"compress_mbps": 21.92,
+"decompress_mbps": 69.11
 },
 {
 "compressor": "go",
@@ -8324,8 +8324,8 @@
 "level": 4,
 "out_size": 56238,
 "ratio": 0.3698,
-"compress_mbps": 26.49,
-"decompress_mbps": 70.65
+"compress_mbps": 21.46,
+"decompress_mbps": 70.96
 },
 {
 "compressor": "go",
@@ -8334,8 +8334,8 @@
 "level": 5,
 "out_size": 54764,
 "ratio": 0.3601,
-"compress_mbps": 16.09,
-"decompress_mbps": 75.58
+"compress_mbps": 16.16,
+"decompress_mbps": 71.22
 },
 {
 "compressor": "go",
@@ -8344,8 +8344,8 @@
 "level": 6,
 "out_size": 54311,
 "ratio": 0.3571,
-"compress_mbps": 11.03,
-"decompress_mbps": 71.03
+"compress_mbps": 10.7,
+"decompress_mbps": 71.22
 },
 {
 "compressor": "go",
@@ -8354,8 +8354,8 @@
 "level": 7,
 "out_size": 54262,
 "ratio": 0.3568,
-"compress_mbps": 11.66,
-"decompress_mbps": 74.11
+"compress_mbps": 9.8,
+"decompress_mbps": 72.02
 },
 {
 "compressor": "go",
@@ -8364,8 +8364,8 @@
 "level": 8,
 "out_size": 54247,
 "ratio": 0.3567,
-"compress_mbps": 10.06,
-"decompress_mbps": 73.17
+"compress_mbps": 9.57,
+"decompress_mbps": 72.02
 },
 {
 "compressor": "go",
@@ -8374,8 +8374,8 @@
 "level": 9,
 "out_size": 54247,
 "ratio": 0.3567,
-"compress_mbps": 11.15,
-"decompress_mbps": 85.04
+"compress_mbps": 9.65,
+"decompress_mbps": 72.57
 },
 {
 "compressor": "go",
@@ -8384,8 +8384,8 @@
 "level": 1,
 "out_size": 56882,
 "ratio": 0.4544,
-"compress_mbps": 35.95,
-"decompress_mbps": 59.11
+"compress_mbps": 37.25,
+"decompress_mbps": 55.92
 },
 {
 "compressor": "go",
@@ -8394,8 +8394,8 @@
 "level": 2,
 "out_size": 52826,
 "ratio": 0.422,
-"compress_mbps": 29.02,
-"decompress_mbps": 77.03
+"compress_mbps": 23.05,
+"decompress_mbps": 62.21
 },
 {
 "compressor": "go",
@@ -8404,8 +8404,8 @@
 "level": 3,
 "out_size": 51625,
 "ratio": 0.4124,
-"compress_mbps": 23.6,
-"decompress_mbps": 72.79
+"compress_mbps": 22.69,
+"decompress_mbps": 65.27
 },
 {
 "compressor": "go",
@@ -8414,8 +8414,8 @@
 "level": 4,
 "out_size": 50034,
 "ratio": 0.3997,
-"compress_mbps": 24.26,
-"decompress_mbps": 68.2
+"compress_mbps": 22.5,
+"decompress_mbps": 65.59
 },
 {
 "compressor": "go",
@@ -8424,8 +8424,8 @@
 "level": 5,
 "out_size": 48912,
 "ratio": 0.3907,
-"compress_mbps": 17.45,
-"decompress_mbps": 65.87
+"compress_mbps": 12.62,
+"decompress_mbps": 65.42
 },
 {
 "compressor": "go",
@@ -8434,8 +8434,8 @@
 "level": 6,
 "out_size": 48738,
 "ratio": 0.3893,
-"compress_mbps": 10.22,
-"decompress_mbps": 67.48
+"compress_mbps": 11.77,
+"decompress_mbps": 65.61
 },
 {
 "compressor": "go",
@@ -8444,8 +8444,8 @@
 "level": 7,
 "out_size": 48719,
 "ratio": 0.3892,
-"compress_mbps": 9.98,
-"decompress_mbps": 66.6
+"compress_mbps": 9.97,
+"decompress_mbps": 65.88
 },
 {
 "compressor": "go",
@@ -8454,8 +8454,8 @@
 "level": 8,
 "out_size": 48716,
 "ratio": 0.3892,
-"compress_mbps": 9.88,
-"decompress_mbps": 66.81
+"compress_mbps": 9.9,
+"decompress_mbps": 68.31
 },
 {
 "compressor": "go",
@@ -8464,8 +8464,8 @@
 "level": 9,
 "out_size": 48716,
 "ratio": 0.3892,
-"compress_mbps": 10.01,
-"decompress_mbps": 65.66
+"compress_mbps": 12.58,
+"decompress_mbps": 64.73
 },
 {
 "compressor": "go",
@@ -8474,8 +8474,8 @@
 "level": 1,
 "out_size": 8988,
 "ratio": 0.3653,
-"compress_mbps": 34.84,
-"decompress_mbps": 97.77
+"compress_mbps": 36.94,
+"decompress_mbps": 103.46
 },
 {
 "compressor": "go",
@@ -8484,8 +8484,8 @@
 "level": 2,
 "out_size": 8564,
 "ratio": 0.3481,
-"compress_mbps": 36.37,
-"decompress_mbps": 107.73
+"compress_mbps": 43.51,
+"decompress_mbps": 102.54
 },
 {
 "compressor": "go",
@@ -8494,8 +8494,8 @@
 "level": 3,
 "out_size": 8390,
 "ratio": 0.341,
-"compress_mbps": 30.51,
-"decompress_mbps": 101.68
+"compress_mbps": 28.97,
+"decompress_mbps": 97.31
 },
 {
 "compressor": "go",
@@ -8504,8 +8504,8 @@
 "level": 4,
 "out_size": 8167,
 "ratio": 0.332,
-"compress_mbps": 39.31,
-"decompress_mbps": 150.64
+"compress_mbps": 37.49,
+"decompress_mbps": 98.37
 },
 {
 "compressor": "go",
@@ -8514,8 +8514,8 @@
 "level": 5,
 "out_size": 7965,
 "ratio": 0.3237,
-"compress_mbps": 27.65,
-"decompress_mbps": 116.16
+"compress_mbps": 28.72,
+"decompress_mbps": 88.78
 },
 {
 "compressor": "go",
@@ -8524,8 +8524,8 @@
 "level": 6,
 "out_size": 7916,
 "ratio": 0.3217,
-"compress_mbps": 29.01,
-"decompress_mbps": 158.88
+"compress_mbps": 22.76,
+"decompress_mbps": 104.8
 },
 {
 "compressor": "go",
@@ -8534,8 +8534,8 @@
 "level": 7,
 "out_size": 7900,
 "ratio": 0.3211,
-"compress_mbps": 18.21,
-"decompress_mbps": 82.57
+"compress_mbps": 21.67,
+"decompress_mbps": 85.25
 },
 {
 "compressor": "go",
@@ -8544,8 +8544,8 @@
 "level": 8,
 "out_size": 7900,
 "ratio": 0.3211,
-"compress_mbps": 20.44,
-"decompress_mbps": 105.04
+"compress_mbps": 20.13,
+"decompress_mbps": 105.7
 },
 {
 "compressor": "go",
@@ -8554,8 +8554,8 @@
 "level": 9,
 "out_size": 7900,
 "ratio": 0.3211,
-"compress_mbps": 20.64,
-"decompress_mbps": 101.22
+"compress_mbps": 27.55,
+"decompress_mbps": 92.8
 },
 {
 "compressor": "go",
@@ -8564,8 +8564,8 @@
 "level": 1,
 "out_size": 3731,
 "ratio": 0.3346,
-"compress_mbps": 19.2,
-"decompress_mbps": 78.63
+"compress_mbps": 18.9,
+"decompress_mbps": 80.13
 },
 {
 "compressor": "go",
@@ -8574,8 +8574,8 @@
 "level": 2,
 "out_size": 3491,
 "ratio": 0.3131,
-"compress_mbps": 24.58,
-"decompress_mbps": 91.07
+"compress_mbps": 23.63,
+"decompress_mbps": 84.66
 },
 {
 "compressor": "go",
@@ -8584,8 +8584,8 @@
 "level": 3,
 "out_size": 3384,
 "ratio": 0.3035,
-"compress_mbps": 23.1,
-"decompress_mbps": 88.61
+"compress_mbps": 22.04,
+"decompress_mbps": 89.77
 },
 {
 "compressor": "go",
@@ -8594,8 +8594,8 @@
 "level": 4,
 "out_size": 3220,
 "ratio": 0.2888,
-"compress_mbps": 21.98,
-"decompress_mbps": 95.14
+"compress_mbps": 21.08,
+"decompress_mbps": 86.53
 },
 {
 "compressor": "go",
@@ -8604,8 +8604,8 @@
 "level": 5,
 "out_size": 3138,
 "ratio": 0.2814,
-"compress_mbps": 16.82,
-"decompress_mbps": 97.05
+"compress_mbps": 17.11,
+"decompress_mbps": 93.05
 },
 {
 "compressor": "go",
@@ -8614,8 +8614,8 @@
 "level": 6,
 "out_size": 3118,
 "ratio": 0.2796,
-"compress_mbps": 14.9,
-"decompress_mbps": 96.4
+"compress_mbps": 15.03,
+"decompress_mbps": 100.03
 },
 {
 "compressor": "go",
@@ -8624,8 +8624,8 @@
 "level": 7,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 14.42,
-"decompress_mbps": 95.72
+"compress_mbps": 14.26,
+"decompress_mbps": 96.56
 },
 {
 "compressor": "go",
@@ -8634,8 +8634,8 @@
 "level": 8,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 14.06,
-"decompress_mbps": 95.76
+"compress_mbps": 14.4,
+"decompress_mbps": 104.06
 },
 {
 "compressor": "go",
@@ -8644,8 +8644,8 @@
 "level": 9,
 "out_size": 3116,
 "ratio": 0.2795,
-"compress_mbps": 13.88,
-"decompress_mbps": 99.01
+"compress_mbps": 15.81,
+"decompress_mbps": 101.86
 },
 {
 "compressor": "go",
@@ -8654,8 +8654,8 @@
 "level": 1,
 "out_size": 1352,
 "ratio": 0.3633,
-"compress_mbps": 9.25,
-"decompress_mbps": 85.2
+"compress_mbps": 8.47,
+"decompress_mbps": 63.54
 },
 {
 "compressor": "go",
@@ -8664,8 +8664,8 @@
 "level": 2,
 "out_size": 1287,
 "ratio": 0.3459,
-"compress_mbps": 12.52,
-"decompress_mbps": 71.36
+"compress_mbps": 11.63,
+"decompress_mbps": 60.62
 },
 {
 "compressor": "go",
@@ -8674,8 +8674,8 @@
 "level": 3,
 "out_size": 1284,
 "ratio": 0.3451,
-"compress_mbps": 12.42,
-"decompress_mbps": 67.11
+"compress_mbps": 11.67,
+"decompress_mbps": 62.5
 },
 {
 "compressor": "go",
@@ -8684,8 +8684,8 @@
 "level": 4,
 "out_size": 1226,
 "ratio": 0.3295,
-"compress_mbps": 10.2,
-"decompress_mbps": 69.98
+"compress_mbps": 11.31,
+"decompress_mbps": 66.96
 },
 {
 "compressor": "go",
@@ -8694,8 +8694,8 @@
 "level": 5,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 9.19,
-"decompress_mbps": 72.4
+"compress_mbps": 9.84,
+"decompress_mbps": 63.24
 },
 {
 "compressor": "go",
@@ -8704,8 +8704,8 @@
 "level": 6,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 10.05,
-"decompress_mbps": 66.29
+"compress_mbps": 10.84,
+"decompress_mbps": 63.7
 },
 {
 "compressor": "go",
@@ -8714,8 +8714,8 @@
 "level": 7,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 8.89,
-"decompress_mbps": 72.27
+"compress_mbps": 10.02,
+"decompress_mbps": 64.11
 },
 {
 "compressor": "go",
@@ -8724,8 +8724,8 @@
 "level": 8,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 9.38,
-"decompress_mbps": 54.85
+"compress_mbps": 10.74,
+"decompress_mbps": 80.94
 },
 {
 "compressor": "go",
@@ -8734,8 +8734,8 @@
 "level": 9,
 "out_size": 1211,
 "ratio": 0.3255,
-"compress_mbps": 10.73,
-"decompress_mbps": 66.9
+"compress_mbps": 11.17,
+"decompress_mbps": 63.88
 },
 {
 "compressor": "go",
@@ -8744,8 +8744,8 @@
 "level": 1,
 "out_size": 245423,
 "ratio": 0.2383,
-"compress_mbps": 91.51,
-"decompress_mbps": 133.02
+"compress_mbps": 123.71,
+"decompress_mbps": 127.4
 },
 {
 "compressor": "go",
@@ -8754,8 +8754,8 @@
 "level": 2,
 "out_size": 229642,
 "ratio": 0.223,
-"compress_mbps": 91,
-"decompress_mbps": 151.64
+"compress_mbps": 92.84,
+"decompress_mbps": 151.73
 },
 {
 "compressor": "go",
@@ -8764,8 +8764,8 @@
 "level": 3,
 "out_size": 225678,
 "ratio": 0.2192,
-"compress_mbps": 90.31,
-"decompress_mbps": 154.77
+"compress_mbps": 109.83,
+"decompress_mbps": 153.59
 },
 {
 "compressor": "go",
@@ -8774,8 +8774,8 @@
 "level": 4,
 "out_size": 218218,
 "ratio": 0.2119,
-"compress_mbps": 85.09,
-"decompress_mbps": 162.27
+"compress_mbps": 99.82,
+"decompress_mbps": 163.61
 },
 {
 "compressor": "go",
@@ -8784,8 +8784,8 @@
 "level": 5,
 "out_size": 210550,
 "ratio": 0.2045,
-"compress_mbps": 59.62,
-"decompress_mbps": 148.86
+"compress_mbps": 48.7,
+"decompress_mbps": 154.12
 },
 {
 "compressor": "go",
@@ -8794,8 +8794,8 @@
 "level": 6,
 "out_size": 207949,
 "ratio": 0.2019,
-"compress_mbps": 27.96,
-"decompress_mbps": 432.34
+"compress_mbps": 27.88,
+"decompress_mbps": 168.6
 },
 {
 "compressor": "go",
@@ -8804,8 +8804,8 @@
 "level": 7,
 "out_size": 207413,
 "ratio": 0.2014,
-"compress_mbps": 18.94,
-"decompress_mbps": 162.58
+"compress_mbps": 18.82,
+"decompress_mbps": 151.74
 },
 {
 "compressor": "go",
@@ -8815,7 +8815,7 @@
 "out_size": 207478,
 "ratio": 0.2015,
 "compress_mbps": 6.77,
-"decompress_mbps": 162.78
+"decompress_mbps": 153.16
 },
 {
 "compressor": "go",
@@ -8824,8 +8824,8 @@
 "level": 9,
 "out_size": 207482,
 "ratio": 0.2015,
-"compress_mbps": 3.58,
-"decompress_mbps": 160.96
+"compress_mbps": 3.56,
+"decompress_mbps": 157.49
 },
 {
 "compressor": "go",
@@ -8834,8 +8834,8 @@
 "level": 1,
 "out_size": 175980,
 "ratio": 0.4124,
-"compress_mbps": 41.39,
-"decompress_mbps": 62.26
+"compress_mbps": 43.31,
+"decompress_mbps": 64.49
 },
 {
 "compressor": "go",
@@ -8844,8 +8844,8 @@
 "level": 2,
 "out_size": 160455,
 "ratio": 0.376,
-"compress_mbps": 40.48,
-"decompress_mbps": 73.31
+"compress_mbps": 70.41,
+"decompress_mbps": 72.33
 },
 {
 "compressor": "go",
@@ -8854,8 +8854,8 @@
 "level": 3,
 "out_size": 156690,
 "ratio": 0.3672,
-"compress_mbps": 28.23,
-"decompress_mbps": 73.71
+"compress_mbps": 32.21,
+"decompress_mbps": 74.1
 },
 {
 "compressor": "go",
@@ -8864,8 +8864,8 @@
 "level": 4,
 "out_size": 149064,
 "ratio": 0.3493,
-"compress_mbps": 26.29,
-"decompress_mbps": 75.84
+"compress_mbps": 36.48,
+"decompress_mbps": 75.59
 },
 {
 "compressor": "go",
@@ -8874,8 +8874,8 @@
 "level": 5,
 "out_size": 145616,
 "ratio": 0.3412,
-"compress_mbps": 23.45,
-"decompress_mbps": 78.53
+"compress_mbps": 20.01,
+"decompress_mbps": 76.95
 },
 {
 "compressor": "go",
@@ -8884,8 +8884,8 @@
 "level": 6,
 "out_size": 144773,
 "ratio": 0.3392,
-"compress_mbps": 17.24,
-"decompress_mbps": 77.08
+"compress_mbps": 17.53,
+"decompress_mbps": 76.34
 },
 {
 "compressor": "go",
@@ -8894,8 +8894,8 @@
 "level": 7,
 "out_size": 144603,
 "ratio": 0.3388,
-"compress_mbps": 16.31,
-"decompress_mbps": 76.52
+"compress_mbps": 19.93,
+"decompress_mbps": 75.91
 },
 {
 "compressor": "go",
@@ -8904,8 +8904,8 @@
 "level": 8,
 "out_size": 144573,
 "ratio": 0.3388,
-"compress_mbps": 20.34,
-"decompress_mbps": 75.62
+"compress_mbps": 16.49,
+"decompress_mbps": 80.22
 },
 {
 "compressor": "go",
@@ -8914,8 +8914,8 @@
 "level": 9,
 "out_size": 144570,
 "ratio": 0.3388,
-"compress_mbps": 16.14,
-"decompress_mbps": 75.77
+"compress_mbps": 15.68,
+"decompress_mbps": 75.93
 },
 {
 "compressor": "go",
@@ -8924,8 +8924,8 @@
 "level": 1,
 "out_size": 228837,
 "ratio": 0.4749,
-"compress_mbps": 38.29,
-"decompress_mbps": 55.94
+"compress_mbps": 35.31,
+"decompress_mbps": 54.63
 },
 {
 "compressor": "go",
@@ -8934,8 +8934,8 @@
 "level": 2,
 "out_size": 211248,
 "ratio": 0.4384,
-"compress_mbps": 42.49,
-"decompress_mbps": 62.83
+"compress_mbps": 31.57,
+"decompress_mbps": 61.56
 },
 {
 "compressor": "go",
@@ -8944,8 +8944,8 @@
 "level": 3,
 "out_size": 205619,
 "ratio": 0.4267,
-"compress_mbps": 42.45,
-"decompress_mbps": 66.52
+"compress_mbps": 25.52,
+"decompress_mbps": 67.59
 },
 {
 "compressor": "go",
@@ -8954,8 +8954,8 @@
 "level": 4,
 "out_size": 200595,
 "ratio": 0.4163,
-"compress_mbps": 23.72,
-"decompress_mbps": 65.74
+"compress_mbps": 34.86,
+"decompress_mbps": 66.46
 },
 {
 "compressor": "go",
@@ -8964,8 +8964,8 @@
 "level": 5,
 "out_size": 195418,
 "ratio": 0.4055,
-"compress_mbps": 22.13,
-"decompress_mbps": 65.81
+"compress_mbps": 18.88,
+"decompress_mbps": 65.35
 },
 {
 "compressor": "go",
@@ -8974,8 +8974,8 @@
 "level": 6,
 "out_size": 194148,
 "ratio": 0.4029,
-"compress_mbps": 15.66,
-"decompress_mbps": 66.02
+"compress_mbps": 15.2,
+"decompress_mbps": 66.36
 },
 {
 "compressor": "go",
@@ -8984,8 +8984,8 @@
 "level": 7,
 "out_size": 193994,
 "ratio": 0.4026,
-"compress_mbps": 14.95,
-"decompress_mbps": 105.66
+"compress_mbps": 16.61,
+"decompress_mbps": 66.46
 },
 {
 "compressor": "go",
@@ -8994,8 +8994,8 @@
 "level": 8,
 "out_size": 193991,
 "ratio": 0.4026,
-"compress_mbps": 14.67,
-"decompress_mbps": 92.53
+"compress_mbps": 14.97,
+"decompress_mbps": 65.37
 },
 {
 "compressor": "go",
@@ -9004,8 +9004,8 @@
 "level": 9,
 "out_size": 193991,
 "ratio": 0.4026,
-"compress_mbps": 15,
-"decompress_mbps": 68.77
+"compress_mbps": 14.75,
+"decompress_mbps": 80.17
 },
 {
 "compressor": "go",
@@ -9014,8 +9014,8 @@
 "level": 1,
 "out_size": 60990,
 "ratio": 0.1188,
-"compress_mbps": 122.72,
-"decompress_mbps": 180.34
+"compress_mbps": 240.46,
+"decompress_mbps": 173.43
 },
 {
 "compressor": "go",
@@ -9024,8 +9024,8 @@
 "level": 2,
 "out_size": 61650,
 "ratio": 0.1201,
-"compress_mbps": 151.36,
-"decompress_mbps": 194.34
+"compress_mbps": 103.12,
+"decompress_mbps": 188.54
 },
 {
 "compressor": "go",
@@ -9034,8 +9034,8 @@
 "level": 3,
 "out_size": 60035,
 "ratio": 0.117,
-"compress_mbps": 137.26,
-"decompress_mbps": 209.01
+"compress_mbps": 90.48,
+"decompress_mbps": 205.17
 },
 {
 "compressor": "go",
@@ -9044,8 +9044,8 @@
 "level": 4,
 "out_size": 57005,
 "ratio": 0.1111,
-"compress_mbps": 113.11,
-"decompress_mbps": 208.57
+"compress_mbps": 91.56,
+"decompress_mbps": 195.56
 },
 {
 "compressor": "go",
@@ -9054,8 +9054,8 @@
 "level": 5,
 "out_size": 55779,
 "ratio": 0.1087,
-"compress_mbps": 149.82,
-"decompress_mbps": 207.87
+"compress_mbps": 81.64,
+"decompress_mbps": 263.29
 },
 {
 "compressor": "go",
@@ -9064,8 +9064,8 @@
 "level": 6,
 "out_size": 54970,
 "ratio": 0.1071,
-"compress_mbps": 42.88,
-"decompress_mbps": 206.16
+"compress_mbps": 69.16,
+"decompress_mbps": 204.84
 },
 {
 "compressor": "go",
@@ -9074,8 +9074,8 @@
 "level": 7,
 "out_size": 53922,
 "ratio": 0.1051,
-"compress_mbps": 48.7,
-"decompress_mbps": 229.16
+"compress_mbps": 76.91,
+"decompress_mbps": 217.15
 },
 {
 "compressor": "go",
@@ -9084,8 +9084,8 @@
 "level": 8,
 "out_size": 51977,
 "ratio": 0.1013,
-"compress_mbps": 20.46,
-"decompress_mbps": 242.39
+"compress_mbps": 17.63,
+"decompress_mbps": 275.85
 },
 {
 "compressor": "go",
@@ -9094,8 +9094,8 @@
 "level": 9,
 "out_size": 51474,
 "ratio": 0.1003,
-"compress_mbps": 6.35,
-"decompress_mbps": 228.79
+"compress_mbps": 6.71,
+"decompress_mbps": 239.18
 },
 {
 "compressor": "go",
@@ -9104,8 +9104,8 @@
 "level": 1,
 "out_size": 14783,
 "ratio": 0.3866,
-"compress_mbps": 40.03,
-"decompress_mbps": 80.88
+"compress_mbps": 32.71,
+"decompress_mbps": 70.98
 },
 {
 "compressor": "go",
@@ -9114,8 +9114,8 @@
 "level": 2,
 "out_size": 14101,
 "ratio": 0.3688,
-"compress_mbps": 37.23,
-"decompress_mbps": 90.07
+"compress_mbps": 33.16,
+"decompress_mbps": 78.17
 },
 {
 "compressor": "go",
@@ -9124,8 +9124,8 @@
 "level": 3,
 "out_size": 13975,
 "ratio": 0.3655,
-"compress_mbps": 39.34,
-"decompress_mbps": 104.76
+"compress_mbps": 28.17,
+"decompress_mbps": 75.22
 },
 {
 "compressor": "go",
@@ -9134,8 +9134,8 @@
 "level": 4,
 "out_size": 13632,
 "ratio": 0.3565,
-"compress_mbps": 26.53,
-"decompress_mbps": 80.69
+"compress_mbps": 30.93,
+"decompress_mbps": 100.62
 },
 {
 "compressor": "go",
@@ -9144,8 +9144,8 @@
 "level": 5,
 "out_size": 13302,
 "ratio": 0.3479,
-"compress_mbps": 21.13,
-"decompress_mbps": 86.28
+"compress_mbps": 25.78,
+"decompress_mbps": 79.98
 },
 {
 "compressor": "go",
@@ -9154,8 +9154,8 @@
 "level": 6,
 "out_size": 13279,
 "ratio": 0.3473,
-"compress_mbps": 17.14,
-"decompress_mbps": 79.33
+"compress_mbps": 21.9,
+"decompress_mbps": 77.99
 },
 {
 "compressor": "go",
@@ -9164,8 +9164,8 @@
 "level": 7,
 "out_size": 13274,
 "ratio": 0.3471,
-"compress_mbps": 15.32,
-"decompress_mbps": 83.88
+"compress_mbps": 19.14,
+"decompress_mbps": 84.74
 },
 {
 "compressor": "go",
@@ -9174,8 +9174,8 @@
 "level": 8,
 "out_size": 13260,
 "ratio": 0.3468,
-"compress_mbps": 7.1,
-"decompress_mbps": 87.92
+"compress_mbps": 7.15,
+"decompress_mbps": 80.47
 },
 {
 "compressor": "go",
@@ -9184,8 +9184,8 @@
 "level": 9,
 "out_size": 13260,
 "ratio": 0.3468,
-"compress_mbps": 4.88,
-"decompress_mbps": 79.05
+"compress_mbps": 4.57,
+"decompress_mbps": 79.18
 },
 {
 "compressor": "go",
@@ -9194,8 +9194,8 @@
 "level": 1,
 "out_size": 1862,
 "ratio": 0.4405,
-"compress_mbps": 7.78,
-"decompress_mbps": 56.77
+"compress_mbps": 9.05,
+"decompress_mbps": 61.67
 },
 {
 "compressor": "go",
@@ -9204,8 +9204,8 @@
 "level": 2,
 "out_size": 1803,
 "ratio": 0.4265,
-"compress_mbps": 13.51,
-"decompress_mbps": 70.27
+"compress_mbps": 12.61,
+"decompress_mbps": 58.6
 },
 {
 "compressor": "go",
@@ -9214,8 +9214,8 @@
 "level": 3,
 "out_size": 1791,
 "ratio": 0.4237,
-"compress_mbps": 9.89,
-"decompress_mbps": 60.57
+"compress_mbps": 12.87,
+"decompress_mbps": 60.15
 },
 {
 "compressor": "go",
@@ -9224,8 +9224,8 @@
 "level": 4,
 "out_size": 1746,
 "ratio": 0.4131,
-"compress_mbps": 9.69,
-"decompress_mbps": 63.5
+"compress_mbps": 12.23,
+"decompress_mbps": 60.76
 },
 {
 "compressor": "go",
@@ -9234,8 +9234,8 @@
 "level": 5,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 10.1,
-"decompress_mbps": 61.29
+"compress_mbps": 10.95,
+"decompress_mbps": 59.77
 },
 {
 "compressor": "go",
@@ -9244,8 +9244,8 @@
 "level": 6,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 9.3,
-"decompress_mbps": 56.29
+"compress_mbps": 11.32,
+"decompress_mbps": 59.78
 },
 {
 "compressor": "go",
@@ -9254,8 +9254,8 @@
 "level": 7,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 9.67,
-"decompress_mbps": 60.03
+"compress_mbps": 10.98,
+"decompress_mbps": 65.28
 },
 {
 "compressor": "go",
@@ -9264,8 +9264,8 @@
 "level": 8,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 11.17,
-"decompress_mbps": 52.92
+"compress_mbps": 11.09,
+"decompress_mbps": 61.29
 },
 {
 "compressor": "go",
@@ -9274,8 +9274,8 @@
 "level": 9,
 "out_size": 1725,
 "ratio": 0.4081,
-"compress_mbps": 11,
-"decompress_mbps": 64.2
+"compress_mbps": 11.55,
+"decompress_mbps": 61.79
 },
 {
 "compressor": "go",
@@ -9284,8 +9284,8 @@
 "level": 1,
 "out_size": 4623589,
 "ratio": 0.4536,
-"compress_mbps": 77.1,
-"decompress_mbps": 122.1
+"compress_mbps": 87.88,
+"decompress_mbps": 121.47
 },
 {
 "compressor": "go",
@@ -9294,8 +9294,8 @@
 "level": 2,
 "out_size": 4241525,
 "ratio": 0.4161,
-"compress_mbps": 61.57,
-"decompress_mbps": 183.36
+"compress_mbps": 59.05,
+"decompress_mbps": 124.77
 },
 {
 "compressor": "go",
@@ -9304,8 +9304,8 @@
 "level": 3,
 "out_size": 4123202,
 "ratio": 0.4045,
-"compress_mbps": 54.72,
-"decompress_mbps": 117.47
+"compress_mbps": 61.06,
+"decompress_mbps": 116.15
 },
 {
 "compressor": "go",
@@ -9314,8 +9314,8 @@
 "level": 4,
 "out_size": 3985937,
 "ratio": 0.3911,
-"compress_mbps": 56.6,
-"decompress_mbps": 154.99
+"compress_mbps": 60.91,
+"decompress_mbps": 204.23
 },
 {
 "compressor": "go",
@@ -9324,8 +9324,8 @@
 "level": 5,
 "out_size": 3883839,
 "ratio": 0.3811,
-"compress_mbps": 34.87,
-"decompress_mbps": 114.82
+"compress_mbps": 35.59,
+"decompress_mbps": 119.76
 },
 {
 "compressor": "go",
@@ -9334,8 +9334,8 @@
 "level": 6,
 "out_size": 3860437,
 "ratio": 0.3788,
-"compress_mbps": 27.55,
-"decompress_mbps": 196.4
+"compress_mbps": 27.93,
+"decompress_mbps": 202.6
 },
 {
 "compressor": "go",
@@ -9344,8 +9344,8 @@
 "level": 7,
 "out_size": 3857076,
 "ratio": 0.3784,
-"compress_mbps": 25.11,
-"decompress_mbps": 193.13
+"compress_mbps": 25.13,
+"decompress_mbps": 126.89
 },
 {
 "compressor": "go",
@@ -9354,8 +9354,8 @@
 "level": 8,
 "out_size": 3856651,
 "ratio": 0.3784,
-"compress_mbps": 24.8,
-"decompress_mbps": 114.82
+"compress_mbps": 24.66,
+"decompress_mbps": 202.36
 },
 {
 "compressor": "go",
@@ -9364,8 +9364,8 @@
 "level": 9,
 "out_size": 3856651,
 "ratio": 0.3784,
-"compress_mbps": 24.78,
-"decompress_mbps": 123.12
+"compress_mbps": 24.68,
+"decompress_mbps": 116.01
 },
 {
 "compressor": "go",
@@ -9374,8 +9374,8 @@
 "level": 1,
 "out_size": 21508211,
 "ratio": 0.4199,
-"compress_mbps": 142.41,
-"decompress_mbps": 235.64
+"compress_mbps": 143.1,
+"decompress_mbps": 239.36
 },
 {
 "compressor": "go",
@@ -9384,8 +9384,8 @@
 "level": 2,
 "out_size": 20538783,
 "ratio": 0.401,
-"compress_mbps": 101.38,
-"decompress_mbps": 212.37
+"compress_mbps": 103.18,
+"decompress_mbps": 229.73
 },
 {
 "compressor": "go",
@@ -9394,8 +9394,8 @@
 "level": 3,
 "out_size": 20334352,
 "ratio": 0.397,
-"compress_mbps": 95.16,
-"decompress_mbps": 231.59
+"compress_mbps": 88.51,
+"decompress_mbps": 208.07
 },
 {
 "compressor": "go",
@@ -9404,8 +9404,8 @@
 "level": 4,
 "out_size": 19886937,
 "ratio": 0.3883,
-"compress_mbps": 89.25,
-"decompress_mbps": 205.76
+"compress_mbps": 86.76,
+"decompress_mbps": 244.41
 },
 {
 "compressor": "go",
@@ -9414,8 +9414,8 @@
 "level": 5,
 "out_size": 19582363,
 "ratio": 0.3823,
-"compress_mbps": 64.33,
-"decompress_mbps": 231.41
+"compress_mbps": 65.59,
+"decompress_mbps": 239.15
 },
 {
 "compressor": "go",
@@ -9424,8 +9424,8 @@
 "level": 6,
 "out_size": 19512479,
 "ratio": 0.381,
-"compress_mbps": 43.83,
-"decompress_mbps": 252.53
+"compress_mbps": 43.56,
+"decompress_mbps": 220.01
 },
 {
 "compressor": "go",
@@ -9434,8 +9434,8 @@
 "level": 7,
 "out_size": 19489160,
 "ratio": 0.3805,
-"compress_mbps": 32.14,
-"decompress_mbps": 255.54
+"compress_mbps": 32.93,
+"decompress_mbps": 227.82
 },
 {
 "compressor": "go",
@@ -9444,8 +9444,8 @@
 "level": 8,
 "out_size": 19475109,
 "ratio": 0.3802,
-"compress_mbps": 18.3,
-"decompress_mbps": 224.66
+"compress_mbps": 18.63,
+"decompress_mbps": 225.38
 },
 {
 "compressor": "go",
@@ -9454,8 +9454,8 @@
 "level": 9,
 "out_size": 19476276,
 "ratio": 0.3802,
-"compress_mbps": 10.45,
-"decompress_mbps": 248.46
+"compress_mbps": 10.28,
+"decompress_mbps": 247.36
 },
 {
 "compressor": "go",
@@ -9464,8 +9464,8 @@
 "level": 1,
 "out_size": 3967718,
 "ratio": 0.3979,
-"compress_mbps": 150.31,
-"decompress_mbps": 122.19
+"compress_mbps": 146.76,
+"decompress_mbps": 172.01
 },
 {
 "compressor": "go",
@@ -9474,8 +9474,8 @@
 "level": 2,
 "out_size": 3773274,
 "ratio": 0.3784,
-"compress_mbps": 105.87,
-"decompress_mbps": 106.97
+"compress_mbps": 105.47,
+"decompress_mbps": 124.64
 },
 {
 "compressor": "go",
@@ -9485,7 +9485,7 @@
 "out_size": 3670460,
 "ratio": 0.3681,
 "compress_mbps": 77.56,
-"decompress_mbps": 128.99
+"decompress_mbps": 182.34
 },
 {
 "compressor": "go",
@@ -9494,8 +9494,8 @@
 "level": 4,
 "out_size": 3655100,
 "ratio": 0.3666,
-"compress_mbps": 87.09,
-"decompress_mbps": 115.3
+"compress_mbps": 87.36,
+"decompress_mbps": 107.18
 },
 {
 "compressor": "go",
@@ -9504,8 +9504,8 @@
 "level": 5,
 "out_size": 3620881,
 "ratio": 0.3632,
-"compress_mbps": 50.36,
-"decompress_mbps": 142.9
+"compress_mbps": 51.01,
+"decompress_mbps": 125.34
 },
 {
 "compressor": "go",
@@ -9514,8 +9514,8 @@
 "level": 6,
 "out_size": 3606626,
 "ratio": 0.3617,
-"compress_mbps": 33.56,
-"decompress_mbps": 114.22
+"compress_mbps": 33.83,
+"decompress_mbps": 183.58
 },
 {
 "compressor": "go",
@@ -9524,8 +9524,8 @@
 "level": 7,
 "out_size": 3605405,
 "ratio": 0.3616,
-"compress_mbps": 30.14,
-"decompress_mbps": 153.09
+"compress_mbps": 31.23,
+"decompress_mbps": 130.79
 },
 {
 "compressor": "go",
@@ -9534,8 +9534,8 @@
 "level": 8,
 "out_size": 3601635,
 "ratio": 0.3612,
-"compress_mbps": 26.03,
-"decompress_mbps": 200.1
+"compress_mbps": 26.28,
+"decompress_mbps": 133.31
 },
 {
 "compressor": "go",
@@ -9544,8 +9544,8 @@
 "level": 9,
 "out_size": 3601151,
 "ratio": 0.3612,
-"compress_mbps": 19.32,
-"decompress_mbps": 136.51
+"compress_mbps": 19.51,
+"decompress_mbps": 120.72
 },
 {
 "compressor": "go",
@@ -9554,8 +9554,8 @@
 "level": 1,
 "out_size": 4501482,
 "ratio": 0.1342,
-"compress_mbps": 292.23,
-"decompress_mbps": 256.55
+"compress_mbps": 294.72,
+"decompress_mbps": 451.24
 },
 {
 "compressor": "go",
@@ -9564,8 +9564,8 @@
 "level": 2,
 "out_size": 3875891,
 "ratio": 0.1155,
-"compress_mbps": 313.24,
-"decompress_mbps": 407.87
+"compress_mbps": 315.51,
+"decompress_mbps": 356.45
 },
 {
 "compressor": "go",
@@ -9574,8 +9574,8 @@
 "level": 3,
 "out_size": 3731525,
 "ratio": 0.1112,
-"compress_mbps": 287.16,
-"decompress_mbps": 372.8
+"compress_mbps": 288.4,
+"decompress_mbps": 372.55
 },
 {
 "compressor": "go",
@@ -9584,8 +9584,8 @@
 "level": 4,
 "out_size": 3542242,
 "ratio": 0.1056,
-"compress_mbps": 237.61,
-"decompress_mbps": 483.22
+"compress_mbps": 236.86,
+"decompress_mbps": 484.44
 },
 {
 "compressor": "go",
@@ -9594,8 +9594,8 @@
 "level": 5,
 "out_size": 3239184,
 "ratio": 0.0965,
-"compress_mbps": 173.52,
-"decompress_mbps": 397.95
+"compress_mbps": 175.14,
+"decompress_mbps": 539.55
 },
 {
 "compressor": "go",
@@ -9604,8 +9604,8 @@
 "level": 6,
 "out_size": 3113927,
 "ratio": 0.0928,
-"compress_mbps": 123.11,
-"decompress_mbps": 410.03
+"compress_mbps": 120.53,
+"decompress_mbps": 330.65
 },
 {
 "compressor": "go",
@@ -9614,8 +9614,8 @@
 "level": 7,
 "out_size": 3063520,
 "ratio": 0.0913,
-"compress_mbps": 83.5,
-"decompress_mbps": 466.13
+"compress_mbps": 84.76,
+"decompress_mbps": 331.22
 },
 {
 "compressor": "go",
@@ -9624,8 +9624,8 @@
 "level": 8,
 "out_size": 2961320,
 "ratio": 0.0883,
-"compress_mbps": 29.16,
-"decompress_mbps": 385.99
+"compress_mbps": 29.61,
+"decompress_mbps": 401.64
 },
 {
 "compressor": "go",
@@ -9634,8 +9634,8 @@
 "level": 9,
 "out_size": 2940087,
 "ratio": 0.0876,
-"compress_mbps": 20.42,
-"decompress_mbps": 619.74
+"compress_mbps": 20.54,
+"decompress_mbps": 474.59
 },
 {
 "compressor": "go",
@@ -9644,8 +9644,8 @@
 "level": 1,
 "out_size": 3462708,
 "ratio": 0.5628,
-"compress_mbps": 62.01,
-"decompress_mbps": 87.53
+"compress_mbps": 65.77,
+"decompress_mbps": 109.92
 },
 {
 "compressor": "go",
@@ -9654,8 +9654,8 @@
 "level": 2,
 "out_size": 3327399,
 "ratio": 0.5408,
-"compress_mbps": 72.35,
-"decompress_mbps": 125.5
+"compress_mbps": 71.78,
+"decompress_mbps": 84.48
 },
 {
 "compressor": "go",
@@ -9664,8 +9664,8 @@
 "level": 3,
 "out_size": 3297422,
 "ratio": 0.536,
-"compress_mbps": 66.76,
-"decompress_mbps": 89.09
+"compress_mbps": 66.06,
+"decompress_mbps": 89.69
 },
 {
 "compressor": "go",
@@ -9674,8 +9674,8 @@
 "level": 4,
 "out_size": 3249485,
 "ratio": 0.5282,
-"compress_mbps": 63.73,
-"decompress_mbps": 91.87
+"compress_mbps": 64.02,
+"decompress_mbps": 122.88
 },
 {
 "compressor": "go",
@@ -9684,8 +9684,8 @@
 "level": 5,
 "out_size": 3220046,
 "ratio": 0.5234,
-"compress_mbps": 48.89,
-"decompress_mbps": 91.37
+"compress_mbps": 49.81,
+"decompress_mbps": 90.58
 },
 {
 "compressor": "go",
@@ -9694,8 +9694,8 @@
 "level": 6,
 "out_size": 3213239,
 "ratio": 0.5223,
-"compress_mbps": 42.97,
-"decompress_mbps": 93.73
+"compress_mbps": 43.12,
+"decompress_mbps": 91.3
 },
 {
 "compressor": "go",
@@ -9704,8 +9704,8 @@
 "level": 7,
 "out_size": 3212009,
 "ratio": 0.5221,
-"compress_mbps": 38.55,
-"decompress_mbps": 113.57
+"compress_mbps": 39.44,
+"decompress_mbps": 177.12
 },
 {
 "compressor": "go",
@@ -9714,8 +9714,8 @@
 "level": 8,
 "out_size": 3211575,
 "ratio": 0.522,
-"compress_mbps": 28.29,
-"decompress_mbps": 92.89
+"compress_mbps": 27.92,
+"decompress_mbps": 92.84
 },
 {
 "compressor": "go",
@@ -9724,8 +9724,8 @@
 "level": 9,
 "out_size": 3211561,
 "ratio": 0.522,
-"compress_mbps": 29.81,
-"decompress_mbps": 84.49
+"compress_mbps": 29.68,
+"decompress_mbps": 92.12
 },
 {
 "compressor": "go",
@@ -9734,8 +9734,8 @@
 "level": 1,
 "out_size": 4334497,
 "ratio": 0.4298,
-"compress_mbps": 131.83,
-"decompress_mbps": 228.82
+"compress_mbps": 130.93,
+"decompress_mbps": 133.29
 },
 {
 "compressor": "go",
@@ -9744,8 +9744,8 @@
 "level": 2,
 "out_size": 3900156,
 "ratio": 0.3867,
-"compress_mbps": 131.13,
-"decompress_mbps": 116.94
+"compress_mbps": 131.77,
+"decompress_mbps": 116.9
 },
 {
 "compressor": "go",
@@ -9754,8 +9754,8 @@
 "level": 3,
 "out_size": 3876099,
 "ratio": 0.3843,
-"compress_mbps": 121.23,
-"decompress_mbps": 257.07
+"compress_mbps": 122.94,
+"decompress_mbps": 133.81
 },
 {
 "compressor": "go",
@@ -9764,8 +9764,8 @@
 "level": 4,
 "out_size": 3782364,
 "ratio": 0.375,
-"compress_mbps": 107.18,
-"decompress_mbps": 149.32
+"compress_mbps": 110.84,
+"decompress_mbps": 135.49
 },
 {
 "compressor": "go",
@@ -9774,8 +9774,8 @@
 "level": 5,
 "out_size": 3679310,
 "ratio": 0.3648,
-"compress_mbps": 88.54,
-"decompress_mbps": 157.7
+"compress_mbps": 89.42,
+"decompress_mbps": 136.59
 },
 {
 "compressor": "go",
@@ -9784,8 +9784,8 @@
 "level": 6,
 "out_size": 3679424,
 "ratio": 0.3648,
-"compress_mbps": 85.7,
-"decompress_mbps": 134.04
+"compress_mbps": 87.41,
+"decompress_mbps": 128.99
 },
 {
 "compressor": "go",
@@ -9794,8 +9794,8 @@
 "level": 7,
 "out_size": 3679163,
 "ratio": 0.3648,
-"compress_mbps": 81.34,
-"decompress_mbps": 154.86
+"compress_mbps": 83.39,
+"decompress_mbps": 141.56
 },
 {
 "compressor": "go",
@@ -9804,8 +9804,8 @@
 "level": 8,
 "out_size": 3679169,
 "ratio": 0.3648,
-"compress_mbps": 81.36,
-"decompress_mbps": 132.98
+"compress_mbps": 82.21,
+"decompress_mbps": 140.66
 },
 {
 "compressor": "go",
@@ -9814,8 +9814,8 @@
 "level": 9,
 "out_size": 3679169,
 "ratio": 0.3648,
-"compress_mbps": 81.21,
-"decompress_mbps": 133.94
+"compress_mbps": 81.84,
+"decompress_mbps": 196.94
 },
 {
 "compressor": "go",
@@ -9824,8 +9824,8 @@
 "level": 1,
 "out_size": 2496363,
 "ratio": 0.3767,
-"compress_mbps": 127.67,
-"decompress_mbps": 96.47
+"compress_mbps": 96.93,
+"decompress_mbps": 111.19
 },
 {
 "compressor": "go",
@@ -9834,8 +9834,8 @@
 "level": 2,
 "out_size": 2202601,
 "ratio": 0.3324,
-"compress_mbps": 85.16,
-"decompress_mbps": 101.69
+"compress_mbps": 92.65,
+"decompress_mbps": 102.3
 },
 {
 "compressor": "go",
@@ -9844,8 +9844,8 @@
 "level": 3,
 "out_size": 2103089,
 "ratio": 0.3173,
-"compress_mbps": 65.11,
-"decompress_mbps": 112.99
+"compress_mbps": 49.73,
+"decompress_mbps": 242.36
 },
 {
 "compressor": "go",
@@ -9854,8 +9854,8 @@
 "level": 4,
 "out_size": 1999697,
 "ratio": 0.3017,
-"compress_mbps": 75.64,
-"decompress_mbps": 135.01
+"compress_mbps": 75.29,
+"decompress_mbps": 121.18
 },
 {
 "compressor": "go",
@@ -9864,8 +9864,8 @@
 "level": 5,
 "out_size": 1892143,
 "ratio": 0.2855,
-"compress_mbps": 37.13,
-"decompress_mbps": 120.58
+"compress_mbps": 37.29,
+"decompress_mbps": 108.65
 },
 {
 "compressor": "go",
@@ -9874,8 +9874,8 @@
 "level": 6,
 "out_size": 1838372,
 "ratio": 0.2774,
-"compress_mbps": 20.25,
-"decompress_mbps": 103.98
+"compress_mbps": 20.3,
+"decompress_mbps": 108.77
 },
 {
 "compressor": "go",
@@ -9884,8 +9884,8 @@
 "level": 7,
 "out_size": 1828850,
 "ratio": 0.276,
-"compress_mbps": 15.63,
-"decompress_mbps": 104.59
+"compress_mbps": 15.87,
+"decompress_mbps": 115.22
 },
 {
 "compressor": "go",
@@ -9895,7 +9895,7 @@
 "out_size": 1823159,
 "ratio": 0.2751,
 "compress_mbps": 12.46,
-"decompress_mbps": 108.27
+"decompress_mbps": 114.31
 },
 {
 "compressor": "go",
@@ -9904,8 +9904,8 @@
 "level": 9,
 "out_size": 1823159,
 "ratio": 0.2751,
-"compress_mbps": 12.45,
-"decompress_mbps": 123.31
+"compress_mbps": 12.53,
+"decompress_mbps": 97.46
 },
 {
 "compressor": "go",
@@ -9914,8 +9914,8 @@
 "level": 1,
 "out_size": 6447290,
 "ratio": 0.2984,
-"compress_mbps": 189.76,
-"decompress_mbps": 197.73
+"compress_mbps": 187.76,
+"decompress_mbps": 292.5
 },
 {
 "compressor": "go",
@@ -9924,8 +9924,8 @@
 "level": 2,
 "out_size": 6030257,
 "ratio": 0.2791,
-"compress_mbps": 134.11,
-"decompress_mbps": 316.04
+"compress_mbps": 147.85,
+"decompress_mbps": 241.28
 },
 {
 "compressor": "go",
@@ -9934,8 +9934,8 @@
 "level": 3,
 "out_size": 5928121,
 "ratio": 0.2744,
-"compress_mbps": 128.48,
-"decompress_mbps": 217.44
+"compress_mbps": 128.5,
+"decompress_mbps": 269.87
 },
 {
 "compressor": "go",
@@ -9944,8 +9944,8 @@
 "level": 4,
 "out_size": 5615804,
 "ratio": 0.2599,
-"compress_mbps": 122.08,
-"decompress_mbps": 207.66
+"compress_mbps": 121.57,
+"decompress_mbps": 280.75
 },
 {
 "compressor": "go",
@@ -9954,8 +9954,8 @@
 "level": 5,
 "out_size": 5496738,
 "ratio": 0.2544,
-"compress_mbps": 79.36,
-"decompress_mbps": 337.82
+"compress_mbps": 80.22,
+"decompress_mbps": 336.14
 },
 {
 "compressor": "go",
@@ -9964,8 +9964,8 @@
 "level": 6,
 "out_size": 5464184,
 "ratio": 0.2529,
-"compress_mbps": 61.56,
-"decompress_mbps": 190
+"compress_mbps": 62.73,
+"decompress_mbps": 195.35
 },
 {
 "compressor": "go",
@@ -9974,8 +9974,8 @@
 "level": 7,
 "out_size": 5429645,
 "ratio": 0.2513,
-"compress_mbps": 49.03,
-"decompress_mbps": 196.3
+"compress_mbps": 47.93,
+"decompress_mbps": 214.77
 },
 {
 "compressor": "go",
@@ -9984,8 +9984,8 @@
 "level": 8,
 "out_size": 5418135,
 "ratio": 0.2508,
-"compress_mbps": 37.39,
-"decompress_mbps": 338.75
+"compress_mbps": 36.65,
+"decompress_mbps": 241.37
 },
 {
 "compressor": "go",
@@ -9994,8 +9994,8 @@
 "level": 9,
 "out_size": 5416628,
 "ratio": 0.2507,
-"compress_mbps": 33.91,
-"decompress_mbps": 289.29
+"compress_mbps": 33.67,
+"decompress_mbps": 233.28
 },
 {
 "compressor": "go",
@@ -10004,8 +10004,8 @@
 "level": 1,
 "out_size": 5759187,
 "ratio": 0.7942,
-"compress_mbps": 95.17,
-"decompress_mbps": 114.01
+"compress_mbps": 91.27,
+"decompress_mbps": 158.91
 },
 {
 "compressor": "go",
@@ -10014,8 +10014,8 @@
 "level": 2,
 "out_size": 5619390,
 "ratio": 0.7749,
-"compress_mbps": 49.5,
-"decompress_mbps": 93.51
+"compress_mbps": 49.54,
+"decompress_mbps": 94.64
 },
 {
 "compressor": "go",
@@ -10024,8 +10024,8 @@
 "level": 3,
 "out_size": 5560914,
 "ratio": 0.7668,
-"compress_mbps": 44.13,
-"decompress_mbps": 93.77
+"compress_mbps": 43.81,
+"decompress_mbps": 115.78
 },
 {
 "compressor": "go",
@@ -10034,8 +10034,8 @@
 "level": 4,
 "out_size": 5544069,
 "ratio": 0.7645,
-"compress_mbps": 50.73,
-"decompress_mbps": 93.55
+"compress_mbps": 44.58,
+"decompress_mbps": 94.11
 },
 {
 "compressor": "go",
@@ -10044,8 +10044,8 @@
 "level": 5,
 "out_size": 5518257,
 "ratio": 0.7609,
-"compress_mbps": 36.4,
-"decompress_mbps": 93.75
+"compress_mbps": 36.73,
+"decompress_mbps": 163.59
 },
 {
 "compressor": "go",
@@ -10054,8 +10054,8 @@
 "level": 6,
 "out_size": 5508662,
 "ratio": 0.7596,
-"compress_mbps": 33.21,
-"decompress_mbps": 96.67
+"compress_mbps": 33.77,
+"decompress_mbps": 95.01
 },
 {
 "compressor": "go",
@@ -10064,8 +10064,8 @@
 "level": 7,
 "out_size": 5507534,
 "ratio": 0.7595,
-"compress_mbps": 32.93,
-"decompress_mbps": 95.78
+"compress_mbps": 35.09,
+"decompress_mbps": 95.76
 },
 {
 "compressor": "go",
@@ -10074,8 +10074,8 @@
 "level": 8,
 "out_size": 5507183,
 "ratio": 0.7594,
-"compress_mbps": 32.29,
-"decompress_mbps": 97.4
+"compress_mbps": 32.41,
+"decompress_mbps": 94.54
 },
 {
 "compressor": "go",
@@ -10084,8 +10084,8 @@
 "level": 9,
 "out_size": 5507183,
 "ratio": 0.7594,
-"compress_mbps": 35.31,
-"decompress_mbps": 96.83
+"compress_mbps": 32.5,
+"decompress_mbps": 117.56
 },
 {
 "compressor": "go",
@@ -10094,8 +10094,8 @@
 "level": 1,
 "out_size": 15230651,
 "ratio": 0.3674,
-"compress_mbps": 122.11,
-"decompress_mbps": 204.99
+"compress_mbps": 123.36,
+"decompress_mbps": 184.33
 },
 {
 "compressor": "go",
@@ -10104,8 +10104,8 @@
 "level": 2,
 "out_size": 13822040,
 "ratio": 0.3334,
-"compress_mbps": 96.92,
-"decompress_mbps": 188.65
+"compress_mbps": 96.36,
+"decompress_mbps": 194.1
 },
 {
 "compressor": "go",
@@ -10114,8 +10114,8 @@
 "level": 3,
 "out_size": 13397592,
 "ratio": 0.3232,
-"compress_mbps": 82.59,
-"decompress_mbps": 197.78
+"compress_mbps": 83.62,
+"decompress_mbps": 202.34
 },
 {
 "compressor": "go",
@@ -10124,8 +10124,8 @@
 "level": 4,
 "out_size": 12759940,
 "ratio": 0.3078,
-"compress_mbps": 80.83,
-"decompress_mbps": 212.94
+"compress_mbps": 80.4,
+"decompress_mbps": 223.21
 },
 {
 "compressor": "go",
@@ -10134,8 +10134,8 @@
 "level": 5,
 "out_size": 12274278,
 "ratio": 0.2961,
-"compress_mbps": 53.88,
-"decompress_mbps": 237.3
+"compress_mbps": 54.6,
+"decompress_mbps": 216.16
 },
 {
 "compressor": "go",
@@ -10144,8 +10144,8 @@
 "level": 6,
 "out_size": 12131738,
 "ratio": 0.2926,
-"compress_mbps": 40.69,
-"decompress_mbps": 208.37
+"compress_mbps": 40.41,
+"decompress_mbps": 218.2
 },
 {
 "compressor": "go",
@@ -10154,8 +10154,8 @@
 "level": 7,
 "out_size": 12060450,
 "ratio": 0.2909,
-"compress_mbps": 33.2,
-"decompress_mbps": 208.57
+"compress_mbps": 33.43,
+"decompress_mbps": 203.45
 },
 {
 "compressor": "go",
@@ -10164,8 +10164,8 @@
 "level": 8,
 "out_size": 12036900,
 "ratio": 0.2903,
-"compress_mbps": 30.02,
-"decompress_mbps": 223.92
+"compress_mbps": 29.91,
+"decompress_mbps": 206.04
 },
 {
 "compressor": "go",
@@ -10174,8 +10174,8 @@
 "level": 9,
 "out_size": 12036900,
 "ratio": 0.2903,
-"compress_mbps": 29.8,
-"decompress_mbps": 223.72
+"compress_mbps": 30.01,
+"decompress_mbps": 223.31
 },
 {
 "compressor": "go",
@@ -10184,8 +10184,8 @@
 "level": 1,
 "out_size": 6653052,
 "ratio": 0.7851,
-"compress_mbps": 101.23,
-"decompress_mbps": 168.68
+"compress_mbps": 124.38,
+"decompress_mbps": 152.55
 },
 {
 "compressor": "go",
@@ -10194,8 +10194,8 @@
 "level": 2,
 "out_size": 6305035,
 "ratio": 0.744,
-"compress_mbps": 68.39,
-"decompress_mbps": 99.08
+"compress_mbps": 53.84,
+"decompress_mbps": 154.18
 },
 {
 "compressor": "go",
@@ -10204,8 +10204,8 @@
 "level": 3,
 "out_size": 6302730,
 "ratio": 0.7438,
-"compress_mbps": 68.76,
-"decompress_mbps": 159.09
+"compress_mbps": 52.94,
+"decompress_mbps": 119.64
 },
 {
 "compressor": "go",
@@ -10214,8 +10214,8 @@
 "level": 4,
 "out_size": 6299134,
 "ratio": 0.7433,
-"compress_mbps": 55.23,
-"decompress_mbps": 98.32
+"compress_mbps": 52.14,
+"decompress_mbps": 156.45
 },
 {
 "compressor": "go",
@@ -10224,8 +10224,8 @@
 "level": 5,
 "out_size": 6289022,
 "ratio": 0.7421,
-"compress_mbps": 61.6,
-"decompress_mbps": 100.51
+"compress_mbps": 64.63,
+"decompress_mbps": 159.21
 },
 {
 "compressor": "go",
@@ -10234,8 +10234,8 @@
 "level": 6,
 "out_size": 6289013,
 "ratio": 0.7421,
-"compress_mbps": 64.84,
-"decompress_mbps": 162.54
+"compress_mbps": 50.64,
+"decompress_mbps": 156.7
 },
 {
 "compressor": "go",
@@ -10244,8 +10244,8 @@
 "level": 7,
 "out_size": 6289013,
 "ratio": 0.7421,
-"compress_mbps": 50.62,
-"decompress_mbps": 162.09
+"compress_mbps": 50.91,
+"decompress_mbps": 165.38
 },
 {
 "compressor": "go",
@@ -10254,8 +10254,8 @@
 "level": 8,
 "out_size": 6289012,
 "ratio": 0.7421,
-"compress_mbps": 50.26,
-"decompress_mbps": 167.1
+"compress_mbps": 64.4,
+"decompress_mbps": 157.39
 },
 {
 "compressor": "go",
@@ -10264,8 +10264,8 @@
 "level": 9,
 "out_size": 6289012,
 "ratio": 0.7421,
-"compress_mbps": 50.61,
-"decompress_mbps": 102.92
+"compress_mbps": 64.37,
+"decompress_mbps": 98.54
 },
 {
 "compressor": "go",
@@ -10274,8 +10274,8 @@
 "level": 1,
 "out_size": 989456,
 "ratio": 0.1851,
-"compress_mbps": 165.95,
-"decompress_mbps": 297.54
+"compress_mbps": 243.16,
+"decompress_mbps": 153.25
 },
 {
 "compressor": "go",
@@ -10284,8 +10284,8 @@
 "level": 2,
 "out_size": 839766,
 "ratio": 0.1571,
-"compress_mbps": 185.49,
-"decompress_mbps": 169.06
+"compress_mbps": 178.46,
+"decompress_mbps": 169.75
 },
 {
 "compressor": "go",
@@ -10294,8 +10294,8 @@
 "level": 3,
 "out_size": 800619,
 "ratio": 0.1498,
-"compress_mbps": 161.42,
-"decompress_mbps": 183.63
+"compress_mbps": 181.16,
+"decompress_mbps": 178.28
 },
 {
 "compressor": "go",
@@ -10304,8 +10304,8 @@
 "level": 4,
 "out_size": 776397,
 "ratio": 0.1452,
-"compress_mbps": 122.26,
-"decompress_mbps": 189.6
+"compress_mbps": 149.67,
+"decompress_mbps": 185.03
 },
 {
 "compressor": "go",
@@ -10314,8 +10314,8 @@
 "level": 5,
 "out_size": 712679,
 "ratio": 0.1333,
-"compress_mbps": 102.21,
-"decompress_mbps": 310.05
+"compress_mbps": 103.54,
+"decompress_mbps": 199.06
 },
 {
 "compressor": "go",
@@ -10324,8 +10324,8 @@
 "level": 6,
 "out_size": 683707,
 "ratio": 0.1279,
-"compress_mbps": 95.34,
-"decompress_mbps": 262.26
+"compress_mbps": 93.5,
+"decompress_mbps": 512.66
 },
 {
 "compressor": "go",
@@ -10334,8 +10334,8 @@
 "level": 7,
 "out_size": 668601,
 "ratio": 0.1251,
-"compress_mbps": 71.48,
-"decompress_mbps": 289.05
+"compress_mbps": 70.7,
+"decompress_mbps": 209.33
 },
 {
 "compressor": "go",
@@ -10344,8 +10344,8 @@
 "level": 8,
 "out_size": 659106,
 "ratio": 0.1233,
-"compress_mbps": 48.35,
-"decompress_mbps": 206.6
+"compress_mbps": 42.04,
+"decompress_mbps": 216.57
 },
 {
 "compressor": "go",
@@ -10354,8 +10354,8 @@
 "level": 9,
 "out_size": 658920,
 "ratio": 0.1233,
-"compress_mbps": 41.59,
-"decompress_mbps": 291.53
+"compress_mbps": 42.13,
+"decompress_mbps": 256.07
 },
 {
 "compressor": "js",
@@ -10364,8 +10364,8 @@
 "level": 1,
 "out_size": 62797,
 "ratio": 0.4129,
-"compress_mbps": 76.05,
-"decompress_mbps": 141.06
+"compress_mbps": 75.96,
+"decompress_mbps": 132.29
 },
 {
 "compressor": "js",
@@ -10374,8 +10374,8 @@
 "level": 2,
 "out_size": 59605,
 "ratio": 0.3919,
-"compress_mbps": 63.18,
-"decompress_mbps": 133.39
+"compress_mbps": 62.87,
+"decompress_mbps": 131.77
 },
 {
 "compressor": "js",
@@ -10384,8 +10384,8 @@
 "level": 3,
 "out_size": 57675,
 "ratio": 0.3792,
-"compress_mbps": 45.32,
-"decompress_mbps": 126.55
+"compress_mbps": 53.89,
+"decompress_mbps": 124.29
 },
 {
 "compressor": "js",
@@ -10394,8 +10394,8 @@
 "level": 4,
 "out_size": 56500,
 "ratio": 0.3715,
-"compress_mbps": 45.86,
-"decompress_mbps": 133.66
+"compress_mbps": 38.93,
+"decompress_mbps": 131.16
 },
 {
 "compressor": "js",
@@ -10404,8 +10404,8 @@
 "level": 5,
 "out_size": 56440,
 "ratio": 0.3711,
-"compress_mbps": 38.8,
-"decompress_mbps": 132.26
+"compress_mbps": 38.82,
+"decompress_mbps": 130.65
 },
 {
 "compressor": "js",
@@ -10414,8 +10414,8 @@
 "level": 6,
 "out_size": 55443,
 "ratio": 0.3645,
-"compress_mbps": 32.65,
-"decompress_mbps": 146.2
+"compress_mbps": 32.14,
+"decompress_mbps": 146.84
 },
 {
 "compressor": "js",
@@ -10424,8 +10424,8 @@
 "level": 7,
 "out_size": 55373,
 "ratio": 0.3641,
-"compress_mbps": 31.53,
-"decompress_mbps": 134.56
+"compress_mbps": 31.65,
+"decompress_mbps": 130.38
 },
 {
 "compressor": "js",
@@ -10434,8 +10434,8 @@
 "level": 8,
 "out_size": 55352,
 "ratio": 0.3639,
-"compress_mbps": 35.49,
-"decompress_mbps": 135.96
+"compress_mbps": 31.32,
+"decompress_mbps": 136.96
 },
 {
 "compressor": "js",
@@ -10444,8 +10444,8 @@
 "level": 9,
 "out_size": 55352,
 "ratio": 0.3639,
-"compress_mbps": 31.2,
-"decompress_mbps": 133.03
+"compress_mbps": 31.37,
+"decompress_mbps": 135.72
 },
 {
 "compressor": "js",
@@ -10454,8 +10454,8 @@
 "level": 1,
 "out_size": 55063,
 "ratio": 0.4399,
-"compress_mbps": 74.96,
-"decompress_mbps": 114.52
+"compress_mbps": 74.97,
+"decompress_mbps": 117.68
 },
 {
 "compressor": "js",
@@ -10464,8 +10464,8 @@
 "level": 2,
 "out_size": 52932,
 "ratio": 0.4229,
-"compress_mbps": 60.84,
-"decompress_mbps": 112.42
+"compress_mbps": 60.75,
+"decompress_mbps": 116.27
 },
 {
 "compressor": "js",
@@ -10474,8 +10474,8 @@
 "level": 3,
 "out_size": 51597,
 "ratio": 0.4122,
-"compress_mbps": 51.25,
-"decompress_mbps": 118.62
+"compress_mbps": 44.1,
+"decompress_mbps": 116.24
 },
 {
 "compressor": "js",
@@ -10484,8 +10484,8 @@
 "level": 4,
 "out_size": 50780,
 "ratio": 0.4057,
-"compress_mbps": 38.15,
-"decompress_mbps": 123.69
+"compress_mbps": 43.18,
+"decompress_mbps": 120.67
 },
 {
 "compressor": "js",
@@ -10494,8 +10494,8 @@
 "level": 5,
 "out_size": 50767,
 "ratio": 0.4056,
-"compress_mbps": 42.83,
-"decompress_mbps": 121.44
+"compress_mbps": 42.85,
+"decompress_mbps": 122.05
 },
 {
 "compressor": "js",
@@ -10504,8 +10504,8 @@
 "level": 6,
 "out_size": 50160,
 "ratio": 0.4007,
-"compress_mbps": 32.88,
-"decompress_mbps": 127.67
+"compress_mbps": 33.03,
+"decompress_mbps": 128.52
 },
 {
 "compressor": "js",
@@ -10514,8 +10514,8 @@
 "level": 7,
 "out_size": 50138,
 "ratio": 0.4005,
-"compress_mbps": 32.53,
-"decompress_mbps": 124.75
+"compress_mbps": 31.52,
+"decompress_mbps": 124.51
 },
 {
 "compressor": "js",
@@ -10524,8 +10524,8 @@
 "level": 8,
 "out_size": 50138,
 "ratio": 0.4005,
-"compress_mbps": 32.23,
-"decompress_mbps": 122.69
+"compress_mbps": 32.14,
+"decompress_mbps": 125.83
 },
 {
 "compressor": "js",
@@ -10534,8 +10534,8 @@
 "level": 9,
 "out_size": 50138,
 "ratio": 0.4005,
-"compress_mbps": 32.33,
-"decompress_mbps": 124.47
+"compress_mbps": 35.79,
+"decompress_mbps": 124.35
 },
 {
 "compressor": "js",
@@ -10544,8 +10544,8 @@
 "level": 1,
 "out_size": 8730,
 "ratio": 0.3548,
-"compress_mbps": 50.41,
-"decompress_mbps": 131.15
+"compress_mbps": 46.94,
+"decompress_mbps": 123.4
 },
 {
 "compressor": "js",
@@ -10554,8 +10554,8 @@
 "level": 2,
 "out_size": 8457,
 "ratio": 0.3437,
-"compress_mbps": 45.45,
-"decompress_mbps": 130.16
+"compress_mbps": 43.65,
+"decompress_mbps": 119.12
 },
 {
 "compressor": "js",
@@ -10564,8 +10564,8 @@
 "level": 3,
 "out_size": 8353,
 "ratio": 0.3395,
-"compress_mbps": 42.76,
-"decompress_mbps": 112.19
+"compress_mbps": 64.98,
+"decompress_mbps": 109.7
 },
 {
 "compressor": "js",
@@ -10574,8 +10574,8 @@
 "level": 4,
 "out_size": 8301,
 "ratio": 0.3374,
-"compress_mbps": 63.24,
-"decompress_mbps": 136.7
+"compress_mbps": 42.45,
+"decompress_mbps": 124.06
 },
 {
 "compressor": "js",
@@ -10584,8 +10584,8 @@
 "level": 5,
 "out_size": 8212,
 "ratio": 0.3338,
-"compress_mbps": 50.56,
-"decompress_mbps": 112.06
+"compress_mbps": 58.84,
+"decompress_mbps": 103.81
 },
 {
 "compressor": "js",
@@ -10594,8 +10594,8 @@
 "level": 6,
 "out_size": 8172,
 "ratio": 0.3322,
-"compress_mbps": 45.37,
-"decompress_mbps": 107.58
+"compress_mbps": 48.55,
+"decompress_mbps": 108.53
 },
 {
 "compressor": "js",
@@ -10604,8 +10604,8 @@
 "level": 7,
 "out_size": 8171,
 "ratio": 0.3321,
-"compress_mbps": 48.54,
-"decompress_mbps": 109.8
+"compress_mbps": 50.28,
+"decompress_mbps": 109.3
 },
 {
 "compressor": "js",
@@ -10614,8 +10614,8 @@
 "level": 8,
 "out_size": 8171,
 "ratio": 0.3321,
-"compress_mbps": 52.95,
-"decompress_mbps": 102.83
+"compress_mbps": 49.23,
+"decompress_mbps": 109.09
 },
 {
 "compressor": "js",
@@ -10624,8 +10624,8 @@
 "level": 9,
 "out_size": 8171,
 "ratio": 0.3321,
-"compress_mbps": 55.39,
-"decompress_mbps": 105.1
+"compress_mbps": 53.75,
+"decompress_mbps": 109.08
 },
 {
 "compressor": "js",
@@ -10634,8 +10634,8 @@
 "level": 1,
 "out_size": 3475,
 "ratio": 0.3117,
-"compress_mbps": 111.63,
-"decompress_mbps": 83.66
+"compress_mbps": 109.11,
+"decompress_mbps": 96.06
 },
 {
 "compressor": "js",
@@ -10644,8 +10644,8 @@
 "level": 2,
 "out_size": 3305,
 "ratio": 0.2964,
-"compress_mbps": 91.35,
-"decompress_mbps": 98.21
+"compress_mbps": 102.67,
+"decompress_mbps": 101.78
 },
 {
 "compressor": "js",
@@ -10654,8 +10654,8 @@
 "level": 3,
 "out_size": 3225,
 "ratio": 0.2892,
-"compress_mbps": 99.89,
-"decompress_mbps": 95.55
+"compress_mbps": 91.21,
+"decompress_mbps": 104.25
 },
 {
 "compressor": "js",
@@ -10664,8 +10664,8 @@
 "level": 4,
 "out_size": 3192,
 "ratio": 0.2863,
-"compress_mbps": 94.13,
-"decompress_mbps": 106.24
+"compress_mbps": 100.3,
+"decompress_mbps": 104.85
 },
 {
 "compressor": "js",
@@ -10674,8 +10674,8 @@
 "level": 5,
 "out_size": 3180,
 "ratio": 0.2852,
-"compress_mbps": 89.38,
-"decompress_mbps": 94.53
+"compress_mbps": 100.47,
+"decompress_mbps": 98.18
 },
 {
 "compressor": "js",
@@ -10684,8 +10684,8 @@
 "level": 6,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 95.12,
-"decompress_mbps": 91.55
+"compress_mbps": 94.55,
+"decompress_mbps": 99.39
 },
 {
 "compressor": "js",
@@ -10694,8 +10694,8 @@
 "level": 7,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 85.6,
-"decompress_mbps": 134.73
+"compress_mbps": 95.62,
+"decompress_mbps": 95.6
 },
 {
 "compressor": "js",
@@ -10704,8 +10704,8 @@
 "level": 8,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 95.9,
-"decompress_mbps": 126.42
+"compress_mbps": 91.52,
+"decompress_mbps": 121.63
 },
 {
 "compressor": "js",
@@ -10714,8 +10714,8 @@
 "level": 9,
 "out_size": 3168,
 "ratio": 0.2841,
-"compress_mbps": 93.09,
-"decompress_mbps": 96.3
+"compress_mbps": 83.09,
+"decompress_mbps": 95.05
 },
 {
 "compressor": "js",
@@ -10724,8 +10724,8 @@
 "level": 1,
 "out_size": 1275,
 "ratio": 0.3426,
-"compress_mbps": 60.59,
-"decompress_mbps": 44.76
+"compress_mbps": 59.58,
+"decompress_mbps": 44.37
 },
 {
 "compressor": "js",
@@ -10734,8 +10734,8 @@
 "level": 2,
 "out_size": 1247,
 "ratio": 0.3351,
-"compress_mbps": 58.36,
-"decompress_mbps": 52.27
+"compress_mbps": 59.47,
+"decompress_mbps": 52.13
 },
 {
 "compressor": "js",
@@ -10744,8 +10744,8 @@
 "level": 3,
 "out_size": 1239,
 "ratio": 0.333,
-"compress_mbps": 58.29,
-"decompress_mbps": 50.66
+"compress_mbps": 56.69,
+"decompress_mbps": 51.11
 },
 {
 "compressor": "js",
@@ -10754,8 +10754,8 @@
 "level": 4,
 "out_size": 1238,
 "ratio": 0.3327,
-"compress_mbps": 56.23,
-"decompress_mbps": 49.05
+"compress_mbps": 58.55,
+"decompress_mbps": 50.63
 },
 {
 "compressor": "js",
@@ -10764,8 +10764,8 @@
 "level": 5,
 "out_size": 1239,
 "ratio": 0.333,
-"compress_mbps": 55.93,
-"decompress_mbps": 48.37
+"compress_mbps": 48.99,
+"decompress_mbps": 51.01
 },
 {
 "compressor": "js",
@@ -10774,8 +10774,8 @@
 "level": 6,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 57.62,
-"decompress_mbps": 47.88
+"compress_mbps": 56.51,
+"decompress_mbps": 50.1
 },
 {
 "compressor": "js",
@@ -10784,8 +10784,8 @@
 "level": 7,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 55.63,
-"decompress_mbps": 48.4
+"compress_mbps": 55.71,
+"decompress_mbps": 51.27
 },
 {
 "compressor": "js",
@@ -10794,8 +10794,8 @@
 "level": 8,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 52.3,
-"decompress_mbps": 46.23
+"compress_mbps": 50.22,
+"decompress_mbps": 48.37
 },
 {
 "compressor": "js",
@@ -10804,8 +10804,8 @@
 "level": 9,
 "out_size": 1237,
 "ratio": 0.3324,
-"compress_mbps": 50.81,
-"decompress_mbps": 45.99
+"compress_mbps": 55.39,
+"decompress_mbps": 48.56
 },
 {
 "compressor": "js",
@@ -10814,8 +10814,8 @@
 "level": 1,
 "out_size": 226284,
 "ratio": 0.2197,
-"compress_mbps": 112.74,
-"decompress_mbps": 178.22
+"compress_mbps": 113.28,
+"decompress_mbps": 183.05
 },
 {
 "compressor": "js",
@@ -10824,8 +10824,8 @@
 "level": 2,
 "out_size": 221369,
 "ratio": 0.215,
-"compress_mbps": 90.86,
-"decompress_mbps": 190.73
+"compress_mbps": 90.24,
+"decompress_mbps": 255.24
 },
 {
 "compressor": "js",
@@ -10834,8 +10834,8 @@
 "level": 3,
 "out_size": 218607,
 "ratio": 0.2123,
-"compress_mbps": 78.8,
-"decompress_mbps": 190.72
+"compress_mbps": 78.67,
+"decompress_mbps": 187.61
 },
 {
 "compressor": "js",
@@ -10844,8 +10844,8 @@
 "level": 4,
 "out_size": 217919,
 "ratio": 0.2116,
-"compress_mbps": 70.99,
-"decompress_mbps": 191.79
+"compress_mbps": 69.94,
+"decompress_mbps": 195.29
 },
 {
 "compressor": "js",
@@ -10854,8 +10854,8 @@
 "level": 5,
 "out_size": 217919,
 "ratio": 0.2116,
-"compress_mbps": 70.12,
-"decompress_mbps": 196.23
+"compress_mbps": 70.92,
+"decompress_mbps": 195.59
 },
 {
 "compressor": "js",
@@ -10864,8 +10864,8 @@
 "level": 6,
 "out_size": 217312,
 "ratio": 0.211,
-"compress_mbps": 43.89,
-"decompress_mbps": 193.38
+"compress_mbps": 44.09,
+"decompress_mbps": 191.18
 },
 {
 "compressor": "js",
@@ -10874,8 +10874,8 @@
 "level": 7,
 "out_size": 215966,
 "ratio": 0.2097,
-"compress_mbps": 31.02,
-"decompress_mbps": 191.16
+"compress_mbps": 31.15,
+"decompress_mbps": 191.54
 },
 {
 "compressor": "js",
@@ -10885,7 +10885,7 @@
 "out_size": 215930,
 "ratio": 0.2097,
 "compress_mbps": 14.32,
-"decompress_mbps": 194.39
+"decompress_mbps": 194.26
 },
 {
 "compressor": "js",
@@ -10894,8 +10894,8 @@
 "level": 9,
 "out_size": 215912,
 "ratio": 0.2097,
-"compress_mbps": 11.24,
-"decompress_mbps": 209.84
+"compress_mbps": 11.1,
+"decompress_mbps": 210.59
 },
 {
 "compressor": "js",
@@ -10904,8 +10904,8 @@
 "level": 1,
 "out_size": 167622,
 "ratio": 0.3928,
-"compress_mbps": 64.98,
-"decompress_mbps": 118.12
+"compress_mbps": 64.39,
+"decompress_mbps": 116.3
 },
 {
 "compressor": "js",
@@ -10914,8 +10914,8 @@
 "level": 2,
 "out_size": 158003,
 "ratio": 0.3702,
-"compress_mbps": 54.15,
-"decompress_mbps": 139.99
+"compress_mbps": 64.34,
+"decompress_mbps": 139.36
 },
 {
 "compressor": "js",
@@ -10924,8 +10924,8 @@
 "level": 3,
 "out_size": 152928,
 "ratio": 0.3584,
-"compress_mbps": 46.69,
-"decompress_mbps": 143.87
+"compress_mbps": 46.67,
+"decompress_mbps": 141.08
 },
 {
 "compressor": "js",
@@ -10934,8 +10934,8 @@
 "level": 4,
 "out_size": 149886,
 "ratio": 0.3512,
-"compress_mbps": 40.39,
-"decompress_mbps": 136.81
+"compress_mbps": 33.71,
+"decompress_mbps": 136.65
 },
 {
 "compressor": "js",
@@ -10944,8 +10944,8 @@
 "level": 5,
 "out_size": 149767,
 "ratio": 0.3509,
-"compress_mbps": 38.7,
-"decompress_mbps": 136.38
+"compress_mbps": 39.31,
+"decompress_mbps": 138
 },
 {
 "compressor": "js",
@@ -10954,8 +10954,8 @@
 "level": 6,
 "out_size": 147818,
 "ratio": 0.3464,
-"compress_mbps": 28.52,
-"decompress_mbps": 151.53
+"compress_mbps": 33.18,
+"decompress_mbps": 150.78
 },
 {
 "compressor": "js",
@@ -10964,8 +10964,8 @@
 "level": 7,
 "out_size": 147733,
 "ratio": 0.3462,
-"compress_mbps": 32.91,
-"decompress_mbps": 152.45
+"compress_mbps": 32.42,
+"decompress_mbps": 154.24
 },
 {
 "compressor": "js",
@@ -10974,8 +10974,8 @@
 "level": 8,
 "out_size": 147709,
 "ratio": 0.3461,
-"compress_mbps": 31.92,
-"decompress_mbps": 149.4
+"compress_mbps": 32.15,
+"decompress_mbps": 151.45
 },
 {
 "compressor": "js",
@@ -10984,8 +10984,8 @@
 "level": 9,
 "out_size": 147705,
 "ratio": 0.3461,
-"compress_mbps": 28.26,
-"decompress_mbps": 136.77
+"compress_mbps": 32.65,
+"decompress_mbps": 138.19
 },
 {
 "compressor": "js",
@@ -10994,8 +10994,8 @@
 "level": 1,
 "out_size": 222866,
 "ratio": 0.4625,
-"compress_mbps": 57.48,
-"decompress_mbps": 101.55
+"compress_mbps": 58.92,
+"decompress_mbps": 105.16
 },
 {
 "compressor": "js",
@@ -11004,8 +11004,8 @@
 "level": 2,
 "out_size": 212925,
 "ratio": 0.4419,
-"compress_mbps": 49.36,
-"decompress_mbps": 118.79
+"compress_mbps": 49.52,
+"decompress_mbps": 118.08
 },
 {
 "compressor": "js",
@@ -11014,8 +11014,8 @@
 "level": 3,
 "out_size": 206913,
 "ratio": 0.4294,
-"compress_mbps": 40.36,
-"decompress_mbps": 118.27
+"compress_mbps": 40.5,
+"decompress_mbps": 116.88
 },
 {
 "compressor": "js",
@@ -11024,8 +11024,8 @@
 "level": 4,
 "out_size": 202875,
 "ratio": 0.421,
-"compress_mbps": 34.31,
-"decompress_mbps": 116.61
+"compress_mbps": 33.54,
+"decompress_mbps": 111.31
 },
 {
 "compressor": "js",
@@ -11034,8 +11034,8 @@
 "level": 5,
 "out_size": 202867,
 "ratio": 0.421,
-"compress_mbps": 34.04,
-"decompress_mbps": 127.97
+"compress_mbps": 33.57,
+"decompress_mbps": 117.4
 },
 {
 "compressor": "js",
@@ -11044,8 +11044,8 @@
 "level": 6,
 "out_size": 199818,
 "ratio": 0.4147,
-"compress_mbps": 28.49,
-"decompress_mbps": 129.39
+"compress_mbps": 28.4,
+"decompress_mbps": 114.8
 },
 {
 "compressor": "js",
@@ -11054,8 +11054,8 @@
 "level": 7,
 "out_size": 199664,
 "ratio": 0.4144,
-"compress_mbps": 27.82,
-"decompress_mbps": 119.82
+"compress_mbps": 27.76,
+"decompress_mbps": 105.02
 },
 {
 "compressor": "js",
@@ -11064,8 +11064,8 @@
 "level": 8,
 "out_size": 199634,
 "ratio": 0.4143,
-"compress_mbps": 28,
-"decompress_mbps": 119.17
+"compress_mbps": 28.19,
+"decompress_mbps": 106.5
 },
 {
 "compressor": "js",
@@ -11074,8 +11074,8 @@
 "level": 9,
 "out_size": 199634,
 "ratio": 0.4143,
-"compress_mbps": 28,
-"decompress_mbps": 161.01
+"compress_mbps": 27.99,
+"decompress_mbps": 121
 },
 {
 "compressor": "js",
@@ -11084,8 +11084,8 @@
 "level": 1,
 "out_size": 60580,
 "ratio": 0.118,
-"compress_mbps": 116.16,
-"decompress_mbps": 253.54
+"compress_mbps": 118.15,
+"decompress_mbps": 253.84
 },
 {
 "compressor": "js",
@@ -11094,8 +11094,8 @@
 "level": 2,
 "out_size": 59663,
 "ratio": 0.1163,
-"compress_mbps": 106.69,
-"decompress_mbps": 292.51
+"compress_mbps": 131.11,
+"decompress_mbps": 295.73
 },
 {
 "compressor": "js",
@@ -11104,8 +11104,8 @@
 "level": 3,
 "out_size": 59465,
 "ratio": 0.1159,
-"compress_mbps": 126.73,
-"decompress_mbps": 280.23
+"compress_mbps": 100.74,
+"decompress_mbps": 295.91
 },
 {
 "compressor": "js",
@@ -11114,8 +11114,8 @@
 "level": 4,
 "out_size": 59353,
 "ratio": 0.1156,
-"compress_mbps": 95.04,
-"decompress_mbps": 292.15
+"compress_mbps": 95.09,
+"decompress_mbps": 302.88
 },
 {
 "compressor": "js",
@@ -11124,8 +11124,8 @@
 "level": 5,
 "out_size": 58830,
 "ratio": 0.1146,
-"compress_mbps": 89.4,
-"decompress_mbps": 277.16
+"compress_mbps": 107.76,
+"decompress_mbps": 221.47
 },
 {
 "compressor": "js",
@@ -11134,8 +11134,8 @@
 "level": 6,
 "out_size": 57884,
 "ratio": 0.1128,
-"compress_mbps": 58.51,
-"decompress_mbps": 292.89
+"compress_mbps": 56.85,
+"decompress_mbps": 285.29
 },
 {
 "compressor": "js",
@@ -11144,8 +11144,8 @@
 "level": 7,
 "out_size": 57206,
 "ratio": 0.1115,
-"compress_mbps": 45.45,
-"decompress_mbps": 315.94
+"compress_mbps": 46.17,
+"decompress_mbps": 299.77
 },
 {
 "compressor": "js",
@@ -11154,8 +11154,8 @@
 "level": 8,
 "out_size": 56545,
 "ratio": 0.1102,
-"compress_mbps": 23.11,
-"decompress_mbps": 281.11
+"compress_mbps": 23.09,
+"decompress_mbps": 280.1
 },
 {
 "compressor": "js",
@@ -11164,8 +11164,8 @@
 "level": 9,
 "out_size": 56454,
 "ratio": 0.11,
-"compress_mbps": 9.14,
-"decompress_mbps": 288.48
+"compress_mbps": 9.11,
+"decompress_mbps": 300.36
 },
 {
 "compressor": "js",
@@ -11174,8 +11174,8 @@
 "level": 1,
 "out_size": 14194,
 "ratio": 0.3712,
-"compress_mbps": 69.06,
-"decompress_mbps": 136.08
+"compress_mbps": 83.27,
+"decompress_mbps": 134.84
 },
 {
 "compressor": "js",
@@ -11184,8 +11184,8 @@
 "level": 2,
 "out_size": 13770,
 "ratio": 0.3601,
-"compress_mbps": 69.84,
-"decompress_mbps": 117.52
+"compress_mbps": 74.14,
+"decompress_mbps": 116.53
 },
 {
 "compressor": "js",
@@ -11194,8 +11194,8 @@
 "level": 3,
 "out_size": 13611,
 "ratio": 0.3559,
-"compress_mbps": 66.55,
-"decompress_mbps": 114.95
+"compress_mbps": 66.24,
+"decompress_mbps": 115.38
 },
 {
 "compressor": "js",
@@ -11204,8 +11204,8 @@
 "level": 4,
 "out_size": 13534,
 "ratio": 0.3539,
-"compress_mbps": 62.69,
-"decompress_mbps": 120.61
+"compress_mbps": 61.31,
+"decompress_mbps": 117.96
 },
 {
 "compressor": "js",
@@ -11214,8 +11214,8 @@
 "level": 5,
 "out_size": 13527,
 "ratio": 0.3537,
-"compress_mbps": 63.23,
-"decompress_mbps": 138.62
+"compress_mbps": 61.97,
+"decompress_mbps": 148.27
 },
 {
 "compressor": "js",
@@ -11224,8 +11224,8 @@
 "level": 6,
 "out_size": 13438,
 "ratio": 0.3514,
-"compress_mbps": 51.86,
-"decompress_mbps": 144.66
+"compress_mbps": 51.17,
+"decompress_mbps": 142.65
 },
 {
 "compressor": "js",
@@ -11234,8 +11234,8 @@
 "level": 7,
 "out_size": 13419,
 "ratio": 0.3509,
-"compress_mbps": 46.83,
-"decompress_mbps": 117.01
+"compress_mbps": 47.83,
+"decompress_mbps": 125.84
 },
 {
 "compressor": "js",
@@ -11244,8 +11244,8 @@
 "level": 8,
 "out_size": 13404,
 "ratio": 0.3505,
-"compress_mbps": 40.59,
-"decompress_mbps": 118.55
+"compress_mbps": 41.2,
+"decompress_mbps": 118.77
 },
 {
 "compressor": "js",
@@ -11254,8 +11254,8 @@
 "level": 9,
 "out_size": 13390,
 "ratio": 0.3502,
-"compress_mbps": 36.42,
-"decompress_mbps": 124.76
+"compress_mbps": 35.78,
+"decompress_mbps": 116.99
 },
 {
 "compressor": "js",
@@ -11264,8 +11264,8 @@
 "level": 1,
 "out_size": 1832,
 "ratio": 0.4334,
-"compress_mbps": 58.16,
-"decompress_mbps": 49.55
+"compress_mbps": 41.01,
+"decompress_mbps": 45
 },
 {
 "compressor": "js",
@@ -11274,8 +11274,8 @@
 "level": 2,
 "out_size": 1776,
 "ratio": 0.4202,
-"compress_mbps": 55.77,
-"decompress_mbps": 57.76
+"compress_mbps": 58.71,
+"decompress_mbps": 64.9
 },
 {
 "compressor": "js",
@@ -11284,8 +11284,8 @@
 "level": 3,
 "out_size": 1764,
 "ratio": 0.4173,
-"compress_mbps": 59.44,
-"decompress_mbps": 54.77
+"compress_mbps": 57.37,
+"decompress_mbps": 62.38
 },
 {
 "compressor": "js",
@@ -11294,8 +11294,8 @@
 "level": 4,
 "out_size": 1763,
 "ratio": 0.4171,
-"compress_mbps": 59.15,
-"decompress_mbps": 56.14
+"compress_mbps": 56.88,
+"decompress_mbps": 53.28
 },
 {
 "compressor": "js",
@@ -11304,8 +11304,8 @@
 "level": 5,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 57.65,
-"decompress_mbps": 50.9
+"compress_mbps": 59.36,
+"decompress_mbps": 48.79
 },
 {
 "compressor": "js",
@@ -11314,8 +11314,8 @@
 "level": 6,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 57.84,
-"decompress_mbps": 49.69
+"compress_mbps": 40.25,
+"decompress_mbps": 47.27
 },
 {
 "compressor": "js",
@@ -11324,8 +11324,8 @@
 "level": 7,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 59.49,
-"decompress_mbps": 50.96
+"compress_mbps": 57.06,
+"decompress_mbps": 48.39
 },
 {
 "compressor": "js",
@@ -11334,8 +11334,8 @@
 "level": 8,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 39.79,
-"decompress_mbps": 61.84
+"compress_mbps": 58.67,
+"decompress_mbps": 52.39
 },
 {
 "compressor": "js",
@@ -11344,8 +11344,8 @@
 "level": 9,
 "out_size": 1760,
 "ratio": 0.4164,
-"compress_mbps": 37.74,
-"decompress_mbps": 48.52
+"compress_mbps": 58.3,
+"decompress_mbps": 62.91
 },
 {
 "compressor": "js",
@@ -11354,8 +11354,8 @@
 "level": 1,
 "out_size": 4462632,
 "ratio": 0.4378,
-"compress_mbps": 62.3,
-"decompress_mbps": 135.54
+"compress_mbps": 61.62,
+"decompress_mbps": 170.85
 },
 {
 "compressor": "js",
@@ -11364,8 +11364,8 @@
 "level": 2,
 "out_size": 4244833,
 "ratio": 0.4165,
-"compress_mbps": 50.68,
-"decompress_mbps": 204.52
+"compress_mbps": 50.24,
+"decompress_mbps": 201.42
 },
 {
 "compressor": "js",
@@ -11374,8 +11374,8 @@
 "level": 3,
 "out_size": 4112285,
 "ratio": 0.4035,
-"compress_mbps": 41.76,
-"decompress_mbps": 136.18
+"compress_mbps": 42.04,
+"decompress_mbps": 178.21
 },
 {
 "compressor": "js",
@@ -11384,8 +11384,8 @@
 "level": 4,
 "out_size": 4020435,
 "ratio": 0.3945,
-"compress_mbps": 35.63,
-"decompress_mbps": 143
+"compress_mbps": 35.5,
+"decompress_mbps": 142.52
 },
 {
 "compressor": "js",
@@ -11394,8 +11394,8 @@
 "level": 5,
 "out_size": 4019177,
 "ratio": 0.3943,
-"compress_mbps": 35.03,
-"decompress_mbps": 141.23
+"compress_mbps": 35.31,
+"decompress_mbps": 170.54
 },
 {
 "compressor": "js",
@@ -11404,8 +11404,8 @@
 "level": 6,
 "out_size": 3956464,
 "ratio": 0.3882,
-"compress_mbps": 29.27,
-"decompress_mbps": 156.61
+"compress_mbps": 28.75,
+"decompress_mbps": 164.24
 },
 {
 "compressor": "js",
@@ -11414,8 +11414,8 @@
 "level": 7,
 "out_size": 3953310,
 "ratio": 0.3879,
-"compress_mbps": 28.42,
-"decompress_mbps": 201.57
+"compress_mbps": 28.47,
+"decompress_mbps": 198.87
 },
 {
 "compressor": "js",
@@ -11424,8 +11424,8 @@
 "level": 8,
 "out_size": 3952872,
 "ratio": 0.3878,
-"compress_mbps": 29.33,
-"decompress_mbps": 224.21
+"compress_mbps": 29.08,
+"decompress_mbps": 220.53
 },
 {
 "compressor": "js",
@@ -11434,8 +11434,8 @@
 "level": 9,
 "out_size": 3952872,
 "ratio": 0.3878,
-"compress_mbps": 29.3,
-"decompress_mbps": 224.69
+"compress_mbps": 29.21,
+"decompress_mbps": 218.12
 },
 {
 "compressor": "js",
@@ -11444,8 +11444,8 @@
 "level": 1,
 "out_size": 20177423,
 "ratio": 0.3939,
-"compress_mbps": 72.21,
-"decompress_mbps": 215.81
+"compress_mbps": 72.68,
+"decompress_mbps": 209.54
 },
 {
 "compressor": "js",
@@ -11454,8 +11454,8 @@
 "level": 2,
 "out_size": 19759467,
 "ratio": 0.3858,
-"compress_mbps": 63.43,
-"decompress_mbps": 196.73
+"compress_mbps": 63.85,
+"decompress_mbps": 193.45
 },
 {
 "compressor": "js",
@@ -11464,8 +11464,8 @@
 "level": 3,
 "out_size": 19583171,
 "ratio": 0.3823,
-"compress_mbps": 57.71,
-"decompress_mbps": 220.64
+"compress_mbps": 57.14,
+"decompress_mbps": 206.47
 },
 {
 "compressor": "js",
@@ -11474,8 +11474,8 @@
 "level": 4,
 "out_size": 19479125,
 "ratio": 0.3803,
-"compress_mbps": 50.61,
-"decompress_mbps": 219.56
+"compress_mbps": 51.03,
+"decompress_mbps": 205.14
 },
 {
 "compressor": "js",
@@ -11484,8 +11484,8 @@
 "level": 5,
 "out_size": 19423693,
 "ratio": 0.3792,
-"compress_mbps": 49.4,
-"decompress_mbps": 202.99
+"compress_mbps": 49.13,
+"decompress_mbps": 200.07
 },
 {
 "compressor": "js",
@@ -11494,8 +11494,8 @@
 "level": 6,
 "out_size": 19337683,
 "ratio": 0.3775,
-"compress_mbps": 36.36,
-"decompress_mbps": 201.74
+"compress_mbps": 36.05,
+"decompress_mbps": 188.48
 },
 {
 "compressor": "js",
@@ -11504,8 +11504,8 @@
 "level": 7,
 "out_size": 19323922,
 "ratio": 0.3773,
-"compress_mbps": 30.39,
-"decompress_mbps": 192.6
+"compress_mbps": 29.08,
+"decompress_mbps": 193.94
 },
 {
 "compressor": "js",
@@ -11515,7 +11515,7 @@
 "out_size": 19314797,
 "ratio": 0.3771,
 "compress_mbps": 19.5,
-"decompress_mbps": 205.3
+"decompress_mbps": 225.36
 },
 {
 "compressor": "js",
@@ -11524,8 +11524,8 @@
 "level": 9,
 "out_size": 19312663,
 "ratio": 0.377,
-"compress_mbps": 11.1,
-"decompress_mbps": 227.07
+"compress_mbps": 11.12,
+"decompress_mbps": 219.23
 },
 {
 "compressor": "js",
@@ -11534,8 +11534,8 @@
 "level": 1,
 "out_size": 3762978,
 "ratio": 0.3774,
-"compress_mbps": 78.61,
-"decompress_mbps": 158.12
+"compress_mbps": 78.68,
+"decompress_mbps": 163.86
 },
 {
 "compressor": "js",
@@ -11544,8 +11544,8 @@
 "level": 2,
 "out_size": 3711615,
 "ratio": 0.3723,
-"compress_mbps": 68.12,
-"decompress_mbps": 202.97
+"compress_mbps": 68.1,
+"decompress_mbps": 196.85
 },
 {
 "compressor": "js",
@@ -11554,8 +11554,8 @@
 "level": 3,
 "out_size": 3663131,
 "ratio": 0.3674,
-"compress_mbps": 57.42,
-"decompress_mbps": 181.04
+"compress_mbps": 57.01,
+"decompress_mbps": 241.11
 },
 {
 "compressor": "js",
@@ -11564,8 +11564,8 @@
 "level": 4,
 "out_size": 3631512,
 "ratio": 0.3642,
-"compress_mbps": 50.24,
-"decompress_mbps": 222.02
+"compress_mbps": 49.21,
+"decompress_mbps": 221.03
 },
 {
 "compressor": "js",
@@ -11574,8 +11574,8 @@
 "level": 5,
 "out_size": 3630867,
 "ratio": 0.3642,
-"compress_mbps": 48.7,
-"decompress_mbps": 223.69
+"compress_mbps": 48.78,
+"decompress_mbps": 216.62
 },
 {
 "compressor": "js",
@@ -11584,8 +11584,8 @@
 "level": 6,
 "out_size": 3615953,
 "ratio": 0.3627,
-"compress_mbps": 37.66,
-"decompress_mbps": 249.33
+"compress_mbps": 37.72,
+"decompress_mbps": 247.65
 },
 {
 "compressor": "js",
@@ -11594,8 +11594,8 @@
 "level": 7,
 "out_size": 3615518,
 "ratio": 0.3626,
-"compress_mbps": 35.64,
-"decompress_mbps": 221.77
+"compress_mbps": 35.3,
+"decompress_mbps": 189.82
 },
 {
 "compressor": "js",
@@ -11604,8 +11604,8 @@
 "level": 8,
 "out_size": 3613845,
 "ratio": 0.3625,
-"compress_mbps": 30.23,
-"decompress_mbps": 213.61
+"compress_mbps": 30.03,
+"decompress_mbps": 255.34
 },
 {
 "compressor": "js",
@@ -11614,8 +11614,8 @@
 "level": 9,
 "out_size": 3614283,
 "ratio": 0.3625,
-"compress_mbps": 26.82,
-"decompress_mbps": 162.6
+"compress_mbps": 26.24,
+"decompress_mbps": 222.16
 },
 {
 "compressor": "js",
@@ -11624,8 +11624,8 @@
 "level": 1,
 "out_size": 4418800,
 "ratio": 0.1317,
-"compress_mbps": 133.39,
-"decompress_mbps": 341.59
+"compress_mbps": 133,
+"decompress_mbps": 338.57
 },
 {
 "compressor": "js",
@@ -11634,8 +11634,8 @@
 "level": 2,
 "out_size": 4026774,
 "ratio": 0.12,
-"compress_mbps": 124.09,
-"decompress_mbps": 340.36
+"compress_mbps": 123.44,
+"decompress_mbps": 339.7
 },
 {
 "compressor": "js",
@@ -11644,8 +11644,8 @@
 "level": 3,
 "out_size": 3837798,
 "ratio": 0.1144,
-"compress_mbps": 115.23,
-"decompress_mbps": 469.72
+"compress_mbps": 116.34,
+"decompress_mbps": 370.54
 },
 {
 "compressor": "js",
@@ -11654,8 +11654,8 @@
 "level": 4,
 "out_size": 3751023,
 "ratio": 0.1118,
-"compress_mbps": 110.56,
-"decompress_mbps": 370.32
+"compress_mbps": 110.1,
+"decompress_mbps": 361.38
 },
 {
 "compressor": "js",
@@ -11664,8 +11664,8 @@
 "level": 5,
 "out_size": 3643468,
 "ratio": 0.1086,
-"compress_mbps": 99.67,
-"decompress_mbps": 356.18
+"compress_mbps": 101.98,
+"decompress_mbps": 371.36
 },
 {
 "compressor": "js",
@@ -11674,8 +11674,8 @@
 "level": 6,
 "out_size": 3379481,
 "ratio": 0.1007,
-"compress_mbps": 68.43,
-"decompress_mbps": 366.08
+"compress_mbps": 68.99,
+"decompress_mbps": 366.05
 },
 {
 "compressor": "js",
@@ -11684,8 +11684,8 @@
 "level": 7,
 "out_size": 3354082,
 "ratio": 0.1,
-"compress_mbps": 60.97,
-"decompress_mbps": 369.9
+"compress_mbps": 61.49,
+"decompress_mbps": 366.51
 },
 {
 "compressor": "js",
@@ -11694,8 +11694,8 @@
 "level": 8,
 "out_size": 3330028,
 "ratio": 0.0992,
-"compress_mbps": 48.02,
-"decompress_mbps": 386.87
+"compress_mbps": 49.65,
+"decompress_mbps": 396.52
 },
 {
 "compressor": "js",
@@ -11704,8 +11704,8 @@
 "level": 9,
 "out_size": 3327482,
 "ratio": 0.0992,
-"compress_mbps": 37.78,
-"decompress_mbps": 371.65
+"compress_mbps": 37.41,
+"decompress_mbps": 367.06
 },
 {
 "compressor": "js",
@@ -11714,8 +11714,8 @@
 "level": 1,
 "out_size": 3233790,
 "ratio": 0.5256,
-"compress_mbps": 53.3,
-"decompress_mbps": 141.8
+"compress_mbps": 52.65,
+"decompress_mbps": 141.02
 },
 {
 "compressor": "js",
@@ -11724,8 +11724,8 @@
 "level": 2,
 "out_size": 3184644,
 "ratio": 0.5176,
-"compress_mbps": 48.44,
-"decompress_mbps": 142.37
+"compress_mbps": 48.35,
+"decompress_mbps": 141.34
 },
 {
 "compressor": "js",
@@ -11734,8 +11734,8 @@
 "level": 3,
 "out_size": 3160521,
 "ratio": 0.5137,
-"compress_mbps": 43.93,
-"decompress_mbps": 146.37
+"compress_mbps": 44.16,
+"decompress_mbps": 134.37
 },
 {
 "compressor": "js",
@@ -11744,8 +11744,8 @@
 "level": 4,
 "out_size": 3141929,
 "ratio": 0.5107,
-"compress_mbps": 39.81,
-"decompress_mbps": 153.04
+"compress_mbps": 40.04,
+"decompress_mbps": 150.29
 },
 {
 "compressor": "js",
@@ -11754,8 +11754,8 @@
 "level": 5,
 "out_size": 3138514,
 "ratio": 0.5101,
-"compress_mbps": 38.94,
-"decompress_mbps": 143.83
+"compress_mbps": 39.11,
+"decompress_mbps": 134.68
 },
 {
 "compressor": "js",
@@ -11764,8 +11764,8 @@
 "level": 6,
 "out_size": 3126843,
 "ratio": 0.5082,
-"compress_mbps": 32.97,
-"decompress_mbps": 110.54
+"compress_mbps": 32.81,
+"decompress_mbps": 149.93
 },
 {
 "compressor": "js",
@@ -11774,8 +11774,8 @@
 "level": 7,
 "out_size": 3126796,
 "ratio": 0.5082,
-"compress_mbps": 29.89,
-"decompress_mbps": 147.75
+"compress_mbps": 30.63,
+"decompress_mbps": 145.05
 },
 {
 "compressor": "js",
@@ -11784,8 +11784,8 @@
 "level": 8,
 "out_size": 3126322,
 "ratio": 0.5082,
-"compress_mbps": 26.77,
-"decompress_mbps": 145.02
+"compress_mbps": 27.28,
+"decompress_mbps": 153.07
 },
 {
 "compressor": "js",
@@ -11794,8 +11794,8 @@
 "level": 9,
 "out_size": 3126286,
 "ratio": 0.5082,
-"compress_mbps": 23.08,
-"decompress_mbps": 108.68
+"compress_mbps": 23.43,
+"decompress_mbps": 154.77
 },
 {
 "compressor": "js",
@@ -11804,8 +11804,8 @@
 "level": 1,
 "out_size": 4076349,
 "ratio": 0.4042,
-"compress_mbps": 78.41,
-"decompress_mbps": 204.75
+"compress_mbps": 79.56,
+"decompress_mbps": 217.72
 },
 {
 "compressor": "js",
@@ -11814,8 +11814,8 @@
 "level": 2,
 "out_size": 3914739,
 "ratio": 0.3881,
-"compress_mbps": 72.23,
-"decompress_mbps": 236.11
+"compress_mbps": 72.11,
+"decompress_mbps": 235.6
 },
 {
 "compressor": "js",
@@ -11824,8 +11824,8 @@
 "level": 3,
 "out_size": 3845160,
 "ratio": 0.3812,
-"compress_mbps": 68.12,
-"decompress_mbps": 271.44
+"compress_mbps": 68.92,
+"decompress_mbps": 265.95
 },
 {
 "compressor": "js",
@@ -11834,8 +11834,8 @@
 "level": 4,
 "out_size": 3822047,
 "ratio": 0.379,
-"compress_mbps": 64.41,
-"decompress_mbps": 241.99
+"compress_mbps": 65.9,
+"decompress_mbps": 249.1
 },
 {
 "compressor": "js",
@@ -11844,8 +11844,8 @@
 "level": 5,
 "out_size": 3799472,
 "ratio": 0.3767,
-"compress_mbps": 59.9,
-"decompress_mbps": 192.04
+"compress_mbps": 60.47,
+"decompress_mbps": 196.63
 },
 {
 "compressor": "js",
@@ -11854,8 +11854,8 @@
 "level": 6,
 "out_size": 3783861,
 "ratio": 0.3752,
-"compress_mbps": 58.33,
-"decompress_mbps": 199
+"compress_mbps": 59.24,
+"decompress_mbps": 206.2
 },
 {
 "compressor": "js",
@@ -11864,8 +11864,8 @@
 "level": 7,
 "out_size": 3783432,
 "ratio": 0.3751,
-"compress_mbps": 57.77,
-"decompress_mbps": 277.51
+"compress_mbps": 57.5,
+"decompress_mbps": 276.55
 },
 {
 "compressor": "js",
@@ -11874,8 +11874,8 @@
 "level": 8,
 "out_size": 3783342,
 "ratio": 0.3751,
-"compress_mbps": 58.02,
-"decompress_mbps": 278.74
+"compress_mbps": 57.79,
+"decompress_mbps": 278.67
 },
 {
 "compressor": "js",
@@ -11884,8 +11884,8 @@
 "level": 9,
 "out_size": 3783342,
 "ratio": 0.3751,
-"compress_mbps": 58.55,
-"decompress_mbps": 201.28
+"compress_mbps": 57.86,
+"decompress_mbps": 279.64
 },
 {
 "compressor": "js",
@@ -11894,8 +11894,8 @@
 "level": 1,
 "out_size": 2261112,
 "ratio": 0.3412,
-"compress_mbps": 70.59,
-"decompress_mbps": 202.5
+"compress_mbps": 71.4,
+"decompress_mbps": 216.97
 },
 {
 "compressor": "js",
@@ -11904,8 +11904,8 @@
 "level": 2,
 "out_size": 2128691,
 "ratio": 0.3212,
-"compress_mbps": 58.76,
-"decompress_mbps": 206.2
+"compress_mbps": 58.57,
+"decompress_mbps": 197.06
 },
 {
 "compressor": "js",
@@ -11914,8 +11914,8 @@
 "level": 3,
 "out_size": 2049023,
 "ratio": 0.3092,
-"compress_mbps": 48.36,
-"decompress_mbps": 212.84
+"compress_mbps": 48.53,
+"decompress_mbps": 209.61
 },
 {
 "compressor": "js",
@@ -11924,8 +11924,8 @@
 "level": 4,
 "out_size": 1990249,
 "ratio": 0.3003,
-"compress_mbps": 40.57,
-"decompress_mbps": 208.73
+"compress_mbps": 41.12,
+"decompress_mbps": 207.91
 },
 {
 "compressor": "js",
@@ -11934,8 +11934,8 @@
 "level": 5,
 "out_size": 1975224,
 "ratio": 0.298,
-"compress_mbps": 39.48,
-"decompress_mbps": 224.74
+"compress_mbps": 39.61,
+"decompress_mbps": 151.52
 },
 {
 "compressor": "js",
@@ -11944,8 +11944,8 @@
 "level": 6,
 "out_size": 1910262,
 "ratio": 0.2882,
-"compress_mbps": 27.24,
-"decompress_mbps": 229.35
+"compress_mbps": 28.21,
+"decompress_mbps": 164.32
 },
 {
 "compressor": "js",
@@ -11954,8 +11954,8 @@
 "level": 7,
 "out_size": 1902923,
 "ratio": 0.2871,
-"compress_mbps": 25.22,
-"decompress_mbps": 226.88
+"compress_mbps": 25.04,
+"decompress_mbps": 221.63
 },
 {
 "compressor": "js",
@@ -11964,8 +11964,8 @@
 "level": 8,
 "out_size": 1900964,
 "ratio": 0.2868,
-"compress_mbps": 23.32,
-"decompress_mbps": 226.28
+"compress_mbps": 23.45,
+"decompress_mbps": 227.66
 },
 {
 "compressor": "js",
@@ -11974,8 +11974,8 @@
 "level": 9,
 "out_size": 1900958,
 "ratio": 0.2868,
-"compress_mbps": 24.68,
-"decompress_mbps": 163.44
+"compress_mbps": 24.4,
+"decompress_mbps": 207.65
 },
 {
 "compressor": "js",
@@ -11984,8 +11984,8 @@
 "level": 1,
 "out_size": 6016919,
 "ratio": 0.2785,
-"compress_mbps": 90.05,
-"decompress_mbps": 253.09
+"compress_mbps": 92.31,
+"decompress_mbps": 250.38
 },
 {
 "compressor": "js",
@@ -11994,8 +11994,8 @@
 "level": 2,
 "out_size": 5767272,
 "ratio": 0.2669,
-"compress_mbps": 82.21,
-"decompress_mbps": 286.5
+"compress_mbps": 81.02,
+"decompress_mbps": 287.18
 },
 {
 "compressor": "js",
@@ -12004,8 +12004,8 @@
 "level": 3,
 "out_size": 5669548,
 "ratio": 0.2624,
-"compress_mbps": 75.74,
-"decompress_mbps": 269.87
+"compress_mbps": 75.87,
+"decompress_mbps": 211.21
 },
 {
 "compressor": "js",
@@ -12014,8 +12014,8 @@
 "level": 4,
 "out_size": 5619947,
 "ratio": 0.2601,
-"compress_mbps": 69.65,
-"decompress_mbps": 221.32
+"compress_mbps": 68.8,
+"decompress_mbps": 271.25
 },
 {
 "compressor": "js",
@@ -12024,8 +12024,8 @@
 "level": 5,
 "out_size": 5586034,
 "ratio": 0.2585,
-"compress_mbps": 64.6,
-"decompress_mbps": 225.88
+"compress_mbps": 64.77,
+"decompress_mbps": 270.13
 },
 {
 "compressor": "js",
@@ -12034,8 +12034,8 @@
 "level": 6,
 "out_size": 5540130,
 "ratio": 0.2564,
-"compress_mbps": 50.88,
-"decompress_mbps": 277.05
+"compress_mbps": 50.72,
+"decompress_mbps": 269.04
 },
 {
 "compressor": "js",
@@ -12044,8 +12044,8 @@
 "level": 7,
 "out_size": 5537271,
 "ratio": 0.2563,
-"compress_mbps": 46.44,
-"decompress_mbps": 279.81
+"compress_mbps": 45.58,
+"decompress_mbps": 209.67
 },
 {
 "compressor": "js",
@@ -12054,8 +12054,8 @@
 "level": 8,
 "out_size": 5530686,
 "ratio": 0.256,
-"compress_mbps": 39.66,
-"decompress_mbps": 304
+"compress_mbps": 35.75,
+"decompress_mbps": 303.18
 },
 {
 "compressor": "js",
@@ -12064,8 +12064,8 @@
 "level": 9,
 "out_size": 5529823,
 "ratio": 0.2559,
-"compress_mbps": 30.72,
-"decompress_mbps": 260.48
+"compress_mbps": 31.59,
+"decompress_mbps": 227.31
 },
 {
 "compressor": "js",
@@ -12074,8 +12074,8 @@
 "level": 1,
 "out_size": 5602819,
 "ratio": 0.7726,
-"compress_mbps": 48.76,
-"decompress_mbps": 114.67
+"compress_mbps": 47.72,
+"decompress_mbps": 166.89
 },
 {
 "compressor": "js",
@@ -12084,8 +12084,8 @@
 "level": 2,
 "out_size": 5504019,
 "ratio": 0.759,
-"compress_mbps": 43.41,
-"decompress_mbps": 154.89
+"compress_mbps": 42.76,
+"decompress_mbps": 153.39
 },
 {
 "compressor": "js",
@@ -12094,8 +12094,8 @@
 "level": 3,
 "out_size": 5452816,
 "ratio": 0.7519,
-"compress_mbps": 38.78,
-"decompress_mbps": 153
+"compress_mbps": 38.01,
+"decompress_mbps": 153.91
 },
 {
 "compressor": "js",
@@ -12104,8 +12104,8 @@
 "level": 4,
 "out_size": 5425752,
 "ratio": 0.7482,
-"compress_mbps": 35.26,
-"decompress_mbps": 178.09
+"compress_mbps": 35.6,
+"decompress_mbps": 177.63
 },
 {
 "compressor": "js",
@@ -12114,8 +12114,8 @@
 "level": 5,
 "out_size": 5425752,
 "ratio": 0.7482,
-"compress_mbps": 35.08,
-"decompress_mbps": 184.88
+"compress_mbps": 36.17,
+"decompress_mbps": 176.78
 },
 {
 "compressor": "js",
@@ -12124,8 +12124,8 @@
 "level": 6,
 "out_size": 5407602,
 "ratio": 0.7457,
-"compress_mbps": 31.2,
-"decompress_mbps": 122.27
+"compress_mbps": 30.72,
+"decompress_mbps": 153.42
 },
 {
 "compressor": "js",
@@ -12134,8 +12134,8 @@
 "level": 7,
 "out_size": 5406417,
 "ratio": 0.7455,
-"compress_mbps": 29.76,
-"decompress_mbps": 154.34
+"compress_mbps": 30.08,
+"decompress_mbps": 155.44
 },
 {
 "compressor": "js",
@@ -12144,8 +12144,8 @@
 "level": 8,
 "out_size": 5406380,
 "ratio": 0.7455,
-"compress_mbps": 30.74,
-"decompress_mbps": 155.22
+"compress_mbps": 30.76,
+"decompress_mbps": 154.32
 },
 {
 "compressor": "js",
@@ -12154,8 +12154,8 @@
 "level": 9,
 "out_size": 5406380,
 "ratio": 0.7455,
-"compress_mbps": 30.24,
-"decompress_mbps": 133.17
+"compress_mbps": 30.68,
+"decompress_mbps": 117.26
 },
 {
 "compressor": "js",
@@ -12164,8 +12164,8 @@
 "level": 1,
 "out_size": 14342407,
 "ratio": 0.3459,
-"compress_mbps": 74.52,
-"decompress_mbps": 184.57
+"compress_mbps": 73.52,
+"decompress_mbps": 197.71
 },
 {
 "compressor": "js",
@@ -12174,8 +12174,8 @@
 "level": 2,
 "out_size": 13424966,
 "ratio": 0.3238,
-"compress_mbps": 63.02,
-"decompress_mbps": 214.45
+"compress_mbps": 63.27,
+"decompress_mbps": 213.25
 },
 {
 "compressor": "js",
@@ -12184,8 +12184,8 @@
 "level": 3,
 "out_size": 13061399,
 "ratio": 0.315,
-"compress_mbps": 54.97,
-"decompress_mbps": 214.04
+"compress_mbps": 56.27,
+"decompress_mbps": 222.06
 },
 {
 "compressor": "js",
@@ -12194,8 +12194,8 @@
 "level": 4,
 "out_size": 12877207,
 "ratio": 0.3106,
-"compress_mbps": 49.89,
-"decompress_mbps": 206.6
+"compress_mbps": 49.84,
+"decompress_mbps": 208.96
 },
 {
 "compressor": "js",
@@ -12204,8 +12204,8 @@
 "level": 5,
 "out_size": 12671090,
 "ratio": 0.3056,
-"compress_mbps": 47.61,
-"decompress_mbps": 211.34
+"compress_mbps": 47.71,
+"decompress_mbps": 209.63
 },
 {
 "compressor": "js",
@@ -12214,8 +12214,8 @@
 "level": 6,
 "out_size": 12511088,
 "ratio": 0.3018,
-"compress_mbps": 40.19,
-"decompress_mbps": 235.11
+"compress_mbps": 40.67,
+"decompress_mbps": 235.26
 },
 {
 "compressor": "js",
@@ -12224,8 +12224,8 @@
 "level": 7,
 "out_size": 12503313,
 "ratio": 0.3016,
-"compress_mbps": 38.49,
-"decompress_mbps": 227.8
+"compress_mbps": 39.02,
+"decompress_mbps": 224.89
 },
 {
 "compressor": "js",
@@ -12234,8 +12234,8 @@
 "level": 8,
 "out_size": 12502263,
 "ratio": 0.3016,
-"compress_mbps": 39.46,
-"decompress_mbps": 228.05
+"compress_mbps": 39.56,
+"decompress_mbps": 227.39
 },
 {
 "compressor": "js",
@@ -12245,7 +12245,7 @@
 "out_size": 12502263,
 "ratio": 0.3016,
 "compress_mbps": 39.56,
-"decompress_mbps": 231.18
+"decompress_mbps": 225.48
 },
 {
 "compressor": "js",
@@ -12254,8 +12254,8 @@
 "level": 1,
 "out_size": 6022390,
 "ratio": 0.7107,
-"compress_mbps": 54.61,
-"decompress_mbps": 151.8
+"compress_mbps": 54.31,
+"decompress_mbps": 145.97
 },
 {
 "compressor": "js",
@@ -12264,8 +12264,8 @@
 "level": 2,
 "out_size": 5997124,
 "ratio": 0.7077,
-"compress_mbps": 47.3,
-"decompress_mbps": 153.84
+"compress_mbps": 48.84,
+"decompress_mbps": 145.24
 },
 {
 "compressor": "js",
@@ -12274,8 +12274,8 @@
 "level": 3,
 "out_size": 5979254,
 "ratio": 0.7056,
-"compress_mbps": 43.86,
-"decompress_mbps": 118
+"compress_mbps": 43.2,
+"decompress_mbps": 149.3
 },
 {
 "compressor": "js",
@@ -12284,8 +12284,8 @@
 "level": 4,
 "out_size": 5967955,
 "ratio": 0.7042,
-"compress_mbps": 41.7,
-"decompress_mbps": 187.4
+"compress_mbps": 42.03,
+"decompress_mbps": 178.27
 },
 {
 "compressor": "js",
@@ -12294,8 +12294,8 @@
 "level": 5,
 "out_size": 5967953,
 "ratio": 0.7042,
-"compress_mbps": 42.08,
-"decompress_mbps": 151.63
+"compress_mbps": 42.1,
+"decompress_mbps": 155.23
 },
 {
 "compressor": "js",
@@ -12304,8 +12304,8 @@
 "level": 6,
 "out_size": 5965386,
 "ratio": 0.7039,
-"compress_mbps": 41.41,
-"decompress_mbps": 152.09
+"compress_mbps": 41.26,
+"decompress_mbps": 150.17
 },
 {
 "compressor": "js",
@@ -12314,8 +12314,8 @@
 "level": 7,
 "out_size": 5965383,
 "ratio": 0.7039,
-"compress_mbps": 42.6,
-"decompress_mbps": 113.12
+"compress_mbps": 41,
+"decompress_mbps": 152.03
 },
 {
 "compressor": "js",
@@ -12324,8 +12324,8 @@
 "level": 8,
 "out_size": 5965383,
 "ratio": 0.7039,
-"compress_mbps": 41.02,
-"decompress_mbps": 156.65
+"compress_mbps": 40.8,
+"decompress_mbps": 151.14
 },
 {
 "compressor": "js",
@@ -12334,8 +12334,8 @@
 "level": 9,
 "out_size": 5965383,
 "ratio": 0.7039,
-"compress_mbps": 40.75,
-"decompress_mbps": 121.79
+"compress_mbps": 41.86,
+"decompress_mbps": 155
 },
 {
 "compressor": "js",
@@ -12344,8 +12344,8 @@
 "level": 1,
 "out_size": 985606,
 "ratio": 0.1844,
-"compress_mbps": 111.87,
-"decompress_mbps": 309.19
+"compress_mbps": 111.12,
+"decompress_mbps": 305.94
 },
 {
 "compressor": "js",
@@ -12355,7 +12355,7 @@
 "out_size": 852636,
 "ratio": 0.1595,
 "compress_mbps": 102.74,
-"decompress_mbps": 257.1
+"decompress_mbps": 250.95
 },
 {
 "compressor": "js",
@@ -12364,8 +12364,8 @@
 "level": 3,
 "out_size": 814293,
 "ratio": 0.1523,
-"compress_mbps": 96.66,
-"decompress_mbps": 227.93
+"compress_mbps": 96.19,
+"decompress_mbps": 221.84
 },
 {
 "compressor": "js",
@@ -12374,8 +12374,8 @@
 "level": 4,
 "out_size": 788388,
 "ratio": 0.1475,
-"compress_mbps": 90.31,
-"decompress_mbps": 251.64
+"compress_mbps": 89.39,
+"decompress_mbps": 250.71
 },
 {
 "compressor": "js",
@@ -12384,8 +12384,8 @@
 "level": 5,
 "out_size": 749390,
 "ratio": 0.1402,
-"compress_mbps": 82.71,
-"decompress_mbps": 306.2
+"compress_mbps": 83.47,
+"decompress_mbps": 304.92
 },
 {
 "compressor": "js",
@@ -12394,8 +12394,8 @@
 "level": 6,
 "out_size": 706892,
 "ratio": 0.1322,
-"compress_mbps": 66.86,
-"decompress_mbps": 276.52
+"compress_mbps": 64.12,
+"decompress_mbps": 266.99
 },
 {
 "compressor": "js",
@@ -12404,8 +12404,8 @@
 "level": 7,
 "out_size": 705695,
 "ratio": 0.132,
-"compress_mbps": 64.85,
-"decompress_mbps": 317.35
+"compress_mbps": 64.27,
+"decompress_mbps": 329.56
 },
 {
 "compressor": "js",
@@ -12414,8 +12414,8 @@
 "level": 8,
 "out_size": 703904,
 "ratio": 0.1317,
-"compress_mbps": 60.82,
-"decompress_mbps": 273.88
+"compress_mbps": 61.16,
+"decompress_mbps": 268.63
 },
 {
 "compressor": "js",
@@ -12424,8 +12424,8 @@
 "level": 9,
 "out_size": 703900,
 "ratio": 0.1317,
-"compress_mbps": 61.01,
-"decompress_mbps": 296.54
+"compress_mbps": 60.89,
+"decompress_mbps": 396.78
 },
 {
 "compressor": "zig",
@@ -12434,8 +12434,8 @@
 "level": 1,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 88.95,
-"decompress_mbps": 310.06
+"compress_mbps": 88.44,
+"decompress_mbps": 310.31
 },
 {
 "compressor": "zig",
@@ -12444,8 +12444,8 @@
 "level": 2,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 88.26,
-"decompress_mbps": 309.23
+"compress_mbps": 87.92,
+"decompress_mbps": 310.59
 },
 {
 "compressor": "zig",
@@ -12454,8 +12454,8 @@
 "level": 3,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 87.99,
-"decompress_mbps": 315.28
+"compress_mbps": 88.84,
+"decompress_mbps": 310.08
 },
 {
 "compressor": "zig",
@@ -12464,8 +12464,8 @@
 "level": 4,
 "out_size": 56099,
 "ratio": 0.3689,
-"compress_mbps": 88.16,
-"decompress_mbps": 313.07
+"compress_mbps": 88.64,
+"decompress_mbps": 314.16
 },
 {
 "compressor": "zig",
@@ -12474,8 +12474,8 @@
 "level": 5,
 "out_size": 54531,
 "ratio": 0.3585,
-"compress_mbps": 55.43,
-"decompress_mbps": 311.35
+"compress_mbps": 55.46,
+"decompress_mbps": 303.62
 },
 {
 "compressor": "zig",
@@ -12484,8 +12484,8 @@
 "level": 6,
 "out_size": 54068,
 "ratio": 0.3555,
-"compress_mbps": 42.01,
-"decompress_mbps": 307.06
+"compress_mbps": 42.11,
+"decompress_mbps": 310.13
 },
 {
 "compressor": "zig",
@@ -12494,8 +12494,8 @@
 "level": 7,
 "out_size": 54003,
 "ratio": 0.3551,
-"compress_mbps": 37.44,
-"decompress_mbps": 306.71
+"compress_mbps": 37.45,
+"decompress_mbps": 307.64
 },
 {
 "compressor": "zig",
@@ -12504,8 +12504,8 @@
 "level": 8,
 "out_size": 53974,
 "ratio": 0.3549,
-"compress_mbps": 33.12,
-"decompress_mbps": 308.78
+"compress_mbps": 33.15,
+"decompress_mbps": 306.21
 },
 {
 "compressor": "zig",
@@ -12514,8 +12514,8 @@
 "level": 9,
 "out_size": 53974,
 "ratio": 0.3549,
-"compress_mbps": 33.01,
-"decompress_mbps": 309.23
+"compress_mbps": 33.03,
+"decompress_mbps": 307.58
 },
 {
 "compressor": "zig",
@@ -12524,8 +12524,8 @@
 "level": 1,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 83.75,
-"decompress_mbps": 277.39
+"compress_mbps": 82.91,
+"decompress_mbps": 273.52
 },
 {
 "compressor": "zig",
@@ -12534,8 +12534,8 @@
 "level": 2,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 83.26,
-"decompress_mbps": 279.31
+"compress_mbps": 83.46,
+"decompress_mbps": 272.35
 },
 {
 "compressor": "zig",
@@ -12544,8 +12544,8 @@
 "level": 3,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 83.72,
-"decompress_mbps": 273.72
+"compress_mbps": 84.13,
+"decompress_mbps": 272.98
 },
 {
 "compressor": "zig",
@@ -12554,8 +12554,8 @@
 "level": 4,
 "out_size": 50031,
 "ratio": 0.3997,
-"compress_mbps": 83.56,
-"decompress_mbps": 275.1
+"compress_mbps": 83.95,
+"decompress_mbps": 268.75
 },
 {
 "compressor": "zig",
@@ -12564,8 +12564,8 @@
 "level": 5,
 "out_size": 48753,
 "ratio": 0.3895,
-"compress_mbps": 50.83,
-"decompress_mbps": 271.14
+"compress_mbps": 50.79,
+"decompress_mbps": 277.44
 },
 {
 "compressor": "zig",
@@ -12574,8 +12574,8 @@
 "level": 6,
 "out_size": 48557,
 "ratio": 0.3879,
-"compress_mbps": 41.0,
-"decompress_mbps": 277.64
+"compress_mbps": 40.8,
+"decompress_mbps": 274.84
 },
 {
 "compressor": "zig",
@@ -12584,8 +12584,8 @@
 "level": 7,
 "out_size": 48523,
 "ratio": 0.3876,
-"compress_mbps": 38.68,
-"decompress_mbps": 277.51
+"compress_mbps": 38.65,
+"decompress_mbps": 273.33
 },
 {
 "compressor": "zig",
@@ -12594,8 +12594,8 @@
 "level": 8,
 "out_size": 48522,
 "ratio": 0.3876,
-"compress_mbps": 38.08,
-"decompress_mbps": 277.16
+"compress_mbps": 37.86,
+"decompress_mbps": 276.85
 },
 {
 "compressor": "zig",
@@ -12604,8 +12604,8 @@
 "level": 9,
 "out_size": 48522,
 "ratio": 0.3876,
-"compress_mbps": 38.04,
-"decompress_mbps": 275.77
+"compress_mbps": 37.9,
+"decompress_mbps": 276.0
 },
 {
 "compressor": "zig",
@@ -12614,8 +12614,8 @@
 "level": 1,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 160.13,
-"decompress_mbps": 280.7
+"compress_mbps": 164.27,
+"decompress_mbps": 279.42
 },
 {
 "compressor": "zig",
@@ -12624,8 +12624,8 @@
 "level": 2,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 159.01,
-"decompress_mbps": 280.89
+"compress_mbps": 172.17,
+"decompress_mbps": 279.97
 },
 {
 "compressor": "zig",
@@ -12634,8 +12634,8 @@
 "level": 3,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 164.82,
-"decompress_mbps": 279.19
+"compress_mbps": 171.79,
+"decompress_mbps": 279.43
 },
 {
 "compressor": "zig",
@@ -12644,8 +12644,8 @@
 "level": 4,
 "out_size": 8182,
 "ratio": 0.3326,
-"compress_mbps": 164.72,
-"decompress_mbps": 279.87
+"compress_mbps": 170.54,
+"decompress_mbps": 279.22
 },
 {
 "compressor": "zig",
@@ -12654,8 +12654,8 @@
 "level": 5,
 "out_size": 7965,
 "ratio": 0.3237,
-"compress_mbps": 110.54,
-"decompress_mbps": 285.07
+"compress_mbps": 110.55,
+"decompress_mbps": 288.06
 },
 {
 "compressor": "zig",
@@ -12664,8 +12664,8 @@
 "level": 6,
 "out_size": 7914,
 "ratio": 0.3217,
-"compress_mbps": 88.58,
-"decompress_mbps": 287.27
+"compress_mbps": 87.16,
+"decompress_mbps": 290.85
 },
 {
 "compressor": "zig",
@@ -12674,8 +12674,8 @@
 "level": 7,
 "out_size": 7895,
 "ratio": 0.3209,
-"compress_mbps": 79.56,
-"decompress_mbps": 288.46
+"compress_mbps": 80.21,
+"decompress_mbps": 290.06
 },
 {
 "compressor": "zig",
@@ -12684,8 +12684,8 @@
 "level": 8,
 "out_size": 7896,
 "ratio": 0.3209,
-"compress_mbps": 73.38,
-"decompress_mbps": 286.96
+"compress_mbps": 73.83,
+"decompress_mbps": 287.97
 },
 {
 "compressor": "zig",
@@ -12694,8 +12694,8 @@
 "level": 9,
 "out_size": 7896,
 "ratio": 0.3209,
-"compress_mbps": 74.49,
-"decompress_mbps": 288.37
+"compress_mbps": 74.8,
+"decompress_mbps": 285.58
 },
 {
 "compressor": "zig",
@@ -12704,8 +12704,8 @@
 "level": 1,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 170.63,
-"decompress_mbps": 256.31
+"compress_mbps": 167.43,
+"decompress_mbps": 252.93
 },
 {
 "compressor": "zig",
@@ -12714,8 +12714,8 @@
 "level": 2,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 165.8,
-"decompress_mbps": 256.53
+"compress_mbps": 171.07,
+"decompress_mbps": 257.31
 },
 {
 "compressor": "zig",
@@ -12724,8 +12724,8 @@
 "level": 3,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 165.83,
-"decompress_mbps": 254.37
+"compress_mbps": 171.82,
+"decompress_mbps": 258.29
 },
 {
 "compressor": "zig",
@@ -12734,8 +12734,8 @@
 "level": 4,
 "out_size": 3218,
 "ratio": 0.2886,
-"compress_mbps": 167.07,
-"decompress_mbps": 255.18
+"compress_mbps": 166.85,
+"decompress_mbps": 256.2
 },
 {
 "compressor": "zig",
@@ -12744,8 +12744,8 @@
 "level": 5,
 "out_size": 3136,
 "ratio": 0.2813,
-"compress_mbps": 142.63,
-"decompress_mbps": 264.86
+"compress_mbps": 143.33,
+"decompress_mbps": 259.73
 },
 {
 "compressor": "zig",
@@ -12754,8 +12754,8 @@
 "level": 6,
 "out_size": 3115,
 "ratio": 0.2794,
-"compress_mbps": 123.43,
-"decompress_mbps": 263.19
+"compress_mbps": 126.88,
+"decompress_mbps": 263.65
 },
 {
 "compressor": "zig",
@@ -12764,8 +12764,8 @@
 "level": 7,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 111.32,
-"decompress_mbps": 266.57
+"compress_mbps": 116.0,
+"decompress_mbps": 266.62
 },
 {
 "compressor": "zig",
@@ -12774,8 +12774,8 @@
 "level": 8,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 105.02,
-"decompress_mbps": 265.31
+"compress_mbps": 105.81,
+"decompress_mbps": 262.03
 },
 {
 "compressor": "zig",
@@ -12784,8 +12784,8 @@
 "level": 9,
 "out_size": 3112,
 "ratio": 0.2791,
-"compress_mbps": 105.86,
-"decompress_mbps": 265.46
+"compress_mbps": 108.16,
+"decompress_mbps": 263.41
 },
 {
 "compressor": "zig",
@@ -12794,8 +12794,8 @@
 "level": 1,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 113.91,
-"decompress_mbps": 116.08
+"compress_mbps": 119.04,
+"decompress_mbps": 119.21
 },
 {
 "compressor": "zig",
@@ -12804,8 +12804,8 @@
 "level": 2,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 112.97,
-"decompress_mbps": 116.36
+"compress_mbps": 114.29,
+"decompress_mbps": 121.57
 },
 {
 "compressor": "zig",
@@ -12814,8 +12814,8 @@
 "level": 3,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 111.36,
-"decompress_mbps": 114.47
+"compress_mbps": 111.93,
+"decompress_mbps": 114.91
 },
 {
 "compressor": "zig",
@@ -12824,8 +12824,8 @@
 "level": 4,
 "out_size": 1221,
 "ratio": 0.3281,
-"compress_mbps": 112.62,
-"decompress_mbps": 113.68
+"compress_mbps": 113.37,
+"decompress_mbps": 116.95
 },
 {
 "compressor": "zig",
@@ -12834,8 +12834,8 @@
 "level": 5,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 103.96,
-"decompress_mbps": 114.45
+"compress_mbps": 104.47,
+"decompress_mbps": 117.21
 },
 {
 "compressor": "zig",
@@ -12844,8 +12844,8 @@
 "level": 6,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 101.09,
-"decompress_mbps": 117.37
+"compress_mbps": 101.17,
+"decompress_mbps": 116.13
 },
 {
 "compressor": "zig",
@@ -12854,8 +12854,8 @@
 "level": 7,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 98.16,
-"decompress_mbps": 112.01
+"compress_mbps": 99.01,
+"decompress_mbps": 115.26
 },
 {
 "compressor": "zig",
@@ -12864,8 +12864,8 @@
 "level": 8,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 98.9,
-"decompress_mbps": 113.5
+"compress_mbps": 100.66,
+"decompress_mbps": 116.17
 },
 {
 "compressor": "zig",
@@ -12874,8 +12874,8 @@
 "level": 9,
 "out_size": 1207,
 "ratio": 0.3244,
-"compress_mbps": 95.01,
-"decompress_mbps": 113.65
+"compress_mbps": 100.75,
+"decompress_mbps": 117.41
 },
 {
 "compressor": "zig",
@@ -12884,8 +12884,8 @@
 "level": 1,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 230.64,
-"decompress_mbps": 459.86
+"compress_mbps": 226.33,
+"decompress_mbps": 462.07
 },
 {
 "compressor": "zig",
@@ -12894,8 +12894,8 @@
 "level": 2,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 231.21,
-"decompress_mbps": 461.54
+"compress_mbps": 232.22,
+"decompress_mbps": 461.76
 },
 {
 "compressor": "zig",
@@ -12904,8 +12904,8 @@
 "level": 3,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 226.26,
-"decompress_mbps": 463.76
+"compress_mbps": 226.95,
+"decompress_mbps": 462.59
 },
 {
 "compressor": "zig",
@@ -12914,8 +12914,8 @@
 "level": 4,
 "out_size": 227063,
 "ratio": 0.2205,
-"compress_mbps": 231.99,
-"decompress_mbps": 460.91
+"compress_mbps": 231.82,
+"decompress_mbps": 462.46
 },
 {
 "compressor": "zig",
@@ -12924,8 +12924,8 @@
 "level": 5,
 "out_size": 218313,
 "ratio": 0.212,
-"compress_mbps": 163.44,
-"decompress_mbps": 446.78
+"compress_mbps": 163.75,
+"decompress_mbps": 447.06
 },
 {
 "compressor": "zig",
@@ -12934,8 +12934,8 @@
 "level": 6,
 "out_size": 215095,
 "ratio": 0.2089,
-"compress_mbps": 106.34,
-"decompress_mbps": 446.0
+"compress_mbps": 107.22,
+"decompress_mbps": 448.7
 },
 {
 "compressor": "zig",
@@ -12944,8 +12944,8 @@
 "level": 7,
 "out_size": 213213,
 "ratio": 0.2071,
-"compress_mbps": 72.98,
-"decompress_mbps": 450.61
+"compress_mbps": 73.07,
+"decompress_mbps": 450.65
 },
 {
 "compressor": "zig",
@@ -12954,8 +12954,8 @@
 "level": 8,
 "out_size": 210955,
 "ratio": 0.2049,
-"compress_mbps": 9.37,
-"decompress_mbps": 450.93
+"compress_mbps": 9.42,
+"decompress_mbps": 452.49
 },
 {
 "compressor": "zig",
@@ -12964,8 +12964,8 @@
 "level": 9,
 "out_size": 210981,
 "ratio": 0.2049,
-"compress_mbps": 4.63,
-"decompress_mbps": 452.54
+"compress_mbps": 4.64,
+"decompress_mbps": 454.09
 },
 {
 "compressor": "zig",
@@ -12974,8 +12974,8 @@
 "level": 1,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 92.2,
-"decompress_mbps": 303.36
+"compress_mbps": 92.55,
+"decompress_mbps": 304.95
 },
 {
 "compressor": "zig",
@@ -12984,8 +12984,8 @@
 "level": 2,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 92.48,
-"decompress_mbps": 302.93
+"compress_mbps": 92.89,
+"decompress_mbps": 306.86
 },
 {
 "compressor": "zig",
@@ -12994,8 +12994,8 @@
 "level": 3,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 92.23,
-"decompress_mbps": 306.34
+"compress_mbps": 92.22,
+"decompress_mbps": 306.2
 },
 {
 "compressor": "zig",
@@ -13004,8 +13004,8 @@
 "level": 4,
 "out_size": 148927,
 "ratio": 0.349,
-"compress_mbps": 91.96,
-"decompress_mbps": 303.92
+"compress_mbps": 92.33,
+"decompress_mbps": 304.41
 },
 {
 "compressor": "zig",
@@ -13014,8 +13014,8 @@
 "level": 5,
 "out_size": 145024,
 "ratio": 0.3398,
-"compress_mbps": 57.59,
-"decompress_mbps": 306.1
+"compress_mbps": 57.83,
+"decompress_mbps": 305.53
 },
 {
 "compressor": "zig",
@@ -13024,8 +13024,8 @@
 "level": 6,
 "out_size": 144159,
 "ratio": 0.3378,
-"compress_mbps": 44.28,
-"decompress_mbps": 304.89
+"compress_mbps": 44.56,
+"decompress_mbps": 304.1
 },
 {
 "compressor": "zig",
@@ -13034,8 +13034,8 @@
 "level": 7,
 "out_size": 143991,
 "ratio": 0.3374,
-"compress_mbps": 40.25,
-"decompress_mbps": 305.98
+"compress_mbps": 40.14,
+"decompress_mbps": 306.23
 },
 {
 "compressor": "zig",
@@ -13044,8 +13044,8 @@
 "level": 8,
 "out_size": 143941,
 "ratio": 0.3373,
-"compress_mbps": 36.97,
-"decompress_mbps": 305.86
+"compress_mbps": 36.87,
+"decompress_mbps": 306.13
 },
 {
 "compressor": "zig",
@@ -13054,8 +13054,8 @@
 "level": 9,
 "out_size": 143939,
 "ratio": 0.3373,
-"compress_mbps": 36.78,
-"decompress_mbps": 302.04
+"compress_mbps": 37.03,
+"decompress_mbps": 305.69
 },
 {
 "compressor": "zig",
@@ -13064,8 +13064,8 @@
 "level": 1,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 81.42,
-"decompress_mbps": 261.6
+"compress_mbps": 81.26,
+"decompress_mbps": 255.97
 },
 {
 "compressor": "zig",
@@ -13074,8 +13074,8 @@
 "level": 2,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 81.35,
-"decompress_mbps": 259.11
+"compress_mbps": 80.9,
+"decompress_mbps": 255.49
 },
 {
 "compressor": "zig",
@@ -13084,8 +13084,8 @@
 "level": 3,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 81.8,
-"decompress_mbps": 256.43
+"compress_mbps": 81.21,
+"decompress_mbps": 255.67
 },
 {
 "compressor": "zig",
@@ -13094,8 +13094,8 @@
 "level": 4,
 "out_size": 200074,
 "ratio": 0.4152,
-"compress_mbps": 81.25,
-"decompress_mbps": 254.43
+"compress_mbps": 81.07,
+"decompress_mbps": 256.32
 },
 {
 "compressor": "zig",
@@ -13104,8 +13104,8 @@
 "level": 5,
 "out_size": 194496,
 "ratio": 0.4036,
-"compress_mbps": 45.71,
-"decompress_mbps": 248.56
+"compress_mbps": 46.0,
+"decompress_mbps": 247.64
 },
 {
 "compressor": "zig",
@@ -13114,8 +13114,8 @@
 "level": 6,
 "out_size": 193176,
 "ratio": 0.4009,
-"compress_mbps": 34.49,
-"decompress_mbps": 252.44
+"compress_mbps": 34.56,
+"decompress_mbps": 253.55
 },
 {
 "compressor": "zig",
@@ -13124,8 +13124,8 @@
 "level": 7,
 "out_size": 192991,
 "ratio": 0.4005,
-"compress_mbps": 31.29,
-"decompress_mbps": 254.6
+"compress_mbps": 31.43,
+"decompress_mbps": 250.63
 },
 {
 "compressor": "zig",
@@ -13134,8 +13134,8 @@
 "level": 8,
 "out_size": 192980,
 "ratio": 0.4005,
-"compress_mbps": 29.76,
-"decompress_mbps": 250.82
+"compress_mbps": 29.91,
+"decompress_mbps": 251.77
 },
 {
 "compressor": "zig",
@@ -13144,8 +13144,8 @@
 "level": 9,
 "out_size": 192980,
 "ratio": 0.4005,
-"compress_mbps": 29.85,
-"decompress_mbps": 255.67
+"compress_mbps": 29.82,
+"decompress_mbps": 253.98
 },
 {
 "compressor": "zig",
@@ -13154,8 +13154,8 @@
 "level": 1,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 298.79,
-"decompress_mbps": 737.74
+"compress_mbps": 294.39,
+"decompress_mbps": 724.52
 },
 {
 "compressor": "zig",
@@ -13164,8 +13164,8 @@
 "level": 2,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 295.5,
-"decompress_mbps": 730.53
+"compress_mbps": 294.6,
+"decompress_mbps": 721.16
 },
 {
 "compressor": "zig",
@@ -13174,8 +13174,8 @@
 "level": 3,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 297.54,
-"decompress_mbps": 734.01
+"compress_mbps": 294.93,
+"decompress_mbps": 721.32
 },
 {
 "compressor": "zig",
@@ -13184,8 +13184,8 @@
 "level": 4,
 "out_size": 57484,
 "ratio": 0.112,
-"compress_mbps": 294.51,
-"decompress_mbps": 728.55
+"compress_mbps": 295.58,
+"decompress_mbps": 727.0
 },
 {
 "compressor": "zig",
@@ -13194,8 +13194,8 @@
 "level": 5,
 "out_size": 56050,
 "ratio": 0.1092,
-"compress_mbps": 230.35,
-"decompress_mbps": 759.24
+"compress_mbps": 229.82,
+"decompress_mbps": 759.78
 },
 {
 "compressor": "zig",
@@ -13204,8 +13204,8 @@
 "level": 6,
 "out_size": 55292,
 "ratio": 0.1077,
-"compress_mbps": 153.55,
-"decompress_mbps": 784.43
+"compress_mbps": 153.4,
+"decompress_mbps": 778.62
 },
 {
 "compressor": "zig",
@@ -13214,8 +13214,8 @@
 "level": 7,
 "out_size": 54651,
 "ratio": 0.1065,
-"compress_mbps": 123.6,
-"decompress_mbps": 788.74
+"compress_mbps": 124.47,
+"decompress_mbps": 790.77
 },
 {
 "compressor": "zig",
@@ -13224,8 +13224,8 @@
 "level": 8,
 "out_size": 52583,
 "ratio": 0.1025,
-"compress_mbps": 46.9,
-"decompress_mbps": 821.6
+"compress_mbps": 46.92,
+"decompress_mbps": 823.54
 },
 {
 "compressor": "zig",
@@ -13234,8 +13234,8 @@
 "level": 9,
 "out_size": 51816,
 "ratio": 0.101,
-"compress_mbps": 15.69,
-"decompress_mbps": 838.91
+"compress_mbps": 15.63,
+"decompress_mbps": 833.02
 },
 {
 "compressor": "zig",
@@ -13244,8 +13244,8 @@
 "level": 1,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 118.76,
-"decompress_mbps": 304.02
+"compress_mbps": 119.63,
+"decompress_mbps": 301.35
 },
 {
 "compressor": "zig",
@@ -13254,8 +13254,8 @@
 "level": 2,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 118.59,
-"decompress_mbps": 299.45
+"compress_mbps": 118.87,
+"decompress_mbps": 304.63
 },
 {
 "compressor": "zig",
@@ -13264,8 +13264,8 @@
 "level": 3,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 118.95,
-"decompress_mbps": 306.31
+"compress_mbps": 120.64,
+"decompress_mbps": 303.05
 },
 {
 "compressor": "zig",
@@ -13274,8 +13274,8 @@
 "level": 4,
 "out_size": 13765,
 "ratio": 0.36,
-"compress_mbps": 118.99,
-"decompress_mbps": 305.06
+"compress_mbps": 118.25,
+"decompress_mbps": 303.27
 },
 {
 "compressor": "zig",
@@ -13284,8 +13284,8 @@
 "level": 5,
 "out_size": 13290,
 "ratio": 0.3475,
-"compress_mbps": 88.47,
-"decompress_mbps": 315.02
+"compress_mbps": 89.99,
+"decompress_mbps": 316.05
 },
 {
 "compressor": "zig",
@@ -13294,8 +13294,8 @@
 "level": 6,
 "out_size": 13258,
 "ratio": 0.3467,
-"compress_mbps": 69.18,
-"decompress_mbps": 318.14
+"compress_mbps": 68.72,
+"decompress_mbps": 317.08
 },
 {
 "compressor": "zig",
@@ -13304,8 +13304,8 @@
 "level": 7,
 "out_size": 13246,
 "ratio": 0.3464,
-"compress_mbps": 55.92,
-"decompress_mbps": 315.51
+"compress_mbps": 57.01,
+"decompress_mbps": 319.69
 },
 {
 "compressor": "zig",
@@ -13314,8 +13314,8 @@
 "level": 8,
 "out_size": 13236,
 "ratio": 0.3461,
-"compress_mbps": 25.46,
-"decompress_mbps": 318.89
+"compress_mbps": 25.4,
+"decompress_mbps": 320.24
 },
 {
 "compressor": "zig",
@@ -13324,8 +13324,8 @@
 "level": 9,
 "out_size": 13233,
 "ratio": 0.3461,
-"compress_mbps": 16.18,
-"decompress_mbps": 318.09
+"compress_mbps": 16.12,
+"decompress_mbps": 322.36
 },
 {
 "compressor": "zig",
@@ -13334,8 +13334,8 @@
 "level": 1,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 93.55,
-"decompress_mbps": 132.26
+"compress_mbps": 95.7,
+"decompress_mbps": 132.85
 },
 {
 "compressor": "zig",
@@ -13344,8 +13344,8 @@
 "level": 2,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 97.87,
-"decompress_mbps": 131.51
+"compress_mbps": 98.31,
+"decompress_mbps": 133.01
 },
 {
 "compressor": "zig",
@@ -13354,8 +13354,8 @@
 "level": 3,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 99.52,
-"decompress_mbps": 132.24
+"compress_mbps": 97.54,
+"decompress_mbps": 132.07
 },
 {
 "compressor": "zig",
@@ -13364,8 +13364,8 @@
 "level": 4,
 "out_size": 1742,
 "ratio": 0.4121,
-"compress_mbps": 99.66,
-"decompress_mbps": 131.33
+"compress_mbps": 100.39,
+"decompress_mbps": 132.0
 },
 {
 "compressor": "zig",
@@ -13374,8 +13374,8 @@
 "level": 5,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 93.96,
-"decompress_mbps": 132.09
+"compress_mbps": 95.29,
+"decompress_mbps": 132.31
 },
 {
 "compressor": "zig",
@@ -13384,8 +13384,8 @@
 "level": 6,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 92.06,
-"decompress_mbps": 131.97
+"compress_mbps": 95.54,
+"decompress_mbps": 134.31
 },
 {
 "compressor": "zig",
@@ -13394,8 +13394,8 @@
 "level": 7,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 93.19,
-"decompress_mbps": 132.96
+"compress_mbps": 93.18,
+"decompress_mbps": 133.95
 },
 {
 "compressor": "zig",
@@ -13404,8 +13404,8 @@
 "level": 8,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 93.02,
-"decompress_mbps": 131.79
+"compress_mbps": 95.09,
+"decompress_mbps": 134.19
 },
 {
 "compressor": "zig",
@@ -13414,8 +13414,8 @@
 "level": 9,
 "out_size": 1720,
 "ratio": 0.4069,
-"compress_mbps": 93.34,
-"decompress_mbps": 132.53
+"compress_mbps": 92.21,
+"decompress_mbps": 134.59
 },
 {
 "compressor": "zig",
@@ -13424,8 +13424,8 @@
 "level": 1,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 84.03,
-"decompress_mbps": 273.24
+"compress_mbps": 84.07,
+"decompress_mbps": 273.96
 },
 {
 "compressor": "zig",
@@ -13434,8 +13434,8 @@
 "level": 2,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 83.7,
-"decompress_mbps": 272.45
+"compress_mbps": 84.3,
+"decompress_mbps": 273.56
 },
 {
 "compressor": "zig",
@@ -13444,8 +13444,8 @@
 "level": 3,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 84.04,
-"decompress_mbps": 271.18
+"compress_mbps": 83.99,
+"decompress_mbps": 274.36
 },
 {
 "compressor": "zig",
@@ -13454,8 +13454,8 @@
 "level": 4,
 "out_size": 3974126,
 "ratio": 0.3899,
-"compress_mbps": 84.43,
-"decompress_mbps": 273.17
+"compress_mbps": 84.24,
+"decompress_mbps": 272.3
 },
 {
 "compressor": "zig",
@@ -13464,8 +13464,8 @@
 "level": 5,
 "out_size": 3863846,
 "ratio": 0.3791,
-"compress_mbps": 49.45,
-"decompress_mbps": 271.03
+"compress_mbps": 49.03,
+"decompress_mbps": 267.64
 },
 {
 "compressor": "zig",
@@ -13474,8 +13474,8 @@
 "level": 6,
 "out_size": 3838854,
 "ratio": 0.3766,
-"compress_mbps": 37.59,
-"decompress_mbps": 272.02
+"compress_mbps": 37.71,
+"decompress_mbps": 272.4
 },
 {
 "compressor": "zig",
@@ -13484,8 +13484,8 @@
 "level": 7,
 "out_size": 3835182,
 "ratio": 0.3763,
-"compress_mbps": 33.58,
-"decompress_mbps": 271.81
+"compress_mbps": 33.64,
+"decompress_mbps": 271.15
 },
 {
 "compressor": "zig",
@@ -13494,8 +13494,8 @@
 "level": 8,
 "out_size": 3834518,
 "ratio": 0.3762,
-"compress_mbps": 31.48,
-"decompress_mbps": 273.75
+"compress_mbps": 31.63,
+"decompress_mbps": 269.9
 },
 {
 "compressor": "zig",
@@ -13504,8 +13504,8 @@
 "level": 9,
 "out_size": 3834518,
 "ratio": 0.3762,
-"compress_mbps": 31.64,
-"decompress_mbps": 271.14
+"compress_mbps": 31.46,
+"decompress_mbps": 270.85
 },
 {
 "compressor": "zig",
@@ -13514,8 +13514,8 @@
 "level": 1,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 103.99,
-"decompress_mbps": 250.23
+"compress_mbps": 103.55,
+"decompress_mbps": 250.87
 },
 {
 "compressor": "zig",
@@ -13524,8 +13524,8 @@
 "level": 2,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 104.04,
-"decompress_mbps": 251.99
+"compress_mbps": 103.76,
+"decompress_mbps": 251.19
 },
 {
 "compressor": "zig",
@@ -13534,8 +13534,8 @@
 "level": 3,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 103.6,
-"decompress_mbps": 251.63
+"compress_mbps": 103.86,
+"decompress_mbps": 251.37
 },
 {
 "compressor": "zig",
@@ -13544,8 +13544,8 @@
 "level": 4,
 "out_size": 19877952,
 "ratio": 0.3881,
-"compress_mbps": 103.94,
-"decompress_mbps": 250.93
+"compress_mbps": 103.63,
+"decompress_mbps": 251.14
 },
 {
 "compressor": "zig",
@@ -13554,8 +13554,8 @@
 "level": 5,
 "out_size": 19578840,
 "ratio": 0.3822,
-"compress_mbps": 77.79,
-"decompress_mbps": 260.24
+"compress_mbps": 78.52,
+"decompress_mbps": 258.92
 },
 {
 "compressor": "zig",
@@ -13564,8 +13564,8 @@
 "level": 6,
 "out_size": 19492445,
 "ratio": 0.3806,
-"compress_mbps": 57.93,
-"decompress_mbps": 262.86
+"compress_mbps": 58.0,
+"decompress_mbps": 261.52
 },
 {
 "compressor": "zig",
@@ -13574,8 +13574,8 @@
 "level": 7,
 "out_size": 19463481,
 "ratio": 0.38,
-"compress_mbps": 46.37,
-"decompress_mbps": 261.95
+"compress_mbps": 46.5,
+"decompress_mbps": 263.14
 },
 {
 "compressor": "zig",
@@ -13584,8 +13584,8 @@
 "level": 8,
 "out_size": 19444704,
 "ratio": 0.3796,
-"compress_mbps": 22.9,
-"decompress_mbps": 264.07
+"compress_mbps": 22.81,
+"decompress_mbps": 262.15
 },
 {
 "compressor": "zig",
@@ -13594,8 +13594,8 @@
 "level": 9,
 "out_size": 19440748,
 "ratio": 0.3796,
-"compress_mbps": 13.1,
-"decompress_mbps": 263.43
+"compress_mbps": 13.07,
+"decompress_mbps": 263.2
 },
 {
 "compressor": "zig",
@@ -13604,8 +13604,8 @@
 "level": 1,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 112.73,
-"decompress_mbps": 263.12
+"compress_mbps": 112.24,
+"decompress_mbps": 259.97
 },
 {
 "compressor": "zig",
@@ -13614,8 +13614,8 @@
 "level": 2,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 112.86,
-"decompress_mbps": 261.27
+"compress_mbps": 112.65,
+"decompress_mbps": 260.85
 },
 {
 "compressor": "zig",
@@ -13624,8 +13624,8 @@
 "level": 3,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 113.41,
-"decompress_mbps": 260.99
+"compress_mbps": 111.43,
+"decompress_mbps": 257.26
 },
 {
 "compressor": "zig",
@@ -13634,8 +13634,8 @@
 "level": 4,
 "out_size": 3662279,
 "ratio": 0.3673,
-"compress_mbps": 112.92,
-"decompress_mbps": 260.96
+"compress_mbps": 112.43,
+"decompress_mbps": 258.95
 },
 {
 "compressor": "zig",
@@ -13644,8 +13644,8 @@
 "level": 5,
 "out_size": 3637736,
 "ratio": 0.3648,
-"compress_mbps": 66.3,
-"decompress_mbps": 269.01
+"compress_mbps": 65.79,
+"decompress_mbps": 267.17
 },
 {
 "compressor": "zig",
@@ -13654,8 +13654,8 @@
 "level": 6,
 "out_size": 3621530,
 "ratio": 0.3632,
-"compress_mbps": 46.61,
-"decompress_mbps": 270.19
+"compress_mbps": 46.42,
+"decompress_mbps": 268.5
 },
 {
 "compressor": "zig",
@@ -13664,8 +13664,8 @@
 "level": 7,
 "out_size": 3623924,
 "ratio": 0.3635,
-"compress_mbps": 42.2,
-"decompress_mbps": 271.51
+"compress_mbps": 42.48,
+"decompress_mbps": 270.13
 },
 {
 "compressor": "zig",
@@ -13674,8 +13674,8 @@
 "level": 8,
 "out_size": 3623112,
 "ratio": 0.3634,
-"compress_mbps": 32.8,
-"decompress_mbps": 270.17
+"compress_mbps": 33.07,
+"decompress_mbps": 270.31
 },
 {
 "compressor": "zig",
@@ -13684,8 +13684,8 @@
 "level": 9,
 "out_size": 3623382,
 "ratio": 0.3634,
-"compress_mbps": 24.83,
-"decompress_mbps": 270.02
+"compress_mbps": 24.87,
+"decompress_mbps": 268.67
 },
 {
 "compressor": "zig",
@@ -13694,8 +13694,8 @@
 "level": 1,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 306.82,
-"decompress_mbps": 873.86
+"compress_mbps": 306.93,
+"decompress_mbps": 882.12
 },
 {
 "compressor": "zig",
@@ -13704,8 +13704,8 @@
 "level": 2,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 308.2,
-"decompress_mbps": 873.14
+"compress_mbps": 309.49,
+"decompress_mbps": 879.51
 },
 {
 "compressor": "zig",
@@ -13714,8 +13714,8 @@
 "level": 3,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 308.27,
-"decompress_mbps": 848.74
+"compress_mbps": 306.65,
+"decompress_mbps": 865.76
 },
 {
 "compressor": "zig",
@@ -13724,8 +13724,8 @@
 "level": 4,
 "out_size": 3580057,
 "ratio": 0.1067,
-"compress_mbps": 307.17,
-"decompress_mbps": 839.59
+"compress_mbps": 309.44,
+"decompress_mbps": 876.41
 },
 {
 "compressor": "zig",
@@ -13734,8 +13734,8 @@
 "level": 5,
 "out_size": 3268887,
 "ratio": 0.0974,
-"compress_mbps": 229.64,
-"decompress_mbps": 929.93
+"compress_mbps": 229.13,
+"decompress_mbps": 923.49
 },
 {
 "compressor": "zig",
@@ -13744,8 +13744,8 @@
 "level": 6,
 "out_size": 3131445,
 "ratio": 0.0933,
-"compress_mbps": 162.77,
-"decompress_mbps": 958.08
+"compress_mbps": 163.5,
+"decompress_mbps": 955.29
 },
 {
 "compressor": "zig",
@@ -13754,8 +13754,8 @@
 "level": 7,
 "out_size": 3080217,
 "ratio": 0.0918,
-"compress_mbps": 129.56,
-"decompress_mbps": 956.29
+"compress_mbps": 129.46,
+"decompress_mbps": 960.33
 },
 {
 "compressor": "zig",
@@ -13764,8 +13764,8 @@
 "level": 8,
 "out_size": 2978354,
 "ratio": 0.0888,
-"compress_mbps": 56.62,
-"decompress_mbps": 964.05
+"compress_mbps": 57.16,
+"decompress_mbps": 973.32
 },
 {
 "compressor": "zig",
@@ -13774,8 +13774,8 @@
 "level": 9,
 "out_size": 2947971,
 "ratio": 0.0879,
-"compress_mbps": 34.82,
-"decompress_mbps": 982.79
+"compress_mbps": 34.51,
+"decompress_mbps": 973.37
 },
 {
 "compressor": "zig",
@@ -13784,8 +13784,8 @@
 "level": 1,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 72.72,
-"decompress_mbps": 183.26
+"compress_mbps": 72.44,
+"decompress_mbps": 182.53
 },
 {
 "compressor": "zig",
@@ -13794,8 +13794,8 @@
 "level": 2,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 73.04,
-"decompress_mbps": 183.19
+"compress_mbps": 72.2,
+"decompress_mbps": 182.46
 },
 {
 "compressor": "zig",
@@ -13804,8 +13804,8 @@
 "level": 3,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 72.43,
-"decompress_mbps": 182.93
+"compress_mbps": 72.32,
+"decompress_mbps": 182.97
 },
 {
 "compressor": "zig",
@@ -13814,8 +13814,8 @@
 "level": 4,
 "out_size": 3221973,
 "ratio": 0.5237,
-"compress_mbps": 72.52,
-"decompress_mbps": 182.66
+"compress_mbps": 72.36,
+"decompress_mbps": 183.16
 },
 {
 "compressor": "zig",
@@ -13824,8 +13824,8 @@
 "level": 5,
 "out_size": 3178914,
 "ratio": 0.5167,
-"compress_mbps": 56.23,
-"decompress_mbps": 190.29
+"compress_mbps": 55.82,
+"decompress_mbps": 189.9
 },
 {
 "compressor": "zig",
@@ -13834,8 +13834,8 @@
 "level": 6,
 "out_size": 3174170,
 "ratio": 0.5159,
-"compress_mbps": 49.26,
-"decompress_mbps": 190.97
+"compress_mbps": 49.39,
+"decompress_mbps": 191.24
 },
 {
 "compressor": "zig",
@@ -13844,8 +13844,8 @@
 "level": 7,
 "out_size": 3172734,
 "ratio": 0.5157,
-"compress_mbps": 46.1,
-"decompress_mbps": 191.83
+"compress_mbps": 45.82,
+"decompress_mbps": 191.56
 },
 {
 "compressor": "zig",
@@ -13855,7 +13855,7 @@
 "out_size": 3171353,
 "ratio": 0.5155,
 "compress_mbps": 38.64,
-"decompress_mbps": 191.23
+"decompress_mbps": 191.37
 },
 {
 "compressor": "zig",
@@ -13864,8 +13864,8 @@
 "level": 9,
 "out_size": 3171299,
 "ratio": 0.5155,
-"compress_mbps": 34.76,
-"decompress_mbps": 191.73
+"compress_mbps": 34.82,
+"decompress_mbps": 191.12
 },
 {
 "compressor": "zig",
@@ -13874,8 +13874,8 @@
 "level": 1,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 122.11,
-"decompress_mbps": 273.71
+"compress_mbps": 123.34,
+"decompress_mbps": 273.16
 },
 {
 "compressor": "zig",
@@ -13884,8 +13884,8 @@
 "level": 2,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 123.19,
-"decompress_mbps": 273.81
+"compress_mbps": 122.2,
+"decompress_mbps": 272.47
 },
 {
 "compressor": "zig",
@@ -13894,8 +13894,8 @@
 "level": 3,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 121.58,
-"decompress_mbps": 273.28
+"compress_mbps": 121.33,
+"decompress_mbps": 269.13
 },
 {
 "compressor": "zig",
@@ -13904,8 +13904,8 @@
 "level": 4,
 "out_size": 3791952,
 "ratio": 0.376,
-"compress_mbps": 122.1,
-"decompress_mbps": 274.09
+"compress_mbps": 122.45,
+"decompress_mbps": 274.58
 },
 {
 "compressor": "zig",
@@ -13914,8 +13914,8 @@
 "level": 5,
 "out_size": 3654027,
 "ratio": 0.3623,
-"compress_mbps": 95.79,
-"decompress_mbps": 276.52
+"compress_mbps": 95.52,
+"decompress_mbps": 276.5
 },
 {
 "compressor": "zig",
@@ -13924,8 +13924,8 @@
 "level": 6,
 "out_size": 3652732,
 "ratio": 0.3622,
-"compress_mbps": 92.52,
-"decompress_mbps": 276.75
+"compress_mbps": 91.8,
+"decompress_mbps": 276.29
 },
 {
 "compressor": "zig",
@@ -13934,8 +13934,8 @@
 "level": 7,
 "out_size": 3652496,
 "ratio": 0.3621,
-"compress_mbps": 86.87,
-"decompress_mbps": 277.71
+"compress_mbps": 87.07,
+"decompress_mbps": 275.95
 },
 {
 "compressor": "zig",
@@ -13944,8 +13944,8 @@
 "level": 8,
 "out_size": 3652505,
 "ratio": 0.3621,
-"compress_mbps": 86.73,
-"decompress_mbps": 276.71
+"compress_mbps": 87.05,
+"decompress_mbps": 277.5
 },
 {
 "compressor": "zig",
@@ -13954,8 +13954,8 @@
 "level": 9,
 "out_size": 3652505,
 "ratio": 0.3621,
-"compress_mbps": 86.54,
-"decompress_mbps": 275.21
+"compress_mbps": 87.07,
+"decompress_mbps": 276.53
 },
 {
 "compressor": "zig",
@@ -13964,8 +13964,8 @@
 "level": 1,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 99.43,
-"decompress_mbps": 354.28
+"compress_mbps": 100.62,
+"decompress_mbps": 354.06
 },
 {
 "compressor": "zig",
@@ -13974,8 +13974,8 @@
 "level": 2,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 99.6,
-"decompress_mbps": 351.91
+"compress_mbps": 100.0,
+"decompress_mbps": 353.82
 },
 {
 "compressor": "zig",
@@ -13984,8 +13984,8 @@
 "level": 3,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 99.78,
-"decompress_mbps": 354.34
+"compress_mbps": 99.59,
+"decompress_mbps": 351.77
 },
 {
 "compressor": "zig",
@@ -13994,8 +13994,8 @@
 "level": 4,
 "out_size": 2009824,
 "ratio": 0.3033,
-"compress_mbps": 99.34,
-"decompress_mbps": 354.37
+"compress_mbps": 99.81,
+"decompress_mbps": 354.23
 },
 {
 "compressor": "zig",
@@ -14004,8 +14004,8 @@
 "level": 5,
 "out_size": 1892183,
 "ratio": 0.2855,
-"compress_mbps": 53.81,
-"decompress_mbps": 353.29
+"compress_mbps": 53.63,
+"decompress_mbps": 353.52
 },
 {
 "compressor": "zig",
@@ -14014,8 +14014,8 @@
 "level": 6,
 "out_size": 1837957,
 "ratio": 0.2773,
-"compress_mbps": 30.66,
-"decompress_mbps": 361.71
+"compress_mbps": 30.64,
+"decompress_mbps": 360.81
 },
 {
 "compressor": "zig",
@@ -14024,8 +14024,8 @@
 "level": 7,
 "out_size": 1826603,
 "ratio": 0.2756,
-"compress_mbps": 24.5,
-"decompress_mbps": 361.49
+"compress_mbps": 24.41,
+"decompress_mbps": 362.4
 },
 {
 "compressor": "zig",
@@ -14034,8 +14034,8 @@
 "level": 8,
 "out_size": 1818702,
 "ratio": 0.2744,
-"compress_mbps": 15.94,
-"decompress_mbps": 361.97
+"compress_mbps": 16.09,
+"decompress_mbps": 362.85
 },
 {
 "compressor": "zig",
@@ -14044,8 +14044,8 @@
 "level": 9,
 "out_size": 1818702,
 "ratio": 0.2744,
-"compress_mbps": 16.06,
-"decompress_mbps": 364.57
+"compress_mbps": 15.95,
+"decompress_mbps": 359.54
 },
 {
 "compressor": "zig",
@@ -14054,8 +14054,8 @@
 "level": 1,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 145.36,
-"decompress_mbps": 402.11
+"compress_mbps": 146.11,
+"decompress_mbps": 399.24
 },
 {
 "compressor": "zig",
@@ -14064,8 +14064,8 @@
 "level": 2,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 145.93,
-"decompress_mbps": 404.95
+"compress_mbps": 145.88,
+"decompress_mbps": 400.49
 },
 {
 "compressor": "zig",
@@ -14074,8 +14074,8 @@
 "level": 3,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 145.31,
-"decompress_mbps": 402.16
+"compress_mbps": 146.06,
+"decompress_mbps": 396.62
 },
 {
 "compressor": "zig",
@@ -14084,8 +14084,8 @@
 "level": 4,
 "out_size": 5633558,
 "ratio": 0.2607,
-"compress_mbps": 145.35,
-"decompress_mbps": 399.05
+"compress_mbps": 144.39,
+"decompress_mbps": 379.0
 },
 {
 "compressor": "zig",
@@ -14094,8 +14094,8 @@
 "level": 5,
 "out_size": 5501344,
 "ratio": 0.2546,
-"compress_mbps": 103.26,
-"decompress_mbps": 404.85
+"compress_mbps": 103.33,
+"decompress_mbps": 402.09
 },
 {
 "compressor": "zig",
@@ -14104,8 +14104,8 @@
 "level": 6,
 "out_size": 5464646,
 "ratio": 0.2529,
-"compress_mbps": 79.34,
-"decompress_mbps": 410.26
+"compress_mbps": 79.54,
+"decompress_mbps": 407.14
 },
 {
 "compressor": "zig",
@@ -14114,8 +14114,8 @@
 "level": 7,
 "out_size": 5429975,
 "ratio": 0.2513,
-"compress_mbps": 66.92,
-"decompress_mbps": 408.67
+"compress_mbps": 66.81,
+"decompress_mbps": 408.73
 },
 {
 "compressor": "zig",
@@ -14124,8 +14124,8 @@
 "level": 8,
 "out_size": 5419566,
 "ratio": 0.2508,
-"compress_mbps": 49.29,
-"decompress_mbps": 412.61
+"compress_mbps": 49.41,
+"decompress_mbps": 410.08
 },
 {
 "compressor": "zig",
@@ -14134,8 +14134,8 @@
 "level": 9,
 "out_size": 5417952,
 "ratio": 0.2508,
-"compress_mbps": 45.43,
-"decompress_mbps": 410.38
+"compress_mbps": 45.54,
+"decompress_mbps": 407.63
 },
 {
 "compressor": "zig",
@@ -14144,8 +14144,8 @@
 "level": 1,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 59.93,
-"decompress_mbps": 161.48
+"compress_mbps": 60.47,
+"decompress_mbps": 161.38
 },
 {
 "compressor": "zig",
@@ -14154,8 +14154,8 @@
 "level": 2,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 60.2,
-"decompress_mbps": 159.86
+"compress_mbps": 60.25,
+"decompress_mbps": 161.25
 },
 {
 "compressor": "zig",
@@ -14164,8 +14164,8 @@
 "level": 3,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 60.28,
-"decompress_mbps": 160.49
+"compress_mbps": 60.34,
+"decompress_mbps": 161.47
 },
 {
 "compressor": "zig",
@@ -14174,8 +14174,8 @@
 "level": 4,
 "out_size": 5481930,
 "ratio": 0.7559,
-"compress_mbps": 60.32,
-"decompress_mbps": 161.28
+"compress_mbps": 60.28,
+"decompress_mbps": 159.84
 },
 {
 "compressor": "zig",
@@ -14184,8 +14184,8 @@
 "level": 5,
 "out_size": 5450496,
 "ratio": 0.7516,
-"compress_mbps": 46.77,
-"decompress_mbps": 164.06
+"compress_mbps": 46.56,
+"decompress_mbps": 163.89
 },
 {
 "compressor": "zig",
@@ -14194,8 +14194,8 @@
 "level": 6,
 "out_size": 5440281,
 "ratio": 0.7502,
-"compress_mbps": 42.16,
-"decompress_mbps": 164.57
+"compress_mbps": 42.07,
+"decompress_mbps": 164.58
 },
 {
 "compressor": "zig",
@@ -14204,8 +14204,8 @@
 "level": 7,
 "out_size": 5439077,
 "ratio": 0.75,
-"compress_mbps": 40.8,
-"decompress_mbps": 164.13
+"compress_mbps": 40.6,
+"decompress_mbps": 164.64
 },
 {
 "compressor": "zig",
@@ -14214,8 +14214,8 @@
 "level": 8,
 "out_size": 5438787,
 "ratio": 0.75,
-"compress_mbps": 39.86,
-"decompress_mbps": 164.23
+"compress_mbps": 39.98,
+"decompress_mbps": 163.79
 },
 {
 "compressor": "zig",
@@ -14224,8 +14224,8 @@
 "level": 9,
 "out_size": 5438787,
 "ratio": 0.75,
-"compress_mbps": 40.0,
-"decompress_mbps": 163.95
+"compress_mbps": 39.92,
+"decompress_mbps": 165.07
 },
 {
 "compressor": "zig",
@@ -14234,8 +14234,8 @@
 "level": 1,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 108.65,
-"decompress_mbps": 315.26
+"compress_mbps": 108.43,
+"decompress_mbps": 313.19
 },
 {
 "compressor": "zig",
@@ -14244,8 +14244,8 @@
 "level": 2,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 108.04,
-"decompress_mbps": 314.18
+"compress_mbps": 108.96,
+"decompress_mbps": 316.83
 },
 {
 "compressor": "zig",
@@ -14254,8 +14254,8 @@
 "level": 3,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 108.74,
-"decompress_mbps": 314.35
+"compress_mbps": 108.45,
+"decompress_mbps": 312.18
 },
 {
 "compressor": "zig",
@@ -14264,8 +14264,8 @@
 "level": 4,
 "out_size": 12756531,
 "ratio": 0.3077,
-"compress_mbps": 108.13,
-"decompress_mbps": 317.98
+"compress_mbps": 108.89,
+"decompress_mbps": 315.83
 },
 {
 "compressor": "zig",
@@ -14274,8 +14274,8 @@
 "level": 5,
 "out_size": 12238874,
 "ratio": 0.2952,
-"compress_mbps": 72.5,
-"decompress_mbps": 319.12
+"compress_mbps": 72.34,
+"decompress_mbps": 317.65
 },
 {
 "compressor": "zig",
@@ -14284,8 +14284,8 @@
 "level": 6,
 "out_size": 12086531,
 "ratio": 0.2915,
-"compress_mbps": 53.59,
-"decompress_mbps": 322.81
+"compress_mbps": 53.58,
+"decompress_mbps": 323.18
 },
 {
 "compressor": "zig",
@@ -14294,8 +14294,8 @@
 "level": 7,
 "out_size": 12020742,
 "ratio": 0.2899,
-"compress_mbps": 46.3,
-"decompress_mbps": 323.61
+"compress_mbps": 46.37,
+"decompress_mbps": 319.97
 },
 {
 "compressor": "zig",
@@ -14305,7 +14305,7 @@
 "out_size": 11987253,
 "ratio": 0.2891,
 "compress_mbps": 38.17,
-"decompress_mbps": 324.88
+"decompress_mbps": 322.52
 },
 {
 "compressor": "zig",
@@ -14314,8 +14314,8 @@
 "level": 9,
 "out_size": 11987245,
 "ratio": 0.2891,
-"compress_mbps": 38.1,
-"decompress_mbps": 321.56
+"compress_mbps": 38.15,
+"decompress_mbps": 319.56
 },
 {
 "compressor": "zig",
@@ -14324,8 +14324,8 @@
 "level": 1,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 60.14,
-"decompress_mbps": 146.87
+"compress_mbps": 60.53,
+"decompress_mbps": 146.13
 },
 {
 "compressor": "zig",
@@ -14334,8 +14334,8 @@
 "level": 2,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 60.57,
-"decompress_mbps": 146.81
+"compress_mbps": 60.39,
+"decompress_mbps": 146.09
 },
 {
 "compressor": "zig",
@@ -14344,8 +14344,8 @@
 "level": 3,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 60.61,
-"decompress_mbps": 146.74
+"compress_mbps": 60.11,
+"decompress_mbps": 146.99
 },
 {
 "compressor": "zig",
@@ -14354,8 +14354,8 @@
 "level": 4,
 "out_size": 6273039,
 "ratio": 0.7402,
-"compress_mbps": 60.51,
-"decompress_mbps": 146.74
+"compress_mbps": 60.42,
+"decompress_mbps": 146.5
 },
 {
 "compressor": "zig",
@@ -14364,8 +14364,8 @@
 "level": 5,
 "out_size": 6244483,
 "ratio": 0.7369,
-"compress_mbps": 54.99,
-"decompress_mbps": 148.41
+"compress_mbps": 55.4,
+"decompress_mbps": 148.54
 },
 {
 "compressor": "zig",
@@ -14374,8 +14374,8 @@
 "level": 6,
 "out_size": 6244482,
 "ratio": 0.7369,
-"compress_mbps": 55.44,
-"decompress_mbps": 148.8
+"compress_mbps": 55.47,
+"decompress_mbps": 148.16
 },
 {
 "compressor": "zig",
@@ -14384,8 +14384,8 @@
 "level": 7,
 "out_size": 6244482,
 "ratio": 0.7369,
-"compress_mbps": 55.56,
-"decompress_mbps": 148.37
+"compress_mbps": 55.08,
+"decompress_mbps": 147.42
 },
 {
 "compressor": "zig",
@@ -14394,8 +14394,8 @@
 "level": 8,
 "out_size": 6244480,
 "ratio": 0.7369,
-"compress_mbps": 55.58,
-"decompress_mbps": 148.49
+"compress_mbps": 55.49,
+"decompress_mbps": 148.22
 },
 {
 "compressor": "zig",
@@ -14404,8 +14404,8 @@
 "level": 9,
 "out_size": 6244480,
 "ratio": 0.7369,
-"compress_mbps": 54.79,
-"decompress_mbps": 147.76
+"compress_mbps": 55.43,
+"decompress_mbps": 147.23
 },
 {
 "compressor": "zig",
@@ -14414,8 +14414,8 @@
 "level": 1,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 230.07,
-"decompress_mbps": 671.22
+"compress_mbps": 230.66,
+"decompress_mbps": 673.8
 },
 {
 "compressor": "zig",
@@ -14424,8 +14424,8 @@
 "level": 2,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 230.71,
-"decompress_mbps": 677.7
+"compress_mbps": 230.52,
+"decompress_mbps": 670.21
 },
 {
 "compressor": "zig",
@@ -14434,8 +14434,8 @@
 "level": 3,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 229.2,
-"decompress_mbps": 671.23
+"compress_mbps": 231.93,
+"decompress_mbps": 669.9
 },
 {
 "compressor": "zig",
@@ -14444,8 +14444,8 @@
 "level": 4,
 "out_size": 785041,
 "ratio": 0.1469,
-"compress_mbps": 230.33,
-"decompress_mbps": 675.75
+"compress_mbps": 230.28,
+"decompress_mbps": 671.23
 },
 {
 "compressor": "zig",
@@ -14454,8 +14454,8 @@
 "level": 5,
 "out_size": 716461,
 "ratio": 0.134,
-"compress_mbps": 166.03,
-"decompress_mbps": 714.12
+"compress_mbps": 166.09,
+"decompress_mbps": 710.38
 },
 {
 "compressor": "zig",
@@ -14464,8 +14464,8 @@
 "level": 6,
 "out_size": 687053,
 "ratio": 0.1285,
-"compress_mbps": 123.93,
-"decompress_mbps": 737.13
+"compress_mbps": 124.29,
+"decompress_mbps": 733.86
 },
 {
 "compressor": "zig",
@@ -14474,8 +14474,8 @@
 "level": 7,
 "out_size": 673597,
 "ratio": 0.126,
-"compress_mbps": 101.0,
-"decompress_mbps": 752.07
+"compress_mbps": 100.95,
+"decompress_mbps": 744.02
 },
 {
 "compressor": "zig",
@@ -14484,8 +14484,8 @@
 "level": 8,
 "out_size": 662156,
 "ratio": 0.1239,
-"compress_mbps": 65.54,
-"decompress_mbps": 751.78
+"compress_mbps": 65.08,
+"decompress_mbps": 750.21
 },
 {
 "compressor": "zig",
@@ -14494,8 +14494,8 @@
 "level": 9,
 "out_size": 661610,
 "ratio": 0.1238,
-"compress_mbps": 60.91,
-"decompress_mbps": 755.71
+"compress_mbps": 61.06,
+"decompress_mbps": 754.5
 },
 {
 "compressor": "ocaml",
@@ -14504,8 +14504,8 @@
 "level": 1,
 "out_size": 73589,
 "ratio": 0.4839,
-"compress_mbps": 33.7,
-"decompress_mbps": 56.65
+"compress_mbps": 33.76,
+"decompress_mbps": 57.05
 },
 {
 "compressor": "ocaml",
@@ -14514,8 +14514,8 @@
 "level": 2,
 "out_size": 69878,
 "ratio": 0.4595,
-"compress_mbps": 32.1,
-"decompress_mbps": 58.01
+"compress_mbps": 32.08,
+"decompress_mbps": 58.09
 },
 {
 "compressor": "ocaml",
@@ -14524,8 +14524,8 @@
 "level": 3,
 "out_size": 66917,
 "ratio": 0.44,
-"compress_mbps": 26.84,
-"decompress_mbps": 66.22
+"compress_mbps": 26.68,
+"decompress_mbps": 66.6
 },
 {
 "compressor": "ocaml",
@@ -14534,8 +14534,8 @@
 "level": 4,
 "out_size": 59388,
 "ratio": 0.3905,
-"compress_mbps": 31.24,
-"decompress_mbps": 79.63
+"compress_mbps": 31.26,
+"decompress_mbps": 80.36
 },
 {
 "compressor": "ocaml",
@@ -14544,8 +14544,8 @@
 "level": 5,
 "out_size": 57062,
 "ratio": 0.3752,
-"compress_mbps": 22.6,
-"decompress_mbps": 78.83
+"compress_mbps": 22.77,
+"decompress_mbps": 80.1
 },
 {
 "compressor": "ocaml",
@@ -14554,8 +14554,8 @@
 "level": 6,
 "out_size": 55472,
 "ratio": 0.3647,
-"compress_mbps": 16.18,
-"decompress_mbps": 78.52
+"compress_mbps": 16.23,
+"decompress_mbps": 79.12
 },
 {
 "compressor": "ocaml",
@@ -14564,8 +14564,8 @@
 "level": 7,
 "out_size": 55265,
 "ratio": 0.3634,
-"compress_mbps": 14.28,
-"decompress_mbps": 78.61
+"compress_mbps": 14.29,
+"decompress_mbps": 79.84
 },
 {
 "compressor": "ocaml",
@@ -14574,8 +14574,8 @@
 "level": 8,
 "out_size": 55168,
 "ratio": 0.3627,
-"compress_mbps": 11.94,
-"decompress_mbps": 78.29
+"compress_mbps": 11.91,
+"decompress_mbps": 78.92
 },
 {
 "compressor": "ocaml",
@@ -14584,8 +14584,8 @@
 "level": 9,
 "out_size": 55168,
 "ratio": 0.3627,
-"compress_mbps": 11.86,
-"decompress_mbps": 79.16
+"compress_mbps": 11.93,
+"decompress_mbps": 78.52
 },
 {
 "compressor": "ocaml",
@@ -14594,8 +14594,8 @@
 "level": 1,
 "out_size": 64551,
 "ratio": 0.5157,
-"compress_mbps": 32.2,
-"decompress_mbps": 54.09
+"compress_mbps": 31.89,
+"decompress_mbps": 53.82
 },
 {
 "compressor": "ocaml",
@@ -14604,8 +14604,8 @@
 "level": 2,
 "out_size": 62089,
 "ratio": 0.496,
-"compress_mbps": 30.28,
-"decompress_mbps": 56.87
+"compress_mbps": 30.15,
+"decompress_mbps": 57.83
 },
 {
 "compressor": "ocaml",
@@ -14614,8 +14614,8 @@
 "level": 3,
 "out_size": 58690,
 "ratio": 0.4688,
-"compress_mbps": 24.62,
-"decompress_mbps": 59.34
+"compress_mbps": 24.34,
+"decompress_mbps": 59.96
 },
 {
 "compressor": "ocaml",
@@ -14624,8 +14624,8 @@
 "level": 4,
 "out_size": 53521,
 "ratio": 0.4276,
-"compress_mbps": 30.14,
-"decompress_mbps": 80.01
+"compress_mbps": 30.1,
+"decompress_mbps": 79.96
 },
 {
 "compressor": "ocaml",
@@ -14634,8 +14634,8 @@
 "level": 5,
 "out_size": 51677,
 "ratio": 0.4128,
-"compress_mbps": 20.84,
-"decompress_mbps": 76.53
+"compress_mbps": 20.89,
+"decompress_mbps": 78.97
 },
 {
 "compressor": "ocaml",
@@ -14644,8 +14644,8 @@
 "level": 6,
 "out_size": 50638,
 "ratio": 0.4045,
-"compress_mbps": 15.0,
-"decompress_mbps": 82.97
+"compress_mbps": 14.85,
+"decompress_mbps": 82.68
 },
 {
 "compressor": "ocaml",
@@ -14654,8 +14654,8 @@
 "level": 7,
 "out_size": 50501,
 "ratio": 0.4034,
-"compress_mbps": 13.52,
-"decompress_mbps": 79.81
+"compress_mbps": 13.53,
+"decompress_mbps": 79.57
 },
 {
 "compressor": "ocaml",
@@ -14664,8 +14664,8 @@
 "level": 8,
 "out_size": 50452,
 "ratio": 0.403,
-"compress_mbps": 12.55,
-"decompress_mbps": 83.02
+"compress_mbps": 12.59,
+"decompress_mbps": 81.82
 },
 {
 "compressor": "ocaml",
@@ -14674,8 +14674,8 @@
 "level": 9,
 "out_size": 50452,
 "ratio": 0.403,
-"compress_mbps": 12.61,
-"decompress_mbps": 83.15
+"compress_mbps": 12.59,
+"decompress_mbps": 81.99
 },
 {
 "compressor": "ocaml",
@@ -14684,8 +14684,8 @@
 "level": 1,
 "out_size": 9859,
 "ratio": 0.4007,
-"compress_mbps": 43.54,
-"decompress_mbps": 111.31
+"compress_mbps": 43.03,
+"decompress_mbps": 111.15
 },
 {
 "compressor": "ocaml",
@@ -14694,8 +14694,8 @@
 "level": 2,
 "out_size": 10473,
 "ratio": 0.4257,
-"compress_mbps": 46.87,
-"decompress_mbps": 149.71
+"compress_mbps": 47.23,
+"decompress_mbps": 149.93
 },
 {
 "compressor": "ocaml",
@@ -14704,8 +14704,8 @@
 "level": 3,
 "out_size": 10172,
 "ratio": 0.4134,
-"compress_mbps": 42.71,
-"decompress_mbps": 153.65
+"compress_mbps": 42.85,
+"decompress_mbps": 148.23
 },
 {
 "compressor": "ocaml",
@@ -14714,8 +14714,8 @@
 "level": 4,
 "out_size": 8692,
 "ratio": 0.3533,
-"compress_mbps": 40.71,
-"decompress_mbps": 153.37
+"compress_mbps": 40.47,
+"decompress_mbps": 152.86
 },
 {
 "compressor": "ocaml",
@@ -14724,8 +14724,8 @@
 "level": 5,
 "out_size": 8440,
 "ratio": 0.343,
-"compress_mbps": 36.08,
-"decompress_mbps": 158.21
+"compress_mbps": 36.18,
+"decompress_mbps": 157.16
 },
 {
 "compressor": "ocaml",
@@ -14734,8 +14734,8 @@
 "level": 6,
 "out_size": 8385,
 "ratio": 0.3408,
-"compress_mbps": 31.73,
-"decompress_mbps": 157.16
+"compress_mbps": 31.88,
+"decompress_mbps": 158.84
 },
 {
 "compressor": "ocaml",
@@ -14744,8 +14744,8 @@
 "level": 7,
 "out_size": 8366,
 "ratio": 0.34,
-"compress_mbps": 30.2,
-"decompress_mbps": 158.76
+"compress_mbps": 29.95,
+"decompress_mbps": 158.95
 },
 {
 "compressor": "ocaml",
@@ -14754,8 +14754,8 @@
 "level": 8,
 "out_size": 8367,
 "ratio": 0.3401,
-"compress_mbps": 28.66,
-"decompress_mbps": 157.83
+"compress_mbps": 28.71,
+"decompress_mbps": 157.48
 },
 {
 "compressor": "ocaml",
@@ -14764,8 +14764,8 @@
 "level": 9,
 "out_size": 8367,
 "ratio": 0.3401,
-"compress_mbps": 28.99,
-"decompress_mbps": 158.84
+"compress_mbps": 28.72,
+"decompress_mbps": 156.54
 },
 {
 "compressor": "ocaml",
@@ -14774,8 +14774,8 @@
 "level": 1,
 "out_size": 4822,
 "ratio": 0.4325,
-"compress_mbps": 53.77,
-"decompress_mbps": 185.7
+"compress_mbps": 54.35,
+"decompress_mbps": 187.68
 },
 {
 "compressor": "ocaml",
@@ -14784,8 +14784,8 @@
 "level": 2,
 "out_size": 4593,
 "ratio": 0.4119,
-"compress_mbps": 53.98,
-"decompress_mbps": 192.69
+"compress_mbps": 52.8,
+"decompress_mbps": 193.41
 },
 {
 "compressor": "ocaml",
@@ -14794,8 +14794,8 @@
 "level": 3,
 "out_size": 4381,
 "ratio": 0.3929,
-"compress_mbps": 49.66,
-"decompress_mbps": 199.95
+"compress_mbps": 49.8,
+"decompress_mbps": 200.8
 },
 {
 "compressor": "ocaml",
@@ -14804,8 +14804,8 @@
 "level": 4,
 "out_size": 3725,
 "ratio": 0.3341,
-"compress_mbps": 49.25,
-"decompress_mbps": 202.48
+"compress_mbps": 51.8,
+"decompress_mbps": 202.76
 },
 {
 "compressor": "ocaml",
@@ -14814,8 +14814,8 @@
 "level": 5,
 "out_size": 3614,
 "ratio": 0.3241,
-"compress_mbps": 44.83,
-"decompress_mbps": 207.77
+"compress_mbps": 43.83,
+"decompress_mbps": 208.48
 },
 {
 "compressor": "ocaml",
@@ -14824,8 +14824,8 @@
 "level": 6,
 "out_size": 3578,
 "ratio": 0.3209,
-"compress_mbps": 39.17,
-"decompress_mbps": 212.51
+"compress_mbps": 39.35,
+"decompress_mbps": 209.91
 },
 {
 "compressor": "ocaml",
@@ -14834,8 +14834,8 @@
 "level": 7,
 "out_size": 3572,
 "ratio": 0.3204,
-"compress_mbps": 35.82,
-"decompress_mbps": 207.62
+"compress_mbps": 36.83,
+"decompress_mbps": 210.72
 },
 {
 "compressor": "ocaml",
@@ -14844,8 +14844,8 @@
 "level": 8,
 "out_size": 3568,
 "ratio": 0.32,
-"compress_mbps": 34.39,
-"decompress_mbps": 207.77
+"compress_mbps": 34.7,
+"decompress_mbps": 208.41
 },
 {
 "compressor": "ocaml",
@@ -14854,8 +14854,8 @@
 "level": 9,
 "out_size": 3568,
 "ratio": 0.32,
-"compress_mbps": 34.56,
-"decompress_mbps": 208.5
+"compress_mbps": 33.66,
+"decompress_mbps": 206.14
 },
 {
 "compressor": "ocaml",
@@ -14864,8 +14864,8 @@
 "level": 1,
 "out_size": 1738,
 "ratio": 0.4671,
-"compress_mbps": 32.48,
-"decompress_mbps": 174.63
+"compress_mbps": 30.09,
+"decompress_mbps": 176.72
 },
 {
 "compressor": "ocaml",
@@ -14874,8 +14874,8 @@
 "level": 2,
 "out_size": 1709,
 "ratio": 0.4593,
-"compress_mbps": 31.71,
-"decompress_mbps": 177.26
+"compress_mbps": 30.1,
+"decompress_mbps": 174.49
 },
 {
 "compressor": "ocaml",
@@ -14884,8 +14884,8 @@
 "level": 3,
 "out_size": 1694,
 "ratio": 0.4553,
-"compress_mbps": 29.7,
-"decompress_mbps": 178.26
+"compress_mbps": 31.7,
+"decompress_mbps": 180.35
 },
 {
 "compressor": "ocaml",
@@ -14894,8 +14894,8 @@
 "level": 4,
 "out_size": 1458,
 "ratio": 0.3918,
-"compress_mbps": 29.97,
-"decompress_mbps": 186.97
+"compress_mbps": 29.73,
+"decompress_mbps": 187.58
 },
 {
 "compressor": "ocaml",
@@ -14904,8 +14904,8 @@
 "level": 5,
 "out_size": 1441,
 "ratio": 0.3873,
-"compress_mbps": 28.83,
-"decompress_mbps": 189.52
+"compress_mbps": 28.44,
+"decompress_mbps": 189.94
 },
 {
 "compressor": "ocaml",
@@ -14914,8 +14914,8 @@
 "level": 6,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 28.26,
-"decompress_mbps": 189.58
+"compress_mbps": 27.18,
+"decompress_mbps": 189.99
 },
 {
 "compressor": "ocaml",
@@ -14924,8 +14924,8 @@
 "level": 7,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 27.56,
-"decompress_mbps": 188.96
+"compress_mbps": 27.68,
+"decompress_mbps": 190.15
 },
 {
 "compressor": "ocaml",
@@ -14934,8 +14934,8 @@
 "level": 8,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 27.47,
-"decompress_mbps": 188.08
+"compress_mbps": 26.12,
+"decompress_mbps": 189.99
 },
 {
 "compressor": "ocaml",
@@ -14944,8 +14944,8 @@
 "level": 9,
 "out_size": 1440,
 "ratio": 0.387,
-"compress_mbps": 26.24,
-"decompress_mbps": 189.94
+"compress_mbps": 27.78,
+"decompress_mbps": 191.2
 },
 {
 "compressor": "ocaml",
@@ -14954,8 +14954,8 @@
 "level": 1,
 "out_size": 260073,
 "ratio": 0.2526,
-"compress_mbps": 52.66,
-"decompress_mbps": 56.46
+"compress_mbps": 52.45,
+"decompress_mbps": 56.85
 },
 {
 "compressor": "ocaml",
@@ -14964,8 +14964,8 @@
 "level": 2,
 "out_size": 296764,
 "ratio": 0.2882,
-"compress_mbps": 49.0,
-"decompress_mbps": 76.74
+"compress_mbps": 48.94,
+"decompress_mbps": 76.97
 },
 {
 "compressor": "ocaml",
@@ -14974,8 +14974,8 @@
 "level": 3,
 "out_size": 288989,
 "ratio": 0.2806,
-"compress_mbps": 37.68,
-"decompress_mbps": 78.07
+"compress_mbps": 37.59,
+"decompress_mbps": 77.33
 },
 {
 "compressor": "ocaml",
@@ -14984,8 +14984,8 @@
 "level": 4,
 "out_size": 246442,
 "ratio": 0.2393,
-"compress_mbps": 54.41,
-"decompress_mbps": 82.33
+"compress_mbps": 54.71,
+"decompress_mbps": 83.32
 },
 {
 "compressor": "ocaml",
@@ -14994,8 +14994,8 @@
 "level": 5,
 "out_size": 218888,
 "ratio": 0.2126,
-"compress_mbps": 40.32,
-"decompress_mbps": 75.78
+"compress_mbps": 40.79,
+"decompress_mbps": 76.86
 },
 {
 "compressor": "ocaml",
@@ -15004,8 +15004,8 @@
 "level": 6,
 "out_size": 217830,
 "ratio": 0.2115,
-"compress_mbps": 24.1,
-"decompress_mbps": 86.8
+"compress_mbps": 24.16,
+"decompress_mbps": 88.24
 },
 {
 "compressor": "ocaml",
@@ -15014,8 +15014,8 @@
 "level": 7,
 "out_size": 221437,
 "ratio": 0.215,
-"compress_mbps": 19.14,
-"decompress_mbps": 86.26
+"compress_mbps": 19.26,
+"decompress_mbps": 86.6
 },
 {
 "compressor": "ocaml",
@@ -15024,8 +15024,8 @@
 "level": 8,
 "out_size": 219666,
 "ratio": 0.2133,
-"compress_mbps": 5.5,
-"decompress_mbps": 85.14
+"compress_mbps": 5.49,
+"decompress_mbps": 86.51
 },
 {
 "compressor": "ocaml",
@@ -15034,8 +15034,8 @@
 "level": 9,
 "out_size": 219921,
 "ratio": 0.2136,
-"compress_mbps": 2.8,
-"decompress_mbps": 86.65
+"compress_mbps": 2.77,
+"decompress_mbps": 85.35
 },
 {
 "compressor": "ocaml",
@@ -15044,8 +15044,8 @@
 "level": 1,
 "out_size": 194588,
 "ratio": 0.456,
-"compress_mbps": 34.52,
-"decompress_mbps": 51.66
+"compress_mbps": 34.47,
+"decompress_mbps": 51.9
 },
 {
 "compressor": "ocaml",
@@ -15054,8 +15054,8 @@
 "level": 2,
 "out_size": 185757,
 "ratio": 0.4353,
-"compress_mbps": 33.15,
-"decompress_mbps": 49.3
+"compress_mbps": 32.92,
+"decompress_mbps": 49.65
 },
 {
 "compressor": "ocaml",
@@ -15064,8 +15064,8 @@
 "level": 3,
 "out_size": 175850,
 "ratio": 0.4121,
-"compress_mbps": 27.26,
-"decompress_mbps": 59.72
+"compress_mbps": 27.11,
+"decompress_mbps": 59.21
 },
 {
 "compressor": "ocaml",
@@ -15074,8 +15074,8 @@
 "level": 4,
 "out_size": 155951,
 "ratio": 0.3654,
-"compress_mbps": 32.27,
-"decompress_mbps": 72.52
+"compress_mbps": 31.95,
+"decompress_mbps": 73.02
 },
 {
 "compressor": "ocaml",
@@ -15084,8 +15084,8 @@
 "level": 5,
 "out_size": 150274,
 "ratio": 0.3521,
-"compress_mbps": 23.03,
-"decompress_mbps": 71.42
+"compress_mbps": 23.12,
+"decompress_mbps": 71.4
 },
 {
 "compressor": "ocaml",
@@ -15094,8 +15094,8 @@
 "level": 6,
 "out_size": 147958,
 "ratio": 0.3467,
-"compress_mbps": 16.76,
-"decompress_mbps": 73.05
+"compress_mbps": 16.73,
+"decompress_mbps": 72.74
 },
 {
 "compressor": "ocaml",
@@ -15104,8 +15104,8 @@
 "level": 7,
 "out_size": 147522,
 "ratio": 0.3457,
-"compress_mbps": 15.07,
-"decompress_mbps": 71.55
+"compress_mbps": 14.93,
+"decompress_mbps": 70.21
 },
 {
 "compressor": "ocaml",
@@ -15114,8 +15114,8 @@
 "level": 8,
 "out_size": 147331,
 "ratio": 0.3452,
-"compress_mbps": 13.67,
-"decompress_mbps": 71.85
+"compress_mbps": 13.5,
+"decompress_mbps": 68.78
 },
 {
 "compressor": "ocaml",
@@ -15124,8 +15124,8 @@
 "level": 9,
 "out_size": 147328,
 "ratio": 0.3452,
-"compress_mbps": 13.47,
-"decompress_mbps": 72.05
+"compress_mbps": 13.48,
+"decompress_mbps": 70.75
 },
 {
 "compressor": "ocaml",
@@ -15134,8 +15134,8 @@
 "level": 1,
 "out_size": 256904,
 "ratio": 0.5331,
-"compress_mbps": 30.1,
-"decompress_mbps": 47.01
+"compress_mbps": 29.73,
+"decompress_mbps": 46.55
 },
 {
 "compressor": "ocaml",
@@ -15144,8 +15144,8 @@
 "level": 2,
 "out_size": 245675,
 "ratio": 0.5098,
-"compress_mbps": 28.47,
-"decompress_mbps": 49.62
+"compress_mbps": 28.42,
+"decompress_mbps": 50.05
 },
 {
 "compressor": "ocaml",
@@ -15154,8 +15154,8 @@
 "level": 3,
 "out_size": 231519,
 "ratio": 0.4805,
-"compress_mbps": 22.44,
-"decompress_mbps": 56.21
+"compress_mbps": 22.58,
+"decompress_mbps": 56.23
 },
 {
 "compressor": "ocaml",
@@ -15165,7 +15165,7 @@
 "out_size": 210028,
 "ratio": 0.4359,
 "compress_mbps": 27.54,
-"decompress_mbps": 64.63
+"decompress_mbps": 64.61
 },
 {
 "compressor": "ocaml",
@@ -15174,8 +15174,8 @@
 "level": 5,
 "out_size": 203312,
 "ratio": 0.4219,
-"compress_mbps": 18.62,
-"decompress_mbps": 61.83
+"compress_mbps": 18.52,
+"decompress_mbps": 61.6
 },
 {
 "compressor": "ocaml",
@@ -15184,8 +15184,8 @@
 "level": 6,
 "out_size": 199287,
 "ratio": 0.4136,
-"compress_mbps": 12.8,
-"decompress_mbps": 65.1
+"compress_mbps": 12.88,
+"decompress_mbps": 65.73
 },
 {
 "compressor": "ocaml",
@@ -15194,8 +15194,8 @@
 "level": 7,
 "out_size": 198474,
 "ratio": 0.4119,
-"compress_mbps": 11.19,
-"decompress_mbps": 65.82
+"compress_mbps": 11.21,
+"decompress_mbps": 66.4
 },
 {
 "compressor": "ocaml",
@@ -15204,8 +15204,8 @@
 "level": 8,
 "out_size": 198080,
 "ratio": 0.4111,
-"compress_mbps": 8.83,
-"decompress_mbps": 65.58
+"compress_mbps": 8.88,
+"decompress_mbps": 65.36
 },
 {
 "compressor": "ocaml",
@@ -15214,8 +15214,8 @@
 "level": 9,
 "out_size": 198080,
 "ratio": 0.4111,
-"compress_mbps": 8.81,
-"decompress_mbps": 65.07
+"compress_mbps": 8.84,
+"decompress_mbps": 65.03
 },
 {
 "compressor": "ocaml",
@@ -15224,8 +15224,8 @@
 "level": 1,
 "out_size": 71229,
 "ratio": 0.1388,
-"compress_mbps": 82.51,
-"decompress_mbps": 135.63
+"compress_mbps": 82.96,
+"decompress_mbps": 136.59
 },
 {
 "compressor": "ocaml",
@@ -15234,8 +15234,8 @@
 "level": 2,
 "out_size": 69946,
 "ratio": 0.1363,
-"compress_mbps": 79.09,
-"decompress_mbps": 136.69
+"compress_mbps": 78.92,
+"decompress_mbps": 137.96
 },
 {
 "compressor": "ocaml",
@@ -15244,8 +15244,8 @@
 "level": 3,
 "out_size": 68538,
 "ratio": 0.1335,
-"compress_mbps": 69.6,
-"decompress_mbps": 151.25
+"compress_mbps": 69.23,
+"decompress_mbps": 151.76
 },
 {
 "compressor": "ocaml",
@@ -15254,8 +15254,8 @@
 "level": 4,
 "out_size": 61320,
 "ratio": 0.1195,
-"compress_mbps": 65.9,
-"decompress_mbps": 163.79
+"compress_mbps": 65.87,
+"decompress_mbps": 164.26
 },
 {
 "compressor": "ocaml",
@@ -15264,8 +15264,8 @@
 "level": 5,
 "out_size": 59993,
 "ratio": 0.1169,
-"compress_mbps": 56.97,
-"decompress_mbps": 167.46
+"compress_mbps": 57.15,
+"decompress_mbps": 169.1
 },
 {
 "compressor": "ocaml",
@@ -15274,8 +15274,8 @@
 "level": 6,
 "out_size": 58637,
 "ratio": 0.1143,
-"compress_mbps": 41.11,
-"decompress_mbps": 168.0
+"compress_mbps": 41.42,
+"decompress_mbps": 166.25
 },
 {
 "compressor": "ocaml",
@@ -15284,8 +15284,8 @@
 "level": 7,
 "out_size": 58209,
 "ratio": 0.1134,
-"compress_mbps": 35.31,
-"decompress_mbps": 171.67
+"compress_mbps": 35.38,
+"decompress_mbps": 173.09
 },
 {
 "compressor": "ocaml",
@@ -15294,8 +15294,8 @@
 "level": 8,
 "out_size": 55749,
 "ratio": 0.1086,
-"compress_mbps": 19.28,
-"decompress_mbps": 176.91
+"compress_mbps": 19.35,
+"decompress_mbps": 176.71
 },
 {
 "compressor": "ocaml",
@@ -15304,8 +15304,8 @@
 "level": 9,
 "out_size": 54927,
 "ratio": 0.107,
-"compress_mbps": 7.51,
-"decompress_mbps": 177.06
+"compress_mbps": 7.52,
+"decompress_mbps": 176.17
 },
 {
 "compressor": "ocaml",
@@ -15314,8 +15314,8 @@
 "level": 1,
 "out_size": 16399,
 "ratio": 0.4288,
-"compress_mbps": 36.54,
-"decompress_mbps": 89.88
+"compress_mbps": 36.37,
+"decompress_mbps": 86.67
 },
 {
 "compressor": "ocaml",
@@ -15324,8 +15324,8 @@
 "level": 2,
 "out_size": 15933,
 "ratio": 0.4167,
-"compress_mbps": 33.58,
-"decompress_mbps": 91.22
+"compress_mbps": 33.72,
+"decompress_mbps": 88.83
 },
 {
 "compressor": "ocaml",
@@ -15334,8 +15334,8 @@
 "level": 3,
 "out_size": 15739,
 "ratio": 0.4116,
-"compress_mbps": 28.25,
-"decompress_mbps": 88.9
+"compress_mbps": 28.05,
+"decompress_mbps": 87.94
 },
 {
 "compressor": "ocaml",
@@ -15344,8 +15344,8 @@
 "level": 4,
 "out_size": 13834,
 "ratio": 0.3618,
-"compress_mbps": 31.89,
-"decompress_mbps": 108.89
+"compress_mbps": 31.73,
+"decompress_mbps": 108.86
 },
 {
 "compressor": "ocaml",
@@ -15354,8 +15354,8 @@
 "level": 5,
 "out_size": 13463,
 "ratio": 0.3521,
-"compress_mbps": 26.23,
-"decompress_mbps": 109.05
+"compress_mbps": 25.96,
+"decompress_mbps": 111.56
 },
 {
 "compressor": "ocaml",
@@ -15364,8 +15364,8 @@
 "level": 6,
 "out_size": 13353,
 "ratio": 0.3492,
-"compress_mbps": 18.79,
-"decompress_mbps": 111.32
+"compress_mbps": 18.86,
+"decompress_mbps": 111.15
 },
 {
 "compressor": "ocaml",
@@ -15374,8 +15374,8 @@
 "level": 7,
 "out_size": 13317,
 "ratio": 0.3482,
-"compress_mbps": 15.84,
-"decompress_mbps": 110.95
+"compress_mbps": 15.93,
+"decompress_mbps": 113.26
 },
 {
 "compressor": "ocaml",
@@ -15384,8 +15384,8 @@
 "level": 8,
 "out_size": 13255,
 "ratio": 0.3466,
-"compress_mbps": 8.39,
-"decompress_mbps": 111.15
+"compress_mbps": 8.38,
+"decompress_mbps": 110.11
 },
 {
 "compressor": "ocaml",
@@ -15395,7 +15395,7 @@
 "out_size": 13171,
 "ratio": 0.3444,
 "compress_mbps": 4.16,
-"decompress_mbps": 112.86
+"decompress_mbps": 114.39
 },
 {
 "compressor": "ocaml",
@@ -15404,8 +15404,8 @@
 "level": 1,
 "out_size": 2512,
 "ratio": 0.5943,
-"compress_mbps": 29.81,
-"decompress_mbps": 154.08
+"compress_mbps": 29.63,
+"decompress_mbps": 155.88
 },
 {
 "compressor": "ocaml",
@@ -15414,8 +15414,8 @@
 "level": 2,
 "out_size": 2477,
 "ratio": 0.586,
-"compress_mbps": 29.79,
-"decompress_mbps": 155.26
+"compress_mbps": 29.51,
+"decompress_mbps": 158.96
 },
 {
 "compressor": "ocaml",
@@ -15424,8 +15424,8 @@
 "level": 3,
 "out_size": 2452,
 "ratio": 0.5801,
-"compress_mbps": 31.0,
-"decompress_mbps": 151.67
+"compress_mbps": 30.37,
+"decompress_mbps": 157.34
 },
 {
 "compressor": "ocaml",
@@ -15434,8 +15434,8 @@
 "level": 4,
 "out_size": 2110,
 "ratio": 0.4992,
-"compress_mbps": 30.3,
-"decompress_mbps": 161.11
+"compress_mbps": 29.99,
+"decompress_mbps": 162.81
 },
 {
 "compressor": "ocaml",
@@ -15444,8 +15444,8 @@
 "level": 5,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 29.02,
-"decompress_mbps": 165.2
+"compress_mbps": 28.87,
+"decompress_mbps": 169.5
 },
 {
 "compressor": "ocaml",
@@ -15454,8 +15454,8 @@
 "level": 6,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 29.08,
-"decompress_mbps": 165.34
+"compress_mbps": 28.86,
+"decompress_mbps": 167.98
 },
 {
 "compressor": "ocaml",
@@ -15464,8 +15464,8 @@
 "level": 7,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 28.71,
-"decompress_mbps": 166.7
+"compress_mbps": 28.5,
+"decompress_mbps": 169.54
 },
 {
 "compressor": "ocaml",
@@ -15474,8 +15474,8 @@
 "level": 8,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 28.43,
-"decompress_mbps": 166.88
+"compress_mbps": 27.54,
+"decompress_mbps": 169.65
 },
 {
 "compressor": "ocaml",
@@ -15484,8 +15484,8 @@
 "level": 9,
 "out_size": 2086,
 "ratio": 0.4935,
-"compress_mbps": 28.46,
-"decompress_mbps": 164.41
+"compress_mbps": 28.63,
+"decompress_mbps": 169.5
 },
 {
 "compressor": "ocaml",
@@ -15494,8 +15494,8 @@
 "level": 1,
 "out_size": 5183792,
 "ratio": 0.5086,
-"compress_mbps": 31.47,
-"decompress_mbps": 38.98
+"compress_mbps": 31.31,
+"decompress_mbps": 40.47
 },
 {
 "compressor": "ocaml",
@@ -15504,8 +15504,8 @@
 "level": 2,
 "out_size": 4956750,
 "ratio": 0.4863,
-"compress_mbps": 30.25,
-"decompress_mbps": 43.89
+"compress_mbps": 29.97,
+"decompress_mbps": 43.45
 },
 {
 "compressor": "ocaml",
@@ -15514,8 +15514,8 @@
 "level": 3,
 "out_size": 4644095,
 "ratio": 0.4556,
-"compress_mbps": 23.95,
-"decompress_mbps": 47.67
+"compress_mbps": 24.06,
+"decompress_mbps": 47.94
 },
 {
 "compressor": "ocaml",
@@ -15524,8 +15524,8 @@
 "level": 4,
 "out_size": 4178564,
 "ratio": 0.41,
-"compress_mbps": 29.16,
-"decompress_mbps": 61.79
+"compress_mbps": 29.06,
+"decompress_mbps": 61.99
 },
 {
 "compressor": "ocaml",
@@ -15534,8 +15534,8 @@
 "level": 5,
 "out_size": 4034632,
 "ratio": 0.3958,
-"compress_mbps": 19.82,
-"decompress_mbps": 59.29
+"compress_mbps": 19.92,
+"decompress_mbps": 61.3
 },
 {
 "compressor": "ocaml",
@@ -15544,8 +15544,8 @@
 "level": 6,
 "out_size": 3952244,
 "ratio": 0.3878,
-"compress_mbps": 13.96,
-"decompress_mbps": 60.98
+"compress_mbps": 13.83,
+"decompress_mbps": 61.12
 },
 {
 "compressor": "ocaml",
@@ -15554,8 +15554,8 @@
 "level": 7,
 "out_size": 3938822,
 "ratio": 0.3864,
-"compress_mbps": 12.24,
-"decompress_mbps": 62.47
+"compress_mbps": 12.23,
+"decompress_mbps": 62.83
 },
 {
 "compressor": "ocaml",
@@ -15564,8 +15564,8 @@
 "level": 8,
 "out_size": 3935171,
 "ratio": 0.3861,
-"compress_mbps": 10.71,
-"decompress_mbps": 60.98
+"compress_mbps": 10.76,
+"decompress_mbps": 60.2
 },
 {
 "compressor": "ocaml",
@@ -15574,8 +15574,8 @@
 "level": 9,
 "out_size": 3935171,
 "ratio": 0.3861,
-"compress_mbps": 10.81,
-"decompress_mbps": 61.24
+"compress_mbps": 10.72,
+"decompress_mbps": 60.89
 },
 {
 "compressor": "ocaml",
@@ -15584,8 +15584,8 @@
 "level": 1,
 "out_size": 25320013,
 "ratio": 0.4943,
-"compress_mbps": 31.93,
-"decompress_mbps": 33.07
+"compress_mbps": 31.71,
+"decompress_mbps": 34.88
 },
 {
 "compressor": "ocaml",
@@ -15594,8 +15594,8 @@
 "level": 2,
 "out_size": 24804084,
 "ratio": 0.4843,
-"compress_mbps": 30.27,
-"decompress_mbps": 36.09
+"compress_mbps": 30.3,
+"decompress_mbps": 36.64
 },
 {
 "compressor": "ocaml",
@@ -15604,8 +15604,8 @@
 "level": 3,
 "out_size": 24241121,
 "ratio": 0.4733,
-"compress_mbps": 25.61,
-"decompress_mbps": 37.55
+"compress_mbps": 25.73,
+"decompress_mbps": 37.97
 },
 {
 "compressor": "ocaml",
@@ -15614,8 +15614,8 @@
 "level": 4,
 "out_size": 20950547,
 "ratio": 0.409,
-"compress_mbps": 29.06,
-"decompress_mbps": 43.69
+"compress_mbps": 28.84,
+"decompress_mbps": 44.03
 },
 {
 "compressor": "ocaml",
@@ -15624,8 +15624,8 @@
 "level": 5,
 "out_size": 20592289,
 "ratio": 0.402,
-"compress_mbps": 24.48,
-"decompress_mbps": 45.78
+"compress_mbps": 24.29,
+"decompress_mbps": 46.14
 },
 {
 "compressor": "ocaml",
@@ -15634,8 +15634,8 @@
 "level": 6,
 "out_size": 20445232,
 "ratio": 0.3992,
-"compress_mbps": 18.62,
-"decompress_mbps": 45.31
+"compress_mbps": 18.69,
+"decompress_mbps": 46.11
 },
 {
 "compressor": "ocaml",
@@ -15644,8 +15644,8 @@
 "level": 7,
 "out_size": 20407676,
 "ratio": 0.3984,
-"compress_mbps": 15.97,
-"decompress_mbps": 46.23
+"compress_mbps": 15.95,
+"decompress_mbps": 46.63
 },
 {
 "compressor": "ocaml",
@@ -15654,8 +15654,8 @@
 "level": 8,
 "out_size": 20389473,
 "ratio": 0.3981,
-"compress_mbps": 10.05,
-"decompress_mbps": 44.91
+"compress_mbps": 10.13,
+"decompress_mbps": 45.4
 },
 {
 "compressor": "ocaml",
@@ -15664,8 +15664,8 @@
 "level": 9,
 "out_size": 20386824,
 "ratio": 0.398,
-"compress_mbps": 6.78,
-"decompress_mbps": 45.36
+"compress_mbps": 6.82,
+"decompress_mbps": 46.45
 },
 {
 "compressor": "ocaml",
@@ -15674,7 +15674,7 @@
 "level": 1,
 "out_size": 3964698,
 "ratio": 0.3976,
-"compress_mbps": 38.0,
+"compress_mbps": 37.98,
 "decompress_mbps": 48.02
 },
 {
@@ -15684,8 +15684,8 @@
 "level": 2,
 "out_size": 3936391,
 "ratio": 0.3948,
-"compress_mbps": 35.55,
-"decompress_mbps": 47.72
+"compress_mbps": 35.52,
+"decompress_mbps": 47.93
 },
 {
 "compressor": "ocaml",
@@ -15694,8 +15694,8 @@
 "level": 3,
 "out_size": 3823540,
 "ratio": 0.3835,
-"compress_mbps": 27.57,
-"decompress_mbps": 51.37
+"compress_mbps": 27.78,
+"decompress_mbps": 51.72
 },
 {
 "compressor": "ocaml",
@@ -15704,8 +15704,8 @@
 "level": 4,
 "out_size": 3799601,
 "ratio": 0.3811,
-"compress_mbps": 32.67,
-"decompress_mbps": 63.56
+"compress_mbps": 33.02,
+"decompress_mbps": 63.69
 },
 {
 "compressor": "ocaml",
@@ -15714,8 +15714,8 @@
 "level": 5,
 "out_size": 3830938,
 "ratio": 0.3842,
-"compress_mbps": 22.43,
-"decompress_mbps": 57.66
+"compress_mbps": 22.58,
+"decompress_mbps": 58.61
 },
 {
 "compressor": "ocaml",
@@ -15724,8 +15724,8 @@
 "level": 6,
 "out_size": 3808303,
 "ratio": 0.382,
-"compress_mbps": 14.66,
-"decompress_mbps": 57.39
+"compress_mbps": 14.79,
+"decompress_mbps": 57.61
 },
 {
 "compressor": "ocaml",
@@ -15734,8 +15734,8 @@
 "level": 7,
 "out_size": 3802814,
 "ratio": 0.3814,
-"compress_mbps": 12.05,
-"decompress_mbps": 57.75
+"compress_mbps": 12.14,
+"decompress_mbps": 57.87
 },
 {
 "compressor": "ocaml",
@@ -15744,8 +15744,8 @@
 "level": 8,
 "out_size": 3800355,
 "ratio": 0.3812,
-"compress_mbps": 6.78,
-"decompress_mbps": 57.82
+"compress_mbps": 6.76,
+"decompress_mbps": 59.01
 },
 {
 "compressor": "ocaml",
@@ -15754,8 +15754,8 @@
 "level": 9,
 "out_size": 3799676,
 "ratio": 0.3811,
-"compress_mbps": 6.04,
-"decompress_mbps": 59.04
+"compress_mbps": 6.05,
+"decompress_mbps": 59.07
 },
 {
 "compressor": "ocaml",
@@ -15764,8 +15764,8 @@
 "level": 1,
 "out_size": 4899547,
 "ratio": 0.146,
-"compress_mbps": 96.35,
-"decompress_mbps": 131.72
+"compress_mbps": 95.3,
+"decompress_mbps": 131.63
 },
 {
 "compressor": "ocaml",
@@ -15774,8 +15774,8 @@
 "level": 2,
 "out_size": 4587004,
 "ratio": 0.1367,
-"compress_mbps": 95.35,
-"decompress_mbps": 143.05
+"compress_mbps": 94.92,
+"decompress_mbps": 142.96
 },
 {
 "compressor": "ocaml",
@@ -15784,8 +15784,8 @@
 "level": 3,
 "out_size": 4229035,
 "ratio": 0.126,
-"compress_mbps": 90.34,
-"decompress_mbps": 152.49
+"compress_mbps": 90.43,
+"decompress_mbps": 152.33
 },
 {
 "compressor": "ocaml",
@@ -15794,8 +15794,8 @@
 "level": 4,
 "out_size": 3791322,
 "ratio": 0.113,
-"compress_mbps": 82.35,
-"decompress_mbps": 160.6
+"compress_mbps": 81.61,
+"decompress_mbps": 160.66
 },
 {
 "compressor": "ocaml",
@@ -15804,8 +15804,8 @@
 "level": 5,
 "out_size": 3449193,
 "ratio": 0.1028,
-"compress_mbps": 73.32,
-"decompress_mbps": 168.31
+"compress_mbps": 72.81,
+"decompress_mbps": 168.1
 },
 {
 "compressor": "ocaml",
@@ -15814,8 +15814,8 @@
 "level": 6,
 "out_size": 3269452,
 "ratio": 0.0974,
-"compress_mbps": 58.73,
-"decompress_mbps": 173.11
+"compress_mbps": 58.66,
+"decompress_mbps": 173.37
 },
 {
 "compressor": "ocaml",
@@ -15824,8 +15824,8 @@
 "level": 7,
 "out_size": 3211286,
 "ratio": 0.0957,
-"compress_mbps": 50.41,
-"decompress_mbps": 174.21
+"compress_mbps": 50.59,
+"decompress_mbps": 173.62
 },
 {
 "compressor": "ocaml",
@@ -15834,8 +15834,8 @@
 "level": 8,
 "out_size": 3101534,
 "ratio": 0.0924,
-"compress_mbps": 27.51,
-"decompress_mbps": 174.65
+"compress_mbps": 27.5,
+"decompress_mbps": 174.42
 },
 {
 "compressor": "ocaml",
@@ -15844,8 +15844,8 @@
 "level": 9,
 "out_size": 3058177,
 "ratio": 0.0911,
-"compress_mbps": 16.54,
-"decompress_mbps": 176.1
+"compress_mbps": 16.6,
+"decompress_mbps": 177.54
 },
 {
 "compressor": "ocaml",
@@ -15854,8 +15854,8 @@
 "level": 1,
 "out_size": 4024327,
 "ratio": 0.6541,
-"compress_mbps": 22.72,
-"decompress_mbps": 29.81
+"compress_mbps": 22.81,
+"decompress_mbps": 29.95
 },
 {
 "compressor": "ocaml",
@@ -15864,8 +15864,8 @@
 "level": 2,
 "out_size": 3953722,
 "ratio": 0.6427,
-"compress_mbps": 21.74,
-"decompress_mbps": 30.42
+"compress_mbps": 21.66,
+"decompress_mbps": 30.5
 },
 {
 "compressor": "ocaml",
@@ -15874,8 +15874,8 @@
 "level": 3,
 "out_size": 3887921,
 "ratio": 0.632,
-"compress_mbps": 18.56,
-"decompress_mbps": 30.97
+"compress_mbps": 18.47,
+"decompress_mbps": 31.15
 },
 {
 "compressor": "ocaml",
@@ -15885,7 +15885,7 @@
 "out_size": 3320440,
 "ratio": 0.5397,
 "compress_mbps": 21.3,
-"decompress_mbps": 37.18
+"decompress_mbps": 37.41
 },
 {
 "compressor": "ocaml",
@@ -15894,8 +15894,8 @@
 "level": 5,
 "out_size": 3279338,
 "ratio": 0.533,
-"compress_mbps": 17.79,
-"decompress_mbps": 38.17
+"compress_mbps": 17.83,
+"decompress_mbps": 38.07
 },
 {
 "compressor": "ocaml",
@@ -15904,8 +15904,8 @@
 "level": 6,
 "out_size": 3254309,
 "ratio": 0.529,
-"compress_mbps": 13.86,
-"decompress_mbps": 37.85
+"compress_mbps": 14.0,
+"decompress_mbps": 37.9
 },
 {
 "compressor": "ocaml",
@@ -15914,8 +15914,8 @@
 "level": 7,
 "out_size": 3250139,
 "ratio": 0.5283,
-"compress_mbps": 12.23,
-"decompress_mbps": 37.74
+"compress_mbps": 12.22,
+"decompress_mbps": 38.09
 },
 {
 "compressor": "ocaml",
@@ -15924,8 +15924,8 @@
 "level": 8,
 "out_size": 3247018,
 "ratio": 0.5278,
-"compress_mbps": 10.19,
-"decompress_mbps": 37.83
+"compress_mbps": 10.17,
+"decompress_mbps": 38.03
 },
 {
 "compressor": "ocaml",
@@ -15934,8 +15934,8 @@
 "level": 9,
 "out_size": 3246865,
 "ratio": 0.5278,
-"compress_mbps": 9.46,
-"decompress_mbps": 37.95
+"compress_mbps": 9.51,
+"decompress_mbps": 38.0
 },
 {
 "compressor": "ocaml",
@@ -15944,8 +15944,8 @@
 "level": 1,
 "out_size": 4471091,
 "ratio": 0.4433,
-"compress_mbps": 34.99,
-"decompress_mbps": 69.27
+"compress_mbps": 34.91,
+"decompress_mbps": 69.94
 },
 {
 "compressor": "ocaml",
@@ -15954,8 +15954,8 @@
 "level": 2,
 "out_size": 4372105,
 "ratio": 0.4335,
-"compress_mbps": 33.79,
-"decompress_mbps": 71.12
+"compress_mbps": 33.82,
+"decompress_mbps": 71.85
 },
 {
 "compressor": "ocaml",
@@ -15964,8 +15964,8 @@
 "level": 3,
 "out_size": 4305270,
 "ratio": 0.4269,
-"compress_mbps": 30.3,
-"decompress_mbps": 73.46
+"compress_mbps": 30.7,
+"decompress_mbps": 73.16
 },
 {
 "compressor": "ocaml",
@@ -15974,8 +15974,8 @@
 "level": 4,
 "out_size": 3920495,
 "ratio": 0.3887,
-"compress_mbps": 30.27,
-"decompress_mbps": 63.98
+"compress_mbps": 30.3,
+"decompress_mbps": 64.84
 },
 {
 "compressor": "ocaml",
@@ -15984,8 +15984,8 @@
 "level": 5,
 "out_size": 3853177,
 "ratio": 0.382,
-"compress_mbps": 26.68,
-"decompress_mbps": 63.59
+"compress_mbps": 26.63,
+"decompress_mbps": 63.95
 },
 {
 "compressor": "ocaml",
@@ -15994,8 +15994,8 @@
 "level": 6,
 "out_size": 3780878,
 "ratio": 0.3749,
-"compress_mbps": 23.33,
-"decompress_mbps": 64.2
+"compress_mbps": 23.38,
+"decompress_mbps": 64.31
 },
 {
 "compressor": "ocaml",
@@ -16004,8 +16004,8 @@
 "level": 7,
 "out_size": 3763880,
 "ratio": 0.3732,
-"compress_mbps": 20.0,
-"decompress_mbps": 72.69
+"compress_mbps": 20.2,
+"decompress_mbps": 72.93
 },
 {
 "compressor": "ocaml",
@@ -16014,8 +16014,8 @@
 "level": 8,
 "out_size": 3757719,
 "ratio": 0.3726,
-"compress_mbps": 18.2,
-"decompress_mbps": 73.09
+"compress_mbps": 18.3,
+"decompress_mbps": 73.42
 },
 {
 "compressor": "ocaml",
@@ -16024,8 +16024,8 @@
 "level": 9,
 "out_size": 3757719,
 "ratio": 0.3726,
-"compress_mbps": 18.29,
-"decompress_mbps": 72.86
+"compress_mbps": 18.25,
+"decompress_mbps": 72.55
 },
 {
 "compressor": "ocaml",
@@ -16034,8 +16034,8 @@
 "level": 1,
 "out_size": 2722387,
 "ratio": 0.4108,
-"compress_mbps": 38.07,
-"decompress_mbps": 64.75
+"compress_mbps": 38.01,
+"decompress_mbps": 64.73
 },
 {
 "compressor": "ocaml",
@@ -16044,8 +16044,8 @@
 "level": 2,
 "out_size": 2572544,
 "ratio": 0.3882,
-"compress_mbps": 37.05,
-"decompress_mbps": 71.13
+"compress_mbps": 36.87,
+"decompress_mbps": 70.55
 },
 {
 "compressor": "ocaml",
@@ -16054,8 +16054,8 @@
 "level": 3,
 "out_size": 2384328,
 "ratio": 0.3598,
-"compress_mbps": 29.52,
-"decompress_mbps": 78.46
+"compress_mbps": 29.15,
+"decompress_mbps": 78.64
 },
 {
 "compressor": "ocaml",
@@ -16064,8 +16064,8 @@
 "level": 4,
 "out_size": 2112060,
 "ratio": 0.3187,
-"compress_mbps": 36.41,
-"decompress_mbps": 85.81
+"compress_mbps": 36.42,
+"decompress_mbps": 85.62
 },
 {
 "compressor": "ocaml",
@@ -16074,8 +16074,8 @@
 "level": 5,
 "out_size": 1991581,
 "ratio": 0.3005,
-"compress_mbps": 25.5,
-"decompress_mbps": 89.89
+"compress_mbps": 25.34,
+"decompress_mbps": 91.01
 },
 {
 "compressor": "ocaml",
@@ -16084,8 +16084,8 @@
 "level": 6,
 "out_size": 1917866,
 "ratio": 0.2894,
-"compress_mbps": 15.01,
-"decompress_mbps": 90.4
+"compress_mbps": 15.03,
+"decompress_mbps": 90.85
 },
 {
 "compressor": "ocaml",
@@ -16095,7 +16095,7 @@
 "out_size": 1895353,
 "ratio": 0.286,
 "compress_mbps": 11.08,
-"decompress_mbps": 90.35
+"decompress_mbps": 90.48
 },
 {
 "compressor": "ocaml",
@@ -16104,8 +16104,8 @@
 "level": 8,
 "out_size": 1880740,
 "ratio": 0.2838,
-"compress_mbps": 5.58,
-"decompress_mbps": 90.54
+"compress_mbps": 5.59,
+"decompress_mbps": 90.95
 },
 {
 "compressor": "ocaml",
@@ -16114,8 +16114,8 @@
 "level": 9,
 "out_size": 1880711,
 "ratio": 0.2838,
-"compress_mbps": 5.57,
-"decompress_mbps": 91.23
+"compress_mbps": 5.56,
+"decompress_mbps": 92.3
 },
 {
 "compressor": "ocaml",
@@ -16124,8 +16124,8 @@
 "level": 1,
 "out_size": 7441483,
 "ratio": 0.3444,
-"compress_mbps": 44.39,
-"decompress_mbps": 66.76
+"compress_mbps": 43.78,
+"decompress_mbps": 66.88
 },
 {
 "compressor": "ocaml",
@@ -16134,8 +16134,8 @@
 "level": 2,
 "out_size": 7229248,
 "ratio": 0.3346,
-"compress_mbps": 43.15,
-"decompress_mbps": 68.57
+"compress_mbps": 43.14,
+"decompress_mbps": 69.03
 },
 {
 "compressor": "ocaml",
@@ -16144,8 +16144,8 @@
 "level": 3,
 "out_size": 7083451,
 "ratio": 0.3278,
-"compress_mbps": 39.07,
-"decompress_mbps": 70.94
+"compress_mbps": 38.92,
+"decompress_mbps": 71.31
 },
 {
 "compressor": "ocaml",
@@ -16155,7 +16155,7 @@
 "out_size": 6189639,
 "ratio": 0.2865,
 "compress_mbps": 42.2,
-"decompress_mbps": 93.13
+"decompress_mbps": 92.76
 },
 {
 "compressor": "ocaml",
@@ -16164,8 +16164,8 @@
 "level": 5,
 "out_size": 6053058,
 "ratio": 0.2802,
-"compress_mbps": 34.69,
-"decompress_mbps": 93.37
+"compress_mbps": 35.08,
+"decompress_mbps": 96.18
 },
 {
 "compressor": "ocaml",
@@ -16174,8 +16174,8 @@
 "level": 6,
 "out_size": 5988137,
 "ratio": 0.2771,
-"compress_mbps": 28.56,
-"decompress_mbps": 102.36
+"compress_mbps": 28.51,
+"decompress_mbps": 101.1
 },
 {
 "compressor": "ocaml",
@@ -16184,8 +16184,8 @@
 "level": 7,
 "out_size": 5949908,
 "ratio": 0.2754,
-"compress_mbps": 25.11,
-"decompress_mbps": 101.73
+"compress_mbps": 25.19,
+"decompress_mbps": 103.3
 },
 {
 "compressor": "ocaml",
@@ -16194,8 +16194,8 @@
 "level": 8,
 "out_size": 5936656,
 "ratio": 0.2748,
-"compress_mbps": 19.15,
-"decompress_mbps": 106.27
+"compress_mbps": 19.22,
+"decompress_mbps": 106.46
 },
 {
 "compressor": "ocaml",
@@ -16204,8 +16204,8 @@
 "level": 9,
 "out_size": 5934701,
 "ratio": 0.2747,
-"compress_mbps": 18.0,
-"decompress_mbps": 99.41
+"compress_mbps": 17.98,
+"decompress_mbps": 105.25
 },
 {
 "compressor": "ocaml",
@@ -16214,8 +16214,8 @@
 "level": 1,
 "out_size": 6335542,
 "ratio": 0.8736,
-"compress_mbps": 18.35,
-"decompress_mbps": 29.49
+"compress_mbps": 18.44,
+"decompress_mbps": 31.75
 },
 {
 "compressor": "ocaml",
@@ -16224,8 +16224,8 @@
 "level": 2,
 "out_size": 6247260,
 "ratio": 0.8615,
-"compress_mbps": 17.47,
-"decompress_mbps": 44.37
+"compress_mbps": 17.59,
+"decompress_mbps": 48.2
 },
 {
 "compressor": "ocaml",
@@ -16234,8 +16234,8 @@
 "level": 3,
 "out_size": 6064713,
 "ratio": 0.8363,
-"compress_mbps": 14.74,
-"decompress_mbps": 55.04
+"compress_mbps": 15.15,
+"decompress_mbps": 56.49
 },
 {
 "compressor": "ocaml",
@@ -16244,8 +16244,8 @@
 "level": 4,
 "out_size": 5568111,
 "ratio": 0.7678,
-"compress_mbps": 17.37,
-"decompress_mbps": 57.52
+"compress_mbps": 17.55,
+"decompress_mbps": 58.99
 },
 {
 "compressor": "ocaml",
@@ -16254,8 +16254,8 @@
 "level": 5,
 "out_size": 5544524,
 "ratio": 0.7646,
-"compress_mbps": 14.36,
-"decompress_mbps": 65.16
+"compress_mbps": 14.42,
+"decompress_mbps": 64.88
 },
 {
 "compressor": "ocaml",
@@ -16264,8 +16264,8 @@
 "level": 6,
 "out_size": 5513056,
 "ratio": 0.7602,
-"compress_mbps": 11.92,
-"decompress_mbps": 62.7
+"compress_mbps": 11.94,
+"decompress_mbps": 62.87
 },
 {
 "compressor": "ocaml",
@@ -16274,8 +16274,8 @@
 "level": 7,
 "out_size": 5508915,
 "ratio": 0.7596,
-"compress_mbps": 11.27,
-"decompress_mbps": 64.41
+"compress_mbps": 11.32,
+"decompress_mbps": 64.42
 },
 {
 "compressor": "ocaml",
@@ -16284,8 +16284,8 @@
 "level": 8,
 "out_size": 5508365,
 "ratio": 0.7596,
-"compress_mbps": 10.55,
-"decompress_mbps": 64.12
+"compress_mbps": 10.52,
+"decompress_mbps": 65.26
 },
 {
 "compressor": "ocaml",
@@ -16295,7 +16295,7 @@
 "out_size": 5508365,
 "ratio": 0.7596,
 "compress_mbps": 10.57,
-"decompress_mbps": 65.17
+"decompress_mbps": 64.3
 },
 {
 "compressor": "ocaml",
@@ -16304,8 +16304,8 @@
 "level": 1,
 "out_size": 16776095,
 "ratio": 0.4046,
-"compress_mbps": 38.08,
-"decompress_mbps": 50.78
+"compress_mbps": 37.73,
+"decompress_mbps": 50.93
 },
 {
 "compressor": "ocaml",
@@ -16314,8 +16314,8 @@
 "level": 2,
 "out_size": 16032651,
 "ratio": 0.3867,
-"compress_mbps": 36.26,
-"decompress_mbps": 54.51
+"compress_mbps": 36.24,
+"decompress_mbps": 54.65
 },
 {
 "compressor": "ocaml",
@@ -16324,8 +16324,8 @@
 "level": 3,
 "out_size": 15180334,
 "ratio": 0.3662,
-"compress_mbps": 31.16,
-"decompress_mbps": 51.55
+"compress_mbps": 31.28,
+"decompress_mbps": 51.85
 },
 {
 "compressor": "ocaml",
@@ -16334,8 +16334,8 @@
 "level": 4,
 "out_size": 13261924,
 "ratio": 0.3199,
-"compress_mbps": 35.95,
-"decompress_mbps": 68.04
+"compress_mbps": 35.24,
+"decompress_mbps": 68.67
 },
 {
 "compressor": "ocaml",
@@ -16344,8 +16344,8 @@
 "level": 5,
 "out_size": 12706028,
 "ratio": 0.3065,
-"compress_mbps": 27.59,
-"decompress_mbps": 71.25
+"compress_mbps": 27.63,
+"decompress_mbps": 70.4
 },
 {
 "compressor": "ocaml",
@@ -16354,8 +16354,8 @@
 "level": 6,
 "out_size": 12464158,
 "ratio": 0.3006,
-"compress_mbps": 21.19,
-"decompress_mbps": 70.45
+"compress_mbps": 21.0,
+"decompress_mbps": 70.64
 },
 {
 "compressor": "ocaml",
@@ -16364,8 +16364,8 @@
 "level": 7,
 "out_size": 12375954,
 "ratio": 0.2985,
-"compress_mbps": 18.25,
-"decompress_mbps": 73.12
+"compress_mbps": 18.31,
+"decompress_mbps": 73.55
 },
 {
 "compressor": "ocaml",
@@ -16374,8 +16374,8 @@
 "level": 8,
 "out_size": 12321552,
 "ratio": 0.2972,
-"compress_mbps": 14.46,
-"decompress_mbps": 70.1
+"compress_mbps": 14.45,
+"decompress_mbps": 70.76
 },
 {
 "compressor": "ocaml",
@@ -16384,8 +16384,8 @@
 "level": 9,
 "out_size": 12320276,
 "ratio": 0.2972,
-"compress_mbps": 14.38,
-"decompress_mbps": 70.13
+"compress_mbps": 14.41,
+"decompress_mbps": 70.34
 },
 {
 "compressor": "ocaml",
@@ -16394,8 +16394,8 @@
 "level": 1,
 "out_size": 6799201,
 "ratio": 0.8023,
-"compress_mbps": 18.32,
-"decompress_mbps": 18.04
+"compress_mbps": 18.34,
+"decompress_mbps": 18.29
 },
 {
 "compressor": "ocaml",
@@ -16404,8 +16404,8 @@
 "level": 2,
 "out_size": 6800500,
 "ratio": 0.8025,
-"compress_mbps": 16.92,
-"decompress_mbps": 18.39
+"compress_mbps": 16.95,
+"decompress_mbps": 18.49
 },
 {
 "compressor": "ocaml",
@@ -16414,8 +16414,8 @@
 "level": 3,
 "out_size": 6803212,
 "ratio": 0.8028,
-"compress_mbps": 14.82,
-"decompress_mbps": 18.26
+"compress_mbps": 14.91,
+"decompress_mbps": 18.44
 },
 {
 "compressor": "ocaml",
@@ -16424,8 +16424,8 @@
 "level": 4,
 "out_size": 6264611,
 "ratio": 0.7393,
-"compress_mbps": 17.39,
-"decompress_mbps": 24.22
+"compress_mbps": 17.32,
+"decompress_mbps": 24.91
 },
 {
 "compressor": "ocaml",
@@ -16434,8 +16434,8 @@
 "level": 5,
 "out_size": 6217901,
 "ratio": 0.7337,
-"compress_mbps": 15.81,
-"decompress_mbps": 25.19
+"compress_mbps": 15.76,
+"decompress_mbps": 25.36
 },
 {
 "compressor": "ocaml",
@@ -16444,8 +16444,8 @@
 "level": 6,
 "out_size": 6201999,
 "ratio": 0.7319,
-"compress_mbps": 15.29,
-"decompress_mbps": 25.07
+"compress_mbps": 15.32,
+"decompress_mbps": 25.35
 },
 {
 "compressor": "ocaml",
@@ -16454,8 +16454,8 @@
 "level": 7,
 "out_size": 6201883,
 "ratio": 0.7319,
-"compress_mbps": 15.23,
-"decompress_mbps": 24.7
+"compress_mbps": 15.24,
+"decompress_mbps": 25.06
 },
 {
 "compressor": "ocaml",
@@ -16464,8 +16464,8 @@
 "level": 8,
 "out_size": 6201887,
 "ratio": 0.7319,
-"compress_mbps": 15.23,
-"decompress_mbps": 24.58
+"compress_mbps": 15.22,
+"decompress_mbps": 24.94
 },
 {
 "compressor": "ocaml",
@@ -16474,8 +16474,8 @@
 "level": 9,
 "out_size": 6201887,
 "ratio": 0.7319,
-"compress_mbps": 15.29,
-"decompress_mbps": 24.13
+"compress_mbps": 15.3,
+"decompress_mbps": 24.93
 },
 {
 "compressor": "ocaml",
@@ -16484,8 +16484,8 @@
 "level": 1,
 "out_size": 1081679,
 "ratio": 0.2024,
-"compress_mbps": 74.47,
-"decompress_mbps": 106.65
+"compress_mbps": 74.26,
+"decompress_mbps": 106.26
 },
 {
 "compressor": "ocaml",
@@ -16494,8 +16494,8 @@
 "level": 2,
 "out_size": 1001890,
 "ratio": 0.1874,
-"compress_mbps": 74.13,
-"decompress_mbps": 117.16
+"compress_mbps": 74.05,
+"decompress_mbps": 118.21
 },
 {
 "compressor": "ocaml",
@@ -16504,8 +16504,8 @@
 "level": 3,
 "out_size": 921722,
 "ratio": 0.1724,
-"compress_mbps": 66.44,
-"decompress_mbps": 127.48
+"compress_mbps": 67.22,
+"decompress_mbps": 127.75
 },
 {
 "compressor": "ocaml",
@@ -16514,8 +16514,8 @@
 "level": 4,
 "out_size": 849263,
 "ratio": 0.1589,
-"compress_mbps": 64.75,
-"decompress_mbps": 141.9
+"compress_mbps": 64.23,
+"decompress_mbps": 142.53
 },
 {
 "compressor": "ocaml",
@@ -16524,8 +16524,8 @@
 "level": 5,
 "out_size": 771964,
 "ratio": 0.1444,
-"compress_mbps": 55.1,
-"decompress_mbps": 143.09
+"compress_mbps": 54.81,
+"decompress_mbps": 144.22
 },
 {
 "compressor": "ocaml",
@@ -16534,8 +16534,8 @@
 "level": 6,
 "out_size": 728098,
 "ratio": 0.1362,
-"compress_mbps": 42.63,
-"decompress_mbps": 149.54
+"compress_mbps": 43.49,
+"decompress_mbps": 150.41
 },
 {
 "compressor": "ocaml",
@@ -16544,8 +16544,8 @@
 "level": 7,
 "out_size": 713635,
 "ratio": 0.1335,
-"compress_mbps": 37.43,
-"decompress_mbps": 153.92
+"compress_mbps": 37.23,
+"decompress_mbps": 154.84
 },
 {
 "compressor": "ocaml",
@@ -16554,8 +16554,8 @@
 "level": 8,
 "out_size": 699093,
 "ratio": 0.1308,
-"compress_mbps": 27.39,
-"decompress_mbps": 147.86
+"compress_mbps": 27.08,
+"decompress_mbps": 146.56
 },
 {
 "compressor": "ocaml",
@@ -16564,8 +16564,8 @@
 "level": 9,
 "out_size": 698459,
 "ratio": 0.1307,
-"compress_mbps": 25.78,
-"decompress_mbps": 149.76
+"compress_mbps": 25.17,
+"decompress_mbps": 148.81
 }
 ]
 }


### PR DESCRIPTION
This PR adds zlib-style `scan_end` prefiltering to the hash-chain LZ77 matcher to cut compression time across levels 1-8 with no change to output. Before running the full `countMatch` byte compare on a chain candidate, `chainWalkPacked` first checks the single discriminating byte at the current best length, `data[cand+bestLen] == data[pos+bestLen]`; a mismatch there proves `countMatch ≤ bestLen`, so the candidate cannot beat the current best and the whole compare loop is skipped. `countMatch` is the matcher's top cost (~65% of L6 compress), and on collision-heavy chains most candidates are doomed, so this is a large and free cut.

The change is output-preserving (byte-identical): a skipped candidate would never have updated the best, so it is proven by equality transfer rather than relaxing the spec. `countMatch_le_of_byte_ne` (the contrapositive of `countMatch_matches`) plus one `by_cases` in `chainWalkPacked_eq` carry the proof; the reference walk and every downstream validity proof are untouched, 0 sorries, full test suite green.

The win is corpus-wide and grows with level as chains deepen. Regenerated dashboard, native Silesia compress geomean over the prior snapshot: L4 1.22x, L6 1.26x, L8 1.16x (L1 1.10x; L9 1.03x is noise — L9 runs the optimal-parse DP, not the prefiltered chain walk). The dashboard refresh confirms 0 of 1656 rows changed ratio across Canterbury and Silesia.

The choice of lever came from new instrumentation included here: `match-hist` now reports nice-length thresholds (ge32/64/128) and a new `compress-pareto` bench subcommand measures steady-state throughput and output size together. The match-length distribution showed niceLen early-exit barely fires on text (matches >=32 B are 0.05%), which redirected the work to this prefilter.

🤖 Prepared with Claude Code