### PR TITLE
perf: lazy-match gating (zlib good_match) for L4-L6 (W8)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -924,17 +924,17 @@ where
     `updateHashes` and `lz77Greedy.trailing`. Equal-quality contracts proven in
     `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazy (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) :
+    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) :
     Array LZ77Token :=
   if data.size < 3 then
     (lz77Greedy.trailing data 0).toArray
   else
     let hashSize := 65536
     (mainLoop data windowSize hashSize maxChain
-      (.replicate hashSize data.size) (.replicate data.size data.size) 0 insertCap).toArray
+      (.replicate hashSize data.size) (.replicate data.size data.size) 0 insertCap goodMatch).toArray
 where
   mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat)
-      (hashTable prev : Array Nat) (pos insertCap : Nat) : List LZ77Token :=
+      (hashTable prev : Array Nat) (pos insertCap goodMatch : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
       let head := headProbeGuarded hashTable h
@@ -949,48 +949,58 @@ where
         if hle : pos + matchLen ≤ data.size then
           -- Lazy: probe pos+1 for a longer, no-farther match (distance-guarded deferral)
           if h3lt : pos + 3 < data.size then
-            let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
-            let head2 := headProbeGuarded hashTable h2
-            let maxLen2 := min 258 (data.size - (pos + 1))
-            have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
-            let m2 :=
-              lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
-            let matchLen2 := m2.1
-            let matchPos2 := m2.2
-            if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
-              if hle2 : pos + 1 + matchLen2 ≤ data.size then
-                -- Longer & no-farther match at pos+1: emit literal at pos + reference at pos+1
-                have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
-                let (hashTable, prev) :=
-                  lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                .literal (data[pos]'(by omega)) ::
-                  .reference matchLen2 (pos + 1 - matchPos2) ::
-                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap
+            -- Lazy gate (zlib `good_match`): probe pos+1 only when the first match is
+            -- short. `goodMatch = 259` (> 258) restores the ungated lazy matcher.
+            if matchLen < goodMatch then
+              let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
+              let head2 := headProbeGuarded hashTable h2
+              let maxLen2 := min 258 (data.size - (pos + 1))
+              have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
+              let m2 :=
+                lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+              let matchLen2 := m2.1
+              let matchPos2 := m2.2
+              if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
+                if hle2 : pos + 1 + matchLen2 ≤ data.size then
+                  -- Longer & no-farther match at pos+1: emit literal at pos + reference at pos+1
+                  have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
+                  let (hashTable, prev) :=
+                    lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
+                  .literal (data[pos]'(by omega)) ::
+                    .reference matchLen2 (pos + 1 - matchPos2) ::
+                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap goodMatch
+                else
+                  -- matchLen2 spills past data: keep match at pos
+                  have : data.size - (pos + matchLen) < data.size - pos := by omega
+                  let (hashTable, prev) :=
+                    lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
+                  .reference matchLen (pos - matchPos) ::
+                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch
               else
-                -- matchLen2 spills past data: keep match at pos
+                -- No better match at pos+1: keep match at pos
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
                 .reference matchLen (pos - matchPos) ::
-                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap
+                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch
             else
-              -- No better match at pos+1: keep match at pos
+              -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
               .reference matchLen (pos - matchPos) ::
-                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap
+                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch
           else
             -- Near end of data: keep match at pos
             have : data.size - (pos + matchLen) < data.size - pos := by omega
             .reference matchLen (pos - matchPos) ::
-              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap
+              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch
         else
           .literal (data[pos]'(by omega)) ::
-            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap
+            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch
       else
         .literal (data[pos]'(by omega)) ::
-          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap
+          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch
     else
       lz77Greedy.trailing data pos
   termination_by data.size - pos
@@ -1002,16 +1012,16 @@ where
     token-emitting `mainLoop` differs (push vs. cons). Proven equal to
     `lz77ChainLazy` in `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazyIter (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) :
+    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) :
     Array LZ77Token :=
   if data.size < 3 then
     lz77GreedyIter.trailing data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch
       (.replicate hashSize data.size) (.replicate data.size data.size) 0 #[]
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch : Nat)
       (hashTable prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
@@ -1027,43 +1037,53 @@ where
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           if h3lt : pos + 3 < data.size then
-            let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
-            let head2 := headProbeGuarded hashTable h2
-            let maxLen2 := min 258 (data.size - (pos + 1))
-            have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
-            let r2 :=
-              chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
-            let matchLen2 := r2 % 512
-            let matchPos2 := r2 / 512
-            if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
-              if hle2 : pos + 1 + matchLen2 ≤ data.size then
-                have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
-                let (hashTable, prev) :=
-                  updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1 + matchLen2)
-                  (acc.push (.literal (data[pos]'(by omega))) |>.push
-                    (.reference matchLen2 (pos + 1 - matchPos2)))
+            -- Lazy gate (zlib `good_match`): probe pos+1 only when the first match is
+            -- short. `goodMatch = 259` (> 258) restores the ungated lazy matcher.
+            if matchLen < goodMatch then
+              let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
+              let head2 := headProbeGuarded hashTable h2
+              let maxLen2 := min 258 (data.size - (pos + 1))
+              have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
+              let r2 :=
+                chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+              let matchLen2 := r2 % 512
+              let matchPos2 := r2 / 512
+              if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
+                if hle2 : pos + 1 + matchLen2 ≤ data.size then
+                  have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
+                  let (hashTable, prev) :=
+                    updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1 + matchLen2)
+                    (acc.push (.literal (data[pos]'(by omega))) |>.push
+                      (.reference matchLen2 (pos + 1 - matchPos2)))
+                else
+                  have : data.size - (pos + matchLen) < data.size - pos := by omega
+                  let (hashTable, prev) :=
+                    updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+                    (acc.push (.reference matchLen (pos - matchPos)))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
                   (acc.push (.reference matchLen (pos - matchPos)))
             else
+              -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
                 (acc.push (.reference matchLen (pos - matchPos)))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
               (acc.push (.reference matchLen (pos - matchPos)))
         else
-          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1)
             (acc.push (.literal (data[pos]'(by omega))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1)
           (acc.push (.literal (data[pos]'(by omega))))
     else
       lz77GreedyIter.trailing data pos acc
@@ -1137,17 +1157,17 @@ where
     identical control flow and chain state, `Array UInt32` accumulator.
     Equal to `(lz77ChainLazyIter ..).map packTok` (`lz77ChainLazyIterP_eq`). -/
 def lz77ChainLazyIterP (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) :
+    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) :
     Array UInt32 :=
   if data.size < 3 then
     trailingP data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch
       (.replicate hashSize data.size) (.replicate data.size data.size) 0
       (Array.emptyWithCapacity data.size)
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch : Nat)
       (hashTable prev : Array Nat) (pos : Nat) (acc : Array UInt32) :
       Array UInt32 :=
     if hlt : pos + 2 < data.size then
@@ -1163,43 +1183,57 @@ where
       if hge : matchLen ≥ 3 then
         if hle : pos + matchLen ≤ data.size then
           if h3lt : pos + 3 < data.size then
-            let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
-            let head2 := headProbeGuarded hashTable h2
-            let maxLen2 := min 258 (data.size - (pos + 1))
-            have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
-            let r2 :=
-              chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
-            let matchLen2 := r2 % 512
-            let matchPos2 := r2 / 512
-            if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
-              if hle2 : pos + 1 + matchLen2 ≤ data.size then
-                have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
-                let (hashTable, prev) :=
-                  updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1 + matchLen2)
-                  (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
-                    (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
+            -- Lazy gate (zlib `good_match`): only run the second `pos+1` chain walk
+            -- when the first match is short (`matchLen < goodMatch`). A long first
+            -- match is rarely improved by deferring, so skipping the lookahead trades
+            -- a negligible amount of ratio for half the lazy walk. `goodMatch = 259`
+            -- (> max match 258) restores the ungated matcher exactly.
+            if matchLen < goodMatch then
+              let h2 := lz77Greedy.hash3 data (pos + 1) hashSize (by omega)
+              let head2 := headProbeGuarded hashTable h2
+              let maxLen2 := min 258 (data.size - (pos + 1))
+              have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
+              let r2 :=
+                chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 hmaxLen2P head2 maxChain 0 0
+              let matchLen2 := r2 % 512
+              let matchPos2 := r2 / 512
+              if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
+                if hle2 : pos + 1 + matchLen2 ≤ data.size then
+                  have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
+                  let (hashTable, prev) :=
+                    updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1 + matchLen2)
+                    (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
+                      (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
+                else
+                  have : data.size - (pos + matchLen) < data.size - pos := by omega
+                  let (hashTable, prev) :=
+                    updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
+                    (acc.push (packTok (.reference matchLen (pos - matchPos))))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
                   (acc.push (packTok (.reference matchLen (pos - matchPos))))
             else
+              -- Gated: first match already long; skip the lookahead, but still insert
+              -- interior hashes for the match (mid-buffer) then emit it.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
                 (acc.push (packTok (.reference matchLen (pos - matchPos))))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + matchLen)
               (acc.push (packTok (.reference matchLen (pos - matchPos))))
         else
-          mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1)
             (acc.push (packTok (.literal (data[pos]'(by omega)))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev (pos + 1)
           (acc.push (packTok (.literal (data[pos]'(by omega)))))
     else
       trailingP data pos acc

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -412,6 +412,14 @@ def insertCap (level : UInt8) : Nat :=
   else if level ≤ 3 then 64
   else 1000000000
 
+/-- Lazy `good_match` threshold (zlib-style): the lazy matcher skips the
+    one-byte-lookahead probe once the first match is at least this long, since a
+    long first match is rarely improved by deferral. Lower → more gating (faster,
+    slightly worse ratio). `259 > 258` disables gating. SPIKE: uniform 8. -/
+def goodMatch (level : UInt8) : Nat :=
+  if level ≤ 6 then 8
+  else 259
+
 /-- The per-level LZ77 matcher (zlib-faithful): levels 1–3 (`deflate_fast`) use the
     greedy hash-chain matcher; levels ≥ 4 (`deflate_slow`) use the one-byte-lookahead
     lazy variant, which improves ratio at equal window/chain depth. Both share the
@@ -419,7 +427,7 @@ def insertCap (level : UInt8) : Nat :=
     (`lzMatch_{encodable,empty,resolves}` in `DeflateBlockSplit`), so the choice is
     transparent to the roundtrip proof. -/
 def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
-  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level)
+  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level)
   else lz77ChainIter data (chainDepth level) 32768 (insertCap level)
 
 /-- Packed-token form of `lzMatch` (Wave 3b stage A): the same per-level
@@ -428,7 +436,7 @@ def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
     `lzMatch` exactly (`lzMatchP_map` in `Zip/Spec/LZ77PackedCorrect.lean`);
     downstream consumers still run on `lzMatch` — stage B moves them here. -/
 def lzMatchP (data : ByteArray) (level : UInt8) : Array UInt32 :=
-  if 4 ≤ level then lz77ChainLazyIterP data (chainDepth level) 32768 (insertCap level)
+  if 4 ≤ level then lz77ChainLazyIterP data (chainDepth level) 32768 (insertCap level) (goodMatch level)
   else lz77ChainIterP data (chainDepth level) 32768 (insertCap level)
 
 /-! ## Self-contained block-split dynamic compression

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -34,7 +34,7 @@ theorem lzMatch_encodable (data : ByteArray) (level : UInt8) :
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level)
+  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level) (goodMatch level)
       (by omega) (by omega)
   · exact lz77ChainIter_encodable data (chainDepth level) 32768 (insertCap level)
       (by omega) (by omega)
@@ -43,7 +43,7 @@ theorem lzMatch_empty (data : ByteArray) (level : UInt8) (hz : data.size = 0) :
     lzMatch data level = #[] := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) hz
+  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) (goodMatch level) hz
   · exact lz77ChainIter_empty data (chainDepth level) 32768 (insertCap level) hz
 
 theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
@@ -51,7 +51,7 @@ theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
       some data.data.toList := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (by omega)
+  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (goodMatch level) (by omega)
   · exact lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (by omega)
 
 set_option maxHeartbeats 800000 in

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -25,9 +25,9 @@ set_option backward.split false in
     reference cases use `chainWalk_spec` (at `pos`, and again at `pos+1` for the
     lookahead) exactly as `lz77Chain_mainLoop_valid` does for the single match. -/
 theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable prev : Array Nat) (pos insertCap : Nat) (hw : windowSize > 0) :
+    (hashTable prev : Array Nat) (pos insertCap goodMatch : Nat) (hw : windowSize > 0) :
     ValidDecomp data pos
-      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap) := by
+      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch) := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -45,50 +45,54 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
         · omega
         · split
           · rename_i h3lt
-            have hspec2 := chainWalk_spec data
-              (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
-              windowSize (pos + 1) (min 258 (data.size - (pos + 1))) (by omega)
-              (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
-                lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
-              maxChain 0 0 (Or.inl rfl)
+            -- Lazy gate: matchLen < goodMatch runs the lookahead; otherwise emit M.
             split
-            · split
-              · rename_i hle2
-                obtain h0' | hQ2 := hspec2
-                · omega
-                · exact .literal (by omega) (getElem!_pos data pos (by omega))
-                    (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
-                      (fun i hi => hQ2.2.2.2.1 i hi)
-                      (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw))
+            · have hspec2 := chainWalk_spec data
+                (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
+                windowSize (pos + 1) (min 258 (data.size - (pos + 1))) (by omega)
+                (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
+                  lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
+                maxChain 0 0 (Or.inl rfl)
+              split
+              · split
+                · rename_i hle2
+                  obtain h0' | hQ2 := hspec2
+                  · omega
+                  · exact .literal (by omega) (getElem!_pos data pos (by omega))
+                      (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
+                        (fun i hi => hQ2.2.2.2.1 i hi)
+                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw))
+                · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
+                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
               · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
             · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
           · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
       · exact .literal (by omega) (getElem!_pos data pos (by omega))
-          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
     · exact .literal (by omega) (getElem!_pos data pos (by omega))
-        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ hw)
+        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ hw)
   · exact trailing_valid data pos
 termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- `lz77ChainLazy` produces a valid decomposition of the input data. -/
-theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap).toList := by
+    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch).toList := by
   simp only [lz77ChainLazy]
   split
   · simp only; exact trailing_valid data 0
-  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap hw
+  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap goodMatch hw
 
 /-- Resolving the LZ77 tokens produced by `lz77ChainLazy` recovers the original data. -/
-theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch)) [] =
       some data.data.toList :=
-  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap hw)
+  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch hw)
 
 /-! ## Encodability -/
 
@@ -100,8 +104,8 @@ private def Enc (t : LZ77Token) : Prop :=
 
 set_option backward.split false in
 theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable prev : Array Nat) (pos insertCap : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap, Enc t := by
+    (hashTable prev : Array Nat) (pos insertCap goodMatch : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch, Enc t := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -119,53 +123,59 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
         · omega
         · split
           · rename_i h3lt
-            have hspec2 := chainWalk_spec data
-              (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
-              windowSize (pos + 1) (min 258 (data.size - (pos + 1))) (by omega)
-              (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
-                lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
-              maxChain 0 0 (Or.inl rfl)
+            -- Lazy gate: matchLen < goodMatch runs the lookahead; otherwise emit M.
             split
-            · split
-              · rename_i hle2
-                obtain h0' | ⟨hQ2a, hQ2b, _, _, hQ2e⟩ := hspec2
-                · omega
+            · have hspec2 := chainWalk_spec data
+                (prev.set! pos hashTable[lz77Greedy.hash3 data pos hashSize hlt]!)
+                windowSize (pos + 1) (min 258 (data.size - (pos + 1))) (by omega)
+                (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
+                  lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
+                maxChain 0 0 (Or.inl rfl)
+              split
+              · split
+                · rename_i hle2
+                  obtain h0' | ⟨hQ2a, hQ2b, _, _, hQ2e⟩ := hspec2
+                  · omega
+                  · intro t ht
+                    cases ht with
+                    | head => trivial
+                    | tail _ h =>
+                      cases h with
+                      | head => exact ⟨by omega, by omega, by omega, by omega⟩
+                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
                 · intro t ht
                   cases ht with
-                  | head => trivial
-                  | tail _ h =>
-                    cases h with
-                    | head => exact ⟨by omega, by omega, by omega, by omega⟩
-                    | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+                  | head => exact ⟨hge, by omega, by omega, by omega⟩
+                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
               · intro t ht
                 cases ht with
                 | head => exact ⟨hge, by omega, by omega, by omega⟩
-                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
             · intro t ht
               cases ht with
               | head => exact ⟨hge, by omega, by omega, by omega⟩
-              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
           · intro t ht
             cases ht with
             | head => exact ⟨hge, by omega, by omega, by omega⟩
-            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
       · intro t ht
         cases ht with
         | head => trivial
-        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
     · intro t ht
       cases ht with
       | head => trivial
-      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ hw hws t h
+      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ hw hws t h
   · intro t ht
     exact trailing_encodable data pos t ht
 termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- Every token `lz77ChainLazy` emits satisfies the encoder bounds. -/
-theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap).toList,
+    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
@@ -174,17 +184,17 @@ theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCa
   · intro t ht
     exact trailing_encodable data 0 t ht
   · intro t ht
-    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap hw hws t ht
+    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap goodMatch hw hws t ht
 
 /-! ## Iterative version: equivalence + transferred contracts -/
 
 /-- The iterative lazy chain `mainLoop` is the accumulator form of the recursive
     one — identical branch structure, push vs. cons at each emission (two pushes in
     the lookahead arm). -/
-private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch : Nat)
     (hashTable prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos acc =
-    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap).toArray := by
+    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev pos acc =
+    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch).toArray := by
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
@@ -192,7 +202,7 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
       updateHashesGuarded_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
-      -- Branch tree: hge / hle / h3lt / (matchLen2 > matchLen) / hle2
+      -- Branch tree: hge / hle / h3lt / gate (matchLen < goodMatch) / (matchLen2 > matchLen) / hle2
       split
       · -- hge : matchLen ≥ 3
         split
@@ -200,17 +210,22 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
           split
           · -- h3lt : pos + 3 < data.size
             split
-            · -- matchLen2 > matchLen
+            · -- matchLen < goodMatch : lookahead
               split
-              · -- hle2 : lookahead emits literal + reference(matchLen2), two pushes
-                rw [ih _ (by omega) _ _ _ _ rfl,
-                  Array.push_eq_append, Array.push_eq_append,
-                  Array.append_assoc, Array.append_assoc,
-                  ← List.toArray_cons, ← List.toArray_cons]
-              · -- ¬hle2 : reference(matchLen) at pos
+              · -- matchLen2 > matchLen
+                split
+                · -- hle2 : lookahead emits literal + reference(matchLen2), two pushes
+                  rw [ih _ (by omega) _ _ _ _ rfl,
+                    Array.push_eq_append, Array.push_eq_append,
+                    Array.append_assoc, Array.append_assoc,
+                    ← List.toArray_cons, ← List.toArray_cons]
+                · -- ¬hle2 : reference(matchLen) at pos
+                  rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
+                    ← Array.append_assoc, Array.push_eq_append]
+              · -- matchLen2 ≤ matchLen : reference(matchLen) at pos
                 rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
                   ← Array.append_assoc, Array.push_eq_append]
-            · -- matchLen2 ≤ matchLen : reference(matchLen) at pos
+            · -- matchLen ≥ goodMatch (gated) : reference(matchLen) at pos
               rw [ih _ (by omega) _ _ _ _ rfl, List.toArray_cons,
                 ← Array.append_assoc, Array.push_eq_append]
           · -- ¬h3lt : reference(matchLen) at pos (near end)
@@ -226,37 +241,37 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
       exact trailing_eq data pos acc
 
 /-- `lz77ChainLazyIter` produces exactly the same tokens as `lz77ChainLazy`. -/
-theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap : Nat) :
-    lz77ChainLazyIter data maxChain windowSize insertCap =
-      lz77ChainLazy data maxChain windowSize insertCap := by
+theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat) :
+    lz77ChainLazyIter data maxChain windowSize insertCap goodMatch =
+      lz77ChainLazy data maxChain windowSize insertCap goodMatch := by
   unfold lz77ChainLazyIter lz77ChainLazy
   split
   · rw [trailing_eq]; simp only [List.append_toArray, List.nil_append]
   · rw [mainLoop_eq_chainLazy]; simp only [List.append_toArray, List.nil_append]
 
-theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap).toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap hw
+    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch).toList := by
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch hw
 
-theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch)) [] =
       some data.data.toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap hw
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch hw
 
-theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap).toList,
+    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
-  exact lz77ChainLazy_encodable data maxChain windowSize insertCap hw hws
+  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch hw hws
 
 /-- The lazy chain matcher emits no tokens on empty input. -/
-theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap : Nat)
-    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap = #[] := by
+theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
+    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap goodMatch = #[] := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
   simp only [lz77ChainLazy, show data.size < 3 from by omega, ↓reduceIte]
   have htrail : lz77Greedy.trailing data 0 = [] := by

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -76,29 +76,33 @@ theorem lz77ChainIterP_eq (data : ByteArray) (maxChain windowSize insertCap : Na
   · simpa only [List.map_toArray, List.map_nil, Array.emptyWithCapacity_eq] using
       mainLoopP_eq data windowSize 65536 maxChain insertCap _ _ 0 #[]
 
-/-- The packed lazy `mainLoop` is the packed image of the boxed one (two
-    pushes in the deferral arm). -/
-private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap : Nat)
+/-- The packed lazy `mainLoop` is the packed image of the boxed one. The gate
+    (`matchLen < goodMatch`) is applied identically in both, so the branch tree
+    stays in lockstep — one extra split versus the ungated proof. -/
+private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch : Nat)
     (hashTable prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos
+    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev pos
         (acc.map packTok) =
-      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap hashTable prev pos
+      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch hashTable prev pos
         acc).map packTok := by
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainLazyIterP.mainLoop lz77ChainLazyIter.mainLoop
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
-      -- Branch tree: hge / hle / h3lt / deferral / hle2
+      -- Branch tree: hge / hle / h3lt / gate / deferral / hle2
       split
       · split
         · split
           · split
             · split
-              · -- deferral arm: literal + reference, two pushes
-                rw [← Array.map_push, ← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+              · split
+                · -- deferral arm: literal + reference, two pushes
+                  rw [← Array.map_push, ← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+                · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
               · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
-            · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
+            · -- gated: reference(matchLen)
+              rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
           · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
         · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
       · rw [← Array.map_push, ih _ (by omega) _ _ _ _ rfl]
@@ -107,14 +111,14 @@ private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChai
 
 /-- `lz77ChainLazyIterP` produces exactly the `packTok` image of
     `lz77ChainLazyIter`. -/
-theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap : Nat) :
-    lz77ChainLazyIterP data maxChain windowSize insertCap =
-      (lz77ChainLazyIter data maxChain windowSize insertCap).map packTok := by
+theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat) :
+    lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch =
+      (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch).map packTok := by
   unfold lz77ChainLazyIterP lz77ChainLazyIter
   split
   · simpa only [List.map_toArray, List.map_nil] using trailingP_eq data 0 #[]
   · simpa only [List.map_toArray, List.map_nil, Array.emptyWithCapacity_eq] using
-      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap _ _ 0 #[]
+      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap goodMatch _ _ 0 #[]
 
 /-! ## View direction: the boxed view recovers the boxed matchers
 
@@ -134,15 +138,15 @@ theorem lz77ChainIterP_map (data : ByteArray) (maxChain windowSize insertCap : N
   rw [hcongr, Array.map_id]
 
 /-- The boxed view of the packed lazy matcher is the boxed lazy matcher. -/
-theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap : Nat)
+theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap goodMatch : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    (lz77ChainLazyIterP data maxChain windowSize insertCap).map unpackTok =
-      lz77ChainLazyIter data maxChain windowSize insertCap := by
-  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap hw hws
+    (lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch).map unpackTok =
+      lz77ChainLazyIter data maxChain windowSize insertCap goodMatch := by
+  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap goodMatch hw hws
   rw [lz77ChainLazyIterP_eq, Array.map_map]
   have hcongr : Array.map (unpackTok ∘ packTok)
-        (lz77ChainLazyIter data maxChain windowSize insertCap) =
-      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap) :=
+        (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch) =
+      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch) :=
     Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa only [Array.mem_toList_iff] using ht))
   rw [hcongr, Array.map_id]
 
@@ -153,7 +157,7 @@ theorem lzMatchP_eq (data : ByteArray) (level : UInt8) :
     lzMatchP data level = (lzMatch data level).map packTok := by
   unfold lzMatchP lzMatch
   split
-  · exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level)
+  · exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level) (goodMatch level)
   · exact lz77ChainIterP_eq data (chainDepth level) 32768 (insertCap level)
 
 /-- The boxed view of the packed token stream is exactly `lzMatch`'s stream:
@@ -163,7 +167,7 @@ theorem lzMatchP_map (data : ByteArray) (level : UInt8) :
     (lzMatchP data level).map unpackTok = lzMatch data level := by
   unfold lzMatchP lzMatch
   split
-  · exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level)
+  · exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level) (goodMatch level)
       (by omega) (by omega)
   · exact lz77ChainIterP_map data (chainDepth level) 32768 (insertCap level)
       (by omega) (by omega)

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p9e899d71ef)">
+   <g clip-path="url(#p32f15071d6)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJHElEQVR4nO3YTY5cVx2H4a7usgGrlQRF+VAiIgaBPTBgzg5YA3vILpgyYcCQFXiAGLEGpCAhSCILNx3j9Ic7LtdlxjzoPfpD6XlW8CvdW0fvPbvj17/bzk7R+fn0gnVe3UwvWOfVy+kFS2wPD9MTltm9/d70hDUeP5lesM6pno+vX00vWGd3ms9s++eX0xOWOc0nBgAwSGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT2fz2/nt6wxMObu+kJy3z8zqfTE5a5PL4/PWGJ3d2L6QnL/PHuz9MTlvjkex9MT1jmcPx2esISLw630xOWORyP0xOW+NnbP5qesIwbLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIjtXj78fpsescL94WZ6wjLvHZ9MT1jn9avpBWvcXk8vWOf9T6cXLHFzdqLv4tnZ2e3h5fSEJT7Y3pqesMyX29X0hCU+ev5iesIybrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtr+8/sf0hiUuLx5PT1jn4avpBcts3/xresIax216wTK7J1fTE5a43J/uGXK5f2d6whqPvz+9YJmP79+anrDEdvdsesIybrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL77fmz6Q18V8fj9AL4j+3vn09PWOPc9+f/HWcj/0OcIAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDb/+r5F9Mblri+fz09YZk/ffFyesIyf/jlz6cnLPHhkx9PT1jmp7/57fSEJX7xk3enJyzz+fX99IQlfvDodO8Mnj79y/SEJe5+/dn0hGVO920EABgisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYrvD8ek2PWKFbTtOT+C/cHF/Mz1hjf3j6QXr3FxNL1jizQ8/mp7Ad3RxwncGr7fD9IQlHh1O83ednbnBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj+/Opv0xvWuNhPL1jn9np6wTLb3e30hDUOb6YXLLP78JPpCUtcfP3V9IR1dif6bX34dnrBMo+24/SEJbarZ9MTljnRfxkAwByBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ+zdzhYjd/MyrmAAAAABJRU5ErkJggg==" id="image15e7df3913" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEElEQVR4nO3YsY6cVx2HYc/u2gRrZQUkYrBQChRR0SIqbiAtN0LNZXAHSEipUlO4pOAWEBIUkWwstNibZT1ebybz0dEneo/+ZPQ8V/AbnU9H75zd8cvPtgd8t9zdTi9Y5+5mesES21f30xOW2T35aHrCGt97PL1gnd3Z9II17vfTC9Y50TPb3rycnrDMaZ4YAMAggQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAELv4Yvd6esMS77/eT09Y5icf/mx6wjKX24+nJyyx219PT1jmz/u/Tk9Y4qePPpqesMzheD89YYmbw+ne+4ftOD1hiV89+Xh6wjJesAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2u3n/+TY9YoV3h9vpCcv86Ph4esI6h/vpBWvcXk0vWOfpz6cXLHG77acnLPP2cDM9YYmn25PpCcu8fPB6esISz66upycs4wULACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYheXb66mNyxxefFoesI6d6+mFyyz3X45PWGN43F6wTK7x/+anrDE5cMPpicsc3n+4fSENR6d7pk9e3c/PWGJbf/P6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIhdbFevpjfwTR2P0wvgf7YX/5iesMaZ/5/fOe5G/o+4QQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACB28durL6Y3LHF99/X0hGX+8uJmesIyf/rNr6cnLPH0+x9PT1jmF3/44/SEJT795IfTE5b527/fTU9Y4vyEnwyeP//79IQl3v7+d9MTljnhzxEAYIbAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI7Q7H59v0iBW27Tg9gW/h/G4/PWGN84vpBeu8fT29YInjD55NT1jmVO/H8xN+M/hqO0xPWOLh4TR/14MHXrAAAHICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdnF2/Wp6A9/U/np6wTLb/j/TE9Y4HKYXLLP75JfTE5Y4e/NyesI6ZxfTC9Y4O903g4fv99MTltiuXkxPWOZ0v0YAgCECCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAg9l+Lhor1UAga2AAAAABJRU5ErkJggg==" id="image1462b9d9f9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m06c7850c92" d="M 0 0 
+       <path id="m44cd03d600" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m06c7850c92" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m06c7850c92" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m06c7850c92" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m06c7850c92" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m06c7850c92" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m06c7850c92" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m06c7850c92" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m06c7850c92" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m06c7850c92" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m06c7850c92" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m06c7850c92" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m44cd03d600" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m5c1063bce0" d="M 0 0 
+       <path id="m1e6952e8d7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5c1063bce0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e6952e8d7" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m5c1063bce0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e6952e8d7" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5c1063bce0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e6952e8d7" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m5c1063bce0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e6952e8d7" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m5c1063bce0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e6952e8d7" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m5c1063bce0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e6952e8d7" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5c1063bce0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e6952e8d7" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m5c1063bce0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1e6952e8d7" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -48 -->
+    <!-- -41 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
@@ -1323,6 +1323,54 @@ L 2419 1100
 L 313 1100 
 L 313 1709 
 L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- -40 -->
+    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -68 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1366,44 +1414,16 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_21">
-    <!-- -45 -->
-    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -71 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
    <g id="text_23">
-    <!-- -89 -->
+    <!-- -88 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1415,43 +1435,10 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- -46 -->
-    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- -9 -->
+    <g transform="translate(308.31529 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_26">
@@ -1463,56 +1450,9 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- -42 -->
+    <!-- -38 -->
     <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -51 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -55 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -94 -->
-    <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- +3 -->
-    <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1546,6 +1486,55 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -35 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -52 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -94 -->
+    <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- +3 -->
+    <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
@@ -1558,26 +1547,26 @@ z
     </g>
    </g>
    <g id="text_33">
-    <!-- +8 -->
+    <!-- +9 -->
     <g transform="translate(189.012035 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- -25 -->
+    <!-- -24 -->
     <g transform="translate(227.74588 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- -17 -->
+    <!-- -16 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_36">
@@ -1589,45 +1578,57 @@ z
     </g>
    </g>
    <g id="text_37">
-    <!-- +6 -->
+    <!-- +5 -->
     <g transform="translate(346.015229 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- +9 -->
+    <!-- +8 -->
     <g transform="translate(385.266027 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- -3 -->
+    <!-- -4 -->
     <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- +12 -->
+    <!-- +11 -->
     <g transform="translate(461.699812 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- -18 -->
+    <!-- -16 -->
     <g transform="translate(502.50147 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_42">
     <!-- +227 -->
     <g transform="translate(106.374813 139.606222) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
@@ -1635,21 +1636,21 @@ z
     </g>
    </g>
    <g id="text_43">
-    <!-- +246 -->
+    <!-- +245 -->
     <g transform="translate(145.625612 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_44">
-    <!-- +302 -->
+    <!-- +303 -->
     <g transform="translate(184.87641 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_45">
@@ -1678,47 +1679,47 @@ z
     </g>
    </g>
    <g id="text_48">
-    <!-- +234 -->
+    <!-- +233 -->
     <g transform="translate(341.879604 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +270 -->
+    <!-- +271 -->
     <g transform="translate(381.130402 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +263 -->
+    <!-- +268 -->
     <g transform="translate(420.381201 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +383 -->
+    <!-- +393 -->
     <g transform="translate(459.631999 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
-    <!-- +18 -->
+    <!-- +20 -->
     <g transform="translate(500.95061 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_53">
@@ -1952,11 +1953,11 @@ z
     </g>
    </g>
    <g id="text_81">
-    <!-- +25 -->
+    <!-- +26 -->
     <g transform="translate(343.947416 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_82">
@@ -2041,11 +2042,11 @@ z
     </g>
    </g>
    <g id="text_92">
-    <!-- +68 -->
+    <!-- +69 -->
     <g transform="translate(343.947416 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_93">
@@ -2074,11 +2075,11 @@ z
     </g>
    </g>
    <g id="text_96">
-    <!-- -52 -->
+    <!-- -51 -->
     <g transform="translate(502.50147 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_97">
@@ -2106,11 +2107,11 @@ z
     </g>
    </g>
    <g id="text_100">
-    <!-- -75 -->
+    <!-- -74 -->
     <g transform="translate(227.74588 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_101">
@@ -2162,11 +2163,11 @@ z
     </g>
    </g>
    <g id="text_107">
-    <!-- -86 -->
+    <!-- -85 -->
     <g transform="translate(502.50147 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2180,23 +2181,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagef515d4aa22" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageb8f4930334" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="md7027e99ee" d="M 0 0 
+       <path id="mb40d318cf5" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md7027e99ee" x="547.779688" y="279.422655" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb40d318cf5" x="547.779688" y="277.020043" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
       <!-- −3 -->
-      <g transform="translate(554.779688 283.221874) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 280.819262) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2214,12 +2215,12 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#md7027e99ee" x="547.779688" y="249.894738" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb40d318cf5" x="547.779688" y="248.292997" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
       <!-- −2 -->
-      <g transform="translate(554.779688 253.693957) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 252.092216) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2228,12 +2229,12 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md7027e99ee" x="547.779688" y="220.366821" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb40d318cf5" x="547.779688" y="219.565951" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
       <!-- −1 -->
-      <g transform="translate(554.779688 224.16604) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 223.36517) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2242,7 +2243,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#md7027e99ee" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb40d318cf5" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2255,12 +2256,12 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md7027e99ee" x="547.779688" y="161.310988" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb40d318cf5" x="547.779688" y="162.111858" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
       <!-- 1 -->
-      <g transform="translate(554.779688 165.110207) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 165.911077) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2268,12 +2269,12 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#md7027e99ee" x="547.779688" y="131.783071" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb40d318cf5" x="547.779688" y="133.384812" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
       <!-- 2 -->
-      <g transform="translate(554.779688 135.58229) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 137.184031) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2281,12 +2282,12 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md7027e99ee" x="547.779688" y="102.255154" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb40d318cf5" x="547.779688" y="104.657766" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
       <!-- 3 -->
-      <g transform="translate(554.779688 106.054373) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 108.456985) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2942,8 +2943,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.074844 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.763672 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3013,13 +3014,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3058,109 +3059,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9e899d71ef">
+  <clipPath id="p32f15071d6">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mac14b36524" d="M 0 0 
+       <path id="m94b0f14fe0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mac14b36524" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94b0f14fe0" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mac14b36524" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94b0f14fe0" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mac14b36524" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94b0f14fe0" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mac14b36524" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94b0f14fe0" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mac14b36524" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94b0f14fe0" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mac14b36524" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94b0f14fe0" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mac14b36524" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m94b0f14fe0" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -852,23 +852,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 347.808005 
-L 637.2 347.808005 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 347.783657 
+L 637.2 347.783657 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m5e76200a3f" d="M 0 0 
+       <path id="m7adcc23853" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5e76200a3f" x="49.078125" y="347.808005" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7adcc23853" x="49.078125" y="347.783657" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 351.607224) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 351.582876) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -893,18 +893,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 238.716621 
-L 637.2 238.716621 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 238.637426 
+L 637.2 238.637426 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5e76200a3f" x="49.078125" y="238.716621" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7adcc23853" x="49.078125" y="238.637426" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 242.51584) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 242.436645) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -913,18 +913,18 @@ L 637.2 238.716621
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 129.625237 
-L 637.2 129.625237 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 129.491195 
+L 637.2 129.491195 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5e76200a3f" x="49.078125" y="129.625237" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7adcc23853" x="49.078125" y="129.491195" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 133.424456) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 133.290413) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -933,330 +933,330 @@ L 637.2 129.625237
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 404.849571 
-L 637.2 404.849571 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 404.853901 
+L 637.2 404.853901 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m0a8cb54ee8" d="M 0 0 
+       <path id="md6ec43c425" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="404.849571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="404.853901" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 391.219831 
-L 637.2 391.219831 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.217309 
+L 637.2 391.217309 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="391.219831" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="391.217309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 380.647784 
-L 637.2 380.647784 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.639947 
+L 637.2 380.639947 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="380.647784" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="380.639947" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 372.009792 
-L 637.2 372.009792 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 371.997612 
+L 637.2 371.997612 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="372.009792" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="371.997612" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 364.706474 
-L 637.2 364.706474 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 364.690622 
+L 637.2 364.690622 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="364.706474" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="364.690622" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 358.380053 
-L 637.2 358.380053 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 358.36102 
+L 637.2 358.36102 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="358.380053" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="358.36102" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 352.799753 
-L 637.2 352.799753 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 352.777915 
+L 637.2 352.777915 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="352.799753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="352.777915" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 314.968226 
-L 637.2 314.968226 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 314.927368 
+L 637.2 314.927368 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="314.968226" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="314.927368" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 295.758187 
-L 637.2 295.758187 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 295.70767 
+L 637.2 295.70767 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="295.758187" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="295.70767" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 282.128447 
-L 637.2 282.128447 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 282.071078 
+L 637.2 282.071078 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="282.128447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="282.071078" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 271.5564 
-L 637.2 271.5564 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.493715 
+L 637.2 271.493715 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="271.5564" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="271.493715" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 262.918408 
-L 637.2 262.918408 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.851381 
+L 637.2 262.851381 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="262.918408" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="262.851381" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 255.61509 
-L 637.2 255.61509 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.544391 
+L 637.2 255.544391 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="255.61509" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="255.544391" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 249.288669 
-L 637.2 249.288669 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.214789 
+L 637.2 249.214789 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="249.288669" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="249.214789" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 243.708369 
-L 637.2 243.708369 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.631683 
+L 637.2 243.631683 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="243.708369" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="243.631683" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 205.876842 
-L 637.2 205.876842 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.781136 
+L 637.2 205.781136 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="205.876842" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="205.781136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 186.666803 
-L 637.2 186.666803 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 186.561439 
+L 637.2 186.561439 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="186.666803" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="186.561439" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 173.037064 
-L 637.2 173.037064 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 172.924847 
+L 637.2 172.924847 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="173.037064" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="172.924847" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 162.465016 
-L 637.2 162.465016 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 162.347484 
+L 637.2 162.347484 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="162.465016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="162.347484" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 153.827024 
-L 637.2 153.827024 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 153.70515 
+L 637.2 153.70515 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="153.827024" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="153.70515" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 146.523706 
-L 637.2 146.523706 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.39816 
+L 637.2 146.39816 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="146.523706" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="146.39816" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 140.197285 
-L 637.2 140.197285 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 140.068557 
+L 637.2 140.068557 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="140.197285" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="140.068557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 134.616985 
-L 637.2 134.616985 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 134.485452 
+L 637.2 134.485452 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="134.616985" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="134.485452" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 49.078125 96.785458 
-L 637.2 96.785458 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 96.634905 
+L 637.2 96.634905 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="96.785458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="96.634905" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 49.078125 77.575419 
-L 637.2 77.575419 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 77.415208 
+L 637.2 77.415208 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="77.575419" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="77.415208" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 49.078125 63.94568 
-L 637.2 63.94568 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 63.778616 
+L 637.2 63.778616 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="63.94568" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="63.778616" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 49.078125 53.373632 
-L 637.2 53.373632 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 53.201253 
+L 637.2 53.201253 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m0a8cb54ee8" x="49.078125" y="53.373632" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md6ec43c425" x="49.078125" y="53.201253" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(271.439833 184.880722) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(271.439833 185.056733) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 343.51445) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 343.911412) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1739,124 +1739,124 @@ z
     </g>
    </g>
    <g id="line2d_75">
-    <path d="M 355.479835 95.429129 
-L 308.273931 102.643215 
-L 271.230161 116.329646 
-L 217.83458 119.884966 
-L 177.077692 138.271575 
-L 162.880539 157.657599 
-L 160.741445 165.059068 
-L 153.966678 183.326897 
-L 151.589614 194.435065 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 355.479835 95.427628 
+L 308.273931 102.74725 
+L 271.230161 116.393477 
+L 217.83458 119.920971 
+L 177.077692 138.382232 
+L 162.880539 157.725182 
+L 160.741445 165.158146 
+L 153.966678 183.397753 
+L 151.589614 194.498928 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mea8ad5ce55" d="M -2.5 2.5 
+     <path id="m2a7a5b2555" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pea58e2e697)">
-     <use xlink:href="#mea8ad5ce55" x="355.479835" y="95.429129" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea8ad5ce55" x="308.273931" y="102.643215" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea8ad5ce55" x="271.230161" y="116.329646" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea8ad5ce55" x="217.83458" y="119.884966" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea8ad5ce55" x="177.077692" y="138.271575" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea8ad5ce55" x="162.880539" y="157.657599" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea8ad5ce55" x="160.741445" y="165.059068" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea8ad5ce55" x="153.966678" y="183.326897" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea8ad5ce55" x="151.589614" y="194.435065" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7e314c3807)">
+     <use xlink:href="#m2a7a5b2555" x="355.479835" y="95.427628" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2a7a5b2555" x="308.273931" y="102.74725" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2a7a5b2555" x="271.230161" y="116.393477" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2a7a5b2555" x="217.83458" y="119.920971" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2a7a5b2555" x="177.077692" y="138.382232" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2a7a5b2555" x="162.880539" y="157.725182" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2a7a5b2555" x="160.741445" y="165.158146" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2a7a5b2555" x="153.966678" y="183.397753" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2a7a5b2555" x="151.589614" y="194.498928" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
-    <path d="M 531.649087 76.334942 
-L 283.721324 99.105471 
-L 218.882044 121.035708 
-L 187.447228 127.081538 
-L 176.342474 138.415762 
-L 163.054314 161.392184 
-L 162.210539 168.835144 
-L 159.303811 175.792312 
-L 157.793928 179.565972 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 531.649087 76.276797 
+L 283.721324 99.171114 
+L 218.882044 120.99437 
+L 187.447228 127.133273 
+L 176.342474 138.440747 
+L 163.054314 161.369521 
+L 162.210539 168.860456 
+L 159.303811 175.80223 
+L 157.793928 179.622924 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2c92bfb742" d="M 0 -2.5 
+     <path id="m7faf17c897" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pea58e2e697)">
-     <use xlink:href="#m2c92bfb742" x="531.649087" y="76.334942" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2c92bfb742" x="283.721324" y="99.105471" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2c92bfb742" x="218.882044" y="121.035708" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2c92bfb742" x="187.447228" y="127.081538" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2c92bfb742" x="176.342474" y="138.415762" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2c92bfb742" x="163.054314" y="161.392184" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2c92bfb742" x="162.210539" y="168.835144" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2c92bfb742" x="159.303811" y="175.792312" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2c92bfb742" x="157.793928" y="179.565972" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7e314c3807)">
+     <use xlink:href="#m7faf17c897" x="531.649087" y="76.276797" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7faf17c897" x="283.721324" y="99.171114" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7faf17c897" x="218.882044" y="120.99437" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7faf17c897" x="187.447228" y="127.133273" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7faf17c897" x="176.342474" y="138.440747" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7faf17c897" x="163.054314" y="161.369521" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7faf17c897" x="162.210539" y="168.860456" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7faf17c897" x="159.303811" y="175.80223" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7faf17c897" x="157.793928" y="179.622924" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
     <path d="M 251.559581 64.890426 
-L 203.775848 82.063415 
-L 186.982691 88.556403 
-L 179.779306 91.272263 
-L 157.610419 99.495121 
-L 148.722526 107.987171 
-L 144.388162 121.598806 
-L 127.071247 144.809212 
-L 124.491988 152.211151 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 203.775848 81.783807 
+L 186.982691 88.406737 
+L 179.779306 91.089504 
+L 157.610419 99.330616 
+L 148.722526 107.797685 
+L 144.388162 121.168591 
+L 127.071247 144.590753 
+L 124.491988 152.069294 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m86e920e76b" d="M -0 3.535534 
+     <path id="m41d36ca341" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pea58e2e697)">
-     <use xlink:href="#m86e920e76b" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m86e920e76b" x="203.775848" y="82.063415" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m86e920e76b" x="186.982691" y="88.556403" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m86e920e76b" x="179.779306" y="91.272263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m86e920e76b" x="157.610419" y="99.495121" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m86e920e76b" x="148.722526" y="107.987171" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m86e920e76b" x="144.388162" y="121.598806" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m86e920e76b" x="127.071247" y="144.809212" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m86e920e76b" x="124.491988" y="152.211151" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7e314c3807)">
+     <use xlink:href="#m41d36ca341" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m41d36ca341" x="203.775848" y="81.783807" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m41d36ca341" x="186.982691" y="88.406737" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m41d36ca341" x="179.779306" y="91.089504" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m41d36ca341" x="157.610419" y="99.330616" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m41d36ca341" x="148.722526" y="107.797685" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m41d36ca341" x="144.388162" y="121.168591" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m41d36ca341" x="127.071247" y="144.590753" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m41d36ca341" x="124.491988" y="152.069294" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2c29801148" d="M -0 2.5 
+     <path id="mac3b85aca3" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pea58e2e697)">
-     <use xlink:href="#m2c29801148" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7e314c3807)">
+     <use xlink:href="#mac3b85aca3" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
-    <path d="M 362.865999 178.208265 
-L 278.798176 181.115507 
-L 251.17632 188.728803 
-L 200.806828 186.370878 
-L 169.803221 202.802663 
-L 161.916638 211.201944 
-L 158.697104 214.083876 
-L 154.26679 230.403077 
-L 153.096464 236.374892 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 362.865999 178.098648 
+L 278.798176 181.007352 
+L 251.17632 188.624476 
+L 200.806828 186.265365 
+L 169.803221 202.705412 
+L 161.916638 211.108915 
+L 158.697104 213.992296 
+L 154.26679 230.319702 
+L 153.096464 236.294519 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mdc895f0b95" d="M -0.833333 2.5 
+     <path id="mf9019b91fc" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,31 +1871,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pea58e2e697)">
-     <use xlink:href="#mdc895f0b95" x="362.865999" y="178.208265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc895f0b95" x="278.798176" y="181.115507" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc895f0b95" x="251.17632" y="188.728803" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc895f0b95" x="200.806828" y="186.370878" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc895f0b95" x="169.803221" y="202.802663" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc895f0b95" x="161.916638" y="211.201944" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc895f0b95" x="158.697104" y="214.083876" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc895f0b95" x="154.26679" y="230.403077" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdc895f0b95" x="153.096464" y="236.374892" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7e314c3807)">
+     <use xlink:href="#mf9019b91fc" x="362.865999" y="178.098648" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9019b91fc" x="278.798176" y="181.007352" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9019b91fc" x="251.17632" y="188.624476" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9019b91fc" x="200.806828" y="186.265365" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9019b91fc" x="169.803221" y="202.705412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9019b91fc" x="161.916638" y="211.108915" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9019b91fc" x="158.697104" y="213.992296" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9019b91fc" x="154.26679" y="230.319702" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf9019b91fc" x="153.096464" y="236.294519" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
-    <path d="M 301.619021 144.709332 
-L 250.236474 147.250669 
-L 225.418659 152.855905 
-L 212.328936 158.971358 
-L 209.030149 156.876474 
-L 197.547749 168.035549 
-L 194.819287 169.543563 
-L 193.12279 177.055726 
-L 192.79794 181.903106 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 301.619021 144.582873 
+L 250.236474 147.125487 
+L 225.418659 152.733542 
+L 212.328936 158.852069 
+L 209.030149 156.756132 
+L 197.547749 167.920818 
+L 194.819287 169.42959 
+L 193.12279 176.94553 
+L 192.79794 181.795347 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9590c0b7b2" d="M -1.25 2.5 
+     <path id="mf2da31bec6" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,31 +1910,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pea58e2e697)">
-     <use xlink:href="#m9590c0b7b2" x="301.619021" y="144.709332" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9590c0b7b2" x="250.236474" y="147.250669" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9590c0b7b2" x="225.418659" y="152.855905" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9590c0b7b2" x="212.328936" y="158.971358" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9590c0b7b2" x="209.030149" y="156.876474" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9590c0b7b2" x="197.547749" y="168.035549" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9590c0b7b2" x="194.819287" y="169.543563" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9590c0b7b2" x="193.12279" y="177.055726" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9590c0b7b2" x="192.79794" y="181.903106" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7e314c3807)">
+     <use xlink:href="#mf2da31bec6" x="301.619021" y="144.582873" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2da31bec6" x="250.236474" y="147.125487" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2da31bec6" x="225.418659" y="152.733542" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2da31bec6" x="212.328936" y="158.852069" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2da31bec6" x="209.030149" y="156.756132" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2da31bec6" x="197.547749" y="167.920818" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2da31bec6" x="194.819287" y="169.42959" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2da31bec6" x="193.12279" y="176.94553" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf2da31bec6" x="192.79794" y="181.795347" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
-    <path d="M 206.45578 118.329216 
-L 206.45578 118.007744 
-L 206.45578 118.087977 
-L 206.45578 118.073237 
-L 171.767499 133.56872 
-L 163.54283 144.454763 
-L 160.174881 150.352936 
-L 154.179217 168.648736 
-L 152.4406 178.37478 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.189494 
+L 206.45578 117.867861 
+L 206.45578 117.948133 
+L 206.45578 117.933386 
+L 171.767499 133.43666 
+L 163.54283 144.328176 
+L 160.174881 150.229314 
+L 154.179217 168.534313 
+L 152.4406 178.265247 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc68bb09df7" d="M 0 -2.5 
+     <path id="mb77c71c18f" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,31 +1947,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pea58e2e697)">
-     <use xlink:href="#mc68bb09df7" x="206.45578" y="118.329216" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc68bb09df7" x="206.45578" y="118.007744" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc68bb09df7" x="206.45578" y="118.087977" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc68bb09df7" x="206.45578" y="118.073237" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc68bb09df7" x="171.767499" y="133.56872" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc68bb09df7" x="163.54283" y="144.454763" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc68bb09df7" x="160.174881" y="150.352936" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc68bb09df7" x="154.179217" y="168.648736" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc68bb09df7" x="152.4406" y="178.37478" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p7e314c3807)">
+     <use xlink:href="#mb77c71c18f" x="206.45578" y="118.189494" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb77c71c18f" x="206.45578" y="117.867861" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb77c71c18f" x="206.45578" y="117.948133" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb77c71c18f" x="206.45578" y="117.933386" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb77c71c18f" x="171.767499" y="133.43666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb77c71c18f" x="163.54283" y="144.328176" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb77c71c18f" x="160.174881" y="150.229314" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb77c71c18f" x="154.179217" y="168.534313" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb77c71c18f" x="152.4406" y="178.265247" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
-    <path d="M 610.467188 173.64683 
-L 592.067397 175.079335 
-L 534.807821 181.440237 
-L 327.802209 176.754212 
-L 275.83761 187.092383 
-L 258.25125 199.202588 
-L 256.777056 204.152158 
-L 248.769854 218.291924 
-L 246.264594 228.041024 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467188 173.53492 
+L 592.067397 174.968145 
+L 534.807821 181.332245 
+L 327.802209 176.643864 
+L 275.83761 186.987233 
+L 258.25125 199.103527 
+L 256.777056 204.055585 
+L 248.769854 218.20246 
+L 246.264594 227.956461 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m10bdf6687a" d="M 0 -2.5 
+     <path id="mc8af8d89ef" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pea58e2e697)">
-     <use xlink:href="#m10bdf6687a" x="610.467188" y="173.64683" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m10bdf6687a" x="592.067397" y="175.079335" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m10bdf6687a" x="534.807821" y="181.440237" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m10bdf6687a" x="327.802209" y="176.754212" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m10bdf6687a" x="275.83761" y="187.092383" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m10bdf6687a" x="258.25125" y="199.202588" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m10bdf6687a" x="256.777056" y="204.152158" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m10bdf6687a" x="248.769854" y="218.291924" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m10bdf6687a" x="246.264594" y="228.041024" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7e314c3807)">
+     <use xlink:href="#mc8af8d89ef" x="610.467188" y="173.53492" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc8af8d89ef" x="592.067397" y="174.968145" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc8af8d89ef" x="534.807821" y="181.332245" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc8af8d89ef" x="327.802209" y="176.643864" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc8af8d89ef" x="275.83761" y="186.987233" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc8af8d89ef" x="258.25125" y="199.103527" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc8af8d89ef" x="256.777056" y="204.055585" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc8af8d89ef" x="248.769854" y="218.20246" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc8af8d89ef" x="246.264594" y="227.956461" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="ma7d6e2f99f" d="M 0 3.5 
+      <path id="mac3c49926e" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#ma7d6e2f99f" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mac3c49926e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mea8ad5ce55" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2a7a5b2555" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2c92bfb742" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7faf17c897" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m86e920e76b" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m41d36ca341" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2c29801148" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mac3b85aca3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdc895f0b95" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf9019b91fc" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9590c0b7b2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf2da31bec6" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc68bb09df7" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mb77c71c18f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m10bdf6687a" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc8af8d89ef" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 266.439833 189.880722 
-L 243.627793 193.091839 
-L 229.515893 196.509364 
-L 184.409647 209.30855 
-L 180.806615 211.443994 
-L 175.118498 217.015324 
-L 162.683902 257.310681 
-L 160.786938 260.103623 
-L 98.348822 348.51445 
-" clip-path="url(#pea58e2e697)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pea58e2e697)">
-     <use xlink:href="#ma7d6e2f99f" x="266.439833" y="189.880722" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma7d6e2f99f" x="243.627793" y="193.091839" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma7d6e2f99f" x="229.515893" y="196.509364" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma7d6e2f99f" x="184.409647" y="209.30855" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma7d6e2f99f" x="180.806615" y="211.443994" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma7d6e2f99f" x="175.118498" y="217.015324" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma7d6e2f99f" x="162.683902" y="257.310681" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma7d6e2f99f" x="160.786938" y="260.103623" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma7d6e2f99f" x="98.348822" y="348.51445" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 266.439833 190.056733 
+L 243.627793 193.366201 
+L 229.515893 196.783234 
+L 202.113895 205.249239 
+L 199.119619 207.210552 
+L 194.929393 211.166016 
+L 162.683902 258.092244 
+L 160.786938 260.752071 
+L 98.348822 348.911412 
+" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p7e314c3807)">
+     <use xlink:href="#mac3c49926e" x="266.439833" y="190.056733" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mac3c49926e" x="243.627793" y="193.366201" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mac3c49926e" x="229.515893" y="196.783234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mac3c49926e" x="202.113895" y="205.249239" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mac3c49926e" x="199.119619" y="207.210552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mac3c49926e" x="194.929393" y="211.166016" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mac3c49926e" x="162.683902" y="258.092244" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mac3c49926e" x="160.786938" y="260.752071" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mac3c49926e" x="98.348822" y="348.911412" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.074844 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.763672 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3000,36 +3000,6 @@ Q 953 2441 691 2322
 L 691 4666 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3071,13 +3041,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3116,109 +3086,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pea58e2e697">
+  <clipPath id="p7e314c3807">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p9216063857)">
+   <g clip-path="url(#pf60e885d76)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+UlEQVR4nO3YwYqkVx2H4aqe7rYnwUFlEsMshewkuHDjbLL2TnIFWYp7r8PkBgQRMZugZONG3IkbEQkhmSSTmaG7p/orL2ESOPKXep/nCn5nUafe7+y3L3973J2aZ59PL1jq+MVpnWe32+3+/f7vpics9c+/PZ+esNy7H/xyesJy+5/9fHrCWvuz6QXrPf10esF6Vw+mFyz14Y9/Mz1huRP8JQEAfHtiCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbX9z+P1xesRqx902PWGp/Qk268XZ5fSEpW636+kJy138/ZPpCcsdfvp4esJSh+12esJyzw9Ppycs9/DEroeXDx5OT1ju9P5lAQC+AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvH8q+kN6928mF6w1nGbXrDe/QfTC5a6nB7wP3B8+nx6wnIX3zyZnrDUxXaYnrDc/VO8766fTS9Y6uL89G48L0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2Px6nR6x2PG7TE5baTuw8u91ud3F2OT1hqbvjYXrCcveePZmesN7335xesNTL7XZ6wnJfXP9nesJyb92cT09Yavvho+kJy3kZAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSzv/62Z+nNyx3tttPT1jqjdceTk9Y7m47TE9Y6vLe1fSE5d776OPpCcv9+hdvT09Y6nDcpics96u//GN6wnKPH70+PWGp9955PD1hOS9DAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASNu/vPvDcXrEard319MTlrq/v5qewCvc7g/TE5b7+ubz6QnL/ejqrekJS23HbXrCcl/dfDY9YbknN59OT1jqJw/emZ6wnJchACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO237U/H6RHA/6HD7fSC9c4vpxfwCtd3L6YnLHd177XpCbyClyEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkne9uX0xvWO9wO71grXvn0wvWOzuxM+1P8Lviyb+mF6z3g0fTC9Y6tbtut9vtvnc5vWC94za9YK0T7IYTvMEBAL49MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkPZfwb+IB8PIhC4AAAAASUVORK5CYII=" id="imagead4fff4c38" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAJAElEQVR4nO3YsaqdWR2H4b2Tc44n0QkoUYcpLAamk2GKaUwj2Hkn0wuWYi9ehnoDgojMNOJgYyN2YiODhDATx5iEc072+baXkAhL/rLf57mC31d8a72s/fbPXxx3p+b559MLljp+cVrfs9vtdp/9+NfTE5b6259fTE9Y7vu//OH0hOX2H3w4PWGt/Z3pBes9ezy9YL3LB9MLlvrVt382PWG5E/yTAADenBgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbXx9+c5wesdpxt01PWGp/gs16fudiesJSN9vV9ITlzv/yx+kJyx2++2h6wlKH7WZ6wnIvDs+mJyz38MSOh1cPHk5PWO70blkAgP+CGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASDs7f/Hl9Ib1rl9OL1jruE0vWO/eg+kFS11MD/gfOD57MT1hufN/P52esNT5dpiesNy9Uzzvrp5PL1jq/Oz0TjwvQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbH7bfHadHrHY8btMTltpO7Ht2u93u/M7F9ISlbo+H6QnL3X3+dHrCem99a3rBUq+2m+kJy31x9Y/pCcu9fX02PWGp7evvTE9YzssQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB29qcnf5jesNyd3X56wlLfvP9wesJyt9thesJSF3cvpycs99Env5+esNxPv/fe9ISlDsdtesJyP/n0r9MTlnv0zlenJyz10fuPpics52UIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftXt789To9Y7eb2anrCUvf2l9MTeI2b/WF6wnL/uv58esJy37h8e3rCUttxm56w3JfXT6YnLPf0+vH0hKXeffD+9ITlvAwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbb9tHx+nRwD/hw430wvWO7uYXsBrXN2+nJ6w3OXd+9MTeA0vQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEg7210/n96w3u1hesFa+xNs1rOL6QVrHbfpBct98p0fTU9Y7gd///n0hLVeXU0vWO7yK1+bnrDeqd1JNy+nFyx3grcsAMCbE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn/AXlXiw4LA/k9AAAAAElFTkSuQmCC" id="image6872edb5cb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m3f04088619" d="M 0 0 
+       <path id="mb80566baca" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3f04088619" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m3f04088619" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m3f04088619" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3f04088619" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m3f04088619" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3f04088619" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m3f04088619" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3f04088619" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m3f04088619" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3f04088619" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m3f04088619" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb80566baca" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mdbf7757ac4" d="M 0 0 
+       <path id="md4c08cb802" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdbf7757ac4" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4c08cb802" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mdbf7757ac4" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4c08cb802" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdbf7757ac4" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4c08cb802" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mdbf7757ac4" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4c08cb802" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdbf7757ac4" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4c08cb802" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mdbf7757ac4" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4c08cb802" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdbf7757ac4" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4c08cb802" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mdbf7757ac4" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4c08cb802" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1355,44 +1355,11 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- +3 -->
-    <g transform="translate(299.170688 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- +19 -->
+    <g transform="translate(297.102876 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_26">
@@ -1410,10 +1377,10 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -1 -->
-    <g transform="translate(414.331902 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    <!-- +1 -->
+    <g transform="translate(412.781042 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -1622,6 +1589,40 @@ z
    <g id="text_55">
     <!-- -3 -->
     <g transform="translate(187.111194 174.957073) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -2092,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8ba8190e13" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagecd8dbe4bbb" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m1d6f68f366" d="M 0 0 
+       <path id="m82d512bf08" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1d6f68f366" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d512bf08" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m1d6f68f366" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d512bf08" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1d6f68f366" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d512bf08" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m1d6f68f366" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d512bf08" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1d6f68f366" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d512bf08" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m1d6f68f366" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d512bf08" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1d6f68f366" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d512bf08" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m1d6f68f366" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d512bf08" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1d6f68f366" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m82d512bf08" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.074844 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.763672 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,13 +2954,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2998,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9216063857">
+  <clipPath id="pf60e885d76">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.250313pt" height="386.202469pt" viewBox="0 0 570.250313 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.872656pt" height="386.202469pt" viewBox="0 0 570.872656 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.250313 386.202469 
-L 570.250313 0 
+L 570.872656 386.202469 
+L 570.872656 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.250156 104.1264 
-L 291.875156 104.1264 
-L 291.875156 74.7432 
-L 187.250156 74.7432 
+    <path d="M 187.561328 104.1264 
+L 292.186328 104.1264 
+L 292.186328 74.7432 
+L 187.561328 74.7432 
 z
-" clip-path="url(#p549027855d)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.875156 104.1264 
-L 396.500156 104.1264 
-L 396.500156 74.7432 
-L 291.875156 74.7432 
+    <path d="M 292.186328 104.1264 
+L 396.811328 104.1264 
+L 396.811328 74.7432 
+L 292.186328 74.7432 
 z
-" clip-path="url(#p549027855d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.500156 104.1264 
-L 501.125156 104.1264 
-L 501.125156 74.7432 
-L 396.500156 74.7432 
+    <path d="M 396.811328 104.1264 
+L 501.436328 104.1264 
+L 501.436328 74.7432 
+L 396.811328 74.7432 
 z
-" clip-path="url(#p549027855d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.250156 133.5096 
-L 291.875156 133.5096 
-L 291.875156 104.1264 
-L 187.250156 104.1264 
+    <path d="M 187.561328 133.5096 
+L 292.186328 133.5096 
+L 292.186328 104.1264 
+L 187.561328 104.1264 
 z
-" clip-path="url(#p549027855d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.875156 133.5096 
-L 396.500156 133.5096 
-L 396.500156 104.1264 
-L 291.875156 104.1264 
+    <path d="M 292.186328 133.5096 
+L 396.811328 133.5096 
+L 396.811328 104.1264 
+L 292.186328 104.1264 
 z
-" clip-path="url(#p549027855d)" style="fill: #fff7b2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #fff7b2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.500156 133.5096 
-L 501.125156 133.5096 
-L 501.125156 104.1264 
-L 396.500156 104.1264 
+    <path d="M 396.811328 133.5096 
+L 501.436328 133.5096 
+L 501.436328 104.1264 
+L 396.811328 104.1264 
 z
-" clip-path="url(#p549027855d)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.250156 162.8928 
-L 291.875156 162.8928 
-L 291.875156 133.5096 
-L 187.250156 133.5096 
+    <path d="M 187.561328 162.8928 
+L 292.186328 162.8928 
+L 292.186328 133.5096 
+L 187.561328 133.5096 
 z
-" clip-path="url(#p549027855d)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.875156 162.8928 
-L 396.500156 162.8928 
-L 396.500156 133.5096 
-L 291.875156 133.5096 
+    <path d="M 292.186328 162.8928 
+L 396.811328 162.8928 
+L 396.811328 133.5096 
+L 292.186328 133.5096 
 z
-" clip-path="url(#p549027855d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.500156 162.8928 
-L 501.125156 162.8928 
-L 501.125156 133.5096 
-L 396.500156 133.5096 
+    <path d="M 396.811328 162.8928 
+L 501.436328 162.8928 
+L 501.436328 133.5096 
+L 396.811328 133.5096 
 z
-" clip-path="url(#p549027855d)" style="fill: #bde379; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #bfe47a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.250156 192.276 
-L 291.875156 192.276 
-L 291.875156 162.8928 
-L 187.250156 162.8928 
+    <path d="M 187.561328 192.276 
+L 292.186328 192.276 
+L 292.186328 162.8928 
+L 187.561328 162.8928 
 z
-" clip-path="url(#p549027855d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.875156 192.276 
-L 396.500156 192.276 
-L 396.500156 162.8928 
-L 291.875156 162.8928 
+    <path d="M 292.186328 192.276 
+L 396.811328 192.276 
+L 396.811328 162.8928 
+L 292.186328 162.8928 
 z
-" clip-path="url(#p549027855d)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.500156 192.276 
-L 501.125156 192.276 
-L 501.125156 162.8928 
-L 396.500156 162.8928 
+    <path d="M 396.811328 192.276 
+L 501.436328 192.276 
+L 501.436328 162.8928 
+L 396.811328 162.8928 
 z
-" clip-path="url(#p549027855d)" style="fill: #abdb6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.250156 221.6592 
-L 291.875156 221.6592 
-L 291.875156 192.276 
-L 187.250156 192.276 
+    <path d="M 187.561328 221.6592 
+L 292.186328 221.6592 
+L 292.186328 192.276 
+L 187.561328 192.276 
 z
-" clip-path="url(#p549027855d)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.875156 221.6592 
-L 396.500156 221.6592 
-L 396.500156 192.276 
-L 291.875156 192.276 
+    <path d="M 292.186328 221.6592 
+L 396.811328 221.6592 
+L 396.811328 192.276 
+L 292.186328 192.276 
 z
-" clip-path="url(#p549027855d)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.500156 221.6592 
-L 501.125156 221.6592 
-L 501.125156 192.276 
-L 396.500156 192.276 
+    <path d="M 396.811328 221.6592 
+L 501.436328 221.6592 
+L 501.436328 192.276 
+L 396.811328 192.276 
 z
-" clip-path="url(#p549027855d)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.250156 251.0424 
-L 291.875156 251.0424 
-L 291.875156 221.6592 
-L 187.250156 221.6592 
+    <path d="M 187.561328 251.0424 
+L 292.186328 251.0424 
+L 292.186328 221.6592 
+L 187.561328 221.6592 
 z
-" clip-path="url(#p549027855d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.875156 251.0424 
-L 396.500156 251.0424 
-L 396.500156 221.6592 
-L 291.875156 221.6592 
+    <path d="M 292.186328 251.0424 
+L 396.811328 251.0424 
+L 396.811328 221.6592 
+L 292.186328 221.6592 
 z
-" clip-path="url(#p549027855d)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.500156 251.0424 
-L 501.125156 251.0424 
-L 501.125156 221.6592 
-L 396.500156 221.6592 
+    <path d="M 396.811328 251.0424 
+L 501.436328 251.0424 
+L 501.436328 221.6592 
+L 396.811328 221.6592 
 z
-" clip-path="url(#p549027855d)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.250156 280.4256 
-L 291.875156 280.4256 
-L 291.875156 251.0424 
-L 187.250156 251.0424 
+    <path d="M 187.561328 280.4256 
+L 292.186328 280.4256 
+L 292.186328 251.0424 
+L 187.561328 251.0424 
 z
-" clip-path="url(#p549027855d)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.875156 280.4256 
-L 396.500156 280.4256 
-L 396.500156 251.0424 
-L 291.875156 251.0424 
+    <path d="M 292.186328 280.4256 
+L 396.811328 280.4256 
+L 396.811328 251.0424 
+L 292.186328 251.0424 
 z
-" clip-path="url(#p549027855d)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.500156 280.4256 
-L 501.125156 280.4256 
-L 501.125156 251.0424 
-L 396.500156 251.0424 
+    <path d="M 396.811328 280.4256 
+L 501.436328 280.4256 
+L 501.436328 251.0424 
+L 396.811328 251.0424 
 z
-" clip-path="url(#p549027855d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.250156 309.8088 
-L 291.875156 309.8088 
-L 291.875156 280.4256 
-L 187.250156 280.4256 
+    <path d="M 187.561328 309.8088 
+L 292.186328 309.8088 
+L 292.186328 280.4256 
+L 187.561328 280.4256 
 z
-" clip-path="url(#p549027855d)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.875156 309.8088 
-L 396.500156 309.8088 
-L 396.500156 280.4256 
-L 291.875156 280.4256 
+    <path d="M 292.186328 309.8088 
+L 396.811328 309.8088 
+L 396.811328 280.4256 
+L 292.186328 280.4256 
 z
-" clip-path="url(#p549027855d)" style="fill: #f57748; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.500156 309.8088 
-L 501.125156 309.8088 
-L 501.125156 280.4256 
-L 396.500156 280.4256 
+    <path d="M 396.811328 309.8088 
+L 501.436328 309.8088 
+L 501.436328 280.4256 
+L 396.811328 280.4256 
 z
-" clip-path="url(#p549027855d)" style="fill: #e65036; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #e65036; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.250156 339.192 
-L 291.875156 339.192 
-L 291.875156 309.8088 
-L 187.250156 309.8088 
+    <path d="M 187.561328 339.192 
+L 292.186328 339.192 
+L 292.186328 309.8088 
+L 187.561328 309.8088 
 z
-" clip-path="url(#p549027855d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.875156 339.192 
-L 396.500156 339.192 
-L 396.500156 309.8088 
-L 291.875156 309.8088 
+    <path d="M 292.186328 339.192 
+L 396.811328 339.192 
+L 396.811328 309.8088 
+L 292.186328 309.8088 
 z
-" clip-path="url(#p549027855d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.500156 339.192 
-L 501.125156 339.192 
-L 501.125156 309.8088 
-L 396.500156 309.8088 
+    <path d="M 396.811328 339.192 
+L 501.436328 339.192 
+L 501.436328 309.8088 
+L 396.811328 309.8088 
 z
-" clip-path="url(#p549027855d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p54e78dd682)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.237422 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.548594 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.521641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.832812 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.09375 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.404922 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.445469 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.756641 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.175156 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.486328 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.111406 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.552656 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.863828 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 931 -->
-    <g transform="translate(441.177656 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.488828 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1076,7 +1076,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.813281 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.124453 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1175,7 +1175,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.111406 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1185,7 +1185,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.097656 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1204,7 +1204,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.177656 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.488828 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1212,7 +1212,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.076406 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.387578 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1236,7 +1236,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.111406 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1246,22 +1246,22 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.097656 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 696 -->
-    <g transform="translate(441.177656 150.4087) scale(0.08 -0.08)">
+    <!-- 693 -->
+    <g transform="translate(441.488828 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.382656 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.693828 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1371,7 +1371,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.111406 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1381,22 +1381,22 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.097656 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 735 -->
-    <g transform="translate(441.177656 179.7919) scale(0.08 -0.08)">
+    <!-- 733 -->
+    <g transform="translate(441.488828 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.538906 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.850078 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1456,7 +1456,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.111406 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1466,7 +1466,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(339.097656 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1494,7 +1494,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.177656 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.488828 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1502,7 +1502,7 @@ z
    </g>
    <g id="text_25">
     <!-- OCaml decompress -->
-    <g transform="translate(95.999531 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(96.310703 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1631,7 +1631,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.321 -->
-    <g transform="translate(228.111406 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1641,14 +1641,14 @@ z
    </g>
    <g id="text_27">
     <!-- 23 -->
-    <g transform="translate(339.097656 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 117 -->
-    <g transform="translate(441.177656 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(441.488828 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1656,7 +1656,7 @@ z
    </g>
    <g id="text_29">
     <!-- Go compress/flate -->
-    <g transform="translate(98.506406 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(98.817578 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1712,7 +1712,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.299 -->
-    <g transform="translate(228.111406 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1722,21 +1722,21 @@ z
    </g>
    <g id="text_31">
     <!-- 18 -->
-    <g transform="translate(339.097656 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 88 -->
-    <g transform="translate(443.722656 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(444.033828 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.884531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.195703 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1844,8 +1844,8 @@ z
     </g>
    </g>
    <g id="text_34">
-    <!-- 0.302 -->
-    <g transform="translate(226.910781 297.3247) scale(0.08 -0.08)">
+    <!-- 0.307 -->
+    <g transform="translate(227.221953 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1907,26 +1907,14 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-32" d="M 1844 884 
-L 3897 884 
-L 3897 0 
-L 506 0 
-L 506 884 
-L 2209 2388 
-Q 2438 2594 2547 2791 
-Q 2656 2988 2656 3200 
-Q 2656 3528 2436 3728 
-Q 2216 3928 1850 3928 
-Q 1569 3928 1234 3808 
-Q 900 3688 519 3450 
-L 519 4475 
-Q 925 4609 1322 4679 
-Q 1719 4750 2100 4750 
-Q 2938 4750 3402 4381 
-Q 3866 4013 3866 3353 
-Q 3866 2972 3669 2642 
-Q 3472 2313 2841 1759 
-L 1844 884 
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1934,12 +1922,12 @@ z
      <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(246.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(246.728516 0)"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- 16 -->
-    <g transform="translate(338.621406 297.3247) scale(0.08 -0.08)">
+    <!-- 18 -->
+    <g transform="translate(338.932578 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1955,44 +1943,53 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
 z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 93 -->
-    <g transform="translate(443.246406 297.3247) scale(0.08 -0.08)">
+    <!-- 92 -->
+    <g transform="translate(443.557578 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -2024,14 +2021,36 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-39"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.220781 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.531953 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2042,7 +2061,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.111406 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2052,13 +2071,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.642656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.953828 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.812656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.123828 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2074,7 +2093,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.633906 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.945078 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2213,6 +2232,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2257,7 +2306,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2399,13 +2448,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2444,110 +2493,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p549027855d">
-   <rect x="82.625156" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p54e78dd682">
+   <rect x="82.936328" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd2c1437810)">
+   <g clip-path="url(#p26b8072c30)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ90lEQVR4nO3YPY5k1R2HYWq6ppkPGNAMAjRIiAQ5NBCSsAN24sQZK2AVDpw5JiOEyAmSHSIkviRrsBGI0UDDVHdXewWO0Hn/7avnWcFPOnXPfW/tjj/89eqZLTucTS9Ya3djesFax4vpBWtt/fwuDtML1rrz4vSCtZ7+PL2A3+PkdHrBWlv/fZ7emV6w1MbffgAAXDcCFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1P6z86+nNyx16+bp9ISlDpcX0xOWeuXeq9MTlvrq8TfTE5a6cbLtb9w3b9+fnrDUxbO3pics9c2Tb6cnLPXw9rbvz6enx+kJS+12Z9MTltr22wEAgGtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9q8//8b0hqUe3H44PWGpR798OT1hqYdn2/5Geu6lP05PWOpkt5+esNTl1cX0hKVeOrk/PWGp/Qun0xOWune67fM7Px6mJyx193CcnrDUtt/uAABcOwIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDUfrfbdoM+Ofw4PWGpO/t70xOWunxwf3rCUo8e/2N6wlJn54fpCUu9/cJb0xOWOuynF6z169Ofpycsde902/fnT0//Mz1hrWdfnl6w1LbrEwCAa0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2l1++uer6RFLHY/TC+B/u+EbkGts6/fn1p8/5/f/bePnt/HTAwDguhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9q9+9vn0hqX2t/bTE5Z69M/vpics9Zc/vTM9YakP//7v6QlLvff6i9MTlvrbJ19NT1jqg/ffnJ6w1EdfPJ6esNQfHtyenrDUv54cpics9e5rd6cnLOUfUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU7v/z4anrESifnh+kJa928Nb1grcPZ9IK19hs/v5P99IK1ro7TC9Y6/216wVq7jf8Hc2Pbz9/5btvP382Li+kJS2386QMA4LoRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPYn3389vWGtq+P0grV22/6GuDr7aXrCUru796cnrHV5mF6w1nHj98vW78/TO9ML1jr/bXrBUjdP9tMT1jqcTS9Yatv1AgDAtSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI/RcUuXuq55miFwAAAABJRU5ErkJggg==" id="image7172971adf" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+ElEQVR4nO3YTY6lZR2H4T5Vp6uLQpqPJtgBYxwYHTEwsgJX4EIYMWQD7MGZI1fgwJGJEwaEhJlONK0mBgE/wLaoPlV9yhUwIs/9L99c1wp+yfN+3O+7O/7jl7f3tuxwOb1grd3J9IK1jjfTC9ba+vndHKYXrHXxyvSCtZ49nV7At3F6Nr1gra1fn2cX0wuW2vjbDwCAu0aAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2n98/WR6w1Ln98+mJyx1dXOYnrDU45ceT09Y6slXf52esNTJ6ba/cX94/sr0hKWePzifnrDUn//zl+kJS735wrafn8/OjtMTltrtLqcnLLXttwMAAHeOAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7b/30venNyz1+vmb0xOW+vTyyfSEpd76ej89YanvPHp7esJSp7ttn9/x3nF6wlIP711MT1jq9OG2r8+XH7w+PWGp6+NhesJSLx62/XzxBxQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtT/d7ac3LPXV4Z/TE5a62D+cnrDU80evTU9Y6tMvP5mesNTTw9X0hKV++uo70xOWOpxOL1jr6tnl9ISlXp4esNi/n302PWGtB29ML1jKH1AAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1O757967nR6x1PE4vQC+2YlvQO6wrT8/t37/Ob//bxs/v42fHgAAd40ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtf/uR3+Y3rDUyX7bjf3Z7z+fnrDUL979yfSEpT748O/TE5b62Q9enZ6w1K9++6fpCUu9//MfTU9Y6td//HJ6wlI/fnQxPWGpz/97PT1hqXcevzA9Yalt1xkAAHeOAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7a6f/+Z2esRKp9eH6Qlr3T+fXrDW4XJ6wVpnF9ML1tpt/Bv39ji9YK3rq+kFa239+jzZTy9Y6nq37fvv/s3N9ISlNn73AQBw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS+9N//W16w1rH4/SCtU42/g1xuJxesNb+fHrBUrdPv5iesNTu4RvTE9a6ejq9YK3jzfSCtc4uphcsdf924+/3jdt4vQAAcNcIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUv8DXtR4oM4hskwAAAAASUVORK5CYII=" id="imagef7163c67df" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m1cd5c4f25e" d="M 0 0 
+       <path id="m74533dfd73" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m1cd5c4f25e" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74533dfd73" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m42b1d9905e" d="M 0 0 
+       <path id="m1abe87e6a1" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m42b1d9905e" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1abe87e6a1" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m42b1d9905e" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1abe87e6a1" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m42b1d9905e" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1abe87e6a1" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m42b1d9905e" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1abe87e6a1" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m42b1d9905e" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1abe87e6a1" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m42b1d9905e" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1abe87e6a1" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m42b1d9905e" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1abe87e6a1" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m42b1d9905e" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1abe87e6a1" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,121 +1138,9 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- -45 -->
+    <!-- -38 -->
     <g transform="translate(110.506785 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -47 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -45 -->
-    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -63 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1285,153 +1173,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -43 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -49 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -50 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -53 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -43 -->
-    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -52 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -47 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -58 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1473,12 +1214,247 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_22">
+    <!-- -39 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -38 -->
+    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -49 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -40 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -64 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -37 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -50 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -55 -->
+    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -44 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -46 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -47 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_33">
-    <!-- +6 -->
+    <!-- +7 -->
     <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1498,7 +1474,7 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_34">
@@ -1533,25 +1509,25 @@ z
     </g>
    </g>
    <g id="text_36">
-    <!-- -16 -->
+    <!-- -15 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- -5 -->
+    <!-- -4 -->
     <g transform="translate(273.684192 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- -1 -->
-    <g transform="translate(313.961591 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    <!-- +0 -->
+    <g transform="translate(312.410731 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_39">
@@ -1594,27 +1570,53 @@ z
    <g id="text_44">
     <!-- -12 -->
     <g transform="translate(553.558169 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +255 -->
+    <!-- +257 -->
     <g transform="translate(106.888113 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- +245 -->
+    <!-- +252 -->
     <g transform="translate(147.165512 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_47">
@@ -1627,21 +1629,21 @@ z
     </g>
    </g>
    <g id="text_48">
-    <!-- +131 -->
+    <!-- +133 -->
     <g transform="translate(227.720309 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +235 -->
+    <!-- +238 -->
     <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
@@ -1654,57 +1656,57 @@ z
     </g>
    </g>
    <g id="text_51">
-    <!-- +279 -->
+    <!-- +280 -->
     <g transform="translate(348.552505 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
-    <!-- +155 -->
+    <!-- +153 -->
     <g transform="translate(388.829903 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_53">
-    <!-- +220 -->
+    <!-- +219 -->
     <g transform="translate(429.107302 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_54">
-    <!-- +191 -->
+    <!-- +187 -->
     <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_55">
-    <!-- +211 -->
+    <!-- +205 -->
     <g transform="translate(509.662099 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_56">
-    <!-- +160 -->
+    <!-- +159 -->
     <g transform="translate(549.939498 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_57">
@@ -1805,58 +1807,58 @@ z
     </g>
    </g>
    <g id="text_69">
-    <!-- +31 -->
+    <!-- +32 -->
     <g transform="translate(108.955926 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_70">
-    <!-- +26 -->
-    <g transform="translate(149.233324 216.896366) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_71">
-    <!-- +28 -->
-    <g transform="translate(189.510723 216.896366) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_72">
-    <!-- +5 -->
-    <g transform="translate(231.855934 216.896366) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_73">
-    <!-- +62 -->
-    <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_70">
+    <!-- +27 -->
+    <g transform="translate(149.233324 216.896366) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_71">
+    <!-- +29 -->
+    <g transform="translate(189.510723 216.896366) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_72">
+    <!-- +6 -->
+    <g transform="translate(231.855934 216.896366) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_73">
+    <!-- +64 -->
+    <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_74">
-    <!-- +75 -->
+    <!-- +77 -->
     <g transform="translate(310.342919 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_75">
-    <!-- -12 -->
+    <!-- -11 -->
     <g transform="translate(352.171177 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_76">
@@ -1868,11 +1870,11 @@ z
     </g>
    </g>
    <g id="text_77">
-    <!-- +46 -->
+    <!-- +47 -->
     <g transform="translate(431.175114 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_78">
@@ -1900,18 +1902,18 @@ z
     </g>
    </g>
    <g id="text_81">
-    <!-- +35 -->
+    <!-- +36 -->
     <g transform="translate(108.955926 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_82">
-    <!-- +4 -->
+    <!-- +5 -->
     <g transform="translate(151.301137 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_83">
@@ -1923,35 +1925,35 @@ z
     </g>
    </g>
    <g id="text_84">
-    <!-- -40 -->
+    <!-- -39 -->
     <g transform="translate(231.338981 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_85">
-    <!-- +24 -->
+    <!-- +25 -->
     <g transform="translate(270.06552 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_86">
-    <!-- +19 -->
+    <!-- +20 -->
     <g transform="translate(310.342919 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_87">
-    <!-- +22 -->
+    <!-- +23 -->
     <g transform="translate(350.620317 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_88">
@@ -1963,19 +1965,19 @@ z
     </g>
    </g>
    <g id="text_89">
-    <!-- +32 -->
+    <!-- +34 -->
     <g transform="translate(431.175114 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_90">
-    <!-- +12 -->
+    <!-- +11 -->
     <g transform="translate(471.452513 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_91">
@@ -1995,19 +1997,19 @@ z
     </g>
    </g>
    <g id="text_93">
-    <!-- +77 -->
+    <!-- +78 -->
     <g transform="translate(108.955926 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_94">
-    <!-- +68 -->
+    <!-- +69 -->
     <g transform="translate(149.233324 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
@@ -2019,35 +2021,35 @@ z
     </g>
    </g>
    <g id="text_96">
-    <!-- +43 -->
+    <!-- +44 -->
     <g transform="translate(229.788122 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_97">
-    <!-- +86 -->
+    <!-- +87 -->
     <g transform="translate(270.06552 290.567931) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_98">
+    <!-- +86 -->
+    <g transform="translate(310.342919 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_98">
-    <!-- +84 -->
-    <g transform="translate(310.342919 290.567931) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
    <g id="text_99">
-    <!-- +33 -->
+    <!-- +34 -->
     <g transform="translate(350.620317 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_100">
@@ -2059,11 +2061,11 @@ z
     </g>
    </g>
    <g id="text_101">
-    <!-- +81 -->
+    <!-- +83 -->
     <g transform="translate(431.175114 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_102">
@@ -2075,19 +2077,19 @@ z
     </g>
    </g>
    <g id="text_103">
-    <!-- +58 -->
+    <!-- +59 -->
     <g transform="translate(511.729912 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_104">
-    <!-- +56 -->
+    <!-- +57 -->
     <g transform="translate(552.00731 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_105">
@@ -2115,11 +2117,11 @@ z
     </g>
    </g>
    <g id="text_108">
-    <!-- -49 -->
+    <!-- -48 -->
     <g transform="translate(231.338981 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_109">
@@ -2139,11 +2141,11 @@ z
     </g>
    </g>
    <g id="text_111">
-    <!-- -35 -->
+    <!-- -34 -->
     <g transform="translate(352.171177 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_112">
@@ -2155,11 +2157,11 @@ z
     </g>
    </g>
    <g id="text_113">
-    <!-- -49 -->
+    <!-- -48 -->
     <g transform="translate(432.725974 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_114">
@@ -2197,23 +2199,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image56c3c682f6" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image6930ffc5bb" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m339af26341" d="M 0 0 
+       <path id="m9ca4d7886c" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m339af26341" x="601.779688" y="320.934248" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ca4d7886c" x="601.779688" y="320.990988" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
       <!-- −3 -->
-      <g transform="translate(608.779688 324.733467) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 324.790207) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2231,12 +2233,12 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m339af26341" x="601.779688" y="279.517792" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ca4d7886c" x="601.779688" y="279.555619" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
       <!-- −2 -->
-      <g transform="translate(608.779688 283.317011) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 283.354838) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2245,12 +2247,12 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m339af26341" x="601.779688" y="238.101337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ca4d7886c" x="601.779688" y="238.12025" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
       <!-- −1 -->
-      <g transform="translate(608.779688 241.900555) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 241.919469) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2259,7 +2261,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m339af26341" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ca4d7886c" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2272,12 +2274,12 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m339af26341" x="601.779688" y="155.268425" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ca4d7886c" x="601.779688" y="155.249512" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
       <!-- 1 -->
-      <g transform="translate(608.779688 159.067644) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 159.04873) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2285,12 +2287,12 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m339af26341" x="601.779688" y="113.851969" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ca4d7886c" x="601.779688" y="113.814142" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
       <!-- 2 -->
-      <g transform="translate(608.779688 117.651188) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 117.613361) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2298,12 +2300,12 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m339af26341" x="601.779688" y="72.435513" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9ca4d7886c" x="601.779688" y="72.378773" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
       <!-- 3 -->
-      <g transform="translate(608.779688 76.234732) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 76.177992) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2914,8 +2916,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.074844 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.763672 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3007,13 +3009,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3052,109 +3054,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd2c1437810">
+  <clipPath id="p26b8072c30">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m224eef2a4f" d="M 0 0 
+       <path id="m9f8a5260db" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m224eef2a4f" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f8a5260db" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m224eef2a4f" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f8a5260db" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m224eef2a4f" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f8a5260db" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m224eef2a4f" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f8a5260db" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m224eef2a4f" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f8a5260db" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m224eef2a4f" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f8a5260db" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m224eef2a4f" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9f8a5260db" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,23 +854,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 368.095486 
-L 637.2 368.095486 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 368.094456 
+L 637.2 368.094456 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m5243c90bac" d="M 0 0 
+       <path id="med1f71fa97" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5243c90bac" x="49.078125" y="368.095486" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#med1f71fa97" x="49.078125" y="368.094456" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 371.894705) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 371.893674) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -895,18 +895,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 243.514978 
-L 637.2 243.514978 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.509386 
+L 637.2 243.509386 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5243c90bac" x="49.078125" y="243.514978" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#med1f71fa97" x="49.078125" y="243.509386" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 247.314197) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 247.308605) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -915,18 +915,18 @@ L 637.2 243.514978
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 118.93447 
-L 637.2 118.93447 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 118.924317 
+L 637.2 118.924317 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5243c90bac" x="49.078125" y="118.93447" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#med1f71fa97" x="49.078125" y="118.924317" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 122.733688) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 122.723536) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -935,282 +935,282 @@ L 637.2 118.93447
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 405.597956 
-L 637.2 405.597956 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 405.598299 
+L 637.2 405.598299 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m3cfac4c507" d="M 0 0 
+       <path id="m0a3d7e3679" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="405.597956" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="405.598299" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 395.733516 
-L 637.2 395.733516 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 395.733497 
+L 637.2 395.733497 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="395.733516" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="395.733497" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 387.393251 
-L 637.2 387.393251 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 387.392927 
+L 637.2 387.392927 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="387.393251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="387.392927" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 380.168585 
-L 637.2 380.168585 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.167996 
+L 637.2 380.167996 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="380.168585" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="380.167996" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 373.795977 
-L 637.2 373.795977 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 373.795156 
+L 637.2 373.795156 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="373.795977" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="373.795156" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 330.593016 
-L 637.2 330.593016 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.590613 
+L 637.2 330.590613 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="330.593016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="330.590613" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 308.655478 
-L 637.2 308.655478 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 308.652271 
+L 637.2 308.652271 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="308.655478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="308.652271" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 293.090546 
-L 637.2 293.090546 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 293.08677 
+L 637.2 293.08677 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="293.090546" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="293.08677" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 281.017448 
-L 637.2 281.017448 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 281.013229 
+L 637.2 281.013229 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="281.017448" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="281.013229" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 271.153008 
-L 637.2 271.153008 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.148428 
+L 637.2 271.148428 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="271.153008" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="271.148428" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 262.812743 
-L 637.2 262.812743 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.807858 
+L 637.2 262.807858 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="262.812743" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="262.807858" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 255.588076 
-L 637.2 255.588076 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.582927 
+L 637.2 255.582927 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="255.588076" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="255.582927" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 249.215469 
-L 637.2 249.215469 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.210086 
+L 637.2 249.210086 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="249.215469" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="249.210086" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 206.012508 
-L 637.2 206.012508 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 206.005543 
+L 637.2 206.005543 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="206.012508" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="206.005543" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 184.074969 
-L 637.2 184.074969 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 184.067202 
+L 637.2 184.067202 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="184.074969" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="184.067202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 168.510038 
-L 637.2 168.510038 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 168.5017 
+L 637.2 168.5017 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="168.510038" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="168.5017" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 156.436939 
-L 637.2 156.436939 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 156.42816 
+L 637.2 156.42816 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="156.436939" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="156.42816" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 146.5725 
-L 637.2 146.5725 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.563359 
+L 637.2 146.563359 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="146.5725" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="146.563359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 138.232234 
-L 637.2 138.232234 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 138.222788 
+L 637.2 138.222788 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="138.232234" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="138.222788" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 131.007568 
-L 637.2 131.007568 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 130.997857 
+L 637.2 130.997857 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="131.007568" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="130.997857" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 124.634961 
-L 637.2 124.634961 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 124.625017 
+L 637.2 124.625017 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="124.634961" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="124.625017" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 81.432 
-L 637.2 81.432 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 81.420474 
+L 637.2 81.420474 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="81.432" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="81.420474" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 59.494461 
-L 637.2 59.494461 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 59.482132 
+L 637.2 59.482132 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m3cfac4c507" x="49.078125" y="59.494461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0a3d7e3679" x="49.078125" y="59.482132" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(292.62732 162.108449) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(292.62732 162.051943) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 370.528992) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 371.184435) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1693,124 +1693,124 @@ z
     </g>
    </g>
    <g id="line2d_67">
-    <path d="M 377.110281 104.391138 
-L 323.801439 110.203287 
-L 272.665744 126.045731 
-L 235.168828 127.593835 
-L 186.228265 149.028964 
-L 158.303164 171.270867 
-L 149.489547 181.98161 
-L 140.563162 202.351012 
-L 138.984853 209.277481 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 377.110281 104.911856 
+L 323.801439 110.575431 
+L 272.665744 126.520079 
+L 235.168828 128.081722 
+L 186.228265 149.433593 
+L 158.303164 171.536947 
+L 149.489547 182.243656 
+L 140.563162 202.555128 
+L 138.984853 209.414141 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md0d172f3d7" d="M -2.5 2.5 
+     <path id="m6c2c128fa1" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd292e4bb55)">
-     <use xlink:href="#md0d172f3d7" x="377.110281" y="104.391138" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d172f3d7" x="323.801439" y="110.203287" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d172f3d7" x="272.665744" y="126.045731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d172f3d7" x="235.168828" y="127.593835" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d172f3d7" x="186.228265" y="149.028964" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d172f3d7" x="158.303164" y="171.270867" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d172f3d7" x="149.489547" y="181.98161" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d172f3d7" x="140.563162" y="202.351012" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md0d172f3d7" x="138.984853" y="209.277481" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5533f3772f)">
+     <use xlink:href="#m6c2c128fa1" x="377.110281" y="104.911856" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c2c128fa1" x="323.801439" y="110.575431" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c2c128fa1" x="272.665744" y="126.520079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c2c128fa1" x="235.168828" y="128.081722" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c2c128fa1" x="186.228265" y="149.433593" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c2c128fa1" x="158.303164" y="171.536947" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c2c128fa1" x="149.489547" y="182.243656" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c2c128fa1" x="140.563162" y="202.555128" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c2c128fa1" x="138.984853" y="209.414141" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 610.467187 72.524581 
-L 319.880958 101.728242 
-L 210.281253 129.683647 
-L 196.287076 133.431152 
-L 176.054419 147.356758 
-L 152.161413 174.758772 
-L 146.720208 186.571841 
-L 143.994022 196.316094 
-L 142.666037 200.148909 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467187 72.783769 
+L 319.880958 101.93596 
+L 210.281253 129.848445 
+L 196.287076 133.742413 
+L 176.054419 147.544128 
+L 152.161413 174.89224 
+L 146.720208 186.684946 
+L 143.994022 196.417999 
+L 142.666037 200.286049 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m020dddbb6b" d="M 0 -2.5 
+     <path id="me8bf5921a5" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd292e4bb55)">
-     <use xlink:href="#m020dddbb6b" x="610.467187" y="72.524581" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m020dddbb6b" x="319.880958" y="101.728242" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m020dddbb6b" x="210.281253" y="129.683647" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m020dddbb6b" x="196.287076" y="133.431152" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m020dddbb6b" x="176.054419" y="147.356758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m020dddbb6b" x="152.161413" y="174.758772" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m020dddbb6b" x="146.720208" y="186.571841" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m020dddbb6b" x="143.994022" y="196.316094" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m020dddbb6b" x="142.666037" y="200.148909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5533f3772f)">
+     <use xlink:href="#me8bf5921a5" x="610.467187" y="72.783769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8bf5921a5" x="319.880958" y="101.93596" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8bf5921a5" x="210.281253" y="129.848445" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8bf5921a5" x="196.287076" y="133.742413" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8bf5921a5" x="176.054419" y="147.544128" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8bf5921a5" x="152.161413" y="174.89224" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8bf5921a5" x="146.720208" y="186.684946" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8bf5921a5" x="143.994022" y="196.417999" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me8bf5921a5" x="142.666037" y="200.286049" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <path d="M 292.033351 64.890426 
-L 242.839153 80.480439 
-L 218.251194 86.014806 
-L 197.814984 89.997741 
-L 166.378359 98.587012 
-L 145.830392 110.01759 
-L 134.598477 125.768606 
-L 124.077268 148.876447 
-L 122.462976 156.979282 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 242.839153 80.619559 
+L 218.251194 86.000655 
+L 197.814984 90.069865 
+L 166.378359 98.986137 
+L 145.830392 110.284604 
+L 134.598477 126.051516 
+L 124.077268 149.014931 
+L 122.462976 157.16811 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m40a0c4fa26" d="M -0 3.535534 
+     <path id="mea3ea56ac0" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd292e4bb55)">
-     <use xlink:href="#m40a0c4fa26" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a0c4fa26" x="242.839153" y="80.480439" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a0c4fa26" x="218.251194" y="86.014806" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a0c4fa26" x="197.814984" y="89.997741" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a0c4fa26" x="166.378359" y="98.587012" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a0c4fa26" x="145.830392" y="110.01759" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a0c4fa26" x="134.598477" y="125.768606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a0c4fa26" x="124.077268" y="148.876447" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40a0c4fa26" x="122.462976" y="156.979282" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5533f3772f)">
+     <use xlink:href="#mea3ea56ac0" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea3ea56ac0" x="242.839153" y="80.619559" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea3ea56ac0" x="218.251194" y="86.000655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea3ea56ac0" x="197.814984" y="90.069865" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea3ea56ac0" x="166.378359" y="98.986137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea3ea56ac0" x="145.830392" y="110.284604" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea3ea56ac0" x="134.598477" y="126.051516" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea3ea56ac0" x="124.077268" y="149.014931" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea3ea56ac0" x="122.462976" y="157.16811" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mde5cf0bd64" d="M -0 2.5 
+     <path id="ma8dc9e0875" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd292e4bb55)">
-     <use xlink:href="#mde5cf0bd64" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5533f3772f)">
+     <use xlink:href="#ma8dc9e0875" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
-    <path d="M 432.495268 103.747894 
-L 300.62247 118.094143 
-L 266.967623 125.752499 
-L 226.040946 126.221492 
-L 180.985721 144.145532 
-L 164.441833 158.518967 
-L 157.761315 167.060702 
-L 151.269082 181.300035 
-L 150.327087 187.035947 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 432.495268 103.737185 
+L 300.62247 118.083959 
+L 266.967623 125.742596 
+L 226.040946 126.211606 
+L 180.985721 144.136302 
+L 164.441833 158.510263 
+L 157.761315 167.052311 
+L 151.269082 181.292165 
+L 150.327087 187.028288 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me81b3c870e" d="M -0.833333 2.5 
+     <path id="m3abe6d6fcc" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,31 +1825,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd292e4bb55)">
-     <use xlink:href="#me81b3c870e" x="432.495268" y="103.747894" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me81b3c870e" x="300.62247" y="118.094143" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me81b3c870e" x="266.967623" y="125.752499" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me81b3c870e" x="226.040946" y="126.221492" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me81b3c870e" x="180.985721" y="144.145532" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me81b3c870e" x="164.441833" y="158.518967" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me81b3c870e" x="157.761315" y="167.060702" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me81b3c870e" x="151.269082" y="181.300035" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me81b3c870e" x="150.327087" y="187.035947" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5533f3772f)">
+     <use xlink:href="#m3abe6d6fcc" x="432.495268" y="103.737185" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3abe6d6fcc" x="300.62247" y="118.083959" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3abe6d6fcc" x="266.967623" y="125.742596" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3abe6d6fcc" x="226.040946" y="126.211606" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3abe6d6fcc" x="180.985721" y="144.136302" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3abe6d6fcc" x="164.441833" y="158.510263" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3abe6d6fcc" x="157.761315" y="167.052311" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3abe6d6fcc" x="151.269082" y="181.292165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3abe6d6fcc" x="150.327087" y="187.028288" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
-    <path d="M 345.030867 135.154118 
-L 273.364924 141.958777 
-L 240.719951 147.997792 
-L 221.353978 153.310468 
-L 207.129625 155.25199 
-L 181.064802 166.749271 
-L 179.282169 170.34322 
-L 177.719335 175.716295 
-L 177.643939 181.088361 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 345.030867 135.144559 
+L 273.364924 141.949468 
+L 240.719951 147.988703 
+L 221.353978 153.301573 
+L 207.129625 155.243167 
+L 181.064802 166.740869 
+L 179.282169 170.33495 
+L 177.719335 175.708221 
+L 177.643939 181.080484 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9747e96383" d="M -1.25 2.5 
+     <path id="m43c4855600" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,31 +1864,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd292e4bb55)">
-     <use xlink:href="#m9747e96383" x="345.030867" y="135.154118" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9747e96383" x="273.364924" y="141.958777" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9747e96383" x="240.719951" y="147.997792" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9747e96383" x="221.353978" y="153.310468" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9747e96383" x="207.129625" y="155.25199" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9747e96383" x="181.064802" y="166.749271" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9747e96383" x="179.282169" y="170.34322" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9747e96383" x="177.719335" y="175.716295" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9747e96383" x="177.643939" y="181.088361" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5533f3772f)">
+     <use xlink:href="#m43c4855600" x="345.030867" y="135.144559" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m43c4855600" x="273.364924" y="141.949468" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m43c4855600" x="240.719951" y="147.988703" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m43c4855600" x="221.353978" y="153.301573" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m43c4855600" x="207.129625" y="155.243167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m43c4855600" x="181.064802" y="166.740869" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m43c4855600" x="179.282169" y="170.33495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m43c4855600" x="177.719335" y="175.708221" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m43c4855600" x="177.643939" y="181.080484" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
-    <path d="M 226.871027 113.151264 
-L 226.871027 113.175348 
-L 226.871027 113.32385 
-L 226.871027 113.232532 
-L 177.768423 132.166507 
-L 160.37503 145.356614 
-L 153.995779 152.489967 
-L 147.106887 167.695749 
-L 145.871703 174.967742 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 226.871027 113.1409 
+L 226.871027 113.164985 
+L 226.871027 113.313492 
+L 226.871027 113.22217 
+L 177.768423 132.156838 
+L 160.37503 145.347429 
+L 153.995779 152.481042 
+L 147.106887 167.687381 
+L 145.871703 174.959641 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m883388886a" d="M 0 -2.5 
+     <path id="m8de2f032c6" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,31 +1901,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pd292e4bb55)">
-     <use xlink:href="#m883388886a" x="226.871027" y="113.151264" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m883388886a" x="226.871027" y="113.175348" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m883388886a" x="226.871027" y="113.32385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m883388886a" x="226.871027" y="113.232532" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m883388886a" x="177.768423" y="132.166507" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m883388886a" x="160.37503" y="145.356614" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m883388886a" x="153.995779" y="152.489967" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m883388886a" x="147.106887" y="167.695749" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m883388886a" x="145.871703" y="174.967742" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p5533f3772f)">
+     <use xlink:href="#m8de2f032c6" x="226.871027" y="113.1409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8de2f032c6" x="226.871027" y="113.164985" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8de2f032c6" x="226.871027" y="113.313492" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8de2f032c6" x="226.871027" y="113.22217" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8de2f032c6" x="177.768423" y="132.156838" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8de2f032c6" x="160.37503" y="145.347429" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8de2f032c6" x="153.995779" y="152.481042" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8de2f032c6" x="147.106887" y="167.687381" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8de2f032c6" x="145.871703" y="174.959641" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
-    <path d="M 585.66883 174.431162 
-L 527.144592 176.495916 
-L 457.339427 184.579548 
-L 292.124837 179.274159 
-L 243.129344 190.954641 
-L 213.541392 204.889391 
-L 204.551957 212.504047 
-L 195.860087 228.932983 
-L 194.019853 234.446928 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 585.66883 174.423041 
+L 527.144592 176.48787 
+L 457.339427 184.571799 
+L 292.124837 179.266215 
+L 243.129344 190.947125 
+L 213.541392 204.882385 
+L 204.551957 212.49732 
+L 195.860087 228.926857 
+L 194.019853 234.441004 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m653b3c45b0" d="M 0 -2.5 
+     <path id="mf96895c333" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd292e4bb55)">
-     <use xlink:href="#m653b3c45b0" x="585.66883" y="174.431162" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m653b3c45b0" x="527.144592" y="176.495916" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m653b3c45b0" x="457.339427" y="184.579548" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m653b3c45b0" x="292.124837" y="179.274159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m653b3c45b0" x="243.129344" y="190.954641" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m653b3c45b0" x="213.541392" y="204.889391" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m653b3c45b0" x="204.551957" y="212.504047" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m653b3c45b0" x="195.860087" y="228.932983" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m653b3c45b0" x="194.019853" y="234.446928" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5533f3772f)">
+     <use xlink:href="#mf96895c333" x="585.66883" y="174.423041" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf96895c333" x="527.144592" y="176.48787" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf96895c333" x="457.339427" y="184.571799" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf96895c333" x="292.124837" y="179.266215" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf96895c333" x="243.129344" y="190.947125" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf96895c333" x="213.541392" y="204.882385" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf96895c333" x="204.551957" y="212.49732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf96895c333" x="195.860087" y="228.926857" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf96895c333" x="194.019853" y="234.441004" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m0881d40586" d="M 0 3.5 
+      <path id="m2ccfa4ff70" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m0881d40586" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m2ccfa4ff70" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md0d172f3d7" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6c2c128fa1" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m020dddbb6b" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me8bf5921a5" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m40a0c4fa26" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mea3ea56ac0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mde5cf0bd64" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma8dc9e0875" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me81b3c870e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3abe6d6fcc" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9747e96383" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m43c4855600" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m883388886a" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m8de2f032c6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m653b3c45b0" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf96895c333" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 287.62732 167.108449 
-L 253.661767 172.302702 
-L 230.111105 177.486697 
-L 195.337271 196.421643 
-L 190.545203 199.822777 
-L 182.839694 208.616652 
-L 155.420659 253.828387 
-L 153.649656 258.139219 
-L 95.319203 375.528992 
-" clip-path="url(#pd292e4bb55)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pd292e4bb55)">
-     <use xlink:href="#m0881d40586" x="287.62732" y="167.108449" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0881d40586" x="253.661767" y="172.302702" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0881d40586" x="230.111105" y="177.486697" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0881d40586" x="195.337271" y="196.421643" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0881d40586" x="190.545203" y="199.822777" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0881d40586" x="182.839694" y="208.616652" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0881d40586" x="155.420659" y="253.828387" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0881d40586" x="153.649656" y="258.139219" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0881d40586" x="95.319203" y="375.528992" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 287.62732 167.051943 
+L 253.661767 175.8127 
+L 230.111105 180.539221 
+L 201.85576 192.323346 
+L 197.114151 194.8929 
+L 189.167523 205.247277 
+L 155.420659 255.586582 
+L 153.649656 262.02238 
+L 95.319203 376.184435 
+" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p5533f3772f)">
+     <use xlink:href="#m2ccfa4ff70" x="287.62732" y="167.051943" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2ccfa4ff70" x="253.661767" y="175.8127" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2ccfa4ff70" x="230.111105" y="180.539221" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2ccfa4ff70" x="201.85576" y="192.323346" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2ccfa4ff70" x="197.114151" y="194.8929" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2ccfa4ff70" x="189.167523" y="205.247277" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2ccfa4ff70" x="155.420659" y="255.586582" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2ccfa4ff70" x="153.649656" y="262.02238" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2ccfa4ff70" x="95.319203" y="376.184435" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.074844 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.763672 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2912,36 +2912,6 @@ Q 953 2441 691 2322
 L 691 4666 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -2983,13 +2953,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3028,109 +2998,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd292e4bb55">
+  <clipPath id="p5533f3772f">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p06274544d0)">
+   <g clip-path="url(#pcb12790487)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKBUlEQVR4nO3Yz4qddx3H8TOdSRMyaSYJGotVFFPcxOpGkLpw1ZXowhtw0ytw48qVeAeuvAHBhRQ3QjZdFqr1X8WFxaqlKiE2TRrTmEwmc7yC90Lqj68cXq8r+MA5fJ/38+yd3vzRdrODjn98Y3rCEmdeemF6wjJ7Vz85PWGJ7W9/Nz1hib0vXp+esMT2wb3pCcvc+u4r0xOWuPqDb0xPWGLvyiemJ6xx/GB6wTKnv9jNe//U9AAAAP5/iUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLev45f2U6PWOHw/VvTE5Z47+L56QnL/Pvk/vSEJT79wfH0hCU++Piz0xOWON2eTk9Y5vLBlekJa9z+6/SCJe5d3s3f65m//HF6wjLbz39lesISviwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJAODm/fnN6wxvlL0wuW2G6Ppycs86lX35iesMZLX59esMTRe/+YnrDG6cn0gnUOd/R+nL0wvWCJi//czefznc9cm56wzOV335yesIQviwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDae/zkxnZ6xAr7t/48PWGJm888PT1hmfuP705PWOLaO3enJyxx8oWvTk9Y4sHJvekJyxztX5qesMT27V9OT1ji4edemJ6wxLk3X5+esMyjL704PWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPezt7+znR6xwpVzh9MTlnjr7u3pCcu8/MNfT09Y4jff/+b0hCWOzh5NT1jie6/9anrCMl977tz0hCW+de3F6QlLvPq316cnLHHhzG7+Dzebzeanf7ozPWEJXxYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPf4yY3t9IgV7jy6NT1hicODi9MTlnnr7u+nJyzx/KXr0xOW2G5PpycsceFkd9+h/366m3fxucPnpycs8fDJg+kJS+zq7dhsNpv9pw6mJyyxu1cRAICPTCwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6WB/72B6wxIf278yPWGN/aenFyxzdPZoesIShwcXpycs8WR7Mj1hidMzu/sO/ez2/PQE/gu7+nw+3j6cnrDMvUe3picssbtXEQCAj0wsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQDjYfvj+9YYntH96YnrDE3vUvT09Y5rMf7ui7y7mH0wuW2D89mZ6wxo7exM1ms3n8k59PT1hi/+VvT09Y4sz2dHrCEvc3u3kTN5vN5uo7705PWGJHn84AAPwviEUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANJ/AJkNm8+5AYuWAAAAAElFTkSuQmCC" id="image90271cbc7c" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKAElEQVR4nO3Yu45eVx2H4ZnMOLY8jse2wEQEFCmOaEKgQUIBQZUKQcE1IC4ACioqxB1Q0VDSoSgFhZuURAFiIFRECQdxkDXY+IBl7PF4Pq7gLVC09EefnucKftLeWvvda/f05o83O1vo+KfXpycsceb1V6cnLLN79ZPTE5bY/PZ30xOW2P3cK9MTltg8vD89YZmj770xPWGJqz/8+vSEJXavfGJ6whrHD6cXLHP6y+0875+ZHgAAwP8vsQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQNr99/Ebm+kRKxz862h6whK3Lp6fnrDMf04eTE9Y4tP3jqcnLHHv489PT1jidHM6PWGZy/tXpiescfvP0wuWuH95O5/Xc3/6w/SEZTaf+eL0hCXcLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPYPbt+c3rDG+UvTC5bYbI6nJyzzqbd+PT1hjde/Nr1gicNb/5iesMbpyfSCdQ629Pw4e2F6wRIX/7md3+c7L16bnrDM5b++Nz1hCTeLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQNp98vT6ZnrECntHf5yesMTN556dnrDMgyd3pycsce0vd6cnLHHy2S9NT1ji4cn96QnLHO5dmp6wxObDX01PWOLRS69OT1ji3HvvTE9Y5vHnX5uesISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDtvvnhdzbTI1a4cu5gesIS79+9PT1hmW/96Mb0hCV+84NvTE9Y4vDs4fSEJb7/i3enJyzz1RfOTU9Y4pvXXpuesMRbf3tnesISF85s53u4s7Oz87MP7kxPWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2nzy9vpkescKdx0fTE5Y42L84PWGZ9+/+fnrCEi9femV6whKbzen0hCUunGzvP/TfT7fzXHzh4OXpCUs8evpwesIS23p27Ozs7Ow9sz89YYntPRUBAPjIxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQ9vd296c3LPGxvSvTE9bYe3Z6wTKHZw+nJyxxsH9xesISTzcn0xOWOD2zvf/Qz2/OT0/gf7Ct3+fjzaPpCcvcf3w0PWGJ7T0VAQD4yMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABpf+fBrekNS2xuvD09YYndL3xlesIyL777wfSENb780vSCJfZOT6YnrHHv5vSCZR7/5OfTE5bY++63pycsceb44fSEJR6cOZ2esMzVt29MT1jCzSIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQ/gunYJutB18TSwAAAABJRU5ErkJggg==" id="imaged85a415faf" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m39dfe71dff" d="M 0 0 
+       <path id="mf18e863ea9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m39dfe71dff" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m39dfe71dff" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m39dfe71dff" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m39dfe71dff" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m39dfe71dff" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m39dfe71dff" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m39dfe71dff" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m39dfe71dff" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m39dfe71dff" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m39dfe71dff" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m39dfe71dff" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m39dfe71dff" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf18e863ea9" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="ma10520c7c7" d="M 0 0 
+       <path id="m69433dd2c6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma10520c7c7" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69433dd2c6" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma10520c7c7" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69433dd2c6" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma10520c7c7" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69433dd2c6" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma10520c7c7" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69433dd2c6" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma10520c7c7" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69433dd2c6" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma10520c7c7" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69433dd2c6" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma10520c7c7" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69433dd2c6" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma10520c7c7" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69433dd2c6" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1176,31 +1176,37 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- +4 -->
+    <!-- +5 -->
     <g transform="translate(149.402701 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_23">
@@ -1211,8 +1217,29 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- +2 -->
+    <!-- +5 -->
     <g transform="translate(227.426251 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +1 -->
+    <g transform="translate(266.438026 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +1 -->
+    <g transform="translate(305.449801 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +2 -->
+    <g transform="translate(344.461576 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1239,50 +1266,6 @@ Q 1991 1309 1228 531
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +0 -->
-    <g transform="translate(266.438026 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- +1 -->
-    <g transform="translate(305.449801 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +2 -->
-    <g transform="translate(344.461576 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
@@ -1328,49 +1311,38 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- +3 -->
+    <!-- +5 -->
     <g transform="translate(539.52045 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- +0 -->
     <g transform="translate(110.390926 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
@@ -1476,6 +1448,40 @@ z
    <g id="text_48">
     <!-- -3 -->
     <g transform="translate(228.97711 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -1539,33 +1545,6 @@ z
    <g id="text_57">
     <!-- -5 -->
     <g transform="translate(111.941786 180.060583) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
@@ -1573,6 +1552,27 @@ z
    <g id="text_58">
     <!-- -4 -->
     <g transform="translate(150.953561 180.060583) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageeb8d76ba13" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image44afe5d8c1" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m9c0c03f34a" d="M 0 0 
+       <path id="m910be63ca4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9c0c03f34a" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m910be63ca4" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m9c0c03f34a" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m910be63ca4" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m9c0c03f34a" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m910be63ca4" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m9c0c03f34a" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m910be63ca4" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m9c0c03f34a" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m910be63ca4" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.074844 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.763672 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2871,13 +2871,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2916,109 +2916,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p06274544d0">
+  <clipPath id="pcb12790487">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.250313pt" height="386.202469pt" viewBox="0 0 570.250313 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.872656pt" height="386.202469pt" viewBox="0 0 570.872656 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.250313 386.202469 
-L 570.250313 0 
+L 570.872656 386.202469 
+L 570.872656 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.250156 104.1264 
-L 291.875156 104.1264 
-L 291.875156 74.7432 
-L 187.250156 74.7432 
+    <path d="M 187.561328 104.1264 
+L 292.186328 104.1264 
+L 292.186328 74.7432 
+L 187.561328 74.7432 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.875156 104.1264 
-L 396.500156 104.1264 
-L 396.500156 74.7432 
-L 291.875156 74.7432 
+    <path d="M 292.186328 104.1264 
+L 396.811328 104.1264 
+L 396.811328 74.7432 
+L 292.186328 74.7432 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.500156 104.1264 
-L 501.125156 104.1264 
-L 501.125156 74.7432 
-L 396.500156 74.7432 
+    <path d="M 396.811328 104.1264 
+L 501.436328 104.1264 
+L 501.436328 74.7432 
+L 396.811328 74.7432 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.250156 133.5096 
-L 291.875156 133.5096 
-L 291.875156 104.1264 
-L 187.250156 104.1264 
+    <path d="M 187.561328 133.5096 
+L 292.186328 133.5096 
+L 292.186328 104.1264 
+L 187.561328 104.1264 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.875156 133.5096 
-L 396.500156 133.5096 
-L 396.500156 104.1264 
-L 291.875156 104.1264 
+    <path d="M 292.186328 133.5096 
+L 396.811328 133.5096 
+L 396.811328 104.1264 
+L 292.186328 104.1264 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.500156 133.5096 
-L 501.125156 133.5096 
-L 501.125156 104.1264 
-L 396.500156 104.1264 
+    <path d="M 396.811328 133.5096 
+L 501.436328 133.5096 
+L 501.436328 104.1264 
+L 396.811328 104.1264 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.250156 162.8928 
-L 291.875156 162.8928 
-L 291.875156 133.5096 
-L 187.250156 133.5096 
+    <path d="M 187.561328 162.8928 
+L 292.186328 162.8928 
+L 292.186328 133.5096 
+L 187.561328 133.5096 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.875156 162.8928 
-L 396.500156 162.8928 
-L 396.500156 133.5096 
-L 291.875156 133.5096 
+    <path d="M 292.186328 162.8928 
+L 396.811328 162.8928 
+L 396.811328 133.5096 
+L 292.186328 133.5096 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.500156 162.8928 
-L 501.125156 162.8928 
-L 501.125156 133.5096 
-L 396.500156 133.5096 
+    <path d="M 396.811328 162.8928 
+L 501.436328 162.8928 
+L 501.436328 133.5096 
+L 396.811328 133.5096 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.250156 192.276 
-L 291.875156 192.276 
-L 291.875156 162.8928 
-L 187.250156 162.8928 
+    <path d="M 187.561328 192.276 
+L 292.186328 192.276 
+L 292.186328 162.8928 
+L 187.561328 162.8928 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.875156 192.276 
-L 396.500156 192.276 
-L 396.500156 162.8928 
-L 291.875156 162.8928 
+    <path d="M 292.186328 192.276 
+L 396.811328 192.276 
+L 396.811328 162.8928 
+L 292.186328 162.8928 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.500156 192.276 
-L 501.125156 192.276 
-L 501.125156 162.8928 
-L 396.500156 162.8928 
+    <path d="M 396.811328 192.276 
+L 501.436328 192.276 
+L 501.436328 162.8928 
+L 396.811328 162.8928 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.250156 221.6592 
-L 291.875156 221.6592 
-L 291.875156 192.276 
-L 187.250156 192.276 
+    <path d="M 187.561328 221.6592 
+L 292.186328 221.6592 
+L 292.186328 192.276 
+L 187.561328 192.276 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.875156 221.6592 
-L 396.500156 221.6592 
-L 396.500156 192.276 
-L 291.875156 192.276 
+    <path d="M 292.186328 221.6592 
+L 396.811328 221.6592 
+L 396.811328 192.276 
+L 292.186328 192.276 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.500156 221.6592 
-L 501.125156 221.6592 
-L 501.125156 192.276 
-L 396.500156 192.276 
+    <path d="M 396.811328 221.6592 
+L 501.436328 221.6592 
+L 501.436328 192.276 
+L 396.811328 192.276 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fff8b4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.250156 251.0424 
-L 291.875156 251.0424 
-L 291.875156 221.6592 
-L 187.250156 221.6592 
+    <path d="M 187.561328 251.0424 
+L 292.186328 251.0424 
+L 292.186328 221.6592 
+L 187.561328 221.6592 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.875156 251.0424 
-L 396.500156 251.0424 
-L 396.500156 221.6592 
-L 291.875156 221.6592 
+    <path d="M 292.186328 251.0424 
+L 396.811328 251.0424 
+L 396.811328 221.6592 
+L 292.186328 221.6592 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.500156 251.0424 
-L 501.125156 251.0424 
-L 501.125156 221.6592 
-L 396.500156 221.6592 
+    <path d="M 396.811328 251.0424 
+L 501.436328 251.0424 
+L 501.436328 221.6592 
+L 396.811328 221.6592 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.250156 280.4256 
-L 291.875156 280.4256 
-L 291.875156 251.0424 
-L 187.250156 251.0424 
+    <path d="M 187.561328 280.4256 
+L 292.186328 280.4256 
+L 292.186328 251.0424 
+L 187.561328 251.0424 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.875156 280.4256 
-L 396.500156 280.4256 
-L 396.500156 251.0424 
-L 291.875156 251.0424 
+    <path d="M 292.186328 280.4256 
+L 396.811328 280.4256 
+L 396.811328 251.0424 
+L 292.186328 251.0424 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.500156 280.4256 
-L 501.125156 280.4256 
-L 501.125156 251.0424 
-L 396.500156 251.0424 
+    <path d="M 396.811328 280.4256 
+L 501.436328 280.4256 
+L 501.436328 251.0424 
+L 396.811328 251.0424 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.250156 309.8088 
-L 291.875156 309.8088 
-L 291.875156 280.4256 
-L 187.250156 280.4256 
+    <path d="M 187.561328 309.8088 
+L 292.186328 309.8088 
+L 292.186328 280.4256 
+L 187.561328 280.4256 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #fdb163; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.875156 309.8088 
-L 396.500156 309.8088 
-L 396.500156 280.4256 
-L 291.875156 280.4256 
+    <path d="M 292.186328 309.8088 
+L 396.811328 309.8088 
+L 396.811328 280.4256 
+L 292.186328 280.4256 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.500156 309.8088 
-L 501.125156 309.8088 
-L 501.125156 280.4256 
-L 396.500156 280.4256 
+    <path d="M 396.811328 309.8088 
+L 501.436328 309.8088 
+L 501.436328 280.4256 
+L 396.811328 280.4256 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #ed5f3c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.250156 339.192 
-L 291.875156 339.192 
-L 291.875156 309.8088 
-L 187.250156 309.8088 
+    <path d="M 187.561328 339.192 
+L 292.186328 339.192 
+L 292.186328 309.8088 
+L 187.561328 309.8088 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.875156 339.192 
-L 396.500156 339.192 
-L 396.500156 309.8088 
-L 291.875156 309.8088 
+    <path d="M 292.186328 339.192 
+L 396.811328 339.192 
+L 396.811328 309.8088 
+L 292.186328 309.8088 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.500156 339.192 
-L 501.125156 339.192 
-L 501.125156 309.8088 
-L 396.500156 309.8088 
+    <path d="M 396.811328 339.192 
+L 501.436328 339.192 
+L 501.436328 309.8088 
+L 396.811328 309.8088 
 z
-" clip-path="url(#p26675f7d94)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p7a6707cffe)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.237422 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.548594 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.521641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.832812 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.09375 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.404922 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.445469 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.756641 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.175156 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.486328 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.111406 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -917,8 +917,8 @@ z
     </g>
    </g>
    <g id="text_7">
-    <!-- 118 -->
-    <g transform="translate(336.552656 91.6423) scale(0.08 -0.08)">
+    <!-- 117 -->
+    <g transform="translate(336.863828 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -934,6 +934,26 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- 889 -->
+    <g transform="translate(441.488828 91.6423) scale(0.08 -0.08)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -973,16 +993,6 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_8">
-    <!-- 891 -->
-    <g transform="translate(441.177656 91.6423) scale(0.08 -0.08)">
-     <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -1015,13 +1025,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.813281 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.124453 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1120,7 +1130,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.111406 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1151,7 +1161,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.097656 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1190,7 +1200,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.177656 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.488828 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1198,7 +1208,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.506406 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.817578 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1369,7 +1379,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.111406 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1406,14 +1416,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(339.097656 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(441.177656 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.488828 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1421,7 +1431,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.538906 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.850078 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1481,7 +1491,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.111406 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1491,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.097656 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(441.177656 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.488828 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1506,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.076406 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.387578 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1530,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.111406 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1540,22 +1550,22 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(339.097656 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 445 -->
-    <g transform="translate(441.177656 209.1751) scale(0.08 -0.08)">
+    <!-- 454 -->
+    <g transform="translate(441.488828 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.382656 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(111.693828 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1614,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.111406 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1624,22 +1634,22 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(339.097656 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 544 -->
-    <g transform="translate(441.177656 238.5583) scale(0.08 -0.08)">
+    <!-- 539 -->
+    <g transform="translate(441.488828 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(95.999531 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.310703 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1704,7 +1714,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.336 -->
-    <g transform="translate(228.111406 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1714,21 +1724,21 @@ z
    </g>
    <g id="text_31">
     <!-- 20 -->
-    <g transform="translate(339.097656 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.408828 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 68 -->
-    <g transform="translate(443.722656 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(444.033828 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.884531 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.195703 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1836,8 +1846,8 @@ z
     </g>
    </g>
    <g id="text_34">
-    <!-- 0.329 -->
-    <g transform="translate(226.910781 297.3247) scale(0.08 -0.08)">
+    <!-- 0.330 -->
+    <g transform="translate(227.221953 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1899,6 +1909,18 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 20 -->
+    <g transform="translate(338.932578 297.3247) scale(0.08 -0.08)">
+     <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
 L 3897 0 
@@ -1921,47 +1943,14 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
-z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-30"/>
-     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(246.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- 19 -->
-    <g transform="translate(338.621406 297.3247) scale(0.08 -0.08)">
+   <g id="text_36">
+    <!-- 100 -->
+    <g transform="translate(440.774453 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1979,41 +1968,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 104 -->
-    <g transform="translate(440.463281 297.3247) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.220781 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.531953 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2024,7 +1985,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.111406 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.422578 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2034,13 +1995,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.642656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.953828 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.812656 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.123828 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2056,7 +2017,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.726875 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(152.038047 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2200,7 +2161,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-16T01:38:48Z  ·  Linux chungus x86_64  ·  commit 5acdb3e9  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2342,13 +2303,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2387,110 +2348,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3188.134766 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3251.611328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3315.087891 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3378.710938 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3440.234375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3503.857422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3535.644531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3567.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3599.21875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3631.005859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3662.792969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3690.576172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3752.099609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3813.378906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3876.757812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3940.234375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3979.097656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4040.279297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4099.458984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4160.982422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4202.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4235.787109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4263.570312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4325.09375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4386.373047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4449.751953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4513.375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4547.066406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4606.246094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4669.869141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4701.65625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4765.279297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4828.902344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4860.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4924.3125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4960.396484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4999.259766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5054.240234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5117.863281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5149.650391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5181.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5213.224609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5245.011719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5276.798828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5316.007812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5379.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5418.25 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5479.431641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5669.666016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5733.142578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5796.521484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5835.730469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5867.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5951.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5983.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6080.505859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6142.029297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6205.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6233.289062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6294.568359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6357.947266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6389.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6441.833984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6505.212891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6566.492188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6629.96875 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6682.068359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6745.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6806.628906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6845.837891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6879.529297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6911.316406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6952.429688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7013.708984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7052.917969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7080.701172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7141.882812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7173.669922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7201.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7253.552734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7285.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7348.816406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7410.339844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7449.548828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7511.072266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7550.435547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7647.847656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7675.630859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7739.009766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7766.792969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7818.892578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7858.101562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7885.884766 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p26675f7d94">
-   <rect x="82.625156" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p7a6707cffe">
+   <rect x="82.936328" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,16571 +1,16571 @@
 {
-"meta": {
-"date": "2026-06-16T01:38:48Z",
-"machine": "Linux chungus x86_64",
-"git_commit": "5acdb3e9",
-"toolchain": "leanprover/lean4:v4.30.0-rc2",
-"note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
-},
-"results": [
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 59545,
-"ratio": 0.3915,
-"compress_mbps": 30.99,
-"decompress_mbps": 85.04
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 57936,
-"ratio": 0.3809,
-"compress_mbps": 28.02,
-"decompress_mbps": 94.27
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 56891,
-"ratio": 0.3741,
-"compress_mbps": 24.67,
-"decompress_mbps": 103.69
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 55541,
-"ratio": 0.3652,
-"compress_mbps": 16.52,
-"decompress_mbps": 103.94
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 55282,
-"ratio": 0.3635,
-"compress_mbps": 15.61,
-"decompress_mbps": 105.63
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54902,
-"ratio": 0.361,
-"compress_mbps": 13.31,
-"decompress_mbps": 110.55
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54533,
-"ratio": 0.3586,
-"compress_mbps": 6.98,
-"decompress_mbps": 109.04
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54492,
-"ratio": 0.3583,
-"compress_mbps": 6.57,
-"decompress_mbps": 109.62
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 52111,
-"ratio": 0.3426,
-"compress_mbps": 0.97,
-"decompress_mbps": 110.73
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 52768,
-"ratio": 0.4215,
-"compress_mbps": 29.26,
-"decompress_mbps": 82.01
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 51760,
-"ratio": 0.4135,
-"compress_mbps": 26.03,
-"decompress_mbps": 86.34
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51056,
-"ratio": 0.4079,
-"compress_mbps": 22.99,
-"decompress_mbps": 92.27
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 49963,
-"ratio": 0.3991,
-"compress_mbps": 15.43,
-"decompress_mbps": 93.92
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 49779,
-"ratio": 0.3977,
-"compress_mbps": 14.43,
-"decompress_mbps": 97.07
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 49540,
-"ratio": 0.3958,
-"compress_mbps": 12.69,
-"decompress_mbps": 98.27
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 49161,
-"ratio": 0.3927,
-"compress_mbps": 6.62,
-"decompress_mbps": 98.52
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 49153,
-"ratio": 0.3927,
-"compress_mbps": 6.48,
-"decompress_mbps": 99.19
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 46881,
-"ratio": 0.3745,
-"compress_mbps": 1.12,
-"decompress_mbps": 98.49
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8430,
-"ratio": 0.3426,
-"compress_mbps": 27.79,
-"decompress_mbps": 84.75
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8297,
-"ratio": 0.3372,
-"compress_mbps": 26.79,
-"decompress_mbps": 88.38
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8218,
-"ratio": 0.334,
-"compress_mbps": 26.08,
-"decompress_mbps": 90.89
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8055,
-"ratio": 0.3274,
-"compress_mbps": 21.82,
-"decompress_mbps": 89.76
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8049,
-"ratio": 0.3272,
-"compress_mbps": 21.31,
-"decompress_mbps": 92.19
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 8043,
-"ratio": 0.3269,
-"compress_mbps": 20.26,
-"decompress_mbps": 91.84
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 8038,
-"ratio": 0.3267,
-"compress_mbps": 8.32,
-"decompress_mbps": 93.29
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 8038,
-"ratio": 0.3267,
-"compress_mbps": 8.33,
-"decompress_mbps": 92.72
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7727,
-"ratio": 0.3141,
-"compress_mbps": 1.28,
-"decompress_mbps": 93.44
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3325,
-"ratio": 0.2982,
-"compress_mbps": 20.86,
-"decompress_mbps": 75.55
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3251,
-"ratio": 0.2916,
-"compress_mbps": 20.26,
-"decompress_mbps": 78.08
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3202,
-"ratio": 0.2872,
-"compress_mbps": 19.87,
-"decompress_mbps": 80.03
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3150,
-"ratio": 0.2825,
-"compress_mbps": 17.36,
-"decompress_mbps": 81.89
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3141,
-"ratio": 0.2817,
-"compress_mbps": 17.12,
-"decompress_mbps": 82.55
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3136,
-"ratio": 0.2813,
-"compress_mbps": 16.53,
-"decompress_mbps": 83.26
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3134,
-"ratio": 0.2811,
-"compress_mbps": 6.45,
-"decompress_mbps": 83.16
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3134,
-"ratio": 0.2811,
-"compress_mbps": 6.43,
-"decompress_mbps": 83.72
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3027,
-"ratio": 0.2715,
-"compress_mbps": 1.35,
-"decompress_mbps": 83.06
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1251,
-"ratio": 0.3362,
-"compress_mbps": 10.6,
-"decompress_mbps": 42.34
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1241,
-"ratio": 0.3335,
-"compress_mbps": 10.54,
-"decompress_mbps": 42.71
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1241,
-"ratio": 0.3335,
-"compress_mbps": 10.42,
-"decompress_mbps": 43.01
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1225,
-"ratio": 0.3292,
-"compress_mbps": 10.04,
-"decompress_mbps": 43.87
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1224,
-"ratio": 0.3289,
-"compress_mbps": 10.0,
-"decompress_mbps": 43.96
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1224,
-"ratio": 0.3289,
-"compress_mbps": 9.98,
-"decompress_mbps": 44.04
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1224,
-"ratio": 0.3289,
-"compress_mbps": 3.64,
-"decompress_mbps": 44.2
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1224,
-"ratio": 0.3289,
-"compress_mbps": 3.65,
-"decompress_mbps": 44.02
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1190,
-"ratio": 0.3198,
-"compress_mbps": 1.14,
-"decompress_mbps": 44.05
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 248840,
-"ratio": 0.2417,
-"compress_mbps": 61.7,
-"decompress_mbps": 128.75
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 247429,
-"ratio": 0.2403,
-"compress_mbps": 57.96,
-"decompress_mbps": 148.45
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 246442,
-"ratio": 0.2393,
-"compress_mbps": 55.72,
-"decompress_mbps": 155.35
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 213851,
-"ratio": 0.2077,
-"compress_mbps": 38.52,
-"decompress_mbps": 161.69
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 212782,
-"ratio": 0.2066,
-"compress_mbps": 35.55,
-"decompress_mbps": 129.14
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 210061,
-"ratio": 0.204,
-"compress_mbps": 26.91,
-"decompress_mbps": 130.13
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 201296,
-"ratio": 0.1955,
-"compress_mbps": 9.44,
-"decompress_mbps": 120.7
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 201458,
-"ratio": 0.1956,
-"compress_mbps": 7.47,
-"decompress_mbps": 119.5
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 178311,
-"ratio": 0.1732,
-"compress_mbps": 0.73,
-"decompress_mbps": 118.28
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 158127,
-"ratio": 0.3705,
-"compress_mbps": 33.58,
-"decompress_mbps": 90.25
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 153708,
-"ratio": 0.3602,
-"compress_mbps": 29.81,
-"decompress_mbps": 96.74
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 150718,
-"ratio": 0.3532,
-"compress_mbps": 26.24,
-"decompress_mbps": 106.55
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 147481,
-"ratio": 0.3456,
-"compress_mbps": 17.48,
-"decompress_mbps": 107.74
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 146857,
-"ratio": 0.3441,
-"compress_mbps": 16.42,
-"decompress_mbps": 111.59
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 146118,
-"ratio": 0.3424,
-"compress_mbps": 14.27,
-"decompress_mbps": 113.34
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 145400,
-"ratio": 0.3407,
-"compress_mbps": 7.55,
-"decompress_mbps": 113.49
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 145324,
-"ratio": 0.3405,
-"compress_mbps": 7.33,
-"decompress_mbps": 113.82
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 138661,
-"ratio": 0.3249,
-"compress_mbps": 1.01,
-"decompress_mbps": 113.96
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 212305,
-"ratio": 0.4406,
-"compress_mbps": 28.92,
-"decompress_mbps": 78.62
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 207350,
-"ratio": 0.4303,
-"compress_mbps": 25.25,
-"decompress_mbps": 85.25
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 203699,
-"ratio": 0.4227,
-"compress_mbps": 21.86,
-"decompress_mbps": 90.71
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 200054,
-"ratio": 0.4152,
-"compress_mbps": 14.12,
-"decompress_mbps": 91.26
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 199229,
-"ratio": 0.4135,
-"compress_mbps": 13.15,
-"decompress_mbps": 94.44
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 198023,
-"ratio": 0.411,
-"compress_mbps": 11.24,
-"decompress_mbps": 96.68
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 197186,
-"ratio": 0.4092,
-"compress_mbps": 6.04,
-"decompress_mbps": 97.18
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 197001,
-"ratio": 0.4088,
-"compress_mbps": 5.64,
-"decompress_mbps": 97.05
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 186472,
-"ratio": 0.387,
-"compress_mbps": 0.99,
-"decompress_mbps": 97.66
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 60352,
-"ratio": 0.1176,
-"compress_mbps": 97.11,
-"decompress_mbps": 242.37
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 59696,
-"ratio": 0.1163,
-"compress_mbps": 86.58,
-"decompress_mbps": 254.25
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 59069,
-"ratio": 0.1151,
-"compress_mbps": 75.9,
-"decompress_mbps": 268.26
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 56435,
-"ratio": 0.11,
-"compress_mbps": 51.74,
-"decompress_mbps": 244.45
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 56350,
-"ratio": 0.1098,
-"compress_mbps": 47.86,
-"decompress_mbps": 257.64
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 56014,
-"ratio": 0.1091,
-"compress_mbps": 37.68,
-"decompress_mbps": 272.61
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 54820,
-"ratio": 0.1068,
-"compress_mbps": 17.43,
-"decompress_mbps": 282.71
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 54111,
-"ratio": 0.1054,
-"compress_mbps": 15.5,
-"decompress_mbps": 293.42
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 51490,
-"ratio": 0.1003,
-"compress_mbps": 0.42,
-"decompress_mbps": 296.74
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 13725,
-"ratio": 0.3589,
-"compress_mbps": 22.47,
-"decompress_mbps": 65.6
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13615,
-"ratio": 0.356,
-"compress_mbps": 21.8,
-"decompress_mbps": 69.1
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13548,
-"ratio": 0.3543,
-"compress_mbps": 20.97,
-"decompress_mbps": 71.76
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13080,
-"ratio": 0.3421,
-"compress_mbps": 17.27,
-"decompress_mbps": 69.52
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13060,
-"ratio": 0.3415,
-"compress_mbps": 16.63,
-"decompress_mbps": 73.31
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13015,
-"ratio": 0.3404,
-"compress_mbps": 14.92,
-"decompress_mbps": 74.2
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12823,
-"ratio": 0.3353,
-"compress_mbps": 5.05,
-"decompress_mbps": 73.57
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12811,
-"ratio": 0.335,
-"compress_mbps": 4.5,
-"decompress_mbps": 77.44
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12278,
-"ratio": 0.3211,
-"compress_mbps": 0.98,
-"decompress_mbps": 75.8
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1781,
-"ratio": 0.4213,
-"compress_mbps": 11.53,
-"decompress_mbps": 42.26
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1764,
-"ratio": 0.4173,
-"compress_mbps": 11.6,
-"decompress_mbps": 43.15
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1765,
-"ratio": 0.4176,
-"compress_mbps": 11.57,
-"decompress_mbps": 43.28
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 11.21,
-"decompress_mbps": 44.04
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 11.2,
-"decompress_mbps": 43.89
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 11.26,
-"decompress_mbps": 44.08
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 3.9,
-"decompress_mbps": 43.71
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1747,
-"ratio": 0.4133,
-"compress_mbps": 3.89,
-"decompress_mbps": 43.69
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1696,
-"ratio": 0.4012,
-"compress_mbps": 1.32,
-"decompress_mbps": 43.65
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 65130,
-"ratio": 0.4282,
-"compress_mbps": 119.77,
-"decompress_mbps": 398.47
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 62270,
-"ratio": 0.4094,
-"compress_mbps": 102.25,
-"decompress_mbps": 414.68
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 59488,
-"ratio": 0.3911,
-"compress_mbps": 67.37,
-"decompress_mbps": 427.91
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 57679,
-"ratio": 0.3792,
-"compress_mbps": 72.22,
-"decompress_mbps": 410.29
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 55616,
-"ratio": 0.3657,
-"compress_mbps": 42.21,
-"decompress_mbps": 400.75
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54398,
-"ratio": 0.3577,
-"compress_mbps": 25.7,
-"decompress_mbps": 413.9
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54253,
-"ratio": 0.3567,
-"compress_mbps": 21.57,
-"decompress_mbps": 419.24
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54164,
-"ratio": 0.3561,
-"compress_mbps": 17.1,
-"decompress_mbps": 418.49
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54164,
-"ratio": 0.3561,
-"compress_mbps": 17.09,
-"decompress_mbps": 417.81
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 56791,
-"ratio": 0.4537,
-"compress_mbps": 116.39,
-"decompress_mbps": 389.77
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 54652,
-"ratio": 0.4366,
-"compress_mbps": 98.68,
-"decompress_mbps": 401.91
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 52663,
-"ratio": 0.4207,
-"compress_mbps": 62.8,
-"decompress_mbps": 423.51
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 51266,
-"ratio": 0.4095,
-"compress_mbps": 67.91,
-"decompress_mbps": 393.09
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 49622,
-"ratio": 0.3964,
-"compress_mbps": 37.73,
-"decompress_mbps": 383.82
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48891,
-"ratio": 0.3906,
-"compress_mbps": 22.94,
-"decompress_mbps": 387.58
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48801,
-"ratio": 0.3898,
-"compress_mbps": 20.17,
-"decompress_mbps": 385.91
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48772,
-"ratio": 0.3896,
-"compress_mbps": 18.27,
-"decompress_mbps": 386.5
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48772,
-"ratio": 0.3896,
-"compress_mbps": 18.26,
-"decompress_mbps": 387.67
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 9028,
-"ratio": 0.3669,
-"compress_mbps": 401.07,
-"decompress_mbps": 1060.82
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8811,
-"ratio": 0.3581,
-"compress_mbps": 216.25,
-"decompress_mbps": 1089.95
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8616,
-"ratio": 0.3502,
-"compress_mbps": 159.42,
-"decompress_mbps": 1097.49
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8219,
-"ratio": 0.3341,
-"compress_mbps": 117.61,
-"decompress_mbps": 1125.44
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8001,
-"ratio": 0.3252,
-"compress_mbps": 85.21,
-"decompress_mbps": 1143.43
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7955,
-"ratio": 0.3233,
-"compress_mbps": 68.99,
-"decompress_mbps": 1151.46
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7933,
-"ratio": 0.3224,
-"compress_mbps": 63.45,
-"decompress_mbps": 1160.4
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7934,
-"ratio": 0.3225,
-"compress_mbps": 58.21,
-"decompress_mbps": 1151.8
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7934,
-"ratio": 0.3225,
-"compress_mbps": 58.06,
-"decompress_mbps": 1156.68
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3647,
-"ratio": 0.3271,
-"compress_mbps": 427.42,
-"decompress_mbps": 1062.5
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3501,
-"ratio": 0.314,
-"compress_mbps": 411.29,
-"decompress_mbps": 1112.87
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3393,
-"ratio": 0.3043,
-"compress_mbps": 340.67,
-"decompress_mbps": 1144.37
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3215,
-"ratio": 0.2883,
-"compress_mbps": 275.8,
-"decompress_mbps": 1171.86
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3140,
-"ratio": 0.2816,
-"compress_mbps": 207.2,
-"decompress_mbps": 1198.41
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 155.1,
-"decompress_mbps": 1212.48
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 132.68,
-"decompress_mbps": 1216.5
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3109,
-"ratio": 0.2788,
-"compress_mbps": 111.99,
-"decompress_mbps": 1214.28
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3109,
-"ratio": 0.2788,
-"compress_mbps": 111.59,
-"decompress_mbps": 1213.73
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1326,
-"ratio": 0.3564,
-"compress_mbps": 318.69,
-"decompress_mbps": 785.96
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1306,
-"ratio": 0.351,
-"compress_mbps": 311.15,
-"decompress_mbps": 793.52
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1301,
-"ratio": 0.3496,
-"compress_mbps": 293.25,
-"decompress_mbps": 796.91
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1228,
-"ratio": 0.33,
-"compress_mbps": 234.5,
-"decompress_mbps": 822.39
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 199.33,
-"decompress_mbps": 829.5
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 178.66,
-"decompress_mbps": 830.28
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 171.22,
-"decompress_mbps": 826.22
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 168.55,
-"decompress_mbps": 828.54
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 168.56,
-"decompress_mbps": 830.48
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 242293,
-"ratio": 0.2353,
-"compress_mbps": 262.57,
-"decompress_mbps": 846.48
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 233553,
-"ratio": 0.2268,
-"compress_mbps": 249.26,
-"decompress_mbps": 1003.16
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 228222,
-"ratio": 0.2216,
-"compress_mbps": 196.63,
-"decompress_mbps": 1061.75
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 223668,
-"ratio": 0.2172,
-"compress_mbps": 177.77,
-"decompress_mbps": 1088.45
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 205994,
-"ratio": 0.2,
-"compress_mbps": 111.43,
-"decompress_mbps": 1046.69
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 203986,
-"ratio": 0.1981,
-"compress_mbps": 50.09,
-"decompress_mbps": 1050.83
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 207681,
-"ratio": 0.2017,
-"compress_mbps": 37.08,
-"decompress_mbps": 1042.31
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 206827,
-"ratio": 0.2009,
-"compress_mbps": 7.29,
-"decompress_mbps": 1009.11
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 207023,
-"ratio": 0.201,
-"compress_mbps": 3.42,
-"decompress_mbps": 1011.27
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 174124,
-"ratio": 0.408,
-"compress_mbps": 124.11,
-"decompress_mbps": 396.62
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 166150,
-"ratio": 0.3893,
-"compress_mbps": 105.44,
-"decompress_mbps": 408.59
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 158784,
-"ratio": 0.3721,
-"compress_mbps": 70.36,
-"decompress_mbps": 424.58
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 152782,
-"ratio": 0.358,
-"compress_mbps": 73.9,
-"decompress_mbps": 410.85
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 147196,
-"ratio": 0.3449,
-"compress_mbps": 43.56,
-"decompress_mbps": 408.28
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144898,
-"ratio": 0.3395,
-"compress_mbps": 26.46,
-"decompress_mbps": 416.34
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144589,
-"ratio": 0.3388,
-"compress_mbps": 22.93,
-"decompress_mbps": 416.12
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144436,
-"ratio": 0.3385,
-"compress_mbps": 19.73,
-"decompress_mbps": 422.96
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 144433,
-"ratio": 0.3384,
-"compress_mbps": 19.67,
-"decompress_mbps": 421.31
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 228883,
-"ratio": 0.475,
-"compress_mbps": 108.67,
-"decompress_mbps": 374.75
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 219047,
-"ratio": 0.4546,
-"compress_mbps": 91.2,
-"decompress_mbps": 392.5
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 209408,
-"ratio": 0.4346,
-"compress_mbps": 55.53,
-"decompress_mbps": 407.38
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 205916,
-"ratio": 0.4273,
-"compress_mbps": 62.69,
-"decompress_mbps": 379.86
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 199188,
-"ratio": 0.4134,
-"compress_mbps": 33.16,
-"decompress_mbps": 364.05
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 195255,
-"ratio": 0.4052,
-"compress_mbps": 19.45,
-"decompress_mbps": 370.07
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 194657,
-"ratio": 0.404,
-"compress_mbps": 16.47,
-"decompress_mbps": 375.18
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 194326,
-"ratio": 0.4033,
-"compress_mbps": 13.0,
-"decompress_mbps": 373.15
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 194326,
-"ratio": 0.4033,
-"compress_mbps": 13.0,
-"decompress_mbps": 370.32
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 65553,
-"ratio": 0.1277,
-"compress_mbps": 275.43,
-"decompress_mbps": 902.03
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 63891,
-"ratio": 0.1245,
-"compress_mbps": 248.32,
-"decompress_mbps": 933.77
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 62515,
-"ratio": 0.1218,
-"compress_mbps": 194.05,
-"decompress_mbps": 996.45
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 58451,
-"ratio": 0.1139,
-"compress_mbps": 169.58,
-"decompress_mbps": 703.31
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 57410,
-"ratio": 0.1119,
-"compress_mbps": 130.49,
-"decompress_mbps": 735.57
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 56459,
-"ratio": 0.11,
-"compress_mbps": 77.12,
-"decompress_mbps": 786.95
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 55358,
-"ratio": 0.1079,
-"compress_mbps": 60.33,
-"decompress_mbps": 822.55
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 52991,
-"ratio": 0.1033,
-"compress_mbps": 27.36,
-"decompress_mbps": 877.49
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 52215,
-"ratio": 0.1017,
-"compress_mbps": 9.72,
-"decompress_mbps": 899.03
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14112,
-"ratio": 0.369,
-"compress_mbps": 130.01,
-"decompress_mbps": 929.35
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13815,
-"ratio": 0.3613,
-"compress_mbps": 110.48,
-"decompress_mbps": 965.85
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13795,
-"ratio": 0.3607,
-"compress_mbps": 79.46,
-"decompress_mbps": 1011.13
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13375,
-"ratio": 0.3498,
-"compress_mbps": 81.06,
-"decompress_mbps": 997.63
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13062,
-"ratio": 0.3416,
-"compress_mbps": 56.29,
-"decompress_mbps": 1035.01
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 12984,
-"ratio": 0.3395,
-"compress_mbps": 33.21,
-"decompress_mbps": 1046.47
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12949,
-"ratio": 0.3386,
-"compress_mbps": 25.5,
-"decompress_mbps": 1053.09
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12894,
-"ratio": 0.3372,
-"compress_mbps": 11.06,
-"decompress_mbps": 1073.52
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12832,
-"ratio": 0.3356,
-"compress_mbps": 5.09,
-"decompress_mbps": 1082.02
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1846,
-"ratio": 0.4367,
-"compress_mbps": 290.56,
-"decompress_mbps": 709.09
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1820,
-"ratio": 0.4306,
-"compress_mbps": 286.26,
-"decompress_mbps": 720.24
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1808,
-"ratio": 0.4277,
-"compress_mbps": 274.49,
-"decompress_mbps": 723.34
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1749,
-"ratio": 0.4138,
-"compress_mbps": 227.24,
-"decompress_mbps": 737.37
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 202.72,
-"decompress_mbps": 752.09
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 200.34,
-"decompress_mbps": 752.37
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 197.9,
-"decompress_mbps": 751.67
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 198.06,
-"decompress_mbps": 749.99
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 197.87,
-"decompress_mbps": 750.83
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 76470,
-"ratio": 0.5028,
-"compress_mbps": 155.5,
-"decompress_mbps": 455.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 62765,
-"ratio": 0.4127,
-"compress_mbps": 132.65,
-"decompress_mbps": 505.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 57162,
-"ratio": 0.3758,
-"compress_mbps": 72.27,
-"decompress_mbps": 564.54
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56826,
-"ratio": 0.3736,
-"compress_mbps": 64.36,
-"decompress_mbps": 550.57
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 55696,
-"ratio": 0.3662,
-"compress_mbps": 46.82,
-"decompress_mbps": 539.47
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54440,
-"ratio": 0.3579,
-"compress_mbps": 26.53,
-"decompress_mbps": 554.14
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54283,
-"ratio": 0.3569,
-"compress_mbps": 22.41,
-"decompress_mbps": 551.14
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54221,
-"ratio": 0.3565,
-"compress_mbps": 19.74,
-"decompress_mbps": 552.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54217,
-"ratio": 0.3565,
-"compress_mbps": 19.49,
-"decompress_mbps": 550.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 64926,
-"ratio": 0.5187,
-"compress_mbps": 150.12,
-"decompress_mbps": 432.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 54985,
-"ratio": 0.4393,
-"compress_mbps": 124.34,
-"decompress_mbps": 480.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51148,
-"ratio": 0.4086,
-"compress_mbps": 67.19,
-"decompress_mbps": 546.47
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50599,
-"ratio": 0.4042,
-"compress_mbps": 59.16,
-"decompress_mbps": 534.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 49775,
-"ratio": 0.3976,
-"compress_mbps": 42.66,
-"decompress_mbps": 516.46
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48967,
-"ratio": 0.3912,
-"compress_mbps": 24.97,
-"decompress_mbps": 530.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48870,
-"ratio": 0.3904,
-"compress_mbps": 22.19,
-"decompress_mbps": 532.32
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48845,
-"ratio": 0.3902,
-"compress_mbps": 20.91,
-"decompress_mbps": 532.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48845,
-"ratio": 0.3902,
-"compress_mbps": 20.92,
-"decompress_mbps": 529.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 10024,
-"ratio": 0.4074,
-"compress_mbps": 565.11,
-"decompress_mbps": 903.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8577,
-"ratio": 0.3486,
-"compress_mbps": 257.53,
-"decompress_mbps": 932.75
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8168,
-"ratio": 0.332,
-"compress_mbps": 157.93,
-"decompress_mbps": 954.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8069,
-"ratio": 0.328,
-"compress_mbps": 115.26,
-"decompress_mbps": 968.4
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7997,
-"ratio": 0.325,
-"compress_mbps": 100.39,
-"decompress_mbps": 996.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7952,
-"ratio": 0.3232,
-"compress_mbps": 74.67,
-"decompress_mbps": 1002.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7947,
-"ratio": 0.323,
-"compress_mbps": 72.27,
-"decompress_mbps": 1006.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7947,
-"ratio": 0.323,
-"compress_mbps": 71.37,
-"decompress_mbps": 1004.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7947,
-"ratio": 0.323,
-"compress_mbps": 70.98,
-"decompress_mbps": 1005.5
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 4061,
-"ratio": 0.3642,
-"compress_mbps": 504.79,
-"decompress_mbps": 854.51
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3446,
-"ratio": 0.3091,
-"compress_mbps": 306.11,
-"decompress_mbps": 897.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3201,
-"ratio": 0.2871,
-"compress_mbps": 234.65,
-"decompress_mbps": 919.77
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 194.54,
-"decompress_mbps": 950.86
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3139,
-"ratio": 0.2815,
-"compress_mbps": 162.89,
-"decompress_mbps": 976.98
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3115,
-"ratio": 0.2794,
-"compress_mbps": 116.43,
-"decompress_mbps": 985.22
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 106.4,
-"decompress_mbps": 986.86
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 103.31,
-"decompress_mbps": 990.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 103.15,
-"decompress_mbps": 984.12
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1410,
-"ratio": 0.3789,
-"compress_mbps": 364.75,
-"decompress_mbps": 585.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1262,
-"ratio": 0.3392,
-"compress_mbps": 233.69,
-"decompress_mbps": 605.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1238,
-"ratio": 0.3327,
-"compress_mbps": 203.84,
-"decompress_mbps": 602.07
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1219,
-"ratio": 0.3276,
-"compress_mbps": 173.55,
-"decompress_mbps": 620.28
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 160.48,
-"decompress_mbps": 625.42
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 147.66,
-"decompress_mbps": 631.65
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 147.04,
-"decompress_mbps": 631.88
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 147.13,
-"decompress_mbps": 629.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 147.07,
-"decompress_mbps": 630.98
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 274412,
-"ratio": 0.2665,
-"compress_mbps": 448.5,
-"decompress_mbps": 803.0
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 213239,
-"ratio": 0.2071,
-"compress_mbps": 273.8,
-"decompress_mbps": 885.6
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 232107,
-"ratio": 0.2254,
-"compress_mbps": 137.01,
-"decompress_mbps": 926.6
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 202733,
-"ratio": 0.1969,
-"compress_mbps": 130.13,
-"decompress_mbps": 928.25
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 207803,
-"ratio": 0.2018,
-"compress_mbps": 84.43,
-"decompress_mbps": 950.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 205270,
-"ratio": 0.1993,
-"compress_mbps": 27.28,
-"decompress_mbps": 978.56
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 209951,
-"ratio": 0.2039,
-"compress_mbps": 19.3,
-"decompress_mbps": 989.27
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 209656,
-"ratio": 0.2036,
-"compress_mbps": 12.23,
-"decompress_mbps": 1005.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 209189,
-"ratio": 0.2031,
-"compress_mbps": 8.96,
-"decompress_mbps": 1008.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 208640,
-"ratio": 0.4889,
-"compress_mbps": 155.24,
-"decompress_mbps": 439.81
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 167329,
-"ratio": 0.3921,
-"compress_mbps": 138.06,
-"decompress_mbps": 475.7
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 151097,
-"ratio": 0.3541,
-"compress_mbps": 73.64,
-"decompress_mbps": 525.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 150035,
-"ratio": 0.3516,
-"compress_mbps": 66.46,
-"decompress_mbps": 518.68
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 147375,
-"ratio": 0.3453,
-"compress_mbps": 48.11,
-"decompress_mbps": 517.72
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144908,
-"ratio": 0.3396,
-"compress_mbps": 28.05,
-"decompress_mbps": 528.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144562,
-"ratio": 0.3387,
-"compress_mbps": 24.62,
-"decompress_mbps": 527.36
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144449,
-"ratio": 0.3385,
-"compress_mbps": 22.39,
-"decompress_mbps": 528.46
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 144438,
-"ratio": 0.3385,
-"compress_mbps": 22.31,
-"decompress_mbps": 528.19
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 264549,
-"ratio": 0.549,
-"compress_mbps": 133.4,
-"decompress_mbps": 390.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 223724,
-"ratio": 0.4643,
-"compress_mbps": 118.5,
-"decompress_mbps": 437.39
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 204825,
-"ratio": 0.4251,
-"compress_mbps": 60.63,
-"decompress_mbps": 488.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 203945,
-"ratio": 0.4232,
-"compress_mbps": 53.99,
-"decompress_mbps": 480.14
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 199780,
-"ratio": 0.4146,
-"compress_mbps": 37.87,
-"decompress_mbps": 462.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 195417,
-"ratio": 0.4055,
-"compress_mbps": 21.16,
-"decompress_mbps": 476.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 194796,
-"ratio": 0.4043,
-"compress_mbps": 17.88,
-"decompress_mbps": 475.83
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 194543,
-"ratio": 0.4037,
-"compress_mbps": 15.7,
-"decompress_mbps": 475.76
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 194460,
-"ratio": 0.4036,
-"compress_mbps": 15.04,
-"decompress_mbps": 476.04
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 67436,
-"ratio": 0.1314,
-"compress_mbps": 622.92,
-"decompress_mbps": 1031.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 59257,
-"ratio": 0.1155,
-"compress_mbps": 277.97,
-"decompress_mbps": 1093.09
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 58316,
-"ratio": 0.1136,
-"compress_mbps": 181.59,
-"decompress_mbps": 1174.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 56291,
-"ratio": 0.1097,
-"compress_mbps": 184.63,
-"decompress_mbps": 1185.14
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 56220,
-"ratio": 0.1095,
-"compress_mbps": 145.94,
-"decompress_mbps": 1241.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55972,
-"ratio": 0.1091,
-"compress_mbps": 74.51,
-"decompress_mbps": 1306.71
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 55121,
-"ratio": 0.1074,
-"compress_mbps": 52.11,
-"decompress_mbps": 1344.87
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 54124,
-"ratio": 0.1055,
-"compress_mbps": 36.67,
-"decompress_mbps": 1417.73
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 53699,
-"ratio": 0.1046,
-"compress_mbps": 28.65,
-"decompress_mbps": 1443.69
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 15612,
-"ratio": 0.4083,
-"compress_mbps": 495.66,
-"decompress_mbps": 854.66
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 14133,
-"ratio": 0.3696,
-"compress_mbps": 145.29,
-"decompress_mbps": 882.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13341,
-"ratio": 0.3489,
-"compress_mbps": 88.03,
-"decompress_mbps": 911.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13289,
-"ratio": 0.3475,
-"compress_mbps": 83.11,
-"decompress_mbps": 945.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13052,
-"ratio": 0.3413,
-"compress_mbps": 66.63,
-"decompress_mbps": 974.55
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 12996,
-"ratio": 0.3399,
-"compress_mbps": 37.11,
-"decompress_mbps": 994.8
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12972,
-"ratio": 0.3392,
-"compress_mbps": 27.18,
-"decompress_mbps": 997.66
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12951,
-"ratio": 0.3387,
-"compress_mbps": 19.02,
-"decompress_mbps": 1005.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12933,
-"ratio": 0.3382,
-"compress_mbps": 14.84,
-"decompress_mbps": 1008.14
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1988,
-"ratio": 0.4703,
-"compress_mbps": 339.21,
-"decompress_mbps": 542.7
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1802,
-"ratio": 0.4263,
-"compress_mbps": 217.41,
-"decompress_mbps": 550.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 204.83,
-"decompress_mbps": 555.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1732,
-"ratio": 0.4097,
-"compress_mbps": 170.03,
-"decompress_mbps": 567.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 165.69,
-"decompress_mbps": 577.12
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 164.52,
-"decompress_mbps": 577.04
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 164.45,
-"decompress_mbps": 574.57
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 164.77,
-"decompress_mbps": 578.03
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 164.14,
-"decompress_mbps": 577.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 59790,
-"ratio": 0.3931,
-"compress_mbps": 263.2,
-"decompress_mbps": 1001.42
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 57173,
-"ratio": 0.3759,
-"compress_mbps": 181.59,
-"decompress_mbps": 1075.31
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 56189,
-"ratio": 0.3694,
-"compress_mbps": 151.17,
-"decompress_mbps": 1147.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 55816,
-"ratio": 0.367,
-"compress_mbps": 138.47,
-"decompress_mbps": 1191.79
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54758,
-"ratio": 0.36,
-"compress_mbps": 108.98,
-"decompress_mbps": 1242.52
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54220,
-"ratio": 0.3565,
-"compress_mbps": 84.13,
-"decompress_mbps": 1278.22
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 53801,
-"ratio": 0.3537,
-"compress_mbps": 61.41,
-"decompress_mbps": 1285.49
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 53573,
-"ratio": 0.3522,
-"compress_mbps": 39.03,
-"decompress_mbps": 1285.81
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 53546,
-"ratio": 0.3521,
-"compress_mbps": 34.48,
-"decompress_mbps": 1289.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 52276,
-"ratio": 0.4176,
-"compress_mbps": 243.31,
-"decompress_mbps": 942.37
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 50534,
-"ratio": 0.4037,
-"compress_mbps": 169.24,
-"decompress_mbps": 995.26
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 49919,
-"ratio": 0.3988,
-"compress_mbps": 141.81,
-"decompress_mbps": 1059.73
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 49715,
-"ratio": 0.3972,
-"compress_mbps": 131.26,
-"decompress_mbps": 1094.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48735,
-"ratio": 0.3893,
-"compress_mbps": 100.85,
-"decompress_mbps": 1140.16
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48422,
-"ratio": 0.3868,
-"compress_mbps": 79.38,
-"decompress_mbps": 1166.67
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48249,
-"ratio": 0.3854,
-"compress_mbps": 61.36,
-"decompress_mbps": 1170.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 47977,
-"ratio": 0.3833,
-"compress_mbps": 43.05,
-"decompress_mbps": 1170.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 47971,
-"ratio": 0.3832,
-"compress_mbps": 41.12,
-"decompress_mbps": 1171.55
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8385,
-"ratio": 0.3408,
-"compress_mbps": 691.83,
-"decompress_mbps": 957.33
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8380,
-"ratio": 0.3406,
-"compress_mbps": 441.02,
-"decompress_mbps": 980.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8286,
-"ratio": 0.3368,
-"compress_mbps": 403.63,
-"decompress_mbps": 998.52
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8163,
-"ratio": 0.3318,
-"compress_mbps": 376.96,
-"decompress_mbps": 1004.46
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8053,
-"ratio": 0.3273,
-"compress_mbps": 339.99,
-"decompress_mbps": 1033.12
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7986,
-"ratio": 0.3246,
-"compress_mbps": 277.58,
-"decompress_mbps": 1032.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7954,
-"ratio": 0.3233,
-"compress_mbps": 191.57,
-"decompress_mbps": 1035.54
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7916,
-"ratio": 0.3217,
-"compress_mbps": 122.86,
-"decompress_mbps": 1039.85
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7916,
-"ratio": 0.3217,
-"compress_mbps": 123.45,
-"decompress_mbps": 1037.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3401,
-"ratio": 0.305,
-"compress_mbps": 585.0,
-"decompress_mbps": 769.76
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3307,
-"ratio": 0.2966,
-"compress_mbps": 397.32,
-"decompress_mbps": 801.98
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3242,
-"ratio": 0.2908,
-"compress_mbps": 371.22,
-"decompress_mbps": 817.83
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3205,
-"ratio": 0.2874,
-"compress_mbps": 348.32,
-"decompress_mbps": 830.74
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3150,
-"ratio": 0.2825,
-"compress_mbps": 314.09,
-"decompress_mbps": 837.54
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3126,
-"ratio": 0.2804,
-"compress_mbps": 267.64,
-"decompress_mbps": 841.85
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3106,
-"ratio": 0.2786,
-"compress_mbps": 207.41,
-"decompress_mbps": 839.73
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3102,
-"ratio": 0.2782,
-"compress_mbps": 147.79,
-"decompress_mbps": 843.39
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3102,
-"ratio": 0.2782,
-"compress_mbps": 140.13,
-"decompress_mbps": 844.66
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1251,
-"ratio": 0.3362,
-"compress_mbps": 381.82,
-"decompress_mbps": 434.24
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1228,
-"ratio": 0.33,
-"compress_mbps": 267.74,
-"decompress_mbps": 434.72
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1219,
-"ratio": 0.3276,
-"compress_mbps": 259.59,
-"decompress_mbps": 436.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1220,
-"ratio": 0.3279,
-"compress_mbps": 252.97,
-"decompress_mbps": 444.24
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 240.0,
-"decompress_mbps": 447.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 222.53,
-"decompress_mbps": 448.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 202.55,
-"decompress_mbps": 443.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1204,
-"ratio": 0.3236,
-"compress_mbps": 169.05,
-"decompress_mbps": 445.64
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1204,
-"ratio": 0.3236,
-"compress_mbps": 168.91,
-"decompress_mbps": 446.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 221813,
-"ratio": 0.2154,
-"compress_mbps": 590.09,
-"decompress_mbps": 1015.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 199825,
-"ratio": 0.1941,
-"compress_mbps": 408.04,
-"decompress_mbps": 1466.99
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 195675,
-"ratio": 0.19,
-"compress_mbps": 282.42,
-"decompress_mbps": 1537.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 195664,
-"ratio": 0.19,
-"compress_mbps": 278.75,
-"decompress_mbps": 1547.12
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 198900,
-"ratio": 0.1932,
-"compress_mbps": 239.32,
-"decompress_mbps": 1132.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 199347,
-"ratio": 0.1936,
-"compress_mbps": 204.7,
-"decompress_mbps": 1134.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 199777,
-"ratio": 0.194,
-"compress_mbps": 123.64,
-"decompress_mbps": 1191.65
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 182094,
-"ratio": 0.1768,
-"compress_mbps": 25.59,
-"decompress_mbps": 1168.99
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 181451,
-"ratio": 0.1762,
-"compress_mbps": 13.6,
-"decompress_mbps": 1181.11
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 159063,
-"ratio": 0.3727,
-"compress_mbps": 266.79,
-"decompress_mbps": 1023.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 152115,
-"ratio": 0.3564,
-"compress_mbps": 187.13,
-"decompress_mbps": 1099.94
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 149162,
-"ratio": 0.3495,
-"compress_mbps": 157.38,
-"decompress_mbps": 1192.84
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 148359,
-"ratio": 0.3476,
-"compress_mbps": 143.1,
-"decompress_mbps": 1047.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145353,
-"ratio": 0.3406,
-"compress_mbps": 113.72,
-"decompress_mbps": 1009.92
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144209,
-"ratio": 0.3379,
-"compress_mbps": 88.45,
-"decompress_mbps": 1054.42
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 143604,
-"ratio": 0.3365,
-"compress_mbps": 66.76,
-"decompress_mbps": 1058.64
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 142086,
-"ratio": 0.3329,
-"compress_mbps": 44.23,
-"decompress_mbps": 1053.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 142027,
-"ratio": 0.3328,
-"compress_mbps": 40.46,
-"decompress_mbps": 1052.52
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 210662,
-"ratio": 0.4372,
-"compress_mbps": 232.01,
-"decompress_mbps": 866.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 202881,
-"ratio": 0.421,
-"compress_mbps": 159.23,
-"decompress_mbps": 937.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 200409,
-"ratio": 0.4159,
-"compress_mbps": 133.69,
-"decompress_mbps": 1020.91
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 199678,
-"ratio": 0.4144,
-"compress_mbps": 123.38,
-"decompress_mbps": 850.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 195798,
-"ratio": 0.4063,
-"compress_mbps": 93.3,
-"decompress_mbps": 804.08
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 194029,
-"ratio": 0.4027,
-"compress_mbps": 71.98,
-"decompress_mbps": 826.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 192773,
-"ratio": 0.4001,
-"compress_mbps": 50.8,
-"decompress_mbps": 830.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 191739,
-"ratio": 0.3979,
-"compress_mbps": 33.69,
-"decompress_mbps": 834.44
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 191676,
-"ratio": 0.3978,
-"compress_mbps": 31.07,
-"decompress_mbps": 831.22
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 58079,
-"ratio": 0.1132,
-"compress_mbps": 373.57,
-"decompress_mbps": 1656.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 57838,
-"ratio": 0.1127,
-"compress_mbps": 413.43,
-"decompress_mbps": 1804.88
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 57554,
-"ratio": 0.1121,
-"compress_mbps": 393.37,
-"decompress_mbps": 1909.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 57064,
-"ratio": 0.1112,
-"compress_mbps": 372.52,
-"decompress_mbps": 1746.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 55743,
-"ratio": 0.1086,
-"compress_mbps": 344.08,
-"decompress_mbps": 1804.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55102,
-"ratio": 0.1074,
-"compress_mbps": 279.88,
-"decompress_mbps": 1883.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 54742,
-"ratio": 0.1067,
-"compress_mbps": 188.48,
-"decompress_mbps": 1935.81
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 53133,
-"ratio": 0.1035,
-"compress_mbps": 102.97,
-"decompress_mbps": 1989.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 52186,
-"ratio": 0.1017,
-"compress_mbps": 72.32,
-"decompress_mbps": 2042.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14122,
-"ratio": 0.3693,
-"compress_mbps": 644.89,
-"decompress_mbps": 827.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13374,
-"ratio": 0.3497,
-"compress_mbps": 332.44,
-"decompress_mbps": 888.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13293,
-"ratio": 0.3476,
-"compress_mbps": 277.6,
-"decompress_mbps": 960.38
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13259,
-"ratio": 0.3467,
-"compress_mbps": 262.14,
-"decompress_mbps": 960.33
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 12641,
-"ratio": 0.3306,
-"compress_mbps": 186.71,
-"decompress_mbps": 947.5
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 12432,
-"ratio": 0.3251,
-"compress_mbps": 160.33,
-"decompress_mbps": 1005.94
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12439,
-"ratio": 0.3253,
-"compress_mbps": 115.01,
-"decompress_mbps": 1010.38
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12579,
-"ratio": 0.3289,
-"compress_mbps": 67.0,
-"decompress_mbps": 1028.38
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12574,
-"ratio": 0.3288,
-"compress_mbps": 47.33,
-"decompress_mbps": 1038.57
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1777,
-"ratio": 0.4204,
-"compress_mbps": 386.8,
-"decompress_mbps": 405.67
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1756,
-"ratio": 0.4154,
-"compress_mbps": 259.36,
-"decompress_mbps": 406.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1746,
-"ratio": 0.4131,
-"compress_mbps": 255.77,
-"decompress_mbps": 408.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1740,
-"ratio": 0.4116,
-"compress_mbps": 253.88,
-"decompress_mbps": 415.29
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1722,
-"ratio": 0.4074,
-"compress_mbps": 237.59,
-"decompress_mbps": 418.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1721,
-"ratio": 0.4071,
-"compress_mbps": 235.41,
-"decompress_mbps": 416.96
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 233.87,
-"decompress_mbps": 419.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1717,
-"ratio": 0.4062,
-"compress_mbps": 216.99,
-"decompress_mbps": 415.29
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1717,
-"ratio": 0.4062,
-"compress_mbps": 217.77,
-"decompress_mbps": 415.71
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4231315,
-"ratio": 0.4151,
-"compress_mbps": 29.05,
-"decompress_mbps": 78.62
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4120658,
-"ratio": 0.4043,
-"compress_mbps": 25.7,
-"decompress_mbps": 84.9
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4037988,
-"ratio": 0.3962,
-"compress_mbps": 22.57,
-"decompress_mbps": 89.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3959738,
-"ratio": 0.3885,
-"compress_mbps": 14.54,
-"decompress_mbps": 88.84
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3941691,
-"ratio": 0.3867,
-"compress_mbps": 13.9,
-"decompress_mbps": 92.0
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3913931,
-"ratio": 0.384,
-"compress_mbps": 11.8,
-"decompress_mbps": 94.64
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3902484,
-"ratio": 0.3829,
-"compress_mbps": 6.44,
-"decompress_mbps": 99.64
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3899047,
-"ratio": 0.3825,
-"compress_mbps": 6.29,
-"decompress_mbps": 99.05
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3712344,
-"ratio": 0.3642,
-"compress_mbps": 1.0,
-"decompress_mbps": 101.67
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20729473,
-"ratio": 0.4047,
-"compress_mbps": 40.35,
-"decompress_mbps": 71.27
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20500337,
-"ratio": 0.4002,
-"compress_mbps": 37.43,
-"decompress_mbps": 75.56
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 20349978,
-"ratio": 0.3973,
-"compress_mbps": 34.25,
-"decompress_mbps": 78.14
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19952001,
-"ratio": 0.3895,
-"compress_mbps": 23.84,
-"decompress_mbps": 78.7
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19925043,
-"ratio": 0.389,
-"compress_mbps": 22.08,
-"decompress_mbps": 82.04
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19882104,
-"ratio": 0.3882,
-"compress_mbps": 18.24,
-"decompress_mbps": 84.17
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 18841079,
-"ratio": 0.3678,
-"compress_mbps": 6.58,
-"decompress_mbps": 83.3
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 18833163,
-"ratio": 0.3677,
-"compress_mbps": 5.98,
-"decompress_mbps": 84.12
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18518350,
-"ratio": 0.3615,
-"compress_mbps": 0.86,
-"decompress_mbps": 84.41
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3773613,
-"ratio": 0.3785,
-"compress_mbps": 43.0,
-"decompress_mbps": 74.69
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3728325,
-"ratio": 0.3739,
-"compress_mbps": 38.4,
-"decompress_mbps": 77.17
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3701126,
-"ratio": 0.3712,
-"compress_mbps": 33.51,
-"decompress_mbps": 79.16
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3718920,
-"ratio": 0.373,
-"compress_mbps": 21.28,
-"decompress_mbps": 73.67
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3715907,
-"ratio": 0.3727,
-"compress_mbps": 19.14,
-"decompress_mbps": 75.79
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3715635,
-"ratio": 0.3727,
-"compress_mbps": 14.63,
-"decompress_mbps": 77.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3649251,
-"ratio": 0.366,
-"compress_mbps": 6.36,
-"decompress_mbps": 75.79
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3648922,
-"ratio": 0.366,
-"compress_mbps": 5.29,
-"decompress_mbps": 78.31
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3520112,
-"ratio": 0.3531,
-"compress_mbps": 0.36,
-"decompress_mbps": 79.14
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3957304,
-"ratio": 0.1179,
-"compress_mbps": 100.59,
-"decompress_mbps": 270.43
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3769595,
-"ratio": 0.1123,
-"compress_mbps": 89.69,
-"decompress_mbps": 297.96
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3594567,
-"ratio": 0.1071,
-"compress_mbps": 78.45,
-"decompress_mbps": 326.65
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3339928,
-"ratio": 0.0995,
-"compress_mbps": 55.26,
-"decompress_mbps": 326.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3315513,
-"ratio": 0.0988,
-"compress_mbps": 51.58,
-"decompress_mbps": 358.58
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3275531,
-"ratio": 0.0976,
-"compress_mbps": 42.92,
-"decompress_mbps": 378.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3249135,
-"ratio": 0.0968,
-"compress_mbps": 22.02,
-"decompress_mbps": 387.34
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3225205,
-"ratio": 0.0961,
-"compress_mbps": 18.36,
-"decompress_mbps": 389.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2868751,
-"ratio": 0.0855,
-"compress_mbps": 0.53,
-"decompress_mbps": 374.8
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3218639,
-"ratio": 0.5232,
-"compress_mbps": 28.21,
-"decompress_mbps": 47.64
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3192732,
-"ratio": 0.519,
-"compress_mbps": 26.13,
-"decompress_mbps": 49.72
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3174297,
-"ratio": 0.516,
-"compress_mbps": 24.48,
-"decompress_mbps": 54.67
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3121308,
-"ratio": 0.5073,
-"compress_mbps": 18.25,
-"decompress_mbps": 53.86
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3117864,
-"ratio": 0.5068,
-"compress_mbps": 17.31,
-"decompress_mbps": 55.84
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3112351,
-"ratio": 0.5059,
-"compress_mbps": 15.22,
-"decompress_mbps": 57.08
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3072891,
-"ratio": 0.4995,
-"compress_mbps": 5.65,
-"decompress_mbps": 57.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3071839,
-"ratio": 0.4993,
-"compress_mbps": 5.34,
-"decompress_mbps": 57.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3017696,
-"ratio": 0.4905,
-"compress_mbps": 1.21,
-"decompress_mbps": 57.41
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3889230,
-"ratio": 0.3856,
-"compress_mbps": 41.29,
-"decompress_mbps": 68.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3811489,
-"ratio": 0.3779,
-"compress_mbps": 37.76,
-"decompress_mbps": 71.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3789217,
-"ratio": 0.3757,
-"compress_mbps": 36.64,
-"decompress_mbps": 73.35
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3742155,
-"ratio": 0.371,
-"compress_mbps": 29.2,
-"decompress_mbps": 74.01
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3734147,
-"ratio": 0.3702,
-"compress_mbps": 28.22,
-"decompress_mbps": 73.04
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3723457,
-"ratio": 0.3692,
-"compress_mbps": 25.31,
-"decompress_mbps": 73.29
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3723087,
-"ratio": 0.3691,
-"compress_mbps": 9.38,
-"decompress_mbps": 72.3
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3723909,
-"ratio": 0.3692,
-"compress_mbps": 8.87,
-"decompress_mbps": 72.47
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3647083,
-"ratio": 0.3616,
-"compress_mbps": 1.52,
-"decompress_mbps": 71.78
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2146953,
-"ratio": 0.324,
-"compress_mbps": 37.5,
-"decompress_mbps": 96.78
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2072169,
-"ratio": 0.3127,
-"compress_mbps": 32.44,
-"decompress_mbps": 108.45
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021398,
-"ratio": 0.305,
-"compress_mbps": 28.5,
-"decompress_mbps": 117.75
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1934888,
-"ratio": 0.292,
-"compress_mbps": 17.78,
-"decompress_mbps": 117.48
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1920522,
-"ratio": 0.2898,
-"compress_mbps": 15.78,
-"decompress_mbps": 121.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1893334,
-"ratio": 0.2857,
-"compress_mbps": 11.42,
-"decompress_mbps": 126.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1854694,
-"ratio": 0.2799,
-"compress_mbps": 6.15,
-"decompress_mbps": 131.5
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1849481,
-"ratio": 0.2791,
-"compress_mbps": 5.05,
-"decompress_mbps": 130.96
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1724560,
-"ratio": 0.2602,
-"compress_mbps": 0.65,
-"decompress_mbps": 137.33
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6185865,
-"ratio": 0.2863,
-"compress_mbps": 53.89,
-"decompress_mbps": 128.05
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 6066146,
-"ratio": 0.2808,
-"compress_mbps": 48.76,
-"decompress_mbps": 134.56
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5993070,
-"ratio": 0.2774,
-"compress_mbps": 44.31,
-"decompress_mbps": 139.93
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5847650,
-"ratio": 0.2706,
-"compress_mbps": 31.63,
-"decompress_mbps": 143.39
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5837234,
-"ratio": 0.2702,
-"compress_mbps": 29.94,
-"decompress_mbps": 147.02
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5823141,
-"ratio": 0.2695,
-"compress_mbps": 26.58,
-"decompress_mbps": 149.46
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5422105,
-"ratio": 0.2509,
-"compress_mbps": 11.28,
-"decompress_mbps": 141.67
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5419419,
-"ratio": 0.2508,
-"compress_mbps": 10.87,
-"decompress_mbps": 146.48
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5169629,
-"ratio": 0.2393,
-"compress_mbps": 0.82,
-"decompress_mbps": 151.21
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5514155,
-"ratio": 0.7604,
-"compress_mbps": 25.35,
-"decompress_mbps": 51.81
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5472540,
-"ratio": 0.7546,
-"compress_mbps": 24.08,
-"decompress_mbps": 53.35
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5448811,
-"ratio": 0.7514,
-"compress_mbps": 22.46,
-"decompress_mbps": 54.36
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5375802,
-"ratio": 0.7413,
-"compress_mbps": 16.07,
-"decompress_mbps": 55.08
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5370794,
-"ratio": 0.7406,
-"compress_mbps": 15.2,
-"decompress_mbps": 55.31
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5362339,
-"ratio": 0.7394,
-"compress_mbps": 13.27,
-"decompress_mbps": 55.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5349148,
-"ratio": 0.7376,
-"compress_mbps": 4.98,
-"decompress_mbps": 55.76
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5348874,
-"ratio": 0.7376,
-"compress_mbps": 5.01,
-"decompress_mbps": 55.29
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5261135,
-"ratio": 0.7255,
-"compress_mbps": 1.28,
-"decompress_mbps": 55.55
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13389198,
-"ratio": 0.323,
-"compress_mbps": 38.35,
-"decompress_mbps": 103.49
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 12991470,
-"ratio": 0.3134,
-"compress_mbps": 34.63,
-"decompress_mbps": 109.66
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12756198,
-"ratio": 0.3077,
-"compress_mbps": 31.27,
-"decompress_mbps": 117.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12441121,
-"ratio": 0.3001,
-"compress_mbps": 21.83,
-"decompress_mbps": 116.79
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12392694,
-"ratio": 0.2989,
-"compress_mbps": 20.52,
-"decompress_mbps": 121.48
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12309254,
-"ratio": 0.2969,
-"compress_mbps": 17.6,
-"decompress_mbps": 124.46
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12265937,
-"ratio": 0.2959,
-"compress_mbps": 9.03,
-"decompress_mbps": 125.62
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12249548,
-"ratio": 0.2955,
-"compress_mbps": 8.5,
-"decompress_mbps": 125.69
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11638957,
-"ratio": 0.2807,
-"compress_mbps": 0.85,
-"decompress_mbps": 125.17
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6018712,
-"ratio": 0.7102,
-"compress_mbps": 25.69,
-"decompress_mbps": 39.99
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 5998688,
-"ratio": 0.7079,
-"compress_mbps": 24.01,
-"decompress_mbps": 42.86
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 5983501,
-"ratio": 0.7061,
-"compress_mbps": 23.12,
-"decompress_mbps": 45.47
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 5965382,
-"ratio": 0.7039,
-"compress_mbps": 19.21,
-"decompress_mbps": 42.41
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 5964821,
-"ratio": 0.7039,
-"compress_mbps": 18.96,
-"decompress_mbps": 43.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5964654,
-"ratio": 0.7039,
-"compress_mbps": 18.66,
-"decompress_mbps": 43.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5937524,
-"ratio": 0.7007,
-"compress_mbps": 5.81,
-"decompress_mbps": 44.2
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5937524,
-"ratio": 0.7007,
-"compress_mbps": 5.84,
-"decompress_mbps": 43.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5825680,
-"ratio": 0.6875,
-"compress_mbps": 1.64,
-"decompress_mbps": 43.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 841047,
-"ratio": 0.1573,
-"compress_mbps": 76.81,
-"decompress_mbps": 202.74
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 796222,
-"ratio": 0.149,
-"compress_mbps": 69.88,
-"decompress_mbps": 227.86
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 765435,
-"ratio": 0.1432,
-"compress_mbps": 61.3,
-"decompress_mbps": 251.28
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 730001,
-"ratio": 0.1366,
-"compress_mbps": 41.75,
-"decompress_mbps": 244.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 722548,
-"ratio": 0.1352,
-"compress_mbps": 39.09,
-"decompress_mbps": 272.02
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 711223,
-"ratio": 0.1331,
-"compress_mbps": 33.38,
-"decompress_mbps": 282.41
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 682684,
-"ratio": 0.1277,
-"compress_mbps": 17.81,
-"decompress_mbps": 282.05
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 681103,
-"ratio": 0.1274,
-"compress_mbps": 16.52,
-"decompress_mbps": 286.26
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 637424,
-"ratio": 0.1192,
-"compress_mbps": 0.67,
-"decompress_mbps": 305.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4585612,
-"ratio": 0.4499,
-"compress_mbps": 113.4,
-"decompress_mbps": 336.89
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4389474,
-"ratio": 0.4307,
-"compress_mbps": 95.9,
-"decompress_mbps": 352.16
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4192079,
-"ratio": 0.4113,
-"compress_mbps": 59.59,
-"decompress_mbps": 381.32
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4095021,
-"ratio": 0.4018,
-"compress_mbps": 66.05,
-"decompress_mbps": 364.33
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3949169,
-"ratio": 0.3875,
-"compress_mbps": 36.0,
-"decompress_mbps": 351.66
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3871628,
-"ratio": 0.3799,
-"compress_mbps": 21.31,
-"decompress_mbps": 361.68
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3858876,
-"ratio": 0.3786,
-"compress_mbps": 17.8,
-"decompress_mbps": 361.95
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3854729,
-"ratio": 0.3782,
-"compress_mbps": 15.13,
-"decompress_mbps": 363.88
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3854729,
-"ratio": 0.3782,
-"compress_mbps": 15.14,
-"decompress_mbps": 364.43
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20577220,
-"ratio": 0.4017,
-"compress_mbps": 113.62,
-"decompress_mbps": 365.07
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20247697,
-"ratio": 0.3953,
-"compress_mbps": 101.71,
-"decompress_mbps": 373.08
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19987880,
-"ratio": 0.3902,
-"compress_mbps": 77.06,
-"decompress_mbps": 382.29
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19512665,
-"ratio": 0.381,
-"compress_mbps": 76.34,
-"decompress_mbps": 370.33
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19213507,
-"ratio": 0.3751,
-"compress_mbps": 53.71,
-"decompress_mbps": 377.3
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19089118,
-"ratio": 0.3727,
-"compress_mbps": 34.53,
-"decompress_mbps": 381.73
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19061204,
-"ratio": 0.3721,
-"compress_mbps": 27.47,
-"decompress_mbps": 380.43
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19040998,
-"ratio": 0.3717,
-"compress_mbps": 15.42,
-"decompress_mbps": 359.03
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19044390,
-"ratio": 0.3718,
-"compress_mbps": 9.54,
-"decompress_mbps": 359.57
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3828360,
-"ratio": 0.384,
-"compress_mbps": 143.44,
-"decompress_mbps": 446.1
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3798539,
-"ratio": 0.381,
-"compress_mbps": 127.72,
-"decompress_mbps": 459.65
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3674568,
-"ratio": 0.3685,
-"compress_mbps": 79.64,
-"decompress_mbps": 473.62
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3680923,
-"ratio": 0.3692,
-"compress_mbps": 89.42,
-"decompress_mbps": 421.88
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3698707,
-"ratio": 0.371,
-"compress_mbps": 47.89,
-"decompress_mbps": 398.05
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3675935,
-"ratio": 0.3687,
-"compress_mbps": 26.38,
-"decompress_mbps": 412.8
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3670281,
-"ratio": 0.3681,
-"compress_mbps": 20.76,
-"decompress_mbps": 413.76
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3661103,
-"ratio": 0.3672,
-"compress_mbps": 11.01,
-"decompress_mbps": 417.83
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3660788,
-"ratio": 0.3672,
-"compress_mbps": 9.54,
-"decompress_mbps": 426.32
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4624591,
-"ratio": 0.1378,
-"compress_mbps": 335.61,
-"decompress_mbps": 818.92
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4303176,
-"ratio": 0.1282,
-"compress_mbps": 301.15,
-"decompress_mbps": 843.73
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 4010156,
-"ratio": 0.1195,
-"compress_mbps": 259.16,
-"decompress_mbps": 920.46
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3713866,
-"ratio": 0.1107,
-"compress_mbps": 214.16,
-"decompress_mbps": 903.31
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3378136,
-"ratio": 0.1007,
-"compress_mbps": 166.92,
-"decompress_mbps": 969.86
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3200182,
-"ratio": 0.0954,
-"compress_mbps": 114.5,
-"decompress_mbps": 1002.33
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3141278,
-"ratio": 0.0936,
-"compress_mbps": 90.7,
-"decompress_mbps": 1010.13
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3031199,
-"ratio": 0.0903,
-"compress_mbps": 39.5,
-"decompress_mbps": 1021.96
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2987995,
-"ratio": 0.0891,
-"compress_mbps": 21.46,
-"decompress_mbps": 1047.14
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3290526,
-"ratio": 0.5349,
-"compress_mbps": 79.38,
-"decompress_mbps": 255.92
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3238282,
-"ratio": 0.5264,
-"compress_mbps": 72.55,
-"decompress_mbps": 259.73
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3193366,
-"ratio": 0.5191,
-"compress_mbps": 57.11,
-"decompress_mbps": 266.63
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3158012,
-"ratio": 0.5133,
-"compress_mbps": 55.9,
-"decompress_mbps": 269.78
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3115309,
-"ratio": 0.5064,
-"compress_mbps": 39.36,
-"decompress_mbps": 274.06
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3097288,
-"ratio": 0.5034,
-"compress_mbps": 26.56,
-"decompress_mbps": 273.04
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3094363,
-"ratio": 0.503,
-"compress_mbps": 22.11,
-"decompress_mbps": 273.38
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3093026,
-"ratio": 0.5028,
-"compress_mbps": 17.26,
-"decompress_mbps": 273.77
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3092920,
-"ratio": 0.5027,
-"compress_mbps": 15.63,
-"decompress_mbps": 272.23
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4076385,
-"ratio": 0.4042,
-"compress_mbps": 128.32,
-"decompress_mbps": 445.83
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3991014,
-"ratio": 0.3957,
-"compress_mbps": 118.47,
-"decompress_mbps": 460.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3934055,
-"ratio": 0.3901,
-"compress_mbps": 94.37,
-"decompress_mbps": 474.51
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3825092,
-"ratio": 0.3793,
-"compress_mbps": 85.67,
-"decompress_mbps": 475.21
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3752932,
-"ratio": 0.3721,
-"compress_mbps": 65.24,
-"decompress_mbps": 465.59
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3695164,
-"ratio": 0.3664,
-"compress_mbps": 49.86,
-"decompress_mbps": 474.34
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3676881,
-"ratio": 0.3646,
-"compress_mbps": 38.39,
-"decompress_mbps": 484.05
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3673171,
-"ratio": 0.3642,
-"compress_mbps": 32.12,
-"decompress_mbps": 488.13
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3673171,
-"ratio": 0.3642,
-"compress_mbps": 31.47,
-"decompress_mbps": 485.26
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2376424,
-"ratio": 0.3586,
-"compress_mbps": 131.07,
-"decompress_mbps": 389.44
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2259060,
-"ratio": 0.3409,
-"compress_mbps": 113.6,
-"decompress_mbps": 407.41
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2135664,
-"ratio": 0.3223,
-"compress_mbps": 73.12,
-"decompress_mbps": 424.09
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2052793,
-"ratio": 0.3098,
-"compress_mbps": 82.63,
-"decompress_mbps": 419.74
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1932127,
-"ratio": 0.2915,
-"compress_mbps": 45.95,
-"decompress_mbps": 427.23
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1860865,
-"ratio": 0.2808,
-"compress_mbps": 23.07,
-"decompress_mbps": 435.0
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1838671,
-"ratio": 0.2774,
-"compress_mbps": 16.08,
-"decompress_mbps": 435.89
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1823235,
-"ratio": 0.2751,
-"compress_mbps": 8.19,
-"decompress_mbps": 431.26
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1823190,
-"ratio": 0.2751,
-"compress_mbps": 8.14,
-"decompress_mbps": 410.97
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6329449,
-"ratio": 0.2929,
-"compress_mbps": 170.41,
-"decompress_mbps": 460.75
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 6128866,
-"ratio": 0.2837,
-"compress_mbps": 156.81,
-"decompress_mbps": 531.63
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5982546,
-"ratio": 0.2769,
-"compress_mbps": 125.92,
-"decompress_mbps": 571.65
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5656400,
-"ratio": 0.2618,
-"compress_mbps": 117.46,
-"decompress_mbps": 570.94
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5511352,
-"ratio": 0.2551,
-"compress_mbps": 82.67,
-"decompress_mbps": 578.92
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5451399,
-"ratio": 0.2523,
-"compress_mbps": 56.89,
-"decompress_mbps": 591.12
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5417123,
-"ratio": 0.2507,
-"compress_mbps": 46.85,
-"decompress_mbps": 593.57
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5404364,
-"ratio": 0.2501,
-"compress_mbps": 32.81,
-"decompress_mbps": 597.41
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5402704,
-"ratio": 0.2501,
-"compress_mbps": 29.92,
-"decompress_mbps": 599.18
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5567768,
-"ratio": 0.7678,
-"compress_mbps": 65.43,
-"decompress_mbps": 314.61
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5504009,
-"ratio": 0.759,
-"compress_mbps": 59.08,
-"decompress_mbps": 324.77
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5439339,
-"ratio": 0.7501,
-"compress_mbps": 46.86,
-"decompress_mbps": 332.26
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5394604,
-"ratio": 0.7439,
-"compress_mbps": 48.62,
-"decompress_mbps": 342.95
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5370116,
-"ratio": 0.7405,
-"compress_mbps": 33.37,
-"decompress_mbps": 333.72
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5331793,
-"ratio": 0.7352,
-"compress_mbps": 23.2,
-"decompress_mbps": 343.29
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5327677,
-"ratio": 0.7347,
-"compress_mbps": 21.23,
-"decompress_mbps": 340.21
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5325914,
-"ratio": 0.7344,
-"compress_mbps": 18.84,
-"decompress_mbps": 340.82
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5325914,
-"ratio": 0.7344,
-"compress_mbps": 18.87,
-"decompress_mbps": 343.3
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 14991236,
-"ratio": 0.3616,
-"compress_mbps": 136.7,
-"decompress_mbps": 375.33
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 14249692,
-"ratio": 0.3437,
-"compress_mbps": 120.32,
-"decompress_mbps": 391.4
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 13627761,
-"ratio": 0.3287,
-"compress_mbps": 87.82,
-"decompress_mbps": 403.94
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 13001990,
-"ratio": 0.3136,
-"compress_mbps": 85.74,
-"decompress_mbps": 388.77
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12445991,
-"ratio": 0.3002,
-"compress_mbps": 55.1,
-"decompress_mbps": 387.91
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12213941,
-"ratio": 0.2946,
-"compress_mbps": 36.43,
-"decompress_mbps": 395.97
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12130416,
-"ratio": 0.2926,
-"compress_mbps": 29.72,
-"decompress_mbps": 396.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12073697,
-"ratio": 0.2912,
-"compress_mbps": 21.51,
-"decompress_mbps": 399.04
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12073469,
-"ratio": 0.2912,
-"compress_mbps": 21.31,
-"decompress_mbps": 398.38
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6033926,
-"ratio": 0.712,
-"compress_mbps": 75.61,
-"decompress_mbps": 281.72
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 5997474,
-"ratio": 0.7077,
-"compress_mbps": 68.71,
-"decompress_mbps": 290.03
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 5966621,
-"ratio": 0.7041,
-"compress_mbps": 55.65,
-"decompress_mbps": 291.1
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6091108,
-"ratio": 0.7188,
-"compress_mbps": 46.17,
-"decompress_mbps": 255.79
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6053566,
-"ratio": 0.7143,
-"compress_mbps": 37.29,
-"decompress_mbps": 261.92
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6045111,
-"ratio": 0.7134,
-"compress_mbps": 35.03,
-"decompress_mbps": 265.89
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6045034,
-"ratio": 0.7133,
-"compress_mbps": 34.93,
-"decompress_mbps": 266.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6045032,
-"ratio": 0.7133,
-"compress_mbps": 34.86,
-"decompress_mbps": 266.11
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6045032,
-"ratio": 0.7133,
-"compress_mbps": 34.89,
-"decompress_mbps": 266.04
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 965242,
-"ratio": 0.1806,
-"compress_mbps": 263.73,
-"decompress_mbps": 686.79
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 887265,
-"ratio": 0.166,
-"compress_mbps": 247.17,
-"decompress_mbps": 752.09
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 822167,
-"ratio": 0.1538,
-"compress_mbps": 191.77,
-"decompress_mbps": 802.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 807518,
-"ratio": 0.1511,
-"compress_mbps": 169.62,
-"decompress_mbps": 767.49
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 730574,
-"ratio": 0.1367,
-"compress_mbps": 122.12,
-"decompress_mbps": 813.74
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 687991,
-"ratio": 0.1287,
-"compress_mbps": 79.52,
-"decompress_mbps": 874.65
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 673933,
-"ratio": 0.1261,
-"compress_mbps": 65.16,
-"decompress_mbps": 846.85
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 659518,
-"ratio": 0.1234,
-"compress_mbps": 43.21,
-"decompress_mbps": 888.65
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 658899,
-"ratio": 0.1233,
-"compress_mbps": 39.95,
-"decompress_mbps": 901.4
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 5363862,
-"ratio": 0.5263,
-"compress_mbps": 139.37,
-"decompress_mbps": 375.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4438205,
-"ratio": 0.4354,
-"compress_mbps": 128.31,
-"decompress_mbps": 444.07
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4054333,
-"ratio": 0.3978,
-"compress_mbps": 63.98,
-"decompress_mbps": 490.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4038550,
-"ratio": 0.3962,
-"compress_mbps": 57.8,
-"decompress_mbps": 480.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3954920,
-"ratio": 0.388,
-"compress_mbps": 40.33,
-"decompress_mbps": 471.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3872874,
-"ratio": 0.38,
-"compress_mbps": 22.62,
-"decompress_mbps": 480.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3859937,
-"ratio": 0.3787,
-"compress_mbps": 18.87,
-"decompress_mbps": 480.93
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3855935,
-"ratio": 0.3783,
-"compress_mbps": 17.1,
-"decompress_mbps": 480.84
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3855791,
-"ratio": 0.3783,
-"compress_mbps": 17.04,
-"decompress_mbps": 480.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 22334882,
-"ratio": 0.4361,
-"compress_mbps": 232.08,
-"decompress_mbps": 374.31
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20150366,
-"ratio": 0.3934,
-"compress_mbps": 119.26,
-"decompress_mbps": 381.57
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19495014,
-"ratio": 0.3806,
-"compress_mbps": 70.01,
-"decompress_mbps": 393.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19424978,
-"ratio": 0.3792,
-"compress_mbps": 71.42,
-"decompress_mbps": 407.0
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19298736,
-"ratio": 0.3768,
-"compress_mbps": 54.07,
-"decompress_mbps": 419.71
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19179167,
-"ratio": 0.3744,
-"compress_mbps": 29.67,
-"decompress_mbps": 429.37
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19151324,
-"ratio": 0.3739,
-"compress_mbps": 21.89,
-"decompress_mbps": 428.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19144373,
-"ratio": 0.3738,
-"compress_mbps": 16.6,
-"decompress_mbps": 430.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19141383,
-"ratio": 0.3737,
-"compress_mbps": 14.2,
-"decompress_mbps": 432.22
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 4249731,
-"ratio": 0.4262,
-"compress_mbps": 308.92,
-"decompress_mbps": 537.71
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3775479,
-"ratio": 0.3787,
-"compress_mbps": 158.58,
-"decompress_mbps": 565.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3656966,
-"ratio": 0.3668,
-"compress_mbps": 80.3,
-"decompress_mbps": 587.01
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3740378,
-"ratio": 0.3751,
-"compress_mbps": 68.2,
-"decompress_mbps": 548.54
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3713604,
-"ratio": 0.3725,
-"compress_mbps": 48.92,
-"decompress_mbps": 514.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3683556,
-"ratio": 0.3694,
-"compress_mbps": 25.27,
-"decompress_mbps": 532.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3683797,
-"ratio": 0.3695,
-"compress_mbps": 19.22,
-"decompress_mbps": 539.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3684477,
-"ratio": 0.3695,
-"compress_mbps": 14.5,
-"decompress_mbps": 513.45
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3679414,
-"ratio": 0.369,
-"compress_mbps": 12.49,
-"decompress_mbps": 545.83
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 5594622,
-"ratio": 0.1667,
-"compress_mbps": 428.92,
-"decompress_mbps": 793.28
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4179532,
-"ratio": 0.1246,
-"compress_mbps": 329.24,
-"decompress_mbps": 963.61
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3542329,
-"ratio": 0.1056,
-"compress_mbps": 213.19,
-"decompress_mbps": 884.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3323363,
-"ratio": 0.099,
-"compress_mbps": 199.57,
-"decompress_mbps": 921.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3230343,
-"ratio": 0.0963,
-"compress_mbps": 163.68,
-"decompress_mbps": 980.95
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3123421,
-"ratio": 0.0931,
-"compress_mbps": 96.44,
-"decompress_mbps": 1031.3
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3093778,
-"ratio": 0.0922,
-"compress_mbps": 70.89,
-"decompress_mbps": 1007.71
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3067318,
-"ratio": 0.0914,
-"compress_mbps": 50.2,
-"decompress_mbps": 1045.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3050695,
-"ratio": 0.0909,
-"compress_mbps": 42.16,
-"decompress_mbps": 1088.3
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3543611,
-"ratio": 0.576,
-"compress_mbps": 168.15,
-"decompress_mbps": 280.16
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3226818,
-"ratio": 0.5245,
-"compress_mbps": 86.2,
-"decompress_mbps": 294.03
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3144140,
-"ratio": 0.5111,
-"compress_mbps": 52.64,
-"decompress_mbps": 304.6
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3129833,
-"ratio": 0.5087,
-"compress_mbps": 51.69,
-"decompress_mbps": 333.32
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3114809,
-"ratio": 0.5063,
-"compress_mbps": 40.37,
-"decompress_mbps": 345.37
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3095705,
-"ratio": 0.5032,
-"compress_mbps": 25.12,
-"decompress_mbps": 350.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3090055,
-"ratio": 0.5023,
-"compress_mbps": 20.44,
-"decompress_mbps": 350.77
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3087665,
-"ratio": 0.5019,
-"compress_mbps": 17.39,
-"decompress_mbps": 353.6
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3087158,
-"ratio": 0.5018,
-"compress_mbps": 16.34,
-"decompress_mbps": 354.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 5419510,
-"ratio": 0.5373,
-"compress_mbps": 242.39,
-"decompress_mbps": 543.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3982547,
-"ratio": 0.3949,
-"compress_mbps": 122.94,
-"decompress_mbps": 563.6
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3806102,
-"ratio": 0.3774,
-"compress_mbps": 82.15,
-"decompress_mbps": 582.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3761477,
-"ratio": 0.373,
-"compress_mbps": 78.93,
-"decompress_mbps": 620.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3740298,
-"ratio": 0.3709,
-"compress_mbps": 67.42,
-"decompress_mbps": 622.75
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3686116,
-"ratio": 0.3655,
-"compress_mbps": 49.55,
-"decompress_mbps": 654.14
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3668442,
-"ratio": 0.3637,
-"compress_mbps": 38.83,
-"decompress_mbps": 665.71
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3665072,
-"ratio": 0.3634,
-"compress_mbps": 33.2,
-"decompress_mbps": 662.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3665057,
-"ratio": 0.3634,
-"compress_mbps": 33.11,
-"decompress_mbps": 660.9
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2842321,
-"ratio": 0.4289,
-"compress_mbps": 188.8,
-"decompress_mbps": 492.72
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2232180,
-"ratio": 0.3368,
-"compress_mbps": 152.31,
-"decompress_mbps": 532.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2003056,
-"ratio": 0.3022,
-"compress_mbps": 82.28,
-"decompress_mbps": 572.07
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1985375,
-"ratio": 0.2996,
-"compress_mbps": 74.23,
-"decompress_mbps": 575.99
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1933775,
-"ratio": 0.2918,
-"compress_mbps": 52.06,
-"decompress_mbps": 551.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1858103,
-"ratio": 0.2804,
-"compress_mbps": 22.05,
-"decompress_mbps": 556.66
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1840414,
-"ratio": 0.2777,
-"compress_mbps": 15.14,
-"decompress_mbps": 559.48
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1831679,
-"ratio": 0.2764,
-"compress_mbps": 11.73,
-"decompress_mbps": 529.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1827137,
-"ratio": 0.2757,
-"compress_mbps": 10.16,
-"decompress_mbps": 556.73
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 7089759,
-"ratio": 0.3281,
-"compress_mbps": 287.53,
-"decompress_mbps": 549.07
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5966231,
-"ratio": 0.2761,
-"compress_mbps": 173.93,
-"decompress_mbps": 644.51
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5611838,
-"ratio": 0.2597,
-"compress_mbps": 111.63,
-"decompress_mbps": 669.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5535436,
-"ratio": 0.2562,
-"compress_mbps": 105.67,
-"decompress_mbps": 690.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5480971,
-"ratio": 0.2537,
-"compress_mbps": 81.48,
-"decompress_mbps": 698.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5437556,
-"ratio": 0.2517,
-"compress_mbps": 49.59,
-"decompress_mbps": 712.63
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5432108,
-"ratio": 0.2514,
-"compress_mbps": 40.49,
-"decompress_mbps": 711.25
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5428571,
-"ratio": 0.2512,
-"compress_mbps": 33.69,
-"decompress_mbps": 720.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5425526,
-"ratio": 0.2511,
-"compress_mbps": 30.54,
-"decompress_mbps": 719.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5900800,
-"ratio": 0.8137,
-"compress_mbps": 187.0,
-"decompress_mbps": 333.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5523611,
-"ratio": 0.7617,
-"compress_mbps": 69.17,
-"decompress_mbps": 346.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5393086,
-"ratio": 0.7437,
-"compress_mbps": 40.35,
-"decompress_mbps": 356.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5401582,
-"ratio": 0.7448,
-"compress_mbps": 40.67,
-"decompress_mbps": 372.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5371274,
-"ratio": 0.7407,
-"compress_mbps": 31.28,
-"decompress_mbps": 363.5
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5330096,
-"ratio": 0.735,
-"compress_mbps": 20.81,
-"decompress_mbps": 369.42
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5325437,
-"ratio": 0.7343,
-"compress_mbps": 19.02,
-"decompress_mbps": 372.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5323934,
-"ratio": 0.7341,
-"compress_mbps": 18.08,
-"decompress_mbps": 369.5
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323621,
-"ratio": 0.7341,
-"compress_mbps": 17.77,
-"decompress_mbps": 370.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 17587173,
-"ratio": 0.4242,
-"compress_mbps": 182.23,
-"decompress_mbps": 386.88
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 14171707,
-"ratio": 0.3418,
-"compress_mbps": 149.07,
-"decompress_mbps": 423.73
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12774851,
-"ratio": 0.3081,
-"compress_mbps": 85.97,
-"decompress_mbps": 455.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12612554,
-"ratio": 0.3042,
-"compress_mbps": 76.45,
-"decompress_mbps": 450.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12392339,
-"ratio": 0.2989,
-"compress_mbps": 58.11,
-"decompress_mbps": 463.39
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12158314,
-"ratio": 0.2933,
-"compress_mbps": 34.38,
-"decompress_mbps": 469.88
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12107840,
-"ratio": 0.292,
-"compress_mbps": 27.64,
-"decompress_mbps": 468.69
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12081311,
-"ratio": 0.2914,
-"compress_mbps": 22.87,
-"decompress_mbps": 476.84
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12081011,
-"ratio": 0.2914,
-"compress_mbps": 22.79,
-"decompress_mbps": 477.79
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6527324,
-"ratio": 0.7703,
-"compress_mbps": 237.95,
-"decompress_mbps": 330.9
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6051483,
-"ratio": 0.7141,
-"compress_mbps": 75.21,
-"decompress_mbps": 334.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6010123,
-"ratio": 0.7092,
-"compress_mbps": 52.11,
-"decompress_mbps": 335.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6024815,
-"ratio": 0.711,
-"compress_mbps": 44.4,
-"decompress_mbps": 287.65
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6005181,
-"ratio": 0.7086,
-"compress_mbps": 40.36,
-"decompress_mbps": 294.61
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5997508,
-"ratio": 0.7077,
-"compress_mbps": 37.82,
-"decompress_mbps": 299.96
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5997403,
-"ratio": 0.7077,
-"compress_mbps": 37.83,
-"decompress_mbps": 299.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5997403,
-"ratio": 0.7077,
-"compress_mbps": 37.88,
-"decompress_mbps": 298.22
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5997403,
-"ratio": 0.7077,
-"compress_mbps": 37.82,
-"decompress_mbps": 299.23
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 1147652,
-"ratio": 0.2147,
-"compress_mbps": 384.13,
-"decompress_mbps": 862.85
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 919639,
-"ratio": 0.172,
-"compress_mbps": 261.19,
-"decompress_mbps": 982.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 752341,
-"ratio": 0.1407,
-"compress_mbps": 167.42,
-"decompress_mbps": 1085.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 735537,
-"ratio": 0.1376,
-"compress_mbps": 161.73,
-"decompress_mbps": 1053.95
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 706789,
-"ratio": 0.1322,
-"compress_mbps": 123.69,
-"decompress_mbps": 1149.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 676279,
-"ratio": 0.1265,
-"compress_mbps": 69.66,
-"decompress_mbps": 1240.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 668772,
-"ratio": 0.1251,
-"compress_mbps": 56.09,
-"decompress_mbps": 1249.6
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 665340,
-"ratio": 0.1245,
-"compress_mbps": 47.65,
-"decompress_mbps": 1211.14
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 664273,
-"ratio": 0.1243,
-"compress_mbps": 45.9,
-"decompress_mbps": 1247.51
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": 243.59,
-"decompress_mbps": 795.98
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4053259,
-"ratio": 0.3977,
-"compress_mbps": 170.2,
-"decompress_mbps": 895.08
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": 139.88,
-"decompress_mbps": 935.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3972869,
-"ratio": 0.3898,
-"compress_mbps": 127.92,
-"decompress_mbps": 847.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3894026,
-"ratio": 0.3821,
-"compress_mbps": 99.07,
-"decompress_mbps": 807.23
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": 75.61,
-"decompress_mbps": 836.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3837515,
-"ratio": 0.3765,
-"compress_mbps": 55.76,
-"decompress_mbps": 818.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3811467,
-"ratio": 0.374,
-"compress_mbps": 36.01,
-"decompress_mbps": 819.21
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": 32.78,
-"decompress_mbps": 811.67
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": 241.63,
-"decompress_mbps": 691.88
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 19374226,
-"ratio": 0.3783,
-"compress_mbps": 186.41,
-"decompress_mbps": 728.31
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": 173.63,
-"decompress_mbps": 741.76
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19145385,
-"ratio": 0.3738,
-"compress_mbps": 161.79,
-"decompress_mbps": 736.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 18878875,
-"ratio": 0.3686,
-"compress_mbps": 144.12,
-"decompress_mbps": 756.99
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": 119.2,
-"decompress_mbps": 768.38
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 18749947,
-"ratio": 0.3661,
-"compress_mbps": 88.03,
-"decompress_mbps": 774.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 18718540,
-"ratio": 0.3655,
-"compress_mbps": 47.56,
-"decompress_mbps": 776.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": 33.69,
-"decompress_mbps": 771.26
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": 293.48,
-"decompress_mbps": 868.65
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3707407,
-"ratio": 0.3718,
-"compress_mbps": 214.93,
-"decompress_mbps": 895.66
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": 184.55,
-"decompress_mbps": 948.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3660011,
-"ratio": 0.3671,
-"compress_mbps": 170.49,
-"decompress_mbps": 863.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3664245,
-"ratio": 0.3675,
-"compress_mbps": 141.76,
-"decompress_mbps": 824.31
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": 106.97,
-"decompress_mbps": 840.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3635323,
-"ratio": 0.3646,
-"compress_mbps": 68.77,
-"decompress_mbps": 857.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3624778,
-"ratio": 0.3635,
-"compress_mbps": 43.07,
-"decompress_mbps": 879.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": 38.9,
-"decompress_mbps": 873.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": 608.67,
-"decompress_mbps": 1536.6
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3714632,
-"ratio": 0.1107,
-"compress_mbps": 465.03,
-"decompress_mbps": 1786.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": 428.65,
-"decompress_mbps": 1912.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3431843,
-"ratio": 0.1023,
-"compress_mbps": 391.23,
-"decompress_mbps": 1786.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3268188,
-"ratio": 0.0974,
-"compress_mbps": 348.92,
-"decompress_mbps": 1799.16
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": 264.09,
-"decompress_mbps": 1862.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3032499,
-"ratio": 0.0904,
-"compress_mbps": 178.34,
-"decompress_mbps": 1805.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 2949097,
-"ratio": 0.0879,
-"compress_mbps": 97.6,
-"decompress_mbps": 1783.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": 69.36,
-"decompress_mbps": 1808.56
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": 166.47,
-"decompress_mbps": 473.56
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3150806,
-"ratio": 0.5121,
-"compress_mbps": 128.41,
-"decompress_mbps": 517.64
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": 120.42,
-"decompress_mbps": 528.41
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3129676,
-"ratio": 0.5087,
-"compress_mbps": 116.91,
-"decompress_mbps": 553.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3079277,
-"ratio": 0.5005,
-"compress_mbps": 99.65,
-"decompress_mbps": 571.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": 88.89,
-"decompress_mbps": 573.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3068123,
-"ratio": 0.4987,
-"compress_mbps": 76.0,
-"decompress_mbps": 573.65
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3067299,
-"ratio": 0.4986,
-"compress_mbps": 55.42,
-"decompress_mbps": 554.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": 49.99,
-"decompress_mbps": 569.15
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": 288.08,
-"decompress_mbps": 892.74
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3839158,
-"ratio": 0.3807,
-"compress_mbps": 213.72,
-"decompress_mbps": 914.92
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": 197.09,
-"decompress_mbps": 930.83
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3789325,
-"ratio": 0.3757,
-"compress_mbps": 180.61,
-"decompress_mbps": 979.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3666476,
-"ratio": 0.3635,
-"compress_mbps": 158.45,
-"decompress_mbps": 982.55
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": 142.58,
-"decompress_mbps": 1018.98
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3659491,
-"ratio": 0.3628,
-"compress_mbps": 135.2,
-"decompress_mbps": 1024.5
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3654863,
-"ratio": 0.3624,
-"compress_mbps": 115.43,
-"decompress_mbps": 1033.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": 115.4,
-"decompress_mbps": 1013.57
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": 301.03,
-"decompress_mbps": 1002.39
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2082309,
-"ratio": 0.3142,
-"compress_mbps": 214.55,
-"decompress_mbps": 1136.41
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": 178.28,
-"decompress_mbps": 1246.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1990952,
-"ratio": 0.3004,
-"compress_mbps": 158.76,
-"decompress_mbps": 1159.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1921113,
-"ratio": 0.2899,
-"compress_mbps": 128.12,
-"decompress_mbps": 1065.36
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": 87.45,
-"decompress_mbps": 1089.6
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1832695,
-"ratio": 0.2765,
-"compress_mbps": 46.82,
-"decompress_mbps": 1106.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1809967,
-"ratio": 0.2731,
-"compress_mbps": 24.36,
-"decompress_mbps": 1089.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": 19.91,
-"decompress_mbps": 1040.19
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": 339.5,
-"decompress_mbps": 918.88
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5695942,
-"ratio": 0.2636,
-"compress_mbps": 258.44,
-"decompress_mbps": 1072.83
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": 236.1,
-"decompress_mbps": 1118.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5553432,
-"ratio": 0.257,
-"compress_mbps": 218.73,
-"decompress_mbps": 1090.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5416713,
-"ratio": 0.2507,
-"compress_mbps": 188.8,
-"decompress_mbps": 1084.04
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": 144.82,
-"decompress_mbps": 1100.67
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5310181,
-"ratio": 0.2458,
-"compress_mbps": 100.81,
-"decompress_mbps": 1090.5
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5272761,
-"ratio": 0.244,
-"compress_mbps": 62.66,
-"decompress_mbps": 1096.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": 50.38,
-"decompress_mbps": 1088.65
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": 162.96,
-"decompress_mbps": 493.08
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5417142,
-"ratio": 0.747,
-"compress_mbps": 117.3,
-"decompress_mbps": 523.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": 105.62,
-"decompress_mbps": 531.88
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5391125,
-"ratio": 0.7434,
-"compress_mbps": 99.83,
-"decompress_mbps": 535.9
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5352212,
-"ratio": 0.738,
-"compress_mbps": 88.53,
-"decompress_mbps": 525.52
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": 74.27,
-"decompress_mbps": 536.9
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5325697,
-"ratio": 0.7344,
-"compress_mbps": 63.91,
-"decompress_mbps": 533.34
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5324004,
-"ratio": 0.7341,
-"compress_mbps": 52.63,
-"decompress_mbps": 522.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": 51.23,
-"decompress_mbps": 533.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": 267.72,
-"decompress_mbps": 838.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 13130705,
-"ratio": 0.3167,
-"compress_mbps": 202.6,
-"decompress_mbps": 980.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": 179.37,
-"decompress_mbps": 1035.45
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12601933,
-"ratio": 0.304,
-"compress_mbps": 164.03,
-"decompress_mbps": 925.96
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12310776,
-"ratio": 0.2969,
-"compress_mbps": 133.37,
-"decompress_mbps": 905.44
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": 105.86,
-"decompress_mbps": 913.37
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12025296,
-"ratio": 0.2901,
-"compress_mbps": 75.68,
-"decompress_mbps": 912.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 11893824,
-"ratio": 0.2869,
-"compress_mbps": 46.17,
-"decompress_mbps": 908.69
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": 39.76,
-"decompress_mbps": 909.14
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": 145.14,
-"decompress_mbps": 524.63
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6058412,
-"ratio": 0.7149,
-"compress_mbps": 120.91,
-"decompress_mbps": 535.34
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": 121.18,
-"decompress_mbps": 539.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6058363,
-"ratio": 0.7149,
-"compress_mbps": 121.22,
-"decompress_mbps": 437.28
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 5998400,
-"ratio": 0.7078,
-"compress_mbps": 108.85,
-"decompress_mbps": 460.99
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": 108.81,
-"decompress_mbps": 452.16
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5998439,
-"ratio": 0.7078,
-"compress_mbps": 108.73,
-"decompress_mbps": 459.69
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": 90.17,
-"decompress_mbps": 462.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": 90.43,
-"decompress_mbps": 457.91
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": 492.13,
-"decompress_mbps": 1317.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 843475,
-"ratio": 0.1578,
-"compress_mbps": 364.82,
-"decompress_mbps": 1479.99
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": 336.39,
-"decompress_mbps": 1592.52
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 747602,
-"ratio": 0.1399,
-"compress_mbps": 304.97,
-"decompress_mbps": 1536.28
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 718615,
-"ratio": 0.1344,
-"compress_mbps": 263.04,
-"decompress_mbps": 1550.47
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": 206.69,
-"decompress_mbps": 1606.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 664859,
-"ratio": 0.1244,
-"compress_mbps": 143.05,
-"decompress_mbps": 1601.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 650835,
-"ratio": 0.1218,
-"compress_mbps": 84.78,
-"decompress_mbps": 1326.69
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": 68.16,
-"decompress_mbps": 1227.38
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 65708,
-"ratio": 0.432,
-"compress_mbps": 42.56,
-"decompress_mbps": 61.17
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 60259,
-"ratio": 0.3962,
-"compress_mbps": 26.21,
-"decompress_mbps": 68.33
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 58544,
-"ratio": 0.3849,
-"compress_mbps": 21.92,
-"decompress_mbps": 69.11
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56238,
-"ratio": 0.3698,
-"compress_mbps": 21.46,
-"decompress_mbps": 70.96
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54764,
-"ratio": 0.3601,
-"compress_mbps": 16.16,
-"decompress_mbps": 71.22
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54311,
-"ratio": 0.3571,
-"compress_mbps": 10.7,
-"decompress_mbps": 71.22
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54262,
-"ratio": 0.3568,
-"compress_mbps": 9.8,
-"decompress_mbps": 72.02
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54247,
-"ratio": 0.3567,
-"compress_mbps": 9.57,
-"decompress_mbps": 72.02
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54247,
-"ratio": 0.3567,
-"compress_mbps": 9.65,
-"decompress_mbps": 72.57
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 56882,
-"ratio": 0.4544,
-"compress_mbps": 37.25,
-"decompress_mbps": 55.92
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 52826,
-"ratio": 0.422,
-"compress_mbps": 23.05,
-"decompress_mbps": 62.21
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51625,
-"ratio": 0.4124,
-"compress_mbps": 22.69,
-"decompress_mbps": 65.27
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50034,
-"ratio": 0.3997,
-"compress_mbps": 22.5,
-"decompress_mbps": 65.59
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48912,
-"ratio": 0.3907,
-"compress_mbps": 12.62,
-"decompress_mbps": 65.42
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48738,
-"ratio": 0.3893,
-"compress_mbps": 11.77,
-"decompress_mbps": 65.61
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48719,
-"ratio": 0.3892,
-"compress_mbps": 9.97,
-"decompress_mbps": 65.88
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48716,
-"ratio": 0.3892,
-"compress_mbps": 9.9,
-"decompress_mbps": 68.31
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48716,
-"ratio": 0.3892,
-"compress_mbps": 12.58,
-"decompress_mbps": 64.73
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8988,
-"ratio": 0.3653,
-"compress_mbps": 36.94,
-"decompress_mbps": 103.46
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8564,
-"ratio": 0.3481,
-"compress_mbps": 43.51,
-"decompress_mbps": 102.54
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8390,
-"ratio": 0.341,
-"compress_mbps": 28.97,
-"decompress_mbps": 97.31
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8167,
-"ratio": 0.332,
-"compress_mbps": 37.49,
-"decompress_mbps": 98.37
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7965,
-"ratio": 0.3237,
-"compress_mbps": 28.72,
-"decompress_mbps": 88.78
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7916,
-"ratio": 0.3217,
-"compress_mbps": 22.76,
-"decompress_mbps": 104.8
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7900,
-"ratio": 0.3211,
-"compress_mbps": 21.67,
-"decompress_mbps": 85.25
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7900,
-"ratio": 0.3211,
-"compress_mbps": 20.13,
-"decompress_mbps": 105.7
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7900,
-"ratio": 0.3211,
-"compress_mbps": 27.55,
-"decompress_mbps": 92.8
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3731,
-"ratio": 0.3346,
-"compress_mbps": 18.9,
-"decompress_mbps": 80.13
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3491,
-"ratio": 0.3131,
-"compress_mbps": 23.63,
-"decompress_mbps": 84.66
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3384,
-"ratio": 0.3035,
-"compress_mbps": 22.04,
-"decompress_mbps": 89.77
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3220,
-"ratio": 0.2888,
-"compress_mbps": 21.08,
-"decompress_mbps": 86.53
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3138,
-"ratio": 0.2814,
-"compress_mbps": 17.11,
-"decompress_mbps": 93.05
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3118,
-"ratio": 0.2796,
-"compress_mbps": 15.03,
-"decompress_mbps": 100.03
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 14.26,
-"decompress_mbps": 96.56
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 14.4,
-"decompress_mbps": 104.06
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 15.81,
-"decompress_mbps": 101.86
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1352,
-"ratio": 0.3633,
-"compress_mbps": 8.47,
-"decompress_mbps": 63.54
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1287,
-"ratio": 0.3459,
-"compress_mbps": 11.63,
-"decompress_mbps": 60.62
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1284,
-"ratio": 0.3451,
-"compress_mbps": 11.67,
-"decompress_mbps": 62.5
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1226,
-"ratio": 0.3295,
-"compress_mbps": 11.31,
-"decompress_mbps": 66.96
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 9.84,
-"decompress_mbps": 63.24
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 10.84,
-"decompress_mbps": 63.7
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 10.02,
-"decompress_mbps": 64.11
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 10.74,
-"decompress_mbps": 80.94
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 11.17,
-"decompress_mbps": 63.88
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 245423,
-"ratio": 0.2383,
-"compress_mbps": 123.71,
-"decompress_mbps": 127.4
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 229642,
-"ratio": 0.223,
-"compress_mbps": 92.84,
-"decompress_mbps": 151.73
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 225678,
-"ratio": 0.2192,
-"compress_mbps": 109.83,
-"decompress_mbps": 153.59
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 218218,
-"ratio": 0.2119,
-"compress_mbps": 99.82,
-"decompress_mbps": 163.61
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 210550,
-"ratio": 0.2045,
-"compress_mbps": 48.7,
-"decompress_mbps": 154.12
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 207949,
-"ratio": 0.2019,
-"compress_mbps": 27.88,
-"decompress_mbps": 168.6
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 207413,
-"ratio": 0.2014,
-"compress_mbps": 18.82,
-"decompress_mbps": 151.74
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 207478,
-"ratio": 0.2015,
-"compress_mbps": 6.77,
-"decompress_mbps": 153.16
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 207482,
-"ratio": 0.2015,
-"compress_mbps": 3.56,
-"decompress_mbps": 157.49
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 175980,
-"ratio": 0.4124,
-"compress_mbps": 43.31,
-"decompress_mbps": 64.49
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 160455,
-"ratio": 0.376,
-"compress_mbps": 70.41,
-"decompress_mbps": 72.33
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 156690,
-"ratio": 0.3672,
-"compress_mbps": 32.21,
-"decompress_mbps": 74.1
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 149064,
-"ratio": 0.3493,
-"compress_mbps": 36.48,
-"decompress_mbps": 75.59
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145616,
-"ratio": 0.3412,
-"compress_mbps": 20.01,
-"decompress_mbps": 76.95
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144773,
-"ratio": 0.3392,
-"compress_mbps": 17.53,
-"decompress_mbps": 76.34
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144603,
-"ratio": 0.3388,
-"compress_mbps": 19.93,
-"decompress_mbps": 75.91
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144573,
-"ratio": 0.3388,
-"compress_mbps": 16.49,
-"decompress_mbps": 80.22
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 144570,
-"ratio": 0.3388,
-"compress_mbps": 15.68,
-"decompress_mbps": 75.93
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 228837,
-"ratio": 0.4749,
-"compress_mbps": 35.31,
-"decompress_mbps": 54.63
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 211248,
-"ratio": 0.4384,
-"compress_mbps": 31.57,
-"decompress_mbps": 61.56
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 205619,
-"ratio": 0.4267,
-"compress_mbps": 25.52,
-"decompress_mbps": 67.59
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 200595,
-"ratio": 0.4163,
-"compress_mbps": 34.86,
-"decompress_mbps": 66.46
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 195418,
-"ratio": 0.4055,
-"compress_mbps": 18.88,
-"decompress_mbps": 65.35
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 194148,
-"ratio": 0.4029,
-"compress_mbps": 15.2,
-"decompress_mbps": 66.36
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 193994,
-"ratio": 0.4026,
-"compress_mbps": 16.61,
-"decompress_mbps": 66.46
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 193991,
-"ratio": 0.4026,
-"compress_mbps": 14.97,
-"decompress_mbps": 65.37
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 193991,
-"ratio": 0.4026,
-"compress_mbps": 14.75,
-"decompress_mbps": 80.17
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 60990,
-"ratio": 0.1188,
-"compress_mbps": 240.46,
-"decompress_mbps": 173.43
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 61650,
-"ratio": 0.1201,
-"compress_mbps": 103.12,
-"decompress_mbps": 188.54
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 60035,
-"ratio": 0.117,
-"compress_mbps": 90.48,
-"decompress_mbps": 205.17
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 57005,
-"ratio": 0.1111,
-"compress_mbps": 91.56,
-"decompress_mbps": 195.56
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 55779,
-"ratio": 0.1087,
-"compress_mbps": 81.64,
-"decompress_mbps": 263.29
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 54970,
-"ratio": 0.1071,
-"compress_mbps": 69.16,
-"decompress_mbps": 204.84
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 53922,
-"ratio": 0.1051,
-"compress_mbps": 76.91,
-"decompress_mbps": 217.15
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 51977,
-"ratio": 0.1013,
-"compress_mbps": 17.63,
-"decompress_mbps": 275.85
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 51474,
-"ratio": 0.1003,
-"compress_mbps": 6.71,
-"decompress_mbps": 239.18
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14783,
-"ratio": 0.3866,
-"compress_mbps": 32.71,
-"decompress_mbps": 70.98
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 14101,
-"ratio": 0.3688,
-"compress_mbps": 33.16,
-"decompress_mbps": 78.17
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13975,
-"ratio": 0.3655,
-"compress_mbps": 28.17,
-"decompress_mbps": 75.22
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13632,
-"ratio": 0.3565,
-"compress_mbps": 30.93,
-"decompress_mbps": 100.62
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13302,
-"ratio": 0.3479,
-"compress_mbps": 25.78,
-"decompress_mbps": 79.98
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13279,
-"ratio": 0.3473,
-"compress_mbps": 21.9,
-"decompress_mbps": 77.99
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13274,
-"ratio": 0.3471,
-"compress_mbps": 19.14,
-"decompress_mbps": 84.74
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13260,
-"ratio": 0.3468,
-"compress_mbps": 7.15,
-"decompress_mbps": 80.47
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13260,
-"ratio": 0.3468,
-"compress_mbps": 4.57,
-"decompress_mbps": 79.18
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1862,
-"ratio": 0.4405,
-"compress_mbps": 9.05,
-"decompress_mbps": 61.67
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1803,
-"ratio": 0.4265,
-"compress_mbps": 12.61,
-"decompress_mbps": 58.6
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1791,
-"ratio": 0.4237,
-"compress_mbps": 12.87,
-"decompress_mbps": 60.15
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1746,
-"ratio": 0.4131,
-"compress_mbps": 12.23,
-"decompress_mbps": 60.76
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 10.95,
-"decompress_mbps": 59.77
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 11.32,
-"decompress_mbps": 59.78
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 10.98,
-"decompress_mbps": 65.28
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 11.09,
-"decompress_mbps": 61.29
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 11.55,
-"decompress_mbps": 61.79
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4623589,
-"ratio": 0.4536,
-"compress_mbps": 87.88,
-"decompress_mbps": 121.47
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4241525,
-"ratio": 0.4161,
-"compress_mbps": 59.05,
-"decompress_mbps": 124.77
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4123202,
-"ratio": 0.4045,
-"compress_mbps": 61.06,
-"decompress_mbps": 116.15
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3985937,
-"ratio": 0.3911,
-"compress_mbps": 60.91,
-"decompress_mbps": 204.23
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3883839,
-"ratio": 0.3811,
-"compress_mbps": 35.59,
-"decompress_mbps": 119.76
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3860437,
-"ratio": 0.3788,
-"compress_mbps": 27.93,
-"decompress_mbps": 202.6
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3857076,
-"ratio": 0.3784,
-"compress_mbps": 25.13,
-"decompress_mbps": 126.89
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3856651,
-"ratio": 0.3784,
-"compress_mbps": 24.66,
-"decompress_mbps": 202.36
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3856651,
-"ratio": 0.3784,
-"compress_mbps": 24.68,
-"decompress_mbps": 116.01
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 21508211,
-"ratio": 0.4199,
-"compress_mbps": 143.1,
-"decompress_mbps": 239.36
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20538783,
-"ratio": 0.401,
-"compress_mbps": 103.18,
-"decompress_mbps": 229.73
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 20334352,
-"ratio": 0.397,
-"compress_mbps": 88.51,
-"decompress_mbps": 208.07
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19886937,
-"ratio": 0.3883,
-"compress_mbps": 86.76,
-"decompress_mbps": 244.41
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19582363,
-"ratio": 0.3823,
-"compress_mbps": 65.59,
-"decompress_mbps": 239.15
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19512479,
-"ratio": 0.381,
-"compress_mbps": 43.56,
-"decompress_mbps": 220.01
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19489160,
-"ratio": 0.3805,
-"compress_mbps": 32.93,
-"decompress_mbps": 227.82
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19475109,
-"ratio": 0.3802,
-"compress_mbps": 18.63,
-"decompress_mbps": 225.38
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19476276,
-"ratio": 0.3802,
-"compress_mbps": 10.28,
-"decompress_mbps": 247.36
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3967718,
-"ratio": 0.3979,
-"compress_mbps": 146.76,
-"decompress_mbps": 172.01
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3773274,
-"ratio": 0.3784,
-"compress_mbps": 105.47,
-"decompress_mbps": 124.64
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3670460,
-"ratio": 0.3681,
-"compress_mbps": 77.56,
-"decompress_mbps": 182.34
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3655100,
-"ratio": 0.3666,
-"compress_mbps": 87.36,
-"decompress_mbps": 107.18
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3620881,
-"ratio": 0.3632,
-"compress_mbps": 51.01,
-"decompress_mbps": 125.34
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3606626,
-"ratio": 0.3617,
-"compress_mbps": 33.83,
-"decompress_mbps": 183.58
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3605405,
-"ratio": 0.3616,
-"compress_mbps": 31.23,
-"decompress_mbps": 130.79
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3601635,
-"ratio": 0.3612,
-"compress_mbps": 26.28,
-"decompress_mbps": 133.31
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3601151,
-"ratio": 0.3612,
-"compress_mbps": 19.51,
-"decompress_mbps": 120.72
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4501482,
-"ratio": 0.1342,
-"compress_mbps": 294.72,
-"decompress_mbps": 451.24
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3875891,
-"ratio": 0.1155,
-"compress_mbps": 315.51,
-"decompress_mbps": 356.45
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3731525,
-"ratio": 0.1112,
-"compress_mbps": 288.4,
-"decompress_mbps": 372.55
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3542242,
-"ratio": 0.1056,
-"compress_mbps": 236.86,
-"decompress_mbps": 484.44
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3239184,
-"ratio": 0.0965,
-"compress_mbps": 175.14,
-"decompress_mbps": 539.55
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3113927,
-"ratio": 0.0928,
-"compress_mbps": 120.53,
-"decompress_mbps": 330.65
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3063520,
-"ratio": 0.0913,
-"compress_mbps": 84.76,
-"decompress_mbps": 331.22
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 2961320,
-"ratio": 0.0883,
-"compress_mbps": 29.61,
-"decompress_mbps": 401.64
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2940087,
-"ratio": 0.0876,
-"compress_mbps": 20.54,
-"decompress_mbps": 474.59
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3462708,
-"ratio": 0.5628,
-"compress_mbps": 65.77,
-"decompress_mbps": 109.92
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3327399,
-"ratio": 0.5408,
-"compress_mbps": 71.78,
-"decompress_mbps": 84.48
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3297422,
-"ratio": 0.536,
-"compress_mbps": 66.06,
-"decompress_mbps": 89.69
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3249485,
-"ratio": 0.5282,
-"compress_mbps": 64.02,
-"decompress_mbps": 122.88
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3220046,
-"ratio": 0.5234,
-"compress_mbps": 49.81,
-"decompress_mbps": 90.58
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3213239,
-"ratio": 0.5223,
-"compress_mbps": 43.12,
-"decompress_mbps": 91.3
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3212009,
-"ratio": 0.5221,
-"compress_mbps": 39.44,
-"decompress_mbps": 177.12
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3211575,
-"ratio": 0.522,
-"compress_mbps": 27.92,
-"decompress_mbps": 92.84
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3211561,
-"ratio": 0.522,
-"compress_mbps": 29.68,
-"decompress_mbps": 92.12
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4334497,
-"ratio": 0.4298,
-"compress_mbps": 130.93,
-"decompress_mbps": 133.29
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3900156,
-"ratio": 0.3867,
-"compress_mbps": 131.77,
-"decompress_mbps": 116.9
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3876099,
-"ratio": 0.3843,
-"compress_mbps": 122.94,
-"decompress_mbps": 133.81
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3782364,
-"ratio": 0.375,
-"compress_mbps": 110.84,
-"decompress_mbps": 135.49
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3679310,
-"ratio": 0.3648,
-"compress_mbps": 89.42,
-"decompress_mbps": 136.59
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3679424,
-"ratio": 0.3648,
-"compress_mbps": 87.41,
-"decompress_mbps": 128.99
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3679163,
-"ratio": 0.3648,
-"compress_mbps": 83.39,
-"decompress_mbps": 141.56
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3679169,
-"ratio": 0.3648,
-"compress_mbps": 82.21,
-"decompress_mbps": 140.66
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3679169,
-"ratio": 0.3648,
-"compress_mbps": 81.84,
-"decompress_mbps": 196.94
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2496363,
-"ratio": 0.3767,
-"compress_mbps": 96.93,
-"decompress_mbps": 111.19
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2202601,
-"ratio": 0.3324,
-"compress_mbps": 92.65,
-"decompress_mbps": 102.3
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2103089,
-"ratio": 0.3173,
-"compress_mbps": 49.73,
-"decompress_mbps": 242.36
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1999697,
-"ratio": 0.3017,
-"compress_mbps": 75.29,
-"decompress_mbps": 121.18
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1892143,
-"ratio": 0.2855,
-"compress_mbps": 37.29,
-"decompress_mbps": 108.65
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1838372,
-"ratio": 0.2774,
-"compress_mbps": 20.3,
-"decompress_mbps": 108.77
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1828850,
-"ratio": 0.276,
-"compress_mbps": 15.87,
-"decompress_mbps": 115.22
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1823159,
-"ratio": 0.2751,
-"compress_mbps": 12.46,
-"decompress_mbps": 114.31
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1823159,
-"ratio": 0.2751,
-"compress_mbps": 12.53,
-"decompress_mbps": 97.46
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6447290,
-"ratio": 0.2984,
-"compress_mbps": 187.76,
-"decompress_mbps": 292.5
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 6030257,
-"ratio": 0.2791,
-"compress_mbps": 147.85,
-"decompress_mbps": 241.28
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5928121,
-"ratio": 0.2744,
-"compress_mbps": 128.5,
-"decompress_mbps": 269.87
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5615804,
-"ratio": 0.2599,
-"compress_mbps": 121.57,
-"decompress_mbps": 280.75
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5496738,
-"ratio": 0.2544,
-"compress_mbps": 80.22,
-"decompress_mbps": 336.14
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5464184,
-"ratio": 0.2529,
-"compress_mbps": 62.73,
-"decompress_mbps": 195.35
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5429645,
-"ratio": 0.2513,
-"compress_mbps": 47.93,
-"decompress_mbps": 214.77
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5418135,
-"ratio": 0.2508,
-"compress_mbps": 36.65,
-"decompress_mbps": 241.37
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5416628,
-"ratio": 0.2507,
-"compress_mbps": 33.67,
-"decompress_mbps": 233.28
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5759187,
-"ratio": 0.7942,
-"compress_mbps": 91.27,
-"decompress_mbps": 158.91
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5619390,
-"ratio": 0.7749,
-"compress_mbps": 49.54,
-"decompress_mbps": 94.64
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5560914,
-"ratio": 0.7668,
-"compress_mbps": 43.81,
-"decompress_mbps": 115.78
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5544069,
-"ratio": 0.7645,
-"compress_mbps": 44.58,
-"decompress_mbps": 94.11
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5518257,
-"ratio": 0.7609,
-"compress_mbps": 36.73,
-"decompress_mbps": 163.59
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5508662,
-"ratio": 0.7596,
-"compress_mbps": 33.77,
-"decompress_mbps": 95.01
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5507534,
-"ratio": 0.7595,
-"compress_mbps": 35.09,
-"decompress_mbps": 95.76
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5507183,
-"ratio": 0.7594,
-"compress_mbps": 32.41,
-"decompress_mbps": 94.54
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5507183,
-"ratio": 0.7594,
-"compress_mbps": 32.5,
-"decompress_mbps": 117.56
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 15230651,
-"ratio": 0.3674,
-"compress_mbps": 123.36,
-"decompress_mbps": 184.33
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 13822040,
-"ratio": 0.3334,
-"compress_mbps": 96.36,
-"decompress_mbps": 194.1
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 13397592,
-"ratio": 0.3232,
-"compress_mbps": 83.62,
-"decompress_mbps": 202.34
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12759940,
-"ratio": 0.3078,
-"compress_mbps": 80.4,
-"decompress_mbps": 223.21
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12274278,
-"ratio": 0.2961,
-"compress_mbps": 54.6,
-"decompress_mbps": 216.16
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12131738,
-"ratio": 0.2926,
-"compress_mbps": 40.41,
-"decompress_mbps": 218.2
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12060450,
-"ratio": 0.2909,
-"compress_mbps": 33.43,
-"decompress_mbps": 203.45
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12036900,
-"ratio": 0.2903,
-"compress_mbps": 29.91,
-"decompress_mbps": 206.04
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12036900,
-"ratio": 0.2903,
-"compress_mbps": 30.01,
-"decompress_mbps": 223.31
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6653052,
-"ratio": 0.7851,
-"compress_mbps": 124.38,
-"decompress_mbps": 152.55
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6305035,
-"ratio": 0.744,
-"compress_mbps": 53.84,
-"decompress_mbps": 154.18
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6302730,
-"ratio": 0.7438,
-"compress_mbps": 52.94,
-"decompress_mbps": 119.64
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6299134,
-"ratio": 0.7433,
-"compress_mbps": 52.14,
-"decompress_mbps": 156.45
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6289022,
-"ratio": 0.7421,
-"compress_mbps": 64.63,
-"decompress_mbps": 159.21
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6289013,
-"ratio": 0.7421,
-"compress_mbps": 50.64,
-"decompress_mbps": 156.7
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6289013,
-"ratio": 0.7421,
-"compress_mbps": 50.91,
-"decompress_mbps": 165.38
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6289012,
-"ratio": 0.7421,
-"compress_mbps": 64.4,
-"decompress_mbps": 157.39
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6289012,
-"ratio": 0.7421,
-"compress_mbps": 64.37,
-"decompress_mbps": 98.54
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 989456,
-"ratio": 0.1851,
-"compress_mbps": 243.16,
-"decompress_mbps": 153.25
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 839766,
-"ratio": 0.1571,
-"compress_mbps": 178.46,
-"decompress_mbps": 169.75
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 800619,
-"ratio": 0.1498,
-"compress_mbps": 181.16,
-"decompress_mbps": 178.28
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 776397,
-"ratio": 0.1452,
-"compress_mbps": 149.67,
-"decompress_mbps": 185.03
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 712679,
-"ratio": 0.1333,
-"compress_mbps": 103.54,
-"decompress_mbps": 199.06
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 683707,
-"ratio": 0.1279,
-"compress_mbps": 93.5,
-"decompress_mbps": 512.66
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 668601,
-"ratio": 0.1251,
-"compress_mbps": 70.7,
-"decompress_mbps": 209.33
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 659106,
-"ratio": 0.1233,
-"compress_mbps": 42.04,
-"decompress_mbps": 216.57
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 658920,
-"ratio": 0.1233,
-"compress_mbps": 42.13,
-"decompress_mbps": 256.07
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 62797,
-"ratio": 0.4129,
-"compress_mbps": 75.96,
-"decompress_mbps": 132.29
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 59605,
-"ratio": 0.3919,
-"compress_mbps": 62.87,
-"decompress_mbps": 131.77
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 57675,
-"ratio": 0.3792,
-"compress_mbps": 53.89,
-"decompress_mbps": 124.29
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56500,
-"ratio": 0.3715,
-"compress_mbps": 38.93,
-"decompress_mbps": 131.16
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 56440,
-"ratio": 0.3711,
-"compress_mbps": 38.82,
-"decompress_mbps": 130.65
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 55443,
-"ratio": 0.3645,
-"compress_mbps": 32.14,
-"decompress_mbps": 146.84
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 55373,
-"ratio": 0.3641,
-"compress_mbps": 31.65,
-"decompress_mbps": 130.38
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 55352,
-"ratio": 0.3639,
-"compress_mbps": 31.32,
-"decompress_mbps": 136.96
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 55352,
-"ratio": 0.3639,
-"compress_mbps": 31.37,
-"decompress_mbps": 135.72
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 55063,
-"ratio": 0.4399,
-"compress_mbps": 74.97,
-"decompress_mbps": 117.68
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 52932,
-"ratio": 0.4229,
-"compress_mbps": 60.75,
-"decompress_mbps": 116.27
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51597,
-"ratio": 0.4122,
-"compress_mbps": 44.1,
-"decompress_mbps": 116.24
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50780,
-"ratio": 0.4057,
-"compress_mbps": 43.18,
-"decompress_mbps": 120.67
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 50767,
-"ratio": 0.4056,
-"compress_mbps": 42.85,
-"decompress_mbps": 122.05
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 50160,
-"ratio": 0.4007,
-"compress_mbps": 33.03,
-"decompress_mbps": 128.52
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 50138,
-"ratio": 0.4005,
-"compress_mbps": 31.52,
-"decompress_mbps": 124.51
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 50138,
-"ratio": 0.4005,
-"compress_mbps": 32.14,
-"decompress_mbps": 125.83
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 50138,
-"ratio": 0.4005,
-"compress_mbps": 35.79,
-"decompress_mbps": 124.35
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8730,
-"ratio": 0.3548,
-"compress_mbps": 46.94,
-"decompress_mbps": 123.4
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8457,
-"ratio": 0.3437,
-"compress_mbps": 43.65,
-"decompress_mbps": 119.12
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8353,
-"ratio": 0.3395,
-"compress_mbps": 64.98,
-"decompress_mbps": 109.7
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8301,
-"ratio": 0.3374,
-"compress_mbps": 42.45,
-"decompress_mbps": 124.06
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8212,
-"ratio": 0.3338,
-"compress_mbps": 58.84,
-"decompress_mbps": 103.81
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 8172,
-"ratio": 0.3322,
-"compress_mbps": 48.55,
-"decompress_mbps": 108.53
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 8171,
-"ratio": 0.3321,
-"compress_mbps": 50.28,
-"decompress_mbps": 109.3
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 8171,
-"ratio": 0.3321,
-"compress_mbps": 49.23,
-"decompress_mbps": 109.09
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 8171,
-"ratio": 0.3321,
-"compress_mbps": 53.75,
-"decompress_mbps": 109.08
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3475,
-"ratio": 0.3117,
-"compress_mbps": 109.11,
-"decompress_mbps": 96.06
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3305,
-"ratio": 0.2964,
-"compress_mbps": 102.67,
-"decompress_mbps": 101.78
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3225,
-"ratio": 0.2892,
-"compress_mbps": 91.21,
-"decompress_mbps": 104.25
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3192,
-"ratio": 0.2863,
-"compress_mbps": 100.3,
-"decompress_mbps": 104.85
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3180,
-"ratio": 0.2852,
-"compress_mbps": 100.47,
-"decompress_mbps": 98.18
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 94.55,
-"decompress_mbps": 99.39
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 95.62,
-"decompress_mbps": 95.6
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 91.52,
-"decompress_mbps": 121.63
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 83.09,
-"decompress_mbps": 95.05
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1275,
-"ratio": 0.3426,
-"compress_mbps": 59.58,
-"decompress_mbps": 44.37
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1247,
-"ratio": 0.3351,
-"compress_mbps": 59.47,
-"decompress_mbps": 52.13
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 56.69,
-"decompress_mbps": 51.11
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1238,
-"ratio": 0.3327,
-"compress_mbps": 58.55,
-"decompress_mbps": 50.63
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 48.99,
-"decompress_mbps": 51.01
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 56.51,
-"decompress_mbps": 50.1
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 55.71,
-"decompress_mbps": 51.27
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 50.22,
-"decompress_mbps": 48.37
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 55.39,
-"decompress_mbps": 48.56
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 226284,
-"ratio": 0.2197,
-"compress_mbps": 113.28,
-"decompress_mbps": 183.05
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 221369,
-"ratio": 0.215,
-"compress_mbps": 90.24,
-"decompress_mbps": 255.24
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 218607,
-"ratio": 0.2123,
-"compress_mbps": 78.67,
-"decompress_mbps": 187.61
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 217919,
-"ratio": 0.2116,
-"compress_mbps": 69.94,
-"decompress_mbps": 195.29
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 217919,
-"ratio": 0.2116,
-"compress_mbps": 70.92,
-"decompress_mbps": 195.59
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 217312,
-"ratio": 0.211,
-"compress_mbps": 44.09,
-"decompress_mbps": 191.18
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 215966,
-"ratio": 0.2097,
-"compress_mbps": 31.15,
-"decompress_mbps": 191.54
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 215930,
-"ratio": 0.2097,
-"compress_mbps": 14.32,
-"decompress_mbps": 194.26
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 215912,
-"ratio": 0.2097,
-"compress_mbps": 11.1,
-"decompress_mbps": 210.59
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 167622,
-"ratio": 0.3928,
-"compress_mbps": 64.39,
-"decompress_mbps": 116.3
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 158003,
-"ratio": 0.3702,
-"compress_mbps": 64.34,
-"decompress_mbps": 139.36
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 152928,
-"ratio": 0.3584,
-"compress_mbps": 46.67,
-"decompress_mbps": 141.08
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 149886,
-"ratio": 0.3512,
-"compress_mbps": 33.71,
-"decompress_mbps": 136.65
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 149767,
-"ratio": 0.3509,
-"compress_mbps": 39.31,
-"decompress_mbps": 138
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 147818,
-"ratio": 0.3464,
-"compress_mbps": 33.18,
-"decompress_mbps": 150.78
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 147733,
-"ratio": 0.3462,
-"compress_mbps": 32.42,
-"decompress_mbps": 154.24
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 147709,
-"ratio": 0.3461,
-"compress_mbps": 32.15,
-"decompress_mbps": 151.45
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 147705,
-"ratio": 0.3461,
-"compress_mbps": 32.65,
-"decompress_mbps": 138.19
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 222866,
-"ratio": 0.4625,
-"compress_mbps": 58.92,
-"decompress_mbps": 105.16
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 212925,
-"ratio": 0.4419,
-"compress_mbps": 49.52,
-"decompress_mbps": 118.08
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 206913,
-"ratio": 0.4294,
-"compress_mbps": 40.5,
-"decompress_mbps": 116.88
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 202875,
-"ratio": 0.421,
-"compress_mbps": 33.54,
-"decompress_mbps": 111.31
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 202867,
-"ratio": 0.421,
-"compress_mbps": 33.57,
-"decompress_mbps": 117.4
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 199818,
-"ratio": 0.4147,
-"compress_mbps": 28.4,
-"decompress_mbps": 114.8
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 199664,
-"ratio": 0.4144,
-"compress_mbps": 27.76,
-"decompress_mbps": 105.02
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 199634,
-"ratio": 0.4143,
-"compress_mbps": 28.19,
-"decompress_mbps": 106.5
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 199634,
-"ratio": 0.4143,
-"compress_mbps": 27.99,
-"decompress_mbps": 121
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 60580,
-"ratio": 0.118,
-"compress_mbps": 118.15,
-"decompress_mbps": 253.84
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 59663,
-"ratio": 0.1163,
-"compress_mbps": 131.11,
-"decompress_mbps": 295.73
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 59465,
-"ratio": 0.1159,
-"compress_mbps": 100.74,
-"decompress_mbps": 295.91
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 59353,
-"ratio": 0.1156,
-"compress_mbps": 95.09,
-"decompress_mbps": 302.88
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 58830,
-"ratio": 0.1146,
-"compress_mbps": 107.76,
-"decompress_mbps": 221.47
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 57884,
-"ratio": 0.1128,
-"compress_mbps": 56.85,
-"decompress_mbps": 285.29
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 57206,
-"ratio": 0.1115,
-"compress_mbps": 46.17,
-"decompress_mbps": 299.77
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 56545,
-"ratio": 0.1102,
-"compress_mbps": 23.09,
-"decompress_mbps": 280.1
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 56454,
-"ratio": 0.11,
-"compress_mbps": 9.11,
-"decompress_mbps": 300.36
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14194,
-"ratio": 0.3712,
-"compress_mbps": 83.27,
-"decompress_mbps": 134.84
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13770,
-"ratio": 0.3601,
-"compress_mbps": 74.14,
-"decompress_mbps": 116.53
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13611,
-"ratio": 0.3559,
-"compress_mbps": 66.24,
-"decompress_mbps": 115.38
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13534,
-"ratio": 0.3539,
-"compress_mbps": 61.31,
-"decompress_mbps": 117.96
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13527,
-"ratio": 0.3537,
-"compress_mbps": 61.97,
-"decompress_mbps": 148.27
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13438,
-"ratio": 0.3514,
-"compress_mbps": 51.17,
-"decompress_mbps": 142.65
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13419,
-"ratio": 0.3509,
-"compress_mbps": 47.83,
-"decompress_mbps": 125.84
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13404,
-"ratio": 0.3505,
-"compress_mbps": 41.2,
-"decompress_mbps": 118.77
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13390,
-"ratio": 0.3502,
-"compress_mbps": 35.78,
-"decompress_mbps": 116.99
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1832,
-"ratio": 0.4334,
-"compress_mbps": 41.01,
-"decompress_mbps": 45
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1776,
-"ratio": 0.4202,
-"compress_mbps": 58.71,
-"decompress_mbps": 64.9
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1764,
-"ratio": 0.4173,
-"compress_mbps": 57.37,
-"decompress_mbps": 62.38
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1763,
-"ratio": 0.4171,
-"compress_mbps": 56.88,
-"decompress_mbps": 53.28
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 59.36,
-"decompress_mbps": 48.79
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 40.25,
-"decompress_mbps": 47.27
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 57.06,
-"decompress_mbps": 48.39
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 58.67,
-"decompress_mbps": 52.39
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 58.3,
-"decompress_mbps": 62.91
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4462632,
-"ratio": 0.4378,
-"compress_mbps": 61.62,
-"decompress_mbps": 170.85
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4244833,
-"ratio": 0.4165,
-"compress_mbps": 50.24,
-"decompress_mbps": 201.42
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4112285,
-"ratio": 0.4035,
-"compress_mbps": 42.04,
-"decompress_mbps": 178.21
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4020435,
-"ratio": 0.3945,
-"compress_mbps": 35.5,
-"decompress_mbps": 142.52
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 4019177,
-"ratio": 0.3943,
-"compress_mbps": 35.31,
-"decompress_mbps": 170.54
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3956464,
-"ratio": 0.3882,
-"compress_mbps": 28.75,
-"decompress_mbps": 164.24
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3953310,
-"ratio": 0.3879,
-"compress_mbps": 28.47,
-"decompress_mbps": 198.87
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3952872,
-"ratio": 0.3878,
-"compress_mbps": 29.08,
-"decompress_mbps": 220.53
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3952872,
-"ratio": 0.3878,
-"compress_mbps": 29.21,
-"decompress_mbps": 218.12
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20177423,
-"ratio": 0.3939,
-"compress_mbps": 72.68,
-"decompress_mbps": 209.54
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 19759467,
-"ratio": 0.3858,
-"compress_mbps": 63.85,
-"decompress_mbps": 193.45
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19583171,
-"ratio": 0.3823,
-"compress_mbps": 57.14,
-"decompress_mbps": 206.47
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19479125,
-"ratio": 0.3803,
-"compress_mbps": 51.03,
-"decompress_mbps": 205.14
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19423693,
-"ratio": 0.3792,
-"compress_mbps": 49.13,
-"decompress_mbps": 200.07
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19337683,
-"ratio": 0.3775,
-"compress_mbps": 36.05,
-"decompress_mbps": 188.48
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19323922,
-"ratio": 0.3773,
-"compress_mbps": 29.08,
-"decompress_mbps": 193.94
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19314797,
-"ratio": 0.3771,
-"compress_mbps": 19.5,
-"decompress_mbps": 225.36
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19312663,
-"ratio": 0.377,
-"compress_mbps": 11.12,
-"decompress_mbps": 219.23
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3762978,
-"ratio": 0.3774,
-"compress_mbps": 78.68,
-"decompress_mbps": 163.86
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3711615,
-"ratio": 0.3723,
-"compress_mbps": 68.1,
-"decompress_mbps": 196.85
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3663131,
-"ratio": 0.3674,
-"compress_mbps": 57.01,
-"decompress_mbps": 241.11
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3631512,
-"ratio": 0.3642,
-"compress_mbps": 49.21,
-"decompress_mbps": 221.03
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3630867,
-"ratio": 0.3642,
-"compress_mbps": 48.78,
-"decompress_mbps": 216.62
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3615953,
-"ratio": 0.3627,
-"compress_mbps": 37.72,
-"decompress_mbps": 247.65
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3615518,
-"ratio": 0.3626,
-"compress_mbps": 35.3,
-"decompress_mbps": 189.82
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3613845,
-"ratio": 0.3625,
-"compress_mbps": 30.03,
-"decompress_mbps": 255.34
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3614283,
-"ratio": 0.3625,
-"compress_mbps": 26.24,
-"decompress_mbps": 222.16
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4418800,
-"ratio": 0.1317,
-"compress_mbps": 133,
-"decompress_mbps": 338.57
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4026774,
-"ratio": 0.12,
-"compress_mbps": 123.44,
-"decompress_mbps": 339.7
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3837798,
-"ratio": 0.1144,
-"compress_mbps": 116.34,
-"decompress_mbps": 370.54
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3751023,
-"ratio": 0.1118,
-"compress_mbps": 110.1,
-"decompress_mbps": 361.38
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3643468,
-"ratio": 0.1086,
-"compress_mbps": 101.98,
-"decompress_mbps": 371.36
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3379481,
-"ratio": 0.1007,
-"compress_mbps": 68.99,
-"decompress_mbps": 366.05
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3354082,
-"ratio": 0.1,
-"compress_mbps": 61.49,
-"decompress_mbps": 366.51
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3330028,
-"ratio": 0.0992,
-"compress_mbps": 49.65,
-"decompress_mbps": 396.52
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3327482,
-"ratio": 0.0992,
-"compress_mbps": 37.41,
-"decompress_mbps": 367.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3233790,
-"ratio": 0.5256,
-"compress_mbps": 52.65,
-"decompress_mbps": 141.02
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3184644,
-"ratio": 0.5176,
-"compress_mbps": 48.35,
-"decompress_mbps": 141.34
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3160521,
-"ratio": 0.5137,
-"compress_mbps": 44.16,
-"decompress_mbps": 134.37
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3141929,
-"ratio": 0.5107,
-"compress_mbps": 40.04,
-"decompress_mbps": 150.29
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3138514,
-"ratio": 0.5101,
-"compress_mbps": 39.11,
-"decompress_mbps": 134.68
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3126843,
-"ratio": 0.5082,
-"compress_mbps": 32.81,
-"decompress_mbps": 149.93
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3126796,
-"ratio": 0.5082,
-"compress_mbps": 30.63,
-"decompress_mbps": 145.05
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3126322,
-"ratio": 0.5082,
-"compress_mbps": 27.28,
-"decompress_mbps": 153.07
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3126286,
-"ratio": 0.5082,
-"compress_mbps": 23.43,
-"decompress_mbps": 154.77
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4076349,
-"ratio": 0.4042,
-"compress_mbps": 79.56,
-"decompress_mbps": 217.72
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3914739,
-"ratio": 0.3881,
-"compress_mbps": 72.11,
-"decompress_mbps": 235.6
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3845160,
-"ratio": 0.3812,
-"compress_mbps": 68.92,
-"decompress_mbps": 265.95
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3822047,
-"ratio": 0.379,
-"compress_mbps": 65.9,
-"decompress_mbps": 249.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3799472,
-"ratio": 0.3767,
-"compress_mbps": 60.47,
-"decompress_mbps": 196.63
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3783861,
-"ratio": 0.3752,
-"compress_mbps": 59.24,
-"decompress_mbps": 206.2
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3783432,
-"ratio": 0.3751,
-"compress_mbps": 57.5,
-"decompress_mbps": 276.55
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3783342,
-"ratio": 0.3751,
-"compress_mbps": 57.79,
-"decompress_mbps": 278.67
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3783342,
-"ratio": 0.3751,
-"compress_mbps": 57.86,
-"decompress_mbps": 279.64
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2261112,
-"ratio": 0.3412,
-"compress_mbps": 71.4,
-"decompress_mbps": 216.97
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2128691,
-"ratio": 0.3212,
-"compress_mbps": 58.57,
-"decompress_mbps": 197.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2049023,
-"ratio": 0.3092,
-"compress_mbps": 48.53,
-"decompress_mbps": 209.61
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1990249,
-"ratio": 0.3003,
-"compress_mbps": 41.12,
-"decompress_mbps": 207.91
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1975224,
-"ratio": 0.298,
-"compress_mbps": 39.61,
-"decompress_mbps": 151.52
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1910262,
-"ratio": 0.2882,
-"compress_mbps": 28.21,
-"decompress_mbps": 164.32
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1902923,
-"ratio": 0.2871,
-"compress_mbps": 25.04,
-"decompress_mbps": 221.63
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1900964,
-"ratio": 0.2868,
-"compress_mbps": 23.45,
-"decompress_mbps": 227.66
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1900958,
-"ratio": 0.2868,
-"compress_mbps": 24.4,
-"decompress_mbps": 207.65
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6016919,
-"ratio": 0.2785,
-"compress_mbps": 92.31,
-"decompress_mbps": 250.38
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5767272,
-"ratio": 0.2669,
-"compress_mbps": 81.02,
-"decompress_mbps": 287.18
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5669548,
-"ratio": 0.2624,
-"compress_mbps": 75.87,
-"decompress_mbps": 211.21
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5619947,
-"ratio": 0.2601,
-"compress_mbps": 68.8,
-"decompress_mbps": 271.25
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5586034,
-"ratio": 0.2585,
-"compress_mbps": 64.77,
-"decompress_mbps": 270.13
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5540130,
-"ratio": 0.2564,
-"compress_mbps": 50.72,
-"decompress_mbps": 269.04
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5537271,
-"ratio": 0.2563,
-"compress_mbps": 45.58,
-"decompress_mbps": 209.67
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5530686,
-"ratio": 0.256,
-"compress_mbps": 35.75,
-"decompress_mbps": 303.18
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5529823,
-"ratio": 0.2559,
-"compress_mbps": 31.59,
-"decompress_mbps": 227.31
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5602819,
-"ratio": 0.7726,
-"compress_mbps": 47.72,
-"decompress_mbps": 166.89
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5504019,
-"ratio": 0.759,
-"compress_mbps": 42.76,
-"decompress_mbps": 153.39
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5452816,
-"ratio": 0.7519,
-"compress_mbps": 38.01,
-"decompress_mbps": 153.91
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5425752,
-"ratio": 0.7482,
-"compress_mbps": 35.6,
-"decompress_mbps": 177.63
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5425752,
-"ratio": 0.7482,
-"compress_mbps": 36.17,
-"decompress_mbps": 176.78
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5407602,
-"ratio": 0.7457,
-"compress_mbps": 30.72,
-"decompress_mbps": 153.42
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5406417,
-"ratio": 0.7455,
-"compress_mbps": 30.08,
-"decompress_mbps": 155.44
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5406380,
-"ratio": 0.7455,
-"compress_mbps": 30.76,
-"decompress_mbps": 154.32
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5406380,
-"ratio": 0.7455,
-"compress_mbps": 30.68,
-"decompress_mbps": 117.26
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 14342407,
-"ratio": 0.3459,
-"compress_mbps": 73.52,
-"decompress_mbps": 197.71
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 13424966,
-"ratio": 0.3238,
-"compress_mbps": 63.27,
-"decompress_mbps": 213.25
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 13061399,
-"ratio": 0.315,
-"compress_mbps": 56.27,
-"decompress_mbps": 222.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12877207,
-"ratio": 0.3106,
-"compress_mbps": 49.84,
-"decompress_mbps": 208.96
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12671090,
-"ratio": 0.3056,
-"compress_mbps": 47.71,
-"decompress_mbps": 209.63
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12511088,
-"ratio": 0.3018,
-"compress_mbps": 40.67,
-"decompress_mbps": 235.26
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12503313,
-"ratio": 0.3016,
-"compress_mbps": 39.02,
-"decompress_mbps": 224.89
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12502263,
-"ratio": 0.3016,
-"compress_mbps": 39.56,
-"decompress_mbps": 227.39
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12502263,
-"ratio": 0.3016,
-"compress_mbps": 39.56,
-"decompress_mbps": 225.48
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6022390,
-"ratio": 0.7107,
-"compress_mbps": 54.31,
-"decompress_mbps": 145.97
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 5997124,
-"ratio": 0.7077,
-"compress_mbps": 48.84,
-"decompress_mbps": 145.24
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 5979254,
-"ratio": 0.7056,
-"compress_mbps": 43.2,
-"decompress_mbps": 149.3
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 5967955,
-"ratio": 0.7042,
-"compress_mbps": 42.03,
-"decompress_mbps": 178.27
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 5967953,
-"ratio": 0.7042,
-"compress_mbps": 42.1,
-"decompress_mbps": 155.23
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5965386,
-"ratio": 0.7039,
-"compress_mbps": 41.26,
-"decompress_mbps": 150.17
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5965383,
-"ratio": 0.7039,
-"compress_mbps": 41,
-"decompress_mbps": 152.03
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5965383,
-"ratio": 0.7039,
-"compress_mbps": 40.8,
-"decompress_mbps": 151.14
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5965383,
-"ratio": 0.7039,
-"compress_mbps": 41.86,
-"decompress_mbps": 155
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 985606,
-"ratio": 0.1844,
-"compress_mbps": 111.12,
-"decompress_mbps": 305.94
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 852636,
-"ratio": 0.1595,
-"compress_mbps": 102.74,
-"decompress_mbps": 250.95
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 814293,
-"ratio": 0.1523,
-"compress_mbps": 96.19,
-"decompress_mbps": 221.84
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 788388,
-"ratio": 0.1475,
-"compress_mbps": 89.39,
-"decompress_mbps": 250.71
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 749390,
-"ratio": 0.1402,
-"compress_mbps": 83.47,
-"decompress_mbps": 304.92
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 706892,
-"ratio": 0.1322,
-"compress_mbps": 64.12,
-"decompress_mbps": 266.99
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 705695,
-"ratio": 0.132,
-"compress_mbps": 64.27,
-"decompress_mbps": 329.56
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 703904,
-"ratio": 0.1317,
-"compress_mbps": 61.16,
-"decompress_mbps": 268.63
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 703900,
-"ratio": 0.1317,
-"compress_mbps": 60.89,
-"decompress_mbps": 396.78
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 88.44,
-"decompress_mbps": 310.31
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 87.92,
-"decompress_mbps": 310.59
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 88.84,
-"decompress_mbps": 310.08
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 88.64,
-"decompress_mbps": 314.16
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54531,
-"ratio": 0.3585,
-"compress_mbps": 55.46,
-"decompress_mbps": 303.62
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54068,
-"ratio": 0.3555,
-"compress_mbps": 42.11,
-"decompress_mbps": 310.13
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54003,
-"ratio": 0.3551,
-"compress_mbps": 37.45,
-"decompress_mbps": 307.64
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 53974,
-"ratio": 0.3549,
-"compress_mbps": 33.15,
-"decompress_mbps": 306.21
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 53974,
-"ratio": 0.3549,
-"compress_mbps": 33.03,
-"decompress_mbps": 307.58
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 82.91,
-"decompress_mbps": 273.52
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 83.46,
-"decompress_mbps": 272.35
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 84.13,
-"decompress_mbps": 272.98
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 83.95,
-"decompress_mbps": 268.75
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48753,
-"ratio": 0.3895,
-"compress_mbps": 50.79,
-"decompress_mbps": 277.44
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48557,
-"ratio": 0.3879,
-"compress_mbps": 40.8,
-"decompress_mbps": 274.84
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48523,
-"ratio": 0.3876,
-"compress_mbps": 38.65,
-"decompress_mbps": 273.33
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48522,
-"ratio": 0.3876,
-"compress_mbps": 37.86,
-"decompress_mbps": 276.85
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48522,
-"ratio": 0.3876,
-"compress_mbps": 37.9,
-"decompress_mbps": 276.0
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 164.27,
-"decompress_mbps": 279.42
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 172.17,
-"decompress_mbps": 279.97
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 171.79,
-"decompress_mbps": 279.43
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 170.54,
-"decompress_mbps": 279.22
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7965,
-"ratio": 0.3237,
-"compress_mbps": 110.55,
-"decompress_mbps": 288.06
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7914,
-"ratio": 0.3217,
-"compress_mbps": 87.16,
-"decompress_mbps": 290.85
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7895,
-"ratio": 0.3209,
-"compress_mbps": 80.21,
-"decompress_mbps": 290.06
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7896,
-"ratio": 0.3209,
-"compress_mbps": 73.83,
-"decompress_mbps": 287.97
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7896,
-"ratio": 0.3209,
-"compress_mbps": 74.8,
-"decompress_mbps": 285.58
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 167.43,
-"decompress_mbps": 252.93
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 171.07,
-"decompress_mbps": 257.31
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 171.82,
-"decompress_mbps": 258.29
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 166.85,
-"decompress_mbps": 256.2
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3136,
-"ratio": 0.2813,
-"compress_mbps": 143.33,
-"decompress_mbps": 259.73
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3115,
-"ratio": 0.2794,
-"compress_mbps": 126.88,
-"decompress_mbps": 263.65
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 116.0,
-"decompress_mbps": 266.62
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 105.81,
-"decompress_mbps": 262.03
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 108.16,
-"decompress_mbps": 263.41
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 119.04,
-"decompress_mbps": 119.21
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 114.29,
-"decompress_mbps": 121.57
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 111.93,
-"decompress_mbps": 114.91
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 113.37,
-"decompress_mbps": 116.95
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 104.47,
-"decompress_mbps": 117.21
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 101.17,
-"decompress_mbps": 116.13
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 99.01,
-"decompress_mbps": 115.26
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 100.66,
-"decompress_mbps": 116.17
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 100.75,
-"decompress_mbps": 117.41
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 226.33,
-"decompress_mbps": 462.07
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 232.22,
-"decompress_mbps": 461.76
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 226.95,
-"decompress_mbps": 462.59
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 231.82,
-"decompress_mbps": 462.46
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 218313,
-"ratio": 0.212,
-"compress_mbps": 163.75,
-"decompress_mbps": 447.06
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 215095,
-"ratio": 0.2089,
-"compress_mbps": 107.22,
-"decompress_mbps": 448.7
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 213213,
-"ratio": 0.2071,
-"compress_mbps": 73.07,
-"decompress_mbps": 450.65
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 210955,
-"ratio": 0.2049,
-"compress_mbps": 9.42,
-"decompress_mbps": 452.49
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 210981,
-"ratio": 0.2049,
-"compress_mbps": 4.64,
-"decompress_mbps": 454.09
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 92.55,
-"decompress_mbps": 304.95
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 92.89,
-"decompress_mbps": 306.86
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 92.22,
-"decompress_mbps": 306.2
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 92.33,
-"decompress_mbps": 304.41
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145024,
-"ratio": 0.3398,
-"compress_mbps": 57.83,
-"decompress_mbps": 305.53
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144159,
-"ratio": 0.3378,
-"compress_mbps": 44.56,
-"decompress_mbps": 304.1
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 143991,
-"ratio": 0.3374,
-"compress_mbps": 40.14,
-"decompress_mbps": 306.23
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 143941,
-"ratio": 0.3373,
-"compress_mbps": 36.87,
-"decompress_mbps": 306.13
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 143939,
-"ratio": 0.3373,
-"compress_mbps": 37.03,
-"decompress_mbps": 305.69
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 81.26,
-"decompress_mbps": 255.97
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 80.9,
-"decompress_mbps": 255.49
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 81.21,
-"decompress_mbps": 255.67
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 81.07,
-"decompress_mbps": 256.32
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 194496,
-"ratio": 0.4036,
-"compress_mbps": 46.0,
-"decompress_mbps": 247.64
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 193176,
-"ratio": 0.4009,
-"compress_mbps": 34.56,
-"decompress_mbps": 253.55
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 192991,
-"ratio": 0.4005,
-"compress_mbps": 31.43,
-"decompress_mbps": 250.63
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 192980,
-"ratio": 0.4005,
-"compress_mbps": 29.91,
-"decompress_mbps": 251.77
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 192980,
-"ratio": 0.4005,
-"compress_mbps": 29.82,
-"decompress_mbps": 253.98
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 294.39,
-"decompress_mbps": 724.52
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 294.6,
-"decompress_mbps": 721.16
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 294.93,
-"decompress_mbps": 721.32
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 295.58,
-"decompress_mbps": 727.0
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 56050,
-"ratio": 0.1092,
-"compress_mbps": 229.82,
-"decompress_mbps": 759.78
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55292,
-"ratio": 0.1077,
-"compress_mbps": 153.4,
-"decompress_mbps": 778.62
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 54651,
-"ratio": 0.1065,
-"compress_mbps": 124.47,
-"decompress_mbps": 790.77
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 52583,
-"ratio": 0.1025,
-"compress_mbps": 46.92,
-"decompress_mbps": 823.54
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 51816,
-"ratio": 0.101,
-"compress_mbps": 15.63,
-"decompress_mbps": 833.02
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 119.63,
-"decompress_mbps": 301.35
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 118.87,
-"decompress_mbps": 304.63
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 120.64,
-"decompress_mbps": 303.05
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 118.25,
-"decompress_mbps": 303.27
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13290,
-"ratio": 0.3475,
-"compress_mbps": 89.99,
-"decompress_mbps": 316.05
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13258,
-"ratio": 0.3467,
-"compress_mbps": 68.72,
-"decompress_mbps": 317.08
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13246,
-"ratio": 0.3464,
-"compress_mbps": 57.01,
-"decompress_mbps": 319.69
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13236,
-"ratio": 0.3461,
-"compress_mbps": 25.4,
-"decompress_mbps": 320.24
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13233,
-"ratio": 0.3461,
-"compress_mbps": 16.12,
-"decompress_mbps": 322.36
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 95.7,
-"decompress_mbps": 132.85
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 98.31,
-"decompress_mbps": 133.01
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 97.54,
-"decompress_mbps": 132.07
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 100.39,
-"decompress_mbps": 132.0
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 95.29,
-"decompress_mbps": 132.31
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 95.54,
-"decompress_mbps": 134.31
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 93.18,
-"decompress_mbps": 133.95
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 95.09,
-"decompress_mbps": 134.19
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 92.21,
-"decompress_mbps": 134.59
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 84.07,
-"decompress_mbps": 273.96
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 84.3,
-"decompress_mbps": 273.56
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 83.99,
-"decompress_mbps": 274.36
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 84.24,
-"decompress_mbps": 272.3
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3863846,
-"ratio": 0.3791,
-"compress_mbps": 49.03,
-"decompress_mbps": 267.64
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3838854,
-"ratio": 0.3766,
-"compress_mbps": 37.71,
-"decompress_mbps": 272.4
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3835182,
-"ratio": 0.3763,
-"compress_mbps": 33.64,
-"decompress_mbps": 271.15
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3834518,
-"ratio": 0.3762,
-"compress_mbps": 31.63,
-"decompress_mbps": 269.9
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3834518,
-"ratio": 0.3762,
-"compress_mbps": 31.46,
-"decompress_mbps": 270.85
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 103.55,
-"decompress_mbps": 250.87
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 103.76,
-"decompress_mbps": 251.19
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 103.86,
-"decompress_mbps": 251.37
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 103.63,
-"decompress_mbps": 251.14
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19578840,
-"ratio": 0.3822,
-"compress_mbps": 78.52,
-"decompress_mbps": 258.92
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19492445,
-"ratio": 0.3806,
-"compress_mbps": 58.0,
-"decompress_mbps": 261.52
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19463481,
-"ratio": 0.38,
-"compress_mbps": 46.5,
-"decompress_mbps": 263.14
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19444704,
-"ratio": 0.3796,
-"compress_mbps": 22.81,
-"decompress_mbps": 262.15
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19440748,
-"ratio": 0.3796,
-"compress_mbps": 13.07,
-"decompress_mbps": 263.2
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 112.24,
-"decompress_mbps": 259.97
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 112.65,
-"decompress_mbps": 260.85
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 111.43,
-"decompress_mbps": 257.26
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 112.43,
-"decompress_mbps": 258.95
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3637736,
-"ratio": 0.3648,
-"compress_mbps": 65.79,
-"decompress_mbps": 267.17
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3621530,
-"ratio": 0.3632,
-"compress_mbps": 46.42,
-"decompress_mbps": 268.5
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3623924,
-"ratio": 0.3635,
-"compress_mbps": 42.48,
-"decompress_mbps": 270.13
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3623112,
-"ratio": 0.3634,
-"compress_mbps": 33.07,
-"decompress_mbps": 270.31
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3623382,
-"ratio": 0.3634,
-"compress_mbps": 24.87,
-"decompress_mbps": 268.67
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 306.93,
-"decompress_mbps": 882.12
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 309.49,
-"decompress_mbps": 879.51
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 306.65,
-"decompress_mbps": 865.76
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 309.44,
-"decompress_mbps": 876.41
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3268887,
-"ratio": 0.0974,
-"compress_mbps": 229.13,
-"decompress_mbps": 923.49
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3131445,
-"ratio": 0.0933,
-"compress_mbps": 163.5,
-"decompress_mbps": 955.29
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3080217,
-"ratio": 0.0918,
-"compress_mbps": 129.46,
-"decompress_mbps": 960.33
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 2978354,
-"ratio": 0.0888,
-"compress_mbps": 57.16,
-"decompress_mbps": 973.32
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2947971,
-"ratio": 0.0879,
-"compress_mbps": 34.51,
-"decompress_mbps": 973.37
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 72.44,
-"decompress_mbps": 182.53
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 72.2,
-"decompress_mbps": 182.46
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 72.32,
-"decompress_mbps": 182.97
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 72.36,
-"decompress_mbps": 183.16
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3178914,
-"ratio": 0.5167,
-"compress_mbps": 55.82,
-"decompress_mbps": 189.9
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3174170,
-"ratio": 0.5159,
-"compress_mbps": 49.39,
-"decompress_mbps": 191.24
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3172734,
-"ratio": 0.5157,
-"compress_mbps": 45.82,
-"decompress_mbps": 191.56
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3171353,
-"ratio": 0.5155,
-"compress_mbps": 38.64,
-"decompress_mbps": 191.37
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3171299,
-"ratio": 0.5155,
-"compress_mbps": 34.82,
-"decompress_mbps": 191.12
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 123.34,
-"decompress_mbps": 273.16
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 122.2,
-"decompress_mbps": 272.47
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 121.33,
-"decompress_mbps": 269.13
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 122.45,
-"decompress_mbps": 274.58
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3654027,
-"ratio": 0.3623,
-"compress_mbps": 95.52,
-"decompress_mbps": 276.5
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3652732,
-"ratio": 0.3622,
-"compress_mbps": 91.8,
-"decompress_mbps": 276.29
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3652496,
-"ratio": 0.3621,
-"compress_mbps": 87.07,
-"decompress_mbps": 275.95
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3652505,
-"ratio": 0.3621,
-"compress_mbps": 87.05,
-"decompress_mbps": 277.5
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3652505,
-"ratio": 0.3621,
-"compress_mbps": 87.07,
-"decompress_mbps": 276.53
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 100.62,
-"decompress_mbps": 354.06
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 100.0,
-"decompress_mbps": 353.82
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 99.59,
-"decompress_mbps": 351.77
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 99.81,
-"decompress_mbps": 354.23
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1892183,
-"ratio": 0.2855,
-"compress_mbps": 53.63,
-"decompress_mbps": 353.52
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1837957,
-"ratio": 0.2773,
-"compress_mbps": 30.64,
-"decompress_mbps": 360.81
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1826603,
-"ratio": 0.2756,
-"compress_mbps": 24.41,
-"decompress_mbps": 362.4
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1818702,
-"ratio": 0.2744,
-"compress_mbps": 16.09,
-"decompress_mbps": 362.85
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1818702,
-"ratio": 0.2744,
-"compress_mbps": 15.95,
-"decompress_mbps": 359.54
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 146.11,
-"decompress_mbps": 399.24
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 145.88,
-"decompress_mbps": 400.49
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 146.06,
-"decompress_mbps": 396.62
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 144.39,
-"decompress_mbps": 379.0
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5501344,
-"ratio": 0.2546,
-"compress_mbps": 103.33,
-"decompress_mbps": 402.09
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5464646,
-"ratio": 0.2529,
-"compress_mbps": 79.54,
-"decompress_mbps": 407.14
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5429975,
-"ratio": 0.2513,
-"compress_mbps": 66.81,
-"decompress_mbps": 408.73
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5419566,
-"ratio": 0.2508,
-"compress_mbps": 49.41,
-"decompress_mbps": 410.08
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5417952,
-"ratio": 0.2508,
-"compress_mbps": 45.54,
-"decompress_mbps": 407.63
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.47,
-"decompress_mbps": 161.38
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.25,
-"decompress_mbps": 161.25
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.34,
-"decompress_mbps": 161.47
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.28,
-"decompress_mbps": 159.84
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5450496,
-"ratio": 0.7516,
-"compress_mbps": 46.56,
-"decompress_mbps": 163.89
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5440281,
-"ratio": 0.7502,
-"compress_mbps": 42.07,
-"decompress_mbps": 164.58
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5439077,
-"ratio": 0.75,
-"compress_mbps": 40.6,
-"decompress_mbps": 164.64
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5438787,
-"ratio": 0.75,
-"compress_mbps": 39.98,
-"decompress_mbps": 163.79
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5438787,
-"ratio": 0.75,
-"compress_mbps": 39.92,
-"decompress_mbps": 165.07
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.43,
-"decompress_mbps": 313.19
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.96,
-"decompress_mbps": 316.83
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.45,
-"decompress_mbps": 312.18
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.89,
-"decompress_mbps": 315.83
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12238874,
-"ratio": 0.2952,
-"compress_mbps": 72.34,
-"decompress_mbps": 317.65
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12086531,
-"ratio": 0.2915,
-"compress_mbps": 53.58,
-"decompress_mbps": 323.18
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12020742,
-"ratio": 0.2899,
-"compress_mbps": 46.37,
-"decompress_mbps": 319.97
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 11987253,
-"ratio": 0.2891,
-"compress_mbps": 38.17,
-"decompress_mbps": 322.52
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11987245,
-"ratio": 0.2891,
-"compress_mbps": 38.15,
-"decompress_mbps": 319.56
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 60.53,
-"decompress_mbps": 146.13
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 60.39,
-"decompress_mbps": 146.09
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 60.11,
-"decompress_mbps": 146.99
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 60.42,
-"decompress_mbps": 146.5
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6244483,
-"ratio": 0.7369,
-"compress_mbps": 55.4,
-"decompress_mbps": 148.54
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6244482,
-"ratio": 0.7369,
-"compress_mbps": 55.47,
-"decompress_mbps": 148.16
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6244482,
-"ratio": 0.7369,
-"compress_mbps": 55.08,
-"decompress_mbps": 147.42
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6244480,
-"ratio": 0.7369,
-"compress_mbps": 55.49,
-"decompress_mbps": 148.22
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6244480,
-"ratio": 0.7369,
-"compress_mbps": 55.43,
-"decompress_mbps": 147.23
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 230.66,
-"decompress_mbps": 673.8
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 230.52,
-"decompress_mbps": 670.21
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 231.93,
-"decompress_mbps": 669.9
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 230.28,
-"decompress_mbps": 671.23
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 716461,
-"ratio": 0.134,
-"compress_mbps": 166.09,
-"decompress_mbps": 710.38
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 687053,
-"ratio": 0.1285,
-"compress_mbps": 124.29,
-"decompress_mbps": 733.86
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 673597,
-"ratio": 0.126,
-"compress_mbps": 100.95,
-"decompress_mbps": 744.02
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 662156,
-"ratio": 0.1239,
-"compress_mbps": 65.08,
-"decompress_mbps": 750.21
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 661610,
-"ratio": 0.1238,
-"compress_mbps": 61.06,
-"decompress_mbps": 754.5
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 73589,
-"ratio": 0.4839,
-"compress_mbps": 33.76,
-"decompress_mbps": 57.05
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 69878,
-"ratio": 0.4595,
-"compress_mbps": 32.08,
-"decompress_mbps": 58.09
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 66917,
-"ratio": 0.44,
-"compress_mbps": 26.68,
-"decompress_mbps": 66.6
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 59388,
-"ratio": 0.3905,
-"compress_mbps": 31.26,
-"decompress_mbps": 80.36
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 57062,
-"ratio": 0.3752,
-"compress_mbps": 22.77,
-"decompress_mbps": 80.1
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 55472,
-"ratio": 0.3647,
-"compress_mbps": 16.23,
-"decompress_mbps": 79.12
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 55265,
-"ratio": 0.3634,
-"compress_mbps": 14.29,
-"decompress_mbps": 79.84
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 55168,
-"ratio": 0.3627,
-"compress_mbps": 11.91,
-"decompress_mbps": 78.92
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 55168,
-"ratio": 0.3627,
-"compress_mbps": 11.93,
-"decompress_mbps": 78.52
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 64551,
-"ratio": 0.5157,
-"compress_mbps": 31.89,
-"decompress_mbps": 53.82
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 62089,
-"ratio": 0.496,
-"compress_mbps": 30.15,
-"decompress_mbps": 57.83
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 58690,
-"ratio": 0.4688,
-"compress_mbps": 24.34,
-"decompress_mbps": 59.96
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 53521,
-"ratio": 0.4276,
-"compress_mbps": 30.1,
-"decompress_mbps": 79.96
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 51677,
-"ratio": 0.4128,
-"compress_mbps": 20.89,
-"decompress_mbps": 78.97
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 50638,
-"ratio": 0.4045,
-"compress_mbps": 14.85,
-"decompress_mbps": 82.68
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 50501,
-"ratio": 0.4034,
-"compress_mbps": 13.53,
-"decompress_mbps": 79.57
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 50452,
-"ratio": 0.403,
-"compress_mbps": 12.59,
-"decompress_mbps": 81.82
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 50452,
-"ratio": 0.403,
-"compress_mbps": 12.59,
-"decompress_mbps": 81.99
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 9859,
-"ratio": 0.4007,
-"compress_mbps": 43.03,
-"decompress_mbps": 111.15
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 10473,
-"ratio": 0.4257,
-"compress_mbps": 47.23,
-"decompress_mbps": 149.93
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 10172,
-"ratio": 0.4134,
-"compress_mbps": 42.85,
-"decompress_mbps": 148.23
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8692,
-"ratio": 0.3533,
-"compress_mbps": 40.47,
-"decompress_mbps": 152.86
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8440,
-"ratio": 0.343,
-"compress_mbps": 36.18,
-"decompress_mbps": 157.16
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 8385,
-"ratio": 0.3408,
-"compress_mbps": 31.88,
-"decompress_mbps": 158.84
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 8366,
-"ratio": 0.34,
-"compress_mbps": 29.95,
-"decompress_mbps": 158.95
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 8367,
-"ratio": 0.3401,
-"compress_mbps": 28.71,
-"decompress_mbps": 157.48
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 8367,
-"ratio": 0.3401,
-"compress_mbps": 28.72,
-"decompress_mbps": 156.54
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 4822,
-"ratio": 0.4325,
-"compress_mbps": 54.35,
-"decompress_mbps": 187.68
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 4593,
-"ratio": 0.4119,
-"compress_mbps": 52.8,
-"decompress_mbps": 193.41
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 4381,
-"ratio": 0.3929,
-"compress_mbps": 49.8,
-"decompress_mbps": 200.8
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3725,
-"ratio": 0.3341,
-"compress_mbps": 51.8,
-"decompress_mbps": 202.76
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3614,
-"ratio": 0.3241,
-"compress_mbps": 43.83,
-"decompress_mbps": 208.48
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3578,
-"ratio": 0.3209,
-"compress_mbps": 39.35,
-"decompress_mbps": 209.91
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3572,
-"ratio": 0.3204,
-"compress_mbps": 36.83,
-"decompress_mbps": 210.72
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3568,
-"ratio": 0.32,
-"compress_mbps": 34.7,
-"decompress_mbps": 208.41
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3568,
-"ratio": 0.32,
-"compress_mbps": 33.66,
-"decompress_mbps": 206.14
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1738,
-"ratio": 0.4671,
-"compress_mbps": 30.09,
-"decompress_mbps": 176.72
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1709,
-"ratio": 0.4593,
-"compress_mbps": 30.1,
-"decompress_mbps": 174.49
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1694,
-"ratio": 0.4553,
-"compress_mbps": 31.7,
-"decompress_mbps": 180.35
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1458,
-"ratio": 0.3918,
-"compress_mbps": 29.73,
-"decompress_mbps": 187.58
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1441,
-"ratio": 0.3873,
-"compress_mbps": 28.44,
-"decompress_mbps": 189.94
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.18,
-"decompress_mbps": 189.99
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.68,
-"decompress_mbps": 190.15
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 26.12,
-"decompress_mbps": 189.99
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.78,
-"decompress_mbps": 191.2
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 260073,
-"ratio": 0.2526,
-"compress_mbps": 52.45,
-"decompress_mbps": 56.85
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 296764,
-"ratio": 0.2882,
-"compress_mbps": 48.94,
-"decompress_mbps": 76.97
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 288989,
-"ratio": 0.2806,
-"compress_mbps": 37.59,
-"decompress_mbps": 77.33
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 246442,
-"ratio": 0.2393,
-"compress_mbps": 54.71,
-"decompress_mbps": 83.32
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 218888,
-"ratio": 0.2126,
-"compress_mbps": 40.79,
-"decompress_mbps": 76.86
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 217830,
-"ratio": 0.2115,
-"compress_mbps": 24.16,
-"decompress_mbps": 88.24
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 221437,
-"ratio": 0.215,
-"compress_mbps": 19.26,
-"decompress_mbps": 86.6
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 219666,
-"ratio": 0.2133,
-"compress_mbps": 5.49,
-"decompress_mbps": 86.51
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 219921,
-"ratio": 0.2136,
-"compress_mbps": 2.77,
-"decompress_mbps": 85.35
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 194588,
-"ratio": 0.456,
-"compress_mbps": 34.47,
-"decompress_mbps": 51.9
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 185757,
-"ratio": 0.4353,
-"compress_mbps": 32.92,
-"decompress_mbps": 49.65
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 175850,
-"ratio": 0.4121,
-"compress_mbps": 27.11,
-"decompress_mbps": 59.21
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 155951,
-"ratio": 0.3654,
-"compress_mbps": 31.95,
-"decompress_mbps": 73.02
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 150274,
-"ratio": 0.3521,
-"compress_mbps": 23.12,
-"decompress_mbps": 71.4
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 147958,
-"ratio": 0.3467,
-"compress_mbps": 16.73,
-"decompress_mbps": 72.74
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 147522,
-"ratio": 0.3457,
-"compress_mbps": 14.93,
-"decompress_mbps": 70.21
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 147331,
-"ratio": 0.3452,
-"compress_mbps": 13.5,
-"decompress_mbps": 68.78
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 147328,
-"ratio": 0.3452,
-"compress_mbps": 13.48,
-"decompress_mbps": 70.75
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 256904,
-"ratio": 0.5331,
-"compress_mbps": 29.73,
-"decompress_mbps": 46.55
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 245675,
-"ratio": 0.5098,
-"compress_mbps": 28.42,
-"decompress_mbps": 50.05
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 231519,
-"ratio": 0.4805,
-"compress_mbps": 22.58,
-"decompress_mbps": 56.23
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 210028,
-"ratio": 0.4359,
-"compress_mbps": 27.54,
-"decompress_mbps": 64.61
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 203312,
-"ratio": 0.4219,
-"compress_mbps": 18.52,
-"decompress_mbps": 61.6
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 199287,
-"ratio": 0.4136,
-"compress_mbps": 12.88,
-"decompress_mbps": 65.73
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 198474,
-"ratio": 0.4119,
-"compress_mbps": 11.21,
-"decompress_mbps": 66.4
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 198080,
-"ratio": 0.4111,
-"compress_mbps": 8.88,
-"decompress_mbps": 65.36
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 198080,
-"ratio": 0.4111,
-"compress_mbps": 8.84,
-"decompress_mbps": 65.03
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 71229,
-"ratio": 0.1388,
-"compress_mbps": 82.96,
-"decompress_mbps": 136.59
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 69946,
-"ratio": 0.1363,
-"compress_mbps": 78.92,
-"decompress_mbps": 137.96
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 68538,
-"ratio": 0.1335,
-"compress_mbps": 69.23,
-"decompress_mbps": 151.76
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 61320,
-"ratio": 0.1195,
-"compress_mbps": 65.87,
-"decompress_mbps": 164.26
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 59993,
-"ratio": 0.1169,
-"compress_mbps": 57.15,
-"decompress_mbps": 169.1
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 58637,
-"ratio": 0.1143,
-"compress_mbps": 41.42,
-"decompress_mbps": 166.25
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 58209,
-"ratio": 0.1134,
-"compress_mbps": 35.38,
-"decompress_mbps": 173.09
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 55749,
-"ratio": 0.1086,
-"compress_mbps": 19.35,
-"decompress_mbps": 176.71
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 54927,
-"ratio": 0.107,
-"compress_mbps": 7.52,
-"decompress_mbps": 176.17
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 16399,
-"ratio": 0.4288,
-"compress_mbps": 36.37,
-"decompress_mbps": 86.67
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 15933,
-"ratio": 0.4167,
-"compress_mbps": 33.72,
-"decompress_mbps": 88.83
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 15739,
-"ratio": 0.4116,
-"compress_mbps": 28.05,
-"decompress_mbps": 87.94
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13834,
-"ratio": 0.3618,
-"compress_mbps": 31.73,
-"decompress_mbps": 108.86
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13463,
-"ratio": 0.3521,
-"compress_mbps": 25.96,
-"decompress_mbps": 111.56
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13353,
-"ratio": 0.3492,
-"compress_mbps": 18.86,
-"decompress_mbps": 111.15
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13317,
-"ratio": 0.3482,
-"compress_mbps": 15.93,
-"decompress_mbps": 113.26
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13255,
-"ratio": 0.3466,
-"compress_mbps": 8.38,
-"decompress_mbps": 110.11
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13171,
-"ratio": 0.3444,
-"compress_mbps": 4.16,
-"decompress_mbps": 114.39
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 2512,
-"ratio": 0.5943,
-"compress_mbps": 29.63,
-"decompress_mbps": 155.88
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 2477,
-"ratio": 0.586,
-"compress_mbps": 29.51,
-"decompress_mbps": 158.96
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 2452,
-"ratio": 0.5801,
-"compress_mbps": 30.37,
-"decompress_mbps": 157.34
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 2110,
-"ratio": 0.4992,
-"compress_mbps": 29.99,
-"decompress_mbps": 162.81
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.87,
-"decompress_mbps": 169.5
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.86,
-"decompress_mbps": 167.98
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.5,
-"decompress_mbps": 169.54
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 27.54,
-"decompress_mbps": 169.65
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.63,
-"decompress_mbps": 169.5
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 5183792,
-"ratio": 0.5086,
-"compress_mbps": 31.31,
-"decompress_mbps": 40.47
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4956750,
-"ratio": 0.4863,
-"compress_mbps": 29.97,
-"decompress_mbps": 43.45
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4644095,
-"ratio": 0.4556,
-"compress_mbps": 24.06,
-"decompress_mbps": 47.94
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4178564,
-"ratio": 0.41,
-"compress_mbps": 29.06,
-"decompress_mbps": 61.99
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 4034632,
-"ratio": 0.3958,
-"compress_mbps": 19.92,
-"decompress_mbps": 61.3
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3952244,
-"ratio": 0.3878,
-"compress_mbps": 13.83,
-"decompress_mbps": 61.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3938822,
-"ratio": 0.3864,
-"compress_mbps": 12.23,
-"decompress_mbps": 62.83
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3935171,
-"ratio": 0.3861,
-"compress_mbps": 10.76,
-"decompress_mbps": 60.2
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3935171,
-"ratio": 0.3861,
-"compress_mbps": 10.72,
-"decompress_mbps": 60.89
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 25320013,
-"ratio": 0.4943,
-"compress_mbps": 31.71,
-"decompress_mbps": 34.88
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 24804084,
-"ratio": 0.4843,
-"compress_mbps": 30.3,
-"decompress_mbps": 36.64
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 24241121,
-"ratio": 0.4733,
-"compress_mbps": 25.73,
-"decompress_mbps": 37.97
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 20950547,
-"ratio": 0.409,
-"compress_mbps": 28.84,
-"decompress_mbps": 44.03
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 20592289,
-"ratio": 0.402,
-"compress_mbps": 24.29,
-"decompress_mbps": 46.14
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 20445232,
-"ratio": 0.3992,
-"compress_mbps": 18.69,
-"decompress_mbps": 46.11
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 20407676,
-"ratio": 0.3984,
-"compress_mbps": 15.95,
-"decompress_mbps": 46.63
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 20389473,
-"ratio": 0.3981,
-"compress_mbps": 10.13,
-"decompress_mbps": 45.4
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 20386824,
-"ratio": 0.398,
-"compress_mbps": 6.82,
-"decompress_mbps": 46.45
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3964698,
-"ratio": 0.3976,
-"compress_mbps": 37.98,
-"decompress_mbps": 48.02
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3936391,
-"ratio": 0.3948,
-"compress_mbps": 35.52,
-"decompress_mbps": 47.93
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3823540,
-"ratio": 0.3835,
-"compress_mbps": 27.78,
-"decompress_mbps": 51.72
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3799601,
-"ratio": 0.3811,
-"compress_mbps": 33.02,
-"decompress_mbps": 63.69
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3830938,
-"ratio": 0.3842,
-"compress_mbps": 22.58,
-"decompress_mbps": 58.61
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3808303,
-"ratio": 0.382,
-"compress_mbps": 14.79,
-"decompress_mbps": 57.61
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3802814,
-"ratio": 0.3814,
-"compress_mbps": 12.14,
-"decompress_mbps": 57.87
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3800355,
-"ratio": 0.3812,
-"compress_mbps": 6.76,
-"decompress_mbps": 59.01
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3799676,
-"ratio": 0.3811,
-"compress_mbps": 6.05,
-"decompress_mbps": 59.07
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4899547,
-"ratio": 0.146,
-"compress_mbps": 95.3,
-"decompress_mbps": 131.63
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4587004,
-"ratio": 0.1367,
-"compress_mbps": 94.92,
-"decompress_mbps": 142.96
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 4229035,
-"ratio": 0.126,
-"compress_mbps": 90.43,
-"decompress_mbps": 152.33
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3791322,
-"ratio": 0.113,
-"compress_mbps": 81.61,
-"decompress_mbps": 160.66
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3449193,
-"ratio": 0.1028,
-"compress_mbps": 72.81,
-"decompress_mbps": 168.1
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3269452,
-"ratio": 0.0974,
-"compress_mbps": 58.66,
-"decompress_mbps": 173.37
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3211286,
-"ratio": 0.0957,
-"compress_mbps": 50.59,
-"decompress_mbps": 173.62
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3101534,
-"ratio": 0.0924,
-"compress_mbps": 27.5,
-"decompress_mbps": 174.42
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3058177,
-"ratio": 0.0911,
-"compress_mbps": 16.6,
-"decompress_mbps": 177.54
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 4024327,
-"ratio": 0.6541,
-"compress_mbps": 22.81,
-"decompress_mbps": 29.95
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3953722,
-"ratio": 0.6427,
-"compress_mbps": 21.66,
-"decompress_mbps": 30.5
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3887921,
-"ratio": 0.632,
-"compress_mbps": 18.47,
-"decompress_mbps": 31.15
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3320440,
-"ratio": 0.5397,
-"compress_mbps": 21.3,
-"decompress_mbps": 37.41
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3279338,
-"ratio": 0.533,
-"compress_mbps": 17.83,
-"decompress_mbps": 38.07
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3254309,
-"ratio": 0.529,
-"compress_mbps": 14.0,
-"decompress_mbps": 37.9
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3250139,
-"ratio": 0.5283,
-"compress_mbps": 12.22,
-"decompress_mbps": 38.09
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3247018,
-"ratio": 0.5278,
-"compress_mbps": 10.17,
-"decompress_mbps": 38.03
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3246865,
-"ratio": 0.5278,
-"compress_mbps": 9.51,
-"decompress_mbps": 38.0
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4471091,
-"ratio": 0.4433,
-"compress_mbps": 34.91,
-"decompress_mbps": 69.94
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 4372105,
-"ratio": 0.4335,
-"compress_mbps": 33.82,
-"decompress_mbps": 71.85
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 4305270,
-"ratio": 0.4269,
-"compress_mbps": 30.7,
-"decompress_mbps": 73.16
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3920495,
-"ratio": 0.3887,
-"compress_mbps": 30.3,
-"decompress_mbps": 64.84
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3853177,
-"ratio": 0.382,
-"compress_mbps": 26.63,
-"decompress_mbps": 63.95
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3780878,
-"ratio": 0.3749,
-"compress_mbps": 23.38,
-"decompress_mbps": 64.31
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3763880,
-"ratio": 0.3732,
-"compress_mbps": 20.2,
-"decompress_mbps": 72.93
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3757719,
-"ratio": 0.3726,
-"compress_mbps": 18.3,
-"decompress_mbps": 73.42
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3757719,
-"ratio": 0.3726,
-"compress_mbps": 18.25,
-"decompress_mbps": 72.55
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2722387,
-"ratio": 0.4108,
-"compress_mbps": 38.01,
-"decompress_mbps": 64.73
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2572544,
-"ratio": 0.3882,
-"compress_mbps": 36.87,
-"decompress_mbps": 70.55
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2384328,
-"ratio": 0.3598,
-"compress_mbps": 29.15,
-"decompress_mbps": 78.64
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2112060,
-"ratio": 0.3187,
-"compress_mbps": 36.42,
-"decompress_mbps": 85.62
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1991581,
-"ratio": 0.3005,
-"compress_mbps": 25.34,
-"decompress_mbps": 91.01
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1917866,
-"ratio": 0.2894,
-"compress_mbps": 15.03,
-"decompress_mbps": 90.85
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1895353,
-"ratio": 0.286,
-"compress_mbps": 11.08,
-"decompress_mbps": 90.48
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1880740,
-"ratio": 0.2838,
-"compress_mbps": 5.59,
-"decompress_mbps": 90.95
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1880711,
-"ratio": 0.2838,
-"compress_mbps": 5.56,
-"decompress_mbps": 92.3
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 7441483,
-"ratio": 0.3444,
-"compress_mbps": 43.78,
-"decompress_mbps": 66.88
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 7229248,
-"ratio": 0.3346,
-"compress_mbps": 43.14,
-"decompress_mbps": 69.03
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 7083451,
-"ratio": 0.3278,
-"compress_mbps": 38.92,
-"decompress_mbps": 71.31
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 6189639,
-"ratio": 0.2865,
-"compress_mbps": 42.2,
-"decompress_mbps": 92.76
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 6053058,
-"ratio": 0.2802,
-"compress_mbps": 35.08,
-"decompress_mbps": 96.18
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5988137,
-"ratio": 0.2771,
-"compress_mbps": 28.51,
-"decompress_mbps": 101.1
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5949908,
-"ratio": 0.2754,
-"compress_mbps": 25.19,
-"decompress_mbps": 103.3
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5936656,
-"ratio": 0.2748,
-"compress_mbps": 19.22,
-"decompress_mbps": 106.46
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5934701,
-"ratio": 0.2747,
-"compress_mbps": 17.98,
-"decompress_mbps": 105.25
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 6335542,
-"ratio": 0.8736,
-"compress_mbps": 18.44,
-"decompress_mbps": 31.75
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 6247260,
-"ratio": 0.8615,
-"compress_mbps": 17.59,
-"decompress_mbps": 48.2
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 6064713,
-"ratio": 0.8363,
-"compress_mbps": 15.15,
-"decompress_mbps": 56.49
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5568111,
-"ratio": 0.7678,
-"compress_mbps": 17.55,
-"decompress_mbps": 58.99
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5544524,
-"ratio": 0.7646,
-"compress_mbps": 14.42,
-"decompress_mbps": 64.88
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5513056,
-"ratio": 0.7602,
-"compress_mbps": 11.94,
-"decompress_mbps": 62.87
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5508915,
-"ratio": 0.7596,
-"compress_mbps": 11.32,
-"decompress_mbps": 64.42
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5508365,
-"ratio": 0.7596,
-"compress_mbps": 10.52,
-"decompress_mbps": 65.26
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5508365,
-"ratio": 0.7596,
-"compress_mbps": 10.57,
-"decompress_mbps": 64.3
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 16776095,
-"ratio": 0.4046,
-"compress_mbps": 37.73,
-"decompress_mbps": 50.93
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 16032651,
-"ratio": 0.3867,
-"compress_mbps": 36.24,
-"decompress_mbps": 54.65
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 15180334,
-"ratio": 0.3662,
-"compress_mbps": 31.28,
-"decompress_mbps": 51.85
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 13261924,
-"ratio": 0.3199,
-"compress_mbps": 35.24,
-"decompress_mbps": 68.67
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12706028,
-"ratio": 0.3065,
-"compress_mbps": 27.63,
-"decompress_mbps": 70.4
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12464158,
-"ratio": 0.3006,
-"compress_mbps": 21.0,
-"decompress_mbps": 70.64
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12375954,
-"ratio": 0.2985,
-"compress_mbps": 18.31,
-"decompress_mbps": 73.55
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12321552,
-"ratio": 0.2972,
-"compress_mbps": 14.45,
-"decompress_mbps": 70.76
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12320276,
-"ratio": 0.2972,
-"compress_mbps": 14.41,
-"decompress_mbps": 70.34
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6799201,
-"ratio": 0.8023,
-"compress_mbps": 18.34,
-"decompress_mbps": 18.29
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6800500,
-"ratio": 0.8025,
-"compress_mbps": 16.95,
-"decompress_mbps": 18.49
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6803212,
-"ratio": 0.8028,
-"compress_mbps": 14.91,
-"decompress_mbps": 18.44
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6264611,
-"ratio": 0.7393,
-"compress_mbps": 17.32,
-"decompress_mbps": 24.91
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6217901,
-"ratio": 0.7337,
-"compress_mbps": 15.76,
-"decompress_mbps": 25.36
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6201999,
-"ratio": 0.7319,
-"compress_mbps": 15.32,
-"decompress_mbps": 25.35
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6201883,
-"ratio": 0.7319,
-"compress_mbps": 15.24,
-"decompress_mbps": 25.06
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6201887,
-"ratio": 0.7319,
-"compress_mbps": 15.22,
-"decompress_mbps": 24.94
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6201887,
-"ratio": 0.7319,
-"compress_mbps": 15.3,
-"decompress_mbps": 24.93
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 1081679,
-"ratio": 0.2024,
-"compress_mbps": 74.26,
-"decompress_mbps": 106.26
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 1001890,
-"ratio": 0.1874,
-"compress_mbps": 74.05,
-"decompress_mbps": 118.21
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 921722,
-"ratio": 0.1724,
-"compress_mbps": 67.22,
-"decompress_mbps": 127.75
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 849263,
-"ratio": 0.1589,
-"compress_mbps": 64.23,
-"decompress_mbps": 142.53
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 771964,
-"ratio": 0.1444,
-"compress_mbps": 54.81,
-"decompress_mbps": 144.22
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 728098,
-"ratio": 0.1362,
-"compress_mbps": 43.49,
-"decompress_mbps": 150.41
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 713635,
-"ratio": 0.1335,
-"compress_mbps": 37.23,
-"decompress_mbps": 154.84
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 699093,
-"ratio": 0.1308,
-"compress_mbps": 27.08,
-"decompress_mbps": 146.56
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 698459,
-"ratio": 0.1307,
-"compress_mbps": 25.17,
-"decompress_mbps": 148.81
-}
-]
+ "meta": {
+  "date": "2026-06-16T04:08:01Z",
+  "machine": "Linux chungus x86_64",
+  "git_commit": "e22d5e5d",
+  "toolchain": "leanprover/lean4:v4.30.0-rc2",
+  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
+ },
+ "results": [
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 59545,
+   "ratio": 0.3915,
+   "compress_mbps": 31.02,
+   "decompress_mbps": 86.4
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 57936,
+   "ratio": 0.3809,
+   "compress_mbps": 27.8,
+   "decompress_mbps": 94.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 56891,
+   "ratio": 0.3741,
+   "compress_mbps": 24.7,
+   "decompress_mbps": 103.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 55596,
+   "ratio": 0.3655,
+   "compress_mbps": 18.22,
+   "decompress_mbps": 104.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 55337,
+   "ratio": 0.3638,
+   "compress_mbps": 17.22,
+   "decompress_mbps": 106.71
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54954,
+   "ratio": 0.3613,
+   "compress_mbps": 15.14,
+   "decompress_mbps": 111.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54533,
+   "ratio": 0.3586,
+   "compress_mbps": 7.0,
+   "decompress_mbps": 109.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54492,
+   "ratio": 0.3583,
+   "compress_mbps": 6.6,
+   "decompress_mbps": 109.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 52111,
+   "ratio": 0.3426,
+   "compress_mbps": 0.97,
+   "decompress_mbps": 109.51
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 52768,
+   "ratio": 0.4215,
+   "compress_mbps": 29.21,
+   "decompress_mbps": 81.47
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 51760,
+   "ratio": 0.4135,
+   "compress_mbps": 26.15,
+   "decompress_mbps": 86.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51056,
+   "ratio": 0.4079,
+   "compress_mbps": 23.11,
+   "decompress_mbps": 92.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 49986,
+   "ratio": 0.3993,
+   "compress_mbps": 16.41,
+   "decompress_mbps": 93.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 49809,
+   "ratio": 0.3979,
+   "compress_mbps": 15.45,
+   "decompress_mbps": 96.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 49570,
+   "ratio": 0.396,
+   "compress_mbps": 13.71,
+   "decompress_mbps": 97.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 49161,
+   "ratio": 0.3927,
+   "compress_mbps": 6.59,
+   "decompress_mbps": 98.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 49153,
+   "ratio": 0.3927,
+   "compress_mbps": 6.49,
+   "decompress_mbps": 98.93
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 46881,
+   "ratio": 0.3745,
+   "compress_mbps": 1.11,
+   "decompress_mbps": 98.25
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8430,
+   "ratio": 0.3426,
+   "compress_mbps": 27.63,
+   "decompress_mbps": 84.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8297,
+   "ratio": 0.3372,
+   "compress_mbps": 26.69,
+   "decompress_mbps": 88.29
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8218,
+   "ratio": 0.334,
+   "compress_mbps": 26.02,
+   "decompress_mbps": 90.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8072,
+   "ratio": 0.3281,
+   "compress_mbps": 23.53,
+   "decompress_mbps": 89.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8066,
+   "ratio": 0.3278,
+   "compress_mbps": 23.24,
+   "decompress_mbps": 91.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 8056,
+   "ratio": 0.3274,
+   "compress_mbps": 22.4,
+   "decompress_mbps": 91.62
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 8038,
+   "ratio": 0.3267,
+   "compress_mbps": 8.32,
+   "decompress_mbps": 92.71
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 8038,
+   "ratio": 0.3267,
+   "compress_mbps": 8.29,
+   "decompress_mbps": 92.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7727,
+   "ratio": 0.3141,
+   "compress_mbps": 1.27,
+   "decompress_mbps": 92.23
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3325,
+   "ratio": 0.2982,
+   "compress_mbps": 20.72,
+   "decompress_mbps": 75.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3251,
+   "ratio": 0.2916,
+   "compress_mbps": 20.21,
+   "decompress_mbps": 77.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3202,
+   "ratio": 0.2872,
+   "compress_mbps": 19.79,
+   "decompress_mbps": 79.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3153,
+   "ratio": 0.2828,
+   "compress_mbps": 18.46,
+   "decompress_mbps": 81.19
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3143,
+   "ratio": 0.2819,
+   "compress_mbps": 18.37,
+   "decompress_mbps": 82.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3139,
+   "ratio": 0.2815,
+   "compress_mbps": 17.97,
+   "decompress_mbps": 82.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3134,
+   "ratio": 0.2811,
+   "compress_mbps": 6.37,
+   "decompress_mbps": 82.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3134,
+   "ratio": 0.2811,
+   "compress_mbps": 6.36,
+   "decompress_mbps": 83.16
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3027,
+   "ratio": 0.2715,
+   "compress_mbps": 1.35,
+   "decompress_mbps": 82.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1251,
+   "ratio": 0.3362,
+   "compress_mbps": 10.44,
+   "decompress_mbps": 41.89
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1241,
+   "ratio": 0.3335,
+   "compress_mbps": 10.38,
+   "decompress_mbps": 42.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1241,
+   "ratio": 0.3335,
+   "compress_mbps": 10.27,
+   "decompress_mbps": 42.52
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1227,
+   "ratio": 0.3298,
+   "compress_mbps": 10.08,
+   "decompress_mbps": 43.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1227,
+   "ratio": 0.3298,
+   "compress_mbps": 10.13,
+   "decompress_mbps": 43.56
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1227,
+   "ratio": 0.3298,
+   "compress_mbps": 10.1,
+   "decompress_mbps": 43.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1224,
+   "ratio": 0.3289,
+   "compress_mbps": 3.61,
+   "decompress_mbps": 43.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1224,
+   "ratio": 0.3289,
+   "compress_mbps": 3.6,
+   "decompress_mbps": 43.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1190,
+   "ratio": 0.3198,
+   "compress_mbps": 1.13,
+   "decompress_mbps": 43.95
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 248840,
+   "ratio": 0.2417,
+   "compress_mbps": 61.39,
+   "decompress_mbps": 129.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 247429,
+   "ratio": 0.2403,
+   "compress_mbps": 56.84,
+   "decompress_mbps": 149.26
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 246442,
+   "ratio": 0.2393,
+   "compress_mbps": 54.75,
+   "decompress_mbps": 157.25
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 242288,
+   "ratio": 0.2353,
+   "compress_mbps": 51.81,
+   "decompress_mbps": 162.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 242066,
+   "ratio": 0.2351,
+   "compress_mbps": 50.24,
+   "decompress_mbps": 130.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 241736,
+   "ratio": 0.2348,
+   "compress_mbps": 45.33,
+   "decompress_mbps": 131.33
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 201296,
+   "ratio": 0.1955,
+   "compress_mbps": 9.4,
+   "decompress_mbps": 122.37
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 201458,
+   "ratio": 0.1956,
+   "compress_mbps": 7.56,
+   "decompress_mbps": 120.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 178311,
+   "ratio": 0.1732,
+   "compress_mbps": 0.72,
+   "decompress_mbps": 120.42
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 158127,
+   "ratio": 0.3705,
+   "compress_mbps": 33.54,
+   "decompress_mbps": 89.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 153708,
+   "ratio": 0.3602,
+   "compress_mbps": 29.85,
+   "decompress_mbps": 96.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 150718,
+   "ratio": 0.3532,
+   "compress_mbps": 26.02,
+   "decompress_mbps": 106.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 147584,
+   "ratio": 0.3458,
+   "compress_mbps": 19.28,
+   "decompress_mbps": 106.83
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 146956,
+   "ratio": 0.3444,
+   "compress_mbps": 16.51,
+   "decompress_mbps": 92.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 146218,
+   "ratio": 0.3426,
+   "compress_mbps": 14.28,
+   "decompress_mbps": 96.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 145400,
+   "ratio": 0.3407,
+   "compress_mbps": 6.47,
+   "decompress_mbps": 96.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 145324,
+   "ratio": 0.3405,
+   "compress_mbps": 6.19,
+   "decompress_mbps": 94.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 138661,
+   "ratio": 0.3249,
+   "compress_mbps": 0.97,
+   "decompress_mbps": 113.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 212305,
+   "ratio": 0.4406,
+   "compress_mbps": 28.44,
+   "decompress_mbps": 78.6
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 207350,
+   "ratio": 0.4303,
+   "compress_mbps": 24.8,
+   "decompress_mbps": 85.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 203699,
+   "ratio": 0.4227,
+   "compress_mbps": 21.47,
+   "decompress_mbps": 90.62
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 200095,
+   "ratio": 0.4153,
+   "compress_mbps": 14.79,
+   "decompress_mbps": 91.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 199269,
+   "ratio": 0.4135,
+   "compress_mbps": 13.83,
+   "decompress_mbps": 94.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 198081,
+   "ratio": 0.4111,
+   "compress_mbps": 11.97,
+   "decompress_mbps": 96.46
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 197186,
+   "ratio": 0.4092,
+   "compress_mbps": 6.02,
+   "decompress_mbps": 96.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 197001,
+   "ratio": 0.4088,
+   "compress_mbps": 5.62,
+   "decompress_mbps": 97.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 186472,
+   "ratio": 0.387,
+   "compress_mbps": 0.99,
+   "decompress_mbps": 97.31
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60352,
+   "ratio": 0.1176,
+   "compress_mbps": 96.74,
+   "decompress_mbps": 240.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 59696,
+   "ratio": 0.1163,
+   "compress_mbps": 86.52,
+   "decompress_mbps": 251.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 59069,
+   "ratio": 0.1151,
+   "compress_mbps": 75.44,
+   "decompress_mbps": 266.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57047,
+   "ratio": 0.1112,
+   "compress_mbps": 59.15,
+   "decompress_mbps": 242.05
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 56965,
+   "ratio": 0.111,
+   "compress_mbps": 56.5,
+   "decompress_mbps": 254.62
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 56766,
+   "ratio": 0.1106,
+   "compress_mbps": 49.78,
+   "decompress_mbps": 268.72
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 54820,
+   "ratio": 0.1068,
+   "compress_mbps": 17.29,
+   "decompress_mbps": 280.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 54111,
+   "ratio": 0.1054,
+   "compress_mbps": 15.38,
+   "decompress_mbps": 290.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51490,
+   "ratio": 0.1003,
+   "compress_mbps": 0.42,
+   "decompress_mbps": 295.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 13725,
+   "ratio": 0.3589,
+   "compress_mbps": 22.37,
+   "decompress_mbps": 65.57
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13615,
+   "ratio": 0.356,
+   "compress_mbps": 21.6,
+   "decompress_mbps": 69.11
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13548,
+   "ratio": 0.3543,
+   "compress_mbps": 20.83,
+   "decompress_mbps": 72.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13098,
+   "ratio": 0.3425,
+   "compress_mbps": 18.02,
+   "decompress_mbps": 70.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13080,
+   "ratio": 0.3421,
+   "compress_mbps": 17.52,
+   "decompress_mbps": 74.01
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13027,
+   "ratio": 0.3407,
+   "compress_mbps": 16.03,
+   "decompress_mbps": 75.06
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12823,
+   "ratio": 0.3353,
+   "compress_mbps": 5.05,
+   "decompress_mbps": 74.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12811,
+   "ratio": 0.335,
+   "compress_mbps": 4.64,
+   "decompress_mbps": 77.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12278,
+   "ratio": 0.3211,
+   "compress_mbps": 0.97,
+   "decompress_mbps": 75.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1781,
+   "ratio": 0.4213,
+   "compress_mbps": 11.47,
+   "decompress_mbps": 42.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1764,
+   "ratio": 0.4173,
+   "compress_mbps": 11.41,
+   "decompress_mbps": 42.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1765,
+   "ratio": 0.4176,
+   "compress_mbps": 11.39,
+   "decompress_mbps": 42.97
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1750,
+   "ratio": 0.414,
+   "compress_mbps": 11.24,
+   "decompress_mbps": 43.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1750,
+   "ratio": 0.414,
+   "compress_mbps": 11.25,
+   "decompress_mbps": 43.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1750,
+   "ratio": 0.414,
+   "compress_mbps": 11.25,
+   "decompress_mbps": 43.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1747,
+   "ratio": 0.4133,
+   "compress_mbps": 3.88,
+   "decompress_mbps": 43.47
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1747,
+   "ratio": 0.4133,
+   "compress_mbps": 3.87,
+   "decompress_mbps": 43.54
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1696,
+   "ratio": 0.4012,
+   "compress_mbps": 1.31,
+   "decompress_mbps": 43.45
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 65130,
+   "ratio": 0.4282,
+   "compress_mbps": 118.8,
+   "decompress_mbps": 397.09
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 62270,
+   "ratio": 0.4094,
+   "compress_mbps": 102.02,
+   "decompress_mbps": 415.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 59488,
+   "ratio": 0.3911,
+   "compress_mbps": 67.28,
+   "decompress_mbps": 428.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 57679,
+   "ratio": 0.3792,
+   "compress_mbps": 72.14,
+   "decompress_mbps": 410.74
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 55616,
+   "ratio": 0.3657,
+   "compress_mbps": 42.19,
+   "decompress_mbps": 401.47
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54398,
+   "ratio": 0.3577,
+   "compress_mbps": 25.62,
+   "decompress_mbps": 415.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54253,
+   "ratio": 0.3567,
+   "compress_mbps": 21.49,
+   "decompress_mbps": 416.57
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54164,
+   "ratio": 0.3561,
+   "compress_mbps": 17.06,
+   "decompress_mbps": 416.96
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54164,
+   "ratio": 0.3561,
+   "compress_mbps": 17.04,
+   "decompress_mbps": 416.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 56791,
+   "ratio": 0.4537,
+   "compress_mbps": 115.9,
+   "decompress_mbps": 388.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 54652,
+   "ratio": 0.4366,
+   "compress_mbps": 98.11,
+   "decompress_mbps": 403.21
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 52663,
+   "ratio": 0.4207,
+   "compress_mbps": 62.56,
+   "decompress_mbps": 424.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 51266,
+   "ratio": 0.4095,
+   "compress_mbps": 67.99,
+   "decompress_mbps": 395.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 49622,
+   "ratio": 0.3964,
+   "compress_mbps": 37.63,
+   "decompress_mbps": 385.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48891,
+   "ratio": 0.3906,
+   "compress_mbps": 22.92,
+   "decompress_mbps": 387.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48801,
+   "ratio": 0.3898,
+   "compress_mbps": 20.1,
+   "decompress_mbps": 394.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48772,
+   "ratio": 0.3896,
+   "compress_mbps": 18.19,
+   "decompress_mbps": 392.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48772,
+   "ratio": 0.3896,
+   "compress_mbps": 18.2,
+   "decompress_mbps": 392.95
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 9028,
+   "ratio": 0.3669,
+   "compress_mbps": 412.21,
+   "decompress_mbps": 1045.04
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8811,
+   "ratio": 0.3581,
+   "compress_mbps": 217.23,
+   "decompress_mbps": 1072.07
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8616,
+   "ratio": 0.3502,
+   "compress_mbps": 160.24,
+   "decompress_mbps": 1099.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8219,
+   "ratio": 0.3341,
+   "compress_mbps": 117.35,
+   "decompress_mbps": 1111.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8001,
+   "ratio": 0.3252,
+   "compress_mbps": 85.23,
+   "decompress_mbps": 1142.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7955,
+   "ratio": 0.3233,
+   "compress_mbps": 68.93,
+   "decompress_mbps": 1144.77
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7933,
+   "ratio": 0.3224,
+   "compress_mbps": 63.18,
+   "decompress_mbps": 1154.46
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 58.33,
+   "decompress_mbps": 1154.23
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 58.22,
+   "decompress_mbps": 1150.95
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3647,
+   "ratio": 0.3271,
+   "compress_mbps": 425.03,
+   "decompress_mbps": 1057.22
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3501,
+   "ratio": 0.314,
+   "compress_mbps": 408.74,
+   "decompress_mbps": 1104.66
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3393,
+   "ratio": 0.3043,
+   "compress_mbps": 337.65,
+   "decompress_mbps": 1135.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3215,
+   "ratio": 0.2883,
+   "compress_mbps": 273.63,
+   "decompress_mbps": 1161.62
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3140,
+   "ratio": 0.2816,
+   "compress_mbps": 205.53,
+   "decompress_mbps": 1195.44
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 153.83,
+   "decompress_mbps": 1207.94
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 132.01,
+   "decompress_mbps": 1211.52
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3109,
+   "ratio": 0.2788,
+   "compress_mbps": 111.29,
+   "decompress_mbps": 1210.96
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3109,
+   "ratio": 0.2788,
+   "compress_mbps": 111.09,
+   "decompress_mbps": 1212.9
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1326,
+   "ratio": 0.3564,
+   "compress_mbps": 313.32,
+   "decompress_mbps": 771.1
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1306,
+   "ratio": 0.351,
+   "compress_mbps": 306.47,
+   "decompress_mbps": 779.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1301,
+   "ratio": 0.3496,
+   "compress_mbps": 289.28,
+   "decompress_mbps": 781.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1228,
+   "ratio": 0.33,
+   "compress_mbps": 231.68,
+   "decompress_mbps": 821.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 197.3,
+   "decompress_mbps": 810.0
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 176.88,
+   "decompress_mbps": 813.9
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 168.98,
+   "decompress_mbps": 812.04
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 166.6,
+   "decompress_mbps": 811.3
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 166.42,
+   "decompress_mbps": 810.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 242293,
+   "ratio": 0.2353,
+   "compress_mbps": 262.03,
+   "decompress_mbps": 839.95
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 233553,
+   "ratio": 0.2268,
+   "compress_mbps": 247.95,
+   "decompress_mbps": 991.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 228222,
+   "ratio": 0.2216,
+   "compress_mbps": 195.75,
+   "decompress_mbps": 1053.53
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 223668,
+   "ratio": 0.2172,
+   "compress_mbps": 177.37,
+   "decompress_mbps": 1083.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 205994,
+   "ratio": 0.2,
+   "compress_mbps": 110.05,
+   "decompress_mbps": 1042.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 203986,
+   "ratio": 0.1981,
+   "compress_mbps": 50.02,
+   "decompress_mbps": 1042.68
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 207681,
+   "ratio": 0.2017,
+   "compress_mbps": 37.04,
+   "decompress_mbps": 1036.03
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 206827,
+   "ratio": 0.2009,
+   "compress_mbps": 7.28,
+   "decompress_mbps": 1013.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 207023,
+   "ratio": 0.201,
+   "compress_mbps": 3.42,
+   "decompress_mbps": 1009.96
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 174124,
+   "ratio": 0.408,
+   "compress_mbps": 123.96,
+   "decompress_mbps": 394.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 166150,
+   "ratio": 0.3893,
+   "compress_mbps": 105.1,
+   "decompress_mbps": 405.11
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 158784,
+   "ratio": 0.3721,
+   "compress_mbps": 70.47,
+   "decompress_mbps": 420.77
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 152782,
+   "ratio": 0.358,
+   "compress_mbps": 74.09,
+   "decompress_mbps": 410.19
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 147196,
+   "ratio": 0.3449,
+   "compress_mbps": 43.64,
+   "decompress_mbps": 405.47
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144898,
+   "ratio": 0.3395,
+   "compress_mbps": 26.43,
+   "decompress_mbps": 416.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144589,
+   "ratio": 0.3388,
+   "compress_mbps": 22.9,
+   "decompress_mbps": 416.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144436,
+   "ratio": 0.3385,
+   "compress_mbps": 19.66,
+   "decompress_mbps": 418.82
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144433,
+   "ratio": 0.3384,
+   "compress_mbps": 19.61,
+   "decompress_mbps": 419.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 228883,
+   "ratio": 0.475,
+   "compress_mbps": 107.9,
+   "decompress_mbps": 371.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 219047,
+   "ratio": 0.4546,
+   "compress_mbps": 90.9,
+   "decompress_mbps": 388.53
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 209408,
+   "ratio": 0.4346,
+   "compress_mbps": 55.55,
+   "decompress_mbps": 401.19
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 205916,
+   "ratio": 0.4273,
+   "compress_mbps": 62.66,
+   "decompress_mbps": 376.95
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 199188,
+   "ratio": 0.4134,
+   "compress_mbps": 33.11,
+   "decompress_mbps": 358.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195255,
+   "ratio": 0.4052,
+   "compress_mbps": 19.41,
+   "decompress_mbps": 367.26
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194657,
+   "ratio": 0.404,
+   "compress_mbps": 16.43,
+   "decompress_mbps": 369.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194326,
+   "ratio": 0.4033,
+   "compress_mbps": 12.95,
+   "decompress_mbps": 368.52
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 194326,
+   "ratio": 0.4033,
+   "compress_mbps": 12.88,
+   "decompress_mbps": 367.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 65553,
+   "ratio": 0.1277,
+   "compress_mbps": 273.05,
+   "decompress_mbps": 889.95
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 63891,
+   "ratio": 0.1245,
+   "compress_mbps": 246.67,
+   "decompress_mbps": 920.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 62515,
+   "ratio": 0.1218,
+   "compress_mbps": 193.29,
+   "decompress_mbps": 975.32
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 58451,
+   "ratio": 0.1139,
+   "compress_mbps": 169.09,
+   "decompress_mbps": 696.08
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 57410,
+   "ratio": 0.1119,
+   "compress_mbps": 130.04,
+   "decompress_mbps": 730.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 56459,
+   "ratio": 0.11,
+   "compress_mbps": 77.17,
+   "decompress_mbps": 774.64
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 55358,
+   "ratio": 0.1079,
+   "compress_mbps": 60.41,
+   "decompress_mbps": 811.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52991,
+   "ratio": 0.1033,
+   "compress_mbps": 27.55,
+   "decompress_mbps": 865.3
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52215,
+   "ratio": 0.1017,
+   "compress_mbps": 9.82,
+   "decompress_mbps": 890.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14112,
+   "ratio": 0.369,
+   "compress_mbps": 129.59,
+   "decompress_mbps": 932.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13815,
+   "ratio": 0.3613,
+   "compress_mbps": 109.91,
+   "decompress_mbps": 964.65
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13795,
+   "ratio": 0.3607,
+   "compress_mbps": 79.05,
+   "decompress_mbps": 1011.13
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13375,
+   "ratio": 0.3498,
+   "compress_mbps": 81.07,
+   "decompress_mbps": 996.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13062,
+   "ratio": 0.3416,
+   "compress_mbps": 56.11,
+   "decompress_mbps": 1041.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12984,
+   "ratio": 0.3395,
+   "compress_mbps": 33.27,
+   "decompress_mbps": 1050.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12949,
+   "ratio": 0.3386,
+   "compress_mbps": 25.56,
+   "decompress_mbps": 1051.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12894,
+   "ratio": 0.3372,
+   "compress_mbps": 11.08,
+   "decompress_mbps": 1069.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12832,
+   "ratio": 0.3356,
+   "compress_mbps": 5.09,
+   "decompress_mbps": 1079.11
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1846,
+   "ratio": 0.4367,
+   "compress_mbps": 289.14,
+   "decompress_mbps": 707.85
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1820,
+   "ratio": 0.4306,
+   "compress_mbps": 283.45,
+   "decompress_mbps": 713.86
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1808,
+   "ratio": 0.4277,
+   "compress_mbps": 270.88,
+   "decompress_mbps": 729.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1749,
+   "ratio": 0.4138,
+   "compress_mbps": 223.74,
+   "decompress_mbps": 744.45
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 199.55,
+   "decompress_mbps": 747.07
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 196.71,
+   "decompress_mbps": 748.32
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 194.15,
+   "decompress_mbps": 751.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 194.4,
+   "decompress_mbps": 749.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 194.82,
+   "decompress_mbps": 749.01
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 76470,
+   "ratio": 0.5028,
+   "compress_mbps": 154.26,
+   "decompress_mbps": 454.01
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 62765,
+   "ratio": 0.4127,
+   "compress_mbps": 131.95,
+   "decompress_mbps": 508.28
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 57162,
+   "ratio": 0.3758,
+   "compress_mbps": 72.26,
+   "decompress_mbps": 564.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56826,
+   "ratio": 0.3736,
+   "compress_mbps": 64.16,
+   "decompress_mbps": 547.78
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 55696,
+   "ratio": 0.3662,
+   "compress_mbps": 46.68,
+   "decompress_mbps": 537.55
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54440,
+   "ratio": 0.3579,
+   "compress_mbps": 26.5,
+   "decompress_mbps": 552.53
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54283,
+   "ratio": 0.3569,
+   "compress_mbps": 22.34,
+   "decompress_mbps": 553.98
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54221,
+   "ratio": 0.3565,
+   "compress_mbps": 19.67,
+   "decompress_mbps": 553.32
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54217,
+   "ratio": 0.3565,
+   "compress_mbps": 19.42,
+   "decompress_mbps": 553.28
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 64926,
+   "ratio": 0.5187,
+   "compress_mbps": 148.29,
+   "decompress_mbps": 433.02
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 54985,
+   "ratio": 0.4393,
+   "compress_mbps": 123.58,
+   "decompress_mbps": 482.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51148,
+   "ratio": 0.4086,
+   "compress_mbps": 67.17,
+   "decompress_mbps": 545.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50599,
+   "ratio": 0.4042,
+   "compress_mbps": 58.92,
+   "decompress_mbps": 529.12
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 49775,
+   "ratio": 0.3976,
+   "compress_mbps": 42.46,
+   "decompress_mbps": 517.64
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48967,
+   "ratio": 0.3912,
+   "compress_mbps": 24.89,
+   "decompress_mbps": 529.56
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48870,
+   "ratio": 0.3904,
+   "compress_mbps": 22.11,
+   "decompress_mbps": 533.55
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48845,
+   "ratio": 0.3902,
+   "compress_mbps": 20.81,
+   "decompress_mbps": 529.55
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48845,
+   "ratio": 0.3902,
+   "compress_mbps": 20.81,
+   "decompress_mbps": 530.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 10024,
+   "ratio": 0.4074,
+   "compress_mbps": 569.29,
+   "decompress_mbps": 904.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8577,
+   "ratio": 0.3486,
+   "compress_mbps": 257.95,
+   "decompress_mbps": 932.15
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8168,
+   "ratio": 0.332,
+   "compress_mbps": 154.5,
+   "decompress_mbps": 953.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8069,
+   "ratio": 0.328,
+   "compress_mbps": 113.91,
+   "decompress_mbps": 968.76
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7997,
+   "ratio": 0.325,
+   "compress_mbps": 100.0,
+   "decompress_mbps": 998.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7952,
+   "ratio": 0.3232,
+   "compress_mbps": 74.82,
+   "decompress_mbps": 1005.11
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 72.03,
+   "decompress_mbps": 1010.08
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 70.84,
+   "decompress_mbps": 1009.65
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 70.97,
+   "decompress_mbps": 1009.74
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 4061,
+   "ratio": 0.3642,
+   "compress_mbps": 507.39,
+   "decompress_mbps": 854.78
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3446,
+   "ratio": 0.3091,
+   "compress_mbps": 303.49,
+   "decompress_mbps": 892.97
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3201,
+   "ratio": 0.2871,
+   "compress_mbps": 235.54,
+   "decompress_mbps": 922.56
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 193.62,
+   "decompress_mbps": 949.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3139,
+   "ratio": 0.2815,
+   "compress_mbps": 162.3,
+   "decompress_mbps": 972.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3115,
+   "ratio": 0.2794,
+   "compress_mbps": 116.79,
+   "decompress_mbps": 982.22
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 106.23,
+   "decompress_mbps": 984.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 103.57,
+   "decompress_mbps": 986.68
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 103.48,
+   "decompress_mbps": 989.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1410,
+   "ratio": 0.3789,
+   "compress_mbps": 365.42,
+   "decompress_mbps": 594.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1262,
+   "ratio": 0.3392,
+   "compress_mbps": 234.67,
+   "decompress_mbps": 606.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1238,
+   "ratio": 0.3327,
+   "compress_mbps": 203.21,
+   "decompress_mbps": 602.58
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 175.23,
+   "decompress_mbps": 623.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 161.11,
+   "decompress_mbps": 632.44
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 148.18,
+   "decompress_mbps": 634.36
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.32,
+   "decompress_mbps": 633.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 148.12,
+   "decompress_mbps": 629.97
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.52,
+   "decompress_mbps": 633.57
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 274412,
+   "ratio": 0.2665,
+   "compress_mbps": 443.65,
+   "decompress_mbps": 799.43
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 213239,
+   "ratio": 0.2071,
+   "compress_mbps": 272.38,
+   "decompress_mbps": 880.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 232107,
+   "ratio": 0.2254,
+   "compress_mbps": 136.69,
+   "decompress_mbps": 923.14
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 202733,
+   "ratio": 0.1969,
+   "compress_mbps": 129.43,
+   "decompress_mbps": 929.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 207803,
+   "ratio": 0.2018,
+   "compress_mbps": 84.08,
+   "decompress_mbps": 945.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 205270,
+   "ratio": 0.1993,
+   "compress_mbps": 27.21,
+   "decompress_mbps": 978.2
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 209951,
+   "ratio": 0.2039,
+   "compress_mbps": 19.25,
+   "decompress_mbps": 982.69
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 209656,
+   "ratio": 0.2036,
+   "compress_mbps": 12.1,
+   "decompress_mbps": 990.53
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 209189,
+   "ratio": 0.2031,
+   "compress_mbps": 8.75,
+   "decompress_mbps": 998.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 208640,
+   "ratio": 0.4889,
+   "compress_mbps": 153.87,
+   "decompress_mbps": 437.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 167329,
+   "ratio": 0.3921,
+   "compress_mbps": 136.94,
+   "decompress_mbps": 476.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 151097,
+   "ratio": 0.3541,
+   "compress_mbps": 73.3,
+   "decompress_mbps": 523.19
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 150035,
+   "ratio": 0.3516,
+   "compress_mbps": 65.88,
+   "decompress_mbps": 516.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 147375,
+   "ratio": 0.3453,
+   "compress_mbps": 47.75,
+   "decompress_mbps": 515.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144908,
+   "ratio": 0.3396,
+   "compress_mbps": 27.87,
+   "decompress_mbps": 525.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144562,
+   "ratio": 0.3387,
+   "compress_mbps": 24.45,
+   "decompress_mbps": 525.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144449,
+   "ratio": 0.3385,
+   "compress_mbps": 22.28,
+   "decompress_mbps": 525.77
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144438,
+   "ratio": 0.3385,
+   "compress_mbps": 22.15,
+   "decompress_mbps": 526.06
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 264549,
+   "ratio": 0.549,
+   "compress_mbps": 132.16,
+   "decompress_mbps": 389.54
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 223724,
+   "ratio": 0.4643,
+   "compress_mbps": 117.41,
+   "decompress_mbps": 434.23
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 204825,
+   "ratio": 0.4251,
+   "compress_mbps": 60.4,
+   "decompress_mbps": 488.71
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 203945,
+   "ratio": 0.4232,
+   "compress_mbps": 53.51,
+   "decompress_mbps": 478.05
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 199780,
+   "ratio": 0.4146,
+   "compress_mbps": 37.6,
+   "decompress_mbps": 460.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195417,
+   "ratio": 0.4055,
+   "compress_mbps": 20.91,
+   "decompress_mbps": 468.06
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194796,
+   "ratio": 0.4043,
+   "compress_mbps": 17.73,
+   "decompress_mbps": 472.19
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194543,
+   "ratio": 0.4037,
+   "compress_mbps": 15.62,
+   "decompress_mbps": 471.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 194460,
+   "ratio": 0.4036,
+   "compress_mbps": 14.96,
+   "decompress_mbps": 471.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 67436,
+   "ratio": 0.1314,
+   "compress_mbps": 615.15,
+   "decompress_mbps": 1029.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 59257,
+   "ratio": 0.1155,
+   "compress_mbps": 276.11,
+   "decompress_mbps": 1085.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 58316,
+   "ratio": 0.1136,
+   "compress_mbps": 180.64,
+   "decompress_mbps": 1175.73
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 56291,
+   "ratio": 0.1097,
+   "compress_mbps": 183.2,
+   "decompress_mbps": 1182.36
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 56220,
+   "ratio": 0.1095,
+   "compress_mbps": 145.21,
+   "decompress_mbps": 1236.28
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55972,
+   "ratio": 0.1091,
+   "compress_mbps": 74.19,
+   "decompress_mbps": 1301.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 55121,
+   "ratio": 0.1074,
+   "compress_mbps": 51.88,
+   "decompress_mbps": 1334.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 54124,
+   "ratio": 0.1055,
+   "compress_mbps": 36.55,
+   "decompress_mbps": 1415.19
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 53699,
+   "ratio": 0.1046,
+   "compress_mbps": 28.58,
+   "decompress_mbps": 1434.08
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 15612,
+   "ratio": 0.4083,
+   "compress_mbps": 505.46,
+   "decompress_mbps": 849.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 14133,
+   "ratio": 0.3696,
+   "compress_mbps": 144.85,
+   "decompress_mbps": 881.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13341,
+   "ratio": 0.3489,
+   "compress_mbps": 88.42,
+   "decompress_mbps": 911.78
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13289,
+   "ratio": 0.3475,
+   "compress_mbps": 83.64,
+   "decompress_mbps": 938.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13052,
+   "ratio": 0.3413,
+   "compress_mbps": 66.5,
+   "decompress_mbps": 977.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12996,
+   "ratio": 0.3399,
+   "compress_mbps": 37.02,
+   "decompress_mbps": 992.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12972,
+   "ratio": 0.3392,
+   "compress_mbps": 27.11,
+   "decompress_mbps": 998.92
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12951,
+   "ratio": 0.3387,
+   "compress_mbps": 18.98,
+   "decompress_mbps": 998.26
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12933,
+   "ratio": 0.3382,
+   "compress_mbps": 14.81,
+   "decompress_mbps": 1001.94
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1988,
+   "ratio": 0.4703,
+   "compress_mbps": 340.62,
+   "decompress_mbps": 547.64
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1802,
+   "ratio": 0.4263,
+   "compress_mbps": 216.68,
+   "decompress_mbps": 552.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 207.05,
+   "decompress_mbps": 552.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 169.21,
+   "decompress_mbps": 563.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 165.89,
+   "decompress_mbps": 574.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 164.72,
+   "decompress_mbps": 573.92
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 164.83,
+   "decompress_mbps": 573.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 165.54,
+   "decompress_mbps": 575.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 164.96,
+   "decompress_mbps": 576.05
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 59790,
+   "ratio": 0.3931,
+   "compress_mbps": 260.81,
+   "decompress_mbps": 999.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 57173,
+   "ratio": 0.3759,
+   "compress_mbps": 180.73,
+   "decompress_mbps": 1071.44
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 56189,
+   "ratio": 0.3694,
+   "compress_mbps": 150.02,
+   "decompress_mbps": 1149.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 55816,
+   "ratio": 0.367,
+   "compress_mbps": 137.21,
+   "decompress_mbps": 1184.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54758,
+   "ratio": 0.36,
+   "compress_mbps": 108.54,
+   "decompress_mbps": 1243.11
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54220,
+   "ratio": 0.3565,
+   "compress_mbps": 83.68,
+   "decompress_mbps": 1275.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 53801,
+   "ratio": 0.3537,
+   "compress_mbps": 60.29,
+   "decompress_mbps": 1285.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 53573,
+   "ratio": 0.3522,
+   "compress_mbps": 38.96,
+   "decompress_mbps": 1289.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 53546,
+   "ratio": 0.3521,
+   "compress_mbps": 34.44,
+   "decompress_mbps": 1284.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 52276,
+   "ratio": 0.4176,
+   "compress_mbps": 242.55,
+   "decompress_mbps": 943.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50534,
+   "ratio": 0.4037,
+   "compress_mbps": 167.4,
+   "decompress_mbps": 991.68
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 49919,
+   "ratio": 0.3988,
+   "compress_mbps": 140.99,
+   "decompress_mbps": 1057.13
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 49715,
+   "ratio": 0.3972,
+   "compress_mbps": 130.7,
+   "decompress_mbps": 1091.16
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48735,
+   "ratio": 0.3893,
+   "compress_mbps": 100.96,
+   "decompress_mbps": 1142.37
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48422,
+   "ratio": 0.3868,
+   "compress_mbps": 79.18,
+   "decompress_mbps": 1163.55
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48249,
+   "ratio": 0.3854,
+   "compress_mbps": 61.18,
+   "decompress_mbps": 1171.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 47977,
+   "ratio": 0.3833,
+   "compress_mbps": 43.04,
+   "decompress_mbps": 1170.38
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 47971,
+   "ratio": 0.3832,
+   "compress_mbps": 41.05,
+   "decompress_mbps": 1171.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8385,
+   "ratio": 0.3408,
+   "compress_mbps": 692.66,
+   "decompress_mbps": 955.34
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8380,
+   "ratio": 0.3406,
+   "compress_mbps": 443.72,
+   "decompress_mbps": 980.33
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8286,
+   "ratio": 0.3368,
+   "compress_mbps": 406.67,
+   "decompress_mbps": 994.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8163,
+   "ratio": 0.3318,
+   "compress_mbps": 377.97,
+   "decompress_mbps": 1008.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8053,
+   "ratio": 0.3273,
+   "compress_mbps": 339.17,
+   "decompress_mbps": 1022.19
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7986,
+   "ratio": 0.3246,
+   "compress_mbps": 277.85,
+   "decompress_mbps": 1031.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7954,
+   "ratio": 0.3233,
+   "compress_mbps": 192.36,
+   "decompress_mbps": 1034.22
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 125.45,
+   "decompress_mbps": 1037.19
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 125.34,
+   "decompress_mbps": 1037.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3401,
+   "ratio": 0.305,
+   "compress_mbps": 586.48,
+   "decompress_mbps": 778.55
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3307,
+   "ratio": 0.2966,
+   "compress_mbps": 399.18,
+   "decompress_mbps": 803.19
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3242,
+   "ratio": 0.2908,
+   "compress_mbps": 367.65,
+   "decompress_mbps": 815.14
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3205,
+   "ratio": 0.2874,
+   "compress_mbps": 349.58,
+   "decompress_mbps": 826.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3150,
+   "ratio": 0.2825,
+   "compress_mbps": 311.46,
+   "decompress_mbps": 835.7
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3126,
+   "ratio": 0.2804,
+   "compress_mbps": 266.22,
+   "decompress_mbps": 840.99
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3106,
+   "ratio": 0.2786,
+   "compress_mbps": 205.69,
+   "decompress_mbps": 842.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3102,
+   "ratio": 0.2782,
+   "compress_mbps": 147.71,
+   "decompress_mbps": 847.09
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3102,
+   "ratio": 0.2782,
+   "compress_mbps": 140.25,
+   "decompress_mbps": 842.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1251,
+   "ratio": 0.3362,
+   "compress_mbps": 381.0,
+   "decompress_mbps": 430.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1228,
+   "ratio": 0.33,
+   "compress_mbps": 268.94,
+   "decompress_mbps": 432.28
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 260.68,
+   "decompress_mbps": 434.03
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1220,
+   "ratio": 0.3279,
+   "compress_mbps": 254.4,
+   "decompress_mbps": 445.25
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 239.14,
+   "decompress_mbps": 445.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 220.64,
+   "decompress_mbps": 449.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 201.89,
+   "decompress_mbps": 450.73
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1204,
+   "ratio": 0.3236,
+   "compress_mbps": 168.55,
+   "decompress_mbps": 449.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1204,
+   "ratio": 0.3236,
+   "compress_mbps": 169.25,
+   "decompress_mbps": 450.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 221813,
+   "ratio": 0.2154,
+   "compress_mbps": 589.05,
+   "decompress_mbps": 1008.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 199825,
+   "ratio": 0.1941,
+   "compress_mbps": 405.32,
+   "decompress_mbps": 1440.65
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 195675,
+   "ratio": 0.19,
+   "compress_mbps": 281.74,
+   "decompress_mbps": 1532.75
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 195664,
+   "ratio": 0.19,
+   "compress_mbps": 278.71,
+   "decompress_mbps": 1533.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 198900,
+   "ratio": 0.1932,
+   "compress_mbps": 239.27,
+   "decompress_mbps": 1130.77
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 199347,
+   "ratio": 0.1936,
+   "compress_mbps": 204.42,
+   "decompress_mbps": 1130.09
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 199777,
+   "ratio": 0.194,
+   "compress_mbps": 123.6,
+   "decompress_mbps": 1179.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 182094,
+   "ratio": 0.1768,
+   "compress_mbps": 25.73,
+   "decompress_mbps": 1168.32
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 181451,
+   "ratio": 0.1762,
+   "compress_mbps": 13.56,
+   "decompress_mbps": 1179.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 159063,
+   "ratio": 0.3727,
+   "compress_mbps": 263.07,
+   "decompress_mbps": 1032.01
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 152115,
+   "ratio": 0.3564,
+   "compress_mbps": 186.6,
+   "decompress_mbps": 1110.18
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 149162,
+   "ratio": 0.3495,
+   "compress_mbps": 156.51,
+   "decompress_mbps": 1197.51
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 148359,
+   "ratio": 0.3476,
+   "compress_mbps": 143.03,
+   "decompress_mbps": 1049.97
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145353,
+   "ratio": 0.3406,
+   "compress_mbps": 113.38,
+   "decompress_mbps": 1021.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144209,
+   "ratio": 0.3379,
+   "compress_mbps": 87.88,
+   "decompress_mbps": 1050.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 143604,
+   "ratio": 0.3365,
+   "compress_mbps": 66.56,
+   "decompress_mbps": 1057.84
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 142086,
+   "ratio": 0.3329,
+   "compress_mbps": 44.23,
+   "decompress_mbps": 1060.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 142027,
+   "ratio": 0.3328,
+   "compress_mbps": 40.4,
+   "decompress_mbps": 1062.13
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 210662,
+   "ratio": 0.4372,
+   "compress_mbps": 228.42,
+   "decompress_mbps": 872.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 202881,
+   "ratio": 0.421,
+   "compress_mbps": 158.21,
+   "decompress_mbps": 939.7
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 200409,
+   "ratio": 0.4159,
+   "compress_mbps": 132.99,
+   "decompress_mbps": 1018.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 199678,
+   "ratio": 0.4144,
+   "compress_mbps": 122.56,
+   "decompress_mbps": 860.05
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 195798,
+   "ratio": 0.4063,
+   "compress_mbps": 93.49,
+   "decompress_mbps": 811.85
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 194029,
+   "ratio": 0.4027,
+   "compress_mbps": 72.07,
+   "decompress_mbps": 837.28
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 192773,
+   "ratio": 0.4001,
+   "compress_mbps": 51.36,
+   "decompress_mbps": 838.03
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 191739,
+   "ratio": 0.3979,
+   "compress_mbps": 33.6,
+   "decompress_mbps": 841.75
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 191676,
+   "ratio": 0.3978,
+   "compress_mbps": 30.97,
+   "decompress_mbps": 842.22
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 58079,
+   "ratio": 0.1132,
+   "compress_mbps": 371.08,
+   "decompress_mbps": 1698.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 57838,
+   "ratio": 0.1127,
+   "compress_mbps": 412.92,
+   "decompress_mbps": 1797.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 57554,
+   "ratio": 0.1121,
+   "compress_mbps": 394.15,
+   "decompress_mbps": 1894.32
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57064,
+   "ratio": 0.1112,
+   "compress_mbps": 373.43,
+   "decompress_mbps": 1725.49
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 55743,
+   "ratio": 0.1086,
+   "compress_mbps": 342.91,
+   "decompress_mbps": 1805.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55102,
+   "ratio": 0.1074,
+   "compress_mbps": 283.88,
+   "decompress_mbps": 1879.75
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 54742,
+   "ratio": 0.1067,
+   "compress_mbps": 192.52,
+   "decompress_mbps": 1918.38
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 53133,
+   "ratio": 0.1035,
+   "compress_mbps": 102.65,
+   "decompress_mbps": 1992.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52186,
+   "ratio": 0.1017,
+   "compress_mbps": 72.09,
+   "decompress_mbps": 2031.63
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14122,
+   "ratio": 0.3693,
+   "compress_mbps": 646.89,
+   "decompress_mbps": 831.23
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13374,
+   "ratio": 0.3497,
+   "compress_mbps": 347.06,
+   "decompress_mbps": 878.51
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13293,
+   "ratio": 0.3476,
+   "compress_mbps": 283.08,
+   "decompress_mbps": 963.27
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13259,
+   "ratio": 0.3467,
+   "compress_mbps": 265.41,
+   "decompress_mbps": 958.01
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 12641,
+   "ratio": 0.3306,
+   "compress_mbps": 190.37,
+   "decompress_mbps": 983.35
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12432,
+   "ratio": 0.3251,
+   "compress_mbps": 164.17,
+   "decompress_mbps": 1012.87
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12439,
+   "ratio": 0.3253,
+   "compress_mbps": 123.29,
+   "decompress_mbps": 1019.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12579,
+   "ratio": 0.3289,
+   "compress_mbps": 67.35,
+   "decompress_mbps": 1029.37
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12574,
+   "ratio": 0.3288,
+   "compress_mbps": 47.38,
+   "decompress_mbps": 1035.27
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1777,
+   "ratio": 0.4204,
+   "compress_mbps": 389.52,
+   "decompress_mbps": 401.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1756,
+   "ratio": 0.4154,
+   "compress_mbps": 260.09,
+   "decompress_mbps": 404.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1746,
+   "ratio": 0.4131,
+   "compress_mbps": 256.26,
+   "decompress_mbps": 408.97
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1740,
+   "ratio": 0.4116,
+   "compress_mbps": 254.08,
+   "decompress_mbps": 411.05
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1722,
+   "ratio": 0.4074,
+   "compress_mbps": 239.04,
+   "decompress_mbps": 415.16
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1721,
+   "ratio": 0.4071,
+   "compress_mbps": 235.37,
+   "decompress_mbps": 415.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 233.46,
+   "decompress_mbps": 414.56
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1717,
+   "ratio": 0.4062,
+   "compress_mbps": 217.24,
+   "decompress_mbps": 409.13
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1717,
+   "ratio": 0.4062,
+   "compress_mbps": 217.56,
+   "decompress_mbps": 408.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4231315,
+   "ratio": 0.4151,
+   "compress_mbps": 29.41,
+   "decompress_mbps": 80.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4120658,
+   "ratio": 0.4043,
+   "compress_mbps": 26.35,
+   "decompress_mbps": 85.51
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4037988,
+   "ratio": 0.3962,
+   "compress_mbps": 23.24,
+   "decompress_mbps": 91.75
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3961310,
+   "ratio": 0.3887,
+   "compress_mbps": 16.1,
+   "decompress_mbps": 90.62
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3943365,
+   "ratio": 0.3869,
+   "compress_mbps": 15.16,
+   "decompress_mbps": 93.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3915657,
+   "ratio": 0.3842,
+   "compress_mbps": 13.1,
+   "decompress_mbps": 95.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3902484,
+   "ratio": 0.3829,
+   "compress_mbps": 6.42,
+   "decompress_mbps": 101.01
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3899047,
+   "ratio": 0.3825,
+   "compress_mbps": 6.27,
+   "decompress_mbps": 98.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3712344,
+   "ratio": 0.3642,
+   "compress_mbps": 1.0,
+   "decompress_mbps": 101.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20729473,
+   "ratio": 0.4047,
+   "compress_mbps": 40.64,
+   "decompress_mbps": 72.33
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20500337,
+   "ratio": 0.4002,
+   "compress_mbps": 37.45,
+   "decompress_mbps": 75.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 20349978,
+   "ratio": 0.3973,
+   "compress_mbps": 34.46,
+   "decompress_mbps": 77.56
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 20049333,
+   "ratio": 0.3914,
+   "compress_mbps": 26.08,
+   "decompress_mbps": 79.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 20022052,
+   "ratio": 0.3909,
+   "compress_mbps": 24.58,
+   "decompress_mbps": 82.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19979491,
+   "ratio": 0.3901,
+   "compress_mbps": 20.98,
+   "decompress_mbps": 83.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 18841079,
+   "ratio": 0.3678,
+   "compress_mbps": 6.57,
+   "decompress_mbps": 84.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 18833163,
+   "ratio": 0.3677,
+   "compress_mbps": 5.98,
+   "decompress_mbps": 85.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 18518350,
+   "ratio": 0.3615,
+   "compress_mbps": 0.88,
+   "decompress_mbps": 85.51
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3773613,
+   "ratio": 0.3785,
+   "compress_mbps": 42.85,
+   "decompress_mbps": 75.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3728325,
+   "ratio": 0.3739,
+   "compress_mbps": 38.65,
+   "decompress_mbps": 77.51
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3701126,
+   "ratio": 0.3712,
+   "compress_mbps": 33.57,
+   "decompress_mbps": 80.46
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3717412,
+   "ratio": 0.3728,
+   "compress_mbps": 22.46,
+   "decompress_mbps": 74.32
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3713907,
+   "ratio": 0.3725,
+   "compress_mbps": 20.56,
+   "decompress_mbps": 76.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3712342,
+   "ratio": 0.3723,
+   "compress_mbps": 16.43,
+   "decompress_mbps": 78.52
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3649251,
+   "ratio": 0.366,
+   "compress_mbps": 6.27,
+   "decompress_mbps": 76.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3648922,
+   "ratio": 0.366,
+   "compress_mbps": 5.29,
+   "decompress_mbps": 77.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3520112,
+   "ratio": 0.3531,
+   "compress_mbps": 0.36,
+   "decompress_mbps": 78.76
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3957304,
+   "ratio": 0.1179,
+   "compress_mbps": 101.14,
+   "decompress_mbps": 269.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3769595,
+   "ratio": 0.1123,
+   "compress_mbps": 89.93,
+   "decompress_mbps": 297.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3594567,
+   "ratio": 0.1071,
+   "compress_mbps": 78.8,
+   "decompress_mbps": 325.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3423500,
+   "ratio": 0.102,
+   "compress_mbps": 68.23,
+   "decompress_mbps": 311.62
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3397370,
+   "ratio": 0.1013,
+   "compress_mbps": 65.0,
+   "decompress_mbps": 360.16
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3352804,
+   "ratio": 0.0999,
+   "compress_mbps": 58.0,
+   "decompress_mbps": 382.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3249135,
+   "ratio": 0.0968,
+   "compress_mbps": 22.22,
+   "decompress_mbps": 389.05
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3225205,
+   "ratio": 0.0961,
+   "compress_mbps": 18.42,
+   "decompress_mbps": 394.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2868751,
+   "ratio": 0.0855,
+   "compress_mbps": 0.53,
+   "decompress_mbps": 381.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3218639,
+   "ratio": 0.5232,
+   "compress_mbps": 28.22,
+   "decompress_mbps": 49.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3192732,
+   "ratio": 0.519,
+   "compress_mbps": 26.62,
+   "decompress_mbps": 51.56
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3174297,
+   "ratio": 0.516,
+   "compress_mbps": 24.66,
+   "decompress_mbps": 54.71
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3122783,
+   "ratio": 0.5076,
+   "compress_mbps": 18.87,
+   "decompress_mbps": 54.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3119358,
+   "ratio": 0.507,
+   "compress_mbps": 17.96,
+   "decompress_mbps": 55.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3113833,
+   "ratio": 0.5061,
+   "compress_mbps": 15.85,
+   "decompress_mbps": 56.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3072891,
+   "ratio": 0.4995,
+   "compress_mbps": 5.64,
+   "decompress_mbps": 56.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3071839,
+   "ratio": 0.4993,
+   "compress_mbps": 5.34,
+   "decompress_mbps": 58.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3017696,
+   "ratio": 0.4905,
+   "compress_mbps": 1.19,
+   "decompress_mbps": 57.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3889230,
+   "ratio": 0.3856,
+   "compress_mbps": 41.4,
+   "decompress_mbps": 68.79
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3811489,
+   "ratio": 0.3779,
+   "compress_mbps": 16.21,
+   "decompress_mbps": 32.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3789217,
+   "ratio": 0.3757,
+   "compress_mbps": 18.06,
+   "decompress_mbps": 37.79
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3742374,
+   "ratio": 0.3711,
+   "compress_mbps": 28.16,
+   "decompress_mbps": 72.75
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3734392,
+   "ratio": 0.3703,
+   "compress_mbps": 28.5,
+   "decompress_mbps": 73.0
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3723638,
+   "ratio": 0.3692,
+   "compress_mbps": 17.63,
+   "decompress_mbps": 70.4
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3723087,
+   "ratio": 0.3691,
+   "compress_mbps": 9.32,
+   "decompress_mbps": 72.54
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3723909,
+   "ratio": 0.3692,
+   "compress_mbps": 4.53,
+   "decompress_mbps": 32.87
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3647083,
+   "ratio": 0.3616,
+   "compress_mbps": 1.51,
+   "decompress_mbps": 72.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2146953,
+   "ratio": 0.324,
+   "compress_mbps": 37.48,
+   "decompress_mbps": 97.58
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2072169,
+   "ratio": 0.3127,
+   "compress_mbps": 33.32,
+   "decompress_mbps": 105.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2021398,
+   "ratio": 0.305,
+   "compress_mbps": 28.42,
+   "decompress_mbps": 54.71
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1941481,
+   "ratio": 0.293,
+   "compress_mbps": 19.08,
+   "decompress_mbps": 112.97
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1927150,
+   "ratio": 0.2908,
+   "compress_mbps": 18.66,
+   "decompress_mbps": 123.73
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1899667,
+   "ratio": 0.2866,
+   "compress_mbps": 14.38,
+   "decompress_mbps": 128.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1854694,
+   "ratio": 0.2799,
+   "compress_mbps": 6.1,
+   "decompress_mbps": 132.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1849481,
+   "ratio": 0.2791,
+   "compress_mbps": 5.01,
+   "decompress_mbps": 138.2
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1724560,
+   "ratio": 0.2602,
+   "compress_mbps": 0.65,
+   "decompress_mbps": 136.54
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6185865,
+   "ratio": 0.2863,
+   "compress_mbps": 53.74,
+   "decompress_mbps": 128.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6066146,
+   "ratio": 0.2808,
+   "compress_mbps": 48.96,
+   "decompress_mbps": 134.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5993070,
+   "ratio": 0.2774,
+   "compress_mbps": 44.18,
+   "decompress_mbps": 138.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5880232,
+   "ratio": 0.2722,
+   "compress_mbps": 35.63,
+   "decompress_mbps": 143.02
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5869068,
+   "ratio": 0.2716,
+   "compress_mbps": 34.11,
+   "decompress_mbps": 145.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5854265,
+   "ratio": 0.271,
+   "compress_mbps": 28.21,
+   "decompress_mbps": 144.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5422105,
+   "ratio": 0.2509,
+   "compress_mbps": 11.22,
+   "decompress_mbps": 146.26
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5419419,
+   "ratio": 0.2508,
+   "compress_mbps": 10.82,
+   "decompress_mbps": 112.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5169629,
+   "ratio": 0.2393,
+   "compress_mbps": 0.73,
+   "decompress_mbps": 144.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5514155,
+   "ratio": 0.7604,
+   "compress_mbps": 25.55,
+   "decompress_mbps": 51.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5472540,
+   "ratio": 0.7546,
+   "compress_mbps": 23.79,
+   "decompress_mbps": 53.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5448811,
+   "ratio": 0.7514,
+   "compress_mbps": 22.16,
+   "decompress_mbps": 54.72
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5376136,
+   "ratio": 0.7413,
+   "compress_mbps": 16.05,
+   "decompress_mbps": 55.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5371177,
+   "ratio": 0.7407,
+   "compress_mbps": 14.93,
+   "decompress_mbps": 51.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5362808,
+   "ratio": 0.7395,
+   "compress_mbps": 10.24,
+   "decompress_mbps": 35.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5349148,
+   "ratio": 0.7376,
+   "compress_mbps": 3.96,
+   "decompress_mbps": 33.65
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5348874,
+   "ratio": 0.7376,
+   "compress_mbps": 4.7,
+   "decompress_mbps": 51.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5261135,
+   "ratio": 0.7255,
+   "compress_mbps": 1.27,
+   "decompress_mbps": 56.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 13389198,
+   "ratio": 0.323,
+   "compress_mbps": 38.12,
+   "decompress_mbps": 103.2
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 12991470,
+   "ratio": 0.3134,
+   "compress_mbps": 34.32,
+   "decompress_mbps": 109.52
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12756198,
+   "ratio": 0.3077,
+   "compress_mbps": 31.26,
+   "decompress_mbps": 118.42
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12487773,
+   "ratio": 0.3012,
+   "compress_mbps": 24.3,
+   "decompress_mbps": 118.79
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12439753,
+   "ratio": 0.3001,
+   "compress_mbps": 22.79,
+   "decompress_mbps": 119.89
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12356447,
+   "ratio": 0.298,
+   "compress_mbps": 20.37,
+   "decompress_mbps": 125.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12265937,
+   "ratio": 0.2959,
+   "compress_mbps": 8.03,
+   "decompress_mbps": 122.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12249548,
+   "ratio": 0.2955,
+   "compress_mbps": 7.62,
+   "decompress_mbps": 121.55
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11638957,
+   "ratio": 0.2807,
+   "compress_mbps": 0.85,
+   "decompress_mbps": 126.16
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6018712,
+   "ratio": 0.7102,
+   "compress_mbps": 25.67,
+   "decompress_mbps": 40.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 5998688,
+   "ratio": 0.7079,
+   "compress_mbps": 24.08,
+   "decompress_mbps": 43.05
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 5983501,
+   "ratio": 0.7061,
+   "compress_mbps": 23.22,
+   "decompress_mbps": 45.66
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 19.38,
+   "decompress_mbps": 42.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 5964823,
+   "ratio": 0.7039,
+   "compress_mbps": 19.05,
+   "decompress_mbps": 43.42
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5964656,
+   "ratio": 0.7039,
+   "compress_mbps": 18.78,
+   "decompress_mbps": 43.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5937524,
+   "ratio": 0.7007,
+   "compress_mbps": 5.8,
+   "decompress_mbps": 43.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5937524,
+   "ratio": 0.7007,
+   "compress_mbps": 5.83,
+   "decompress_mbps": 43.95
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5825680,
+   "ratio": 0.6875,
+   "compress_mbps": 1.63,
+   "decompress_mbps": 43.77
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 841047,
+   "ratio": 0.1573,
+   "compress_mbps": 75.93,
+   "decompress_mbps": 205.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 796222,
+   "ratio": 0.149,
+   "compress_mbps": 69.84,
+   "decompress_mbps": 230.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 765435,
+   "ratio": 0.1432,
+   "compress_mbps": 60.99,
+   "decompress_mbps": 252.72
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 739407,
+   "ratio": 0.1383,
+   "compress_mbps": 48.47,
+   "decompress_mbps": 248.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 732214,
+   "ratio": 0.137,
+   "compress_mbps": 45.8,
+   "decompress_mbps": 271.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 721492,
+   "ratio": 0.135,
+   "compress_mbps": 41.67,
+   "decompress_mbps": 292.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 682684,
+   "ratio": 0.1277,
+   "compress_mbps": 17.61,
+   "decompress_mbps": 277.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 681103,
+   "ratio": 0.1274,
+   "compress_mbps": 16.47,
+   "decompress_mbps": 285.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 637424,
+   "ratio": 0.1192,
+   "compress_mbps": 0.66,
+   "decompress_mbps": 274.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4585612,
+   "ratio": 0.4499,
+   "compress_mbps": 112.42,
+   "decompress_mbps": 350.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4389474,
+   "ratio": 0.4307,
+   "compress_mbps": 95.08,
+   "decompress_mbps": 361.4
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4192079,
+   "ratio": 0.4113,
+   "compress_mbps": 59.1,
+   "decompress_mbps": 401.85
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4095021,
+   "ratio": 0.4018,
+   "compress_mbps": 65.75,
+   "decompress_mbps": 383.13
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3949169,
+   "ratio": 0.3875,
+   "compress_mbps": 35.72,
+   "decompress_mbps": 371.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3871628,
+   "ratio": 0.3799,
+   "compress_mbps": 21.15,
+   "decompress_mbps": 379.61
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3858876,
+   "ratio": 0.3786,
+   "compress_mbps": 17.64,
+   "decompress_mbps": 381.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3854729,
+   "ratio": 0.3782,
+   "compress_mbps": 15.02,
+   "decompress_mbps": 364.85
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3854729,
+   "ratio": 0.3782,
+   "compress_mbps": 15.01,
+   "decompress_mbps": 382.09
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20577220,
+   "ratio": 0.4017,
+   "compress_mbps": 111.93,
+   "decompress_mbps": 349.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20247697,
+   "ratio": 0.3953,
+   "compress_mbps": 100.14,
+   "decompress_mbps": 370.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19987880,
+   "ratio": 0.3902,
+   "compress_mbps": 76.0,
+   "decompress_mbps": 377.96
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19512665,
+   "ratio": 0.381,
+   "compress_mbps": 75.6,
+   "decompress_mbps": 367.97
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19213507,
+   "ratio": 0.3751,
+   "compress_mbps": 53.26,
+   "decompress_mbps": 374.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19089118,
+   "ratio": 0.3727,
+   "compress_mbps": 34.34,
+   "decompress_mbps": 379.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19061204,
+   "ratio": 0.3721,
+   "compress_mbps": 27.28,
+   "decompress_mbps": 380.61
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19040998,
+   "ratio": 0.3717,
+   "compress_mbps": 15.38,
+   "decompress_mbps": 388.07
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19044390,
+   "ratio": 0.3718,
+   "compress_mbps": 9.53,
+   "decompress_mbps": 388.16
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3828360,
+   "ratio": 0.384,
+   "compress_mbps": 143.56,
+   "decompress_mbps": 450.35
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3798539,
+   "ratio": 0.381,
+   "compress_mbps": 127.44,
+   "decompress_mbps": 490.01
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3674568,
+   "ratio": 0.3685,
+   "compress_mbps": 79.74,
+   "decompress_mbps": 511.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3680923,
+   "ratio": 0.3692,
+   "compress_mbps": 89.18,
+   "decompress_mbps": 451.78
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3698707,
+   "ratio": 0.371,
+   "compress_mbps": 47.85,
+   "decompress_mbps": 424.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3675935,
+   "ratio": 0.3687,
+   "compress_mbps": 26.32,
+   "decompress_mbps": 438.57
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3670281,
+   "ratio": 0.3681,
+   "compress_mbps": 20.77,
+   "decompress_mbps": 442.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3661103,
+   "ratio": 0.3672,
+   "compress_mbps": 10.95,
+   "decompress_mbps": 452.72
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3660788,
+   "ratio": 0.3672,
+   "compress_mbps": 9.47,
+   "decompress_mbps": 451.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4624591,
+   "ratio": 0.1378,
+   "compress_mbps": 331.64,
+   "decompress_mbps": 826.4
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4303176,
+   "ratio": 0.1282,
+   "compress_mbps": 306.94,
+   "decompress_mbps": 852.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 4010156,
+   "ratio": 0.1195,
+   "compress_mbps": 256.69,
+   "decompress_mbps": 932.94
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3713866,
+   "ratio": 0.1107,
+   "compress_mbps": 211.59,
+   "decompress_mbps": 908.17
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3378136,
+   "ratio": 0.1007,
+   "compress_mbps": 165.04,
+   "decompress_mbps": 965.7
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3200182,
+   "ratio": 0.0954,
+   "compress_mbps": 113.42,
+   "decompress_mbps": 1009.46
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3141278,
+   "ratio": 0.0936,
+   "compress_mbps": 89.96,
+   "decompress_mbps": 1013.87
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3031199,
+   "ratio": 0.0903,
+   "compress_mbps": 39.18,
+   "decompress_mbps": 1034.15
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2987995,
+   "ratio": 0.0891,
+   "compress_mbps": 21.34,
+   "decompress_mbps": 1029.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3290526,
+   "ratio": 0.5349,
+   "compress_mbps": 78.22,
+   "decompress_mbps": 253.01
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3238282,
+   "ratio": 0.5264,
+   "compress_mbps": 71.4,
+   "decompress_mbps": 258.77
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3193366,
+   "ratio": 0.5191,
+   "compress_mbps": 56.41,
+   "decompress_mbps": 264.86
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3158012,
+   "ratio": 0.5133,
+   "compress_mbps": 55.13,
+   "decompress_mbps": 266.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3115309,
+   "ratio": 0.5064,
+   "compress_mbps": 38.95,
+   "decompress_mbps": 270.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3097288,
+   "ratio": 0.5034,
+   "compress_mbps": 26.35,
+   "decompress_mbps": 273.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3094363,
+   "ratio": 0.503,
+   "compress_mbps": 21.93,
+   "decompress_mbps": 274.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3093026,
+   "ratio": 0.5028,
+   "compress_mbps": 17.11,
+   "decompress_mbps": 274.94
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3092920,
+   "ratio": 0.5027,
+   "compress_mbps": 15.54,
+   "decompress_mbps": 274.77
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4076385,
+   "ratio": 0.4042,
+   "compress_mbps": 126.69,
+   "decompress_mbps": 476.58
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3991014,
+   "ratio": 0.3957,
+   "compress_mbps": 117.61,
+   "decompress_mbps": 498.31
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3934055,
+   "ratio": 0.3901,
+   "compress_mbps": 93.62,
+   "decompress_mbps": 513.48
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3825092,
+   "ratio": 0.3793,
+   "compress_mbps": 84.8,
+   "decompress_mbps": 511.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3752932,
+   "ratio": 0.3721,
+   "compress_mbps": 64.64,
+   "decompress_mbps": 499.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3695164,
+   "ratio": 0.3664,
+   "compress_mbps": 49.43,
+   "decompress_mbps": 510.55
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3676881,
+   "ratio": 0.3646,
+   "compress_mbps": 38.12,
+   "decompress_mbps": 520.16
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3673171,
+   "ratio": 0.3642,
+   "compress_mbps": 31.95,
+   "decompress_mbps": 522.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3673171,
+   "ratio": 0.3642,
+   "compress_mbps": 31.91,
+   "decompress_mbps": 522.88
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2376424,
+   "ratio": 0.3586,
+   "compress_mbps": 129.7,
+   "decompress_mbps": 396.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2259060,
+   "ratio": 0.3409,
+   "compress_mbps": 111.68,
+   "decompress_mbps": 418.18
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2135664,
+   "ratio": 0.3223,
+   "compress_mbps": 72.01,
+   "decompress_mbps": 430.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2052793,
+   "ratio": 0.3098,
+   "compress_mbps": 81.07,
+   "decompress_mbps": 434.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1932127,
+   "ratio": 0.2915,
+   "compress_mbps": 45.34,
+   "decompress_mbps": 442.84
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1860865,
+   "ratio": 0.2808,
+   "compress_mbps": 22.93,
+   "decompress_mbps": 447.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1838671,
+   "ratio": 0.2774,
+   "compress_mbps": 15.98,
+   "decompress_mbps": 441.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1823235,
+   "ratio": 0.2751,
+   "compress_mbps": 8.14,
+   "decompress_mbps": 445.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1823190,
+   "ratio": 0.2751,
+   "compress_mbps": 8.1,
+   "decompress_mbps": 446.32
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6329449,
+   "ratio": 0.2929,
+   "compress_mbps": 169.67,
+   "decompress_mbps": 462.4
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6128866,
+   "ratio": 0.2837,
+   "compress_mbps": 156.15,
+   "decompress_mbps": 555.76
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5982546,
+   "ratio": 0.2769,
+   "compress_mbps": 125.54,
+   "decompress_mbps": 580.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5656400,
+   "ratio": 0.2618,
+   "compress_mbps": 117.31,
+   "decompress_mbps": 578.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5511352,
+   "ratio": 0.2551,
+   "compress_mbps": 82.61,
+   "decompress_mbps": 582.62
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5451399,
+   "ratio": 0.2523,
+   "compress_mbps": 56.83,
+   "decompress_mbps": 594.35
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5417123,
+   "ratio": 0.2507,
+   "compress_mbps": 46.8,
+   "decompress_mbps": 595.18
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5404364,
+   "ratio": 0.2501,
+   "compress_mbps": 32.76,
+   "decompress_mbps": 597.8
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5402704,
+   "ratio": 0.2501,
+   "compress_mbps": 29.7,
+   "decompress_mbps": 598.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5567768,
+   "ratio": 0.7678,
+   "compress_mbps": 64.13,
+   "decompress_mbps": 318.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5504009,
+   "ratio": 0.759,
+   "compress_mbps": 58.11,
+   "decompress_mbps": 327.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5439339,
+   "ratio": 0.7501,
+   "compress_mbps": 46.08,
+   "decompress_mbps": 335.66
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5394604,
+   "ratio": 0.7439,
+   "compress_mbps": 48.02,
+   "decompress_mbps": 347.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5370116,
+   "ratio": 0.7405,
+   "compress_mbps": 33.04,
+   "decompress_mbps": 337.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5331793,
+   "ratio": 0.7352,
+   "compress_mbps": 22.99,
+   "decompress_mbps": 345.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5327677,
+   "ratio": 0.7347,
+   "compress_mbps": 21.08,
+   "decompress_mbps": 347.74
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5325914,
+   "ratio": 0.7344,
+   "compress_mbps": 18.89,
+   "decompress_mbps": 346.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5325914,
+   "ratio": 0.7344,
+   "compress_mbps": 18.88,
+   "decompress_mbps": 347.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 14991236,
+   "ratio": 0.3616,
+   "compress_mbps": 136.56,
+   "decompress_mbps": 379.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 14249692,
+   "ratio": 0.3437,
+   "compress_mbps": 119.84,
+   "decompress_mbps": 397.03
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13627761,
+   "ratio": 0.3287,
+   "compress_mbps": 87.05,
+   "decompress_mbps": 412.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 13001990,
+   "ratio": 0.3136,
+   "compress_mbps": 84.9,
+   "decompress_mbps": 391.55
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12445991,
+   "ratio": 0.3002,
+   "compress_mbps": 54.55,
+   "decompress_mbps": 391.05
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12213941,
+   "ratio": 0.2946,
+   "compress_mbps": 36.52,
+   "decompress_mbps": 395.66
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12130416,
+   "ratio": 0.2926,
+   "compress_mbps": 29.67,
+   "decompress_mbps": 396.94
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12073697,
+   "ratio": 0.2912,
+   "compress_mbps": 21.46,
+   "decompress_mbps": 404.12
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12073469,
+   "ratio": 0.2912,
+   "compress_mbps": 21.32,
+   "decompress_mbps": 406.77
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6033926,
+   "ratio": 0.712,
+   "compress_mbps": 74.36,
+   "decompress_mbps": 292.66
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 5997474,
+   "ratio": 0.7077,
+   "compress_mbps": 68.1,
+   "decompress_mbps": 303.07
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 5966621,
+   "ratio": 0.7041,
+   "compress_mbps": 55.04,
+   "decompress_mbps": 309.58
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6091108,
+   "ratio": 0.7188,
+   "compress_mbps": 46.0,
+   "decompress_mbps": 263.17
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6053566,
+   "ratio": 0.7143,
+   "compress_mbps": 37.15,
+   "decompress_mbps": 272.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6045111,
+   "ratio": 0.7134,
+   "compress_mbps": 34.92,
+   "decompress_mbps": 278.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6045034,
+   "ratio": 0.7133,
+   "compress_mbps": 34.83,
+   "decompress_mbps": 276.89
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6045032,
+   "ratio": 0.7133,
+   "compress_mbps": 34.92,
+   "decompress_mbps": 279.29
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6045032,
+   "ratio": 0.7133,
+   "compress_mbps": 34.83,
+   "decompress_mbps": 278.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 965242,
+   "ratio": 0.1806,
+   "compress_mbps": 262.94,
+   "decompress_mbps": 691.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 887265,
+   "ratio": 0.166,
+   "compress_mbps": 246.29,
+   "decompress_mbps": 740.68
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 822167,
+   "ratio": 0.1538,
+   "compress_mbps": 191.44,
+   "decompress_mbps": 789.3
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 807518,
+   "ratio": 0.1511,
+   "compress_mbps": 167.77,
+   "decompress_mbps": 756.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 730574,
+   "ratio": 0.1367,
+   "compress_mbps": 121.41,
+   "decompress_mbps": 809.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 687991,
+   "ratio": 0.1287,
+   "compress_mbps": 79.32,
+   "decompress_mbps": 844.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 673933,
+   "ratio": 0.1261,
+   "compress_mbps": 65.03,
+   "decompress_mbps": 873.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 659518,
+   "ratio": 0.1234,
+   "compress_mbps": 43.05,
+   "decompress_mbps": 892.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 658899,
+   "ratio": 0.1233,
+   "compress_mbps": 39.78,
+   "decompress_mbps": 880.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 5363862,
+   "ratio": 0.5263,
+   "compress_mbps": 138.79,
+   "decompress_mbps": 402.28
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4438205,
+   "ratio": 0.4354,
+   "compress_mbps": 127.63,
+   "decompress_mbps": 442.06
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4054333,
+   "ratio": 0.3978,
+   "compress_mbps": 63.91,
+   "decompress_mbps": 489.94
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4038550,
+   "ratio": 0.3962,
+   "compress_mbps": 57.47,
+   "decompress_mbps": 481.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3954920,
+   "ratio": 0.388,
+   "compress_mbps": 40.18,
+   "decompress_mbps": 469.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3872874,
+   "ratio": 0.38,
+   "compress_mbps": 22.54,
+   "decompress_mbps": 478.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3859937,
+   "ratio": 0.3787,
+   "compress_mbps": 18.81,
+   "decompress_mbps": 480.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3855935,
+   "ratio": 0.3783,
+   "compress_mbps": 17.05,
+   "decompress_mbps": 480.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3855791,
+   "ratio": 0.3783,
+   "compress_mbps": 16.97,
+   "decompress_mbps": 481.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 22334882,
+   "ratio": 0.4361,
+   "compress_mbps": 230.25,
+   "decompress_mbps": 379.46
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20150366,
+   "ratio": 0.3934,
+   "compress_mbps": 119.24,
+   "decompress_mbps": 382.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19495014,
+   "ratio": 0.3806,
+   "compress_mbps": 69.01,
+   "decompress_mbps": 396.76
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19424978,
+   "ratio": 0.3792,
+   "compress_mbps": 71.0,
+   "decompress_mbps": 410.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19298736,
+   "ratio": 0.3768,
+   "compress_mbps": 53.98,
+   "decompress_mbps": 428.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19179167,
+   "ratio": 0.3744,
+   "compress_mbps": 29.58,
+   "decompress_mbps": 410.38
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19151324,
+   "ratio": 0.3739,
+   "compress_mbps": 21.9,
+   "decompress_mbps": 433.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19144373,
+   "ratio": 0.3738,
+   "compress_mbps": 16.57,
+   "decompress_mbps": 433.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19141383,
+   "ratio": 0.3737,
+   "compress_mbps": 14.17,
+   "decompress_mbps": 432.76
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 4249731,
+   "ratio": 0.4262,
+   "compress_mbps": 305.95,
+   "decompress_mbps": 538.37
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3775479,
+   "ratio": 0.3787,
+   "compress_mbps": 156.83,
+   "decompress_mbps": 562.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3656966,
+   "ratio": 0.3668,
+   "compress_mbps": 80.0,
+   "decompress_mbps": 584.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3740378,
+   "ratio": 0.3751,
+   "compress_mbps": 67.37,
+   "decompress_mbps": 545.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3713604,
+   "ratio": 0.3725,
+   "compress_mbps": 48.51,
+   "decompress_mbps": 484.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3683556,
+   "ratio": 0.3694,
+   "compress_mbps": 25.2,
+   "decompress_mbps": 527.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3683797,
+   "ratio": 0.3695,
+   "compress_mbps": 19.19,
+   "decompress_mbps": 541.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3684477,
+   "ratio": 0.3695,
+   "compress_mbps": 14.48,
+   "decompress_mbps": 553.96
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3679414,
+   "ratio": 0.369,
+   "compress_mbps": 12.46,
+   "decompress_mbps": 553.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 5594622,
+   "ratio": 0.1667,
+   "compress_mbps": 427.24,
+   "decompress_mbps": 862.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4179532,
+   "ratio": 0.1246,
+   "compress_mbps": 328.94,
+   "decompress_mbps": 984.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3542329,
+   "ratio": 0.1056,
+   "compress_mbps": 213.2,
+   "decompress_mbps": 881.48
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3323363,
+   "ratio": 0.099,
+   "compress_mbps": 199.0,
+   "decompress_mbps": 931.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3230343,
+   "ratio": 0.0963,
+   "compress_mbps": 162.98,
+   "decompress_mbps": 1000.38
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3123421,
+   "ratio": 0.0931,
+   "compress_mbps": 96.32,
+   "decompress_mbps": 1059.98
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3093778,
+   "ratio": 0.0922,
+   "compress_mbps": 70.78,
+   "decompress_mbps": 1016.77
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3067318,
+   "ratio": 0.0914,
+   "compress_mbps": 50.19,
+   "decompress_mbps": 1054.41
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3050695,
+   "ratio": 0.0909,
+   "compress_mbps": 42.13,
+   "decompress_mbps": 1065.41
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3543611,
+   "ratio": 0.576,
+   "compress_mbps": 164.78,
+   "decompress_mbps": 280.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3226818,
+   "ratio": 0.5245,
+   "compress_mbps": 86.26,
+   "decompress_mbps": 298.31
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3144140,
+   "ratio": 0.5111,
+   "compress_mbps": 52.97,
+   "decompress_mbps": 310.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3129833,
+   "ratio": 0.5087,
+   "compress_mbps": 51.8,
+   "decompress_mbps": 337.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3114809,
+   "ratio": 0.5063,
+   "compress_mbps": 40.44,
+   "decompress_mbps": 350.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3095705,
+   "ratio": 0.5032,
+   "compress_mbps": 25.18,
+   "decompress_mbps": 356.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3090055,
+   "ratio": 0.5023,
+   "compress_mbps": 20.51,
+   "decompress_mbps": 358.26
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3087665,
+   "ratio": 0.5019,
+   "compress_mbps": 17.44,
+   "decompress_mbps": 355.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3087158,
+   "ratio": 0.5018,
+   "compress_mbps": 16.35,
+   "decompress_mbps": 359.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 5419510,
+   "ratio": 0.5373,
+   "compress_mbps": 240.77,
+   "decompress_mbps": 544.48
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3982547,
+   "ratio": 0.3949,
+   "compress_mbps": 123.38,
+   "decompress_mbps": 560.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3806102,
+   "ratio": 0.3774,
+   "compress_mbps": 82.03,
+   "decompress_mbps": 580.99
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3761477,
+   "ratio": 0.373,
+   "compress_mbps": 78.68,
+   "decompress_mbps": 617.31
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3740298,
+   "ratio": 0.3709,
+   "compress_mbps": 67.49,
+   "decompress_mbps": 621.76
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3686116,
+   "ratio": 0.3655,
+   "compress_mbps": 49.45,
+   "decompress_mbps": 653.96
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3668442,
+   "ratio": 0.3637,
+   "compress_mbps": 38.81,
+   "decompress_mbps": 670.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3665072,
+   "ratio": 0.3634,
+   "compress_mbps": 33.14,
+   "decompress_mbps": 662.87
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3665057,
+   "ratio": 0.3634,
+   "compress_mbps": 32.96,
+   "decompress_mbps": 660.26
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2842321,
+   "ratio": 0.4289,
+   "compress_mbps": 189.93,
+   "decompress_mbps": 451.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2232180,
+   "ratio": 0.3368,
+   "compress_mbps": 151.48,
+   "decompress_mbps": 524.72
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2003056,
+   "ratio": 0.3022,
+   "compress_mbps": 81.98,
+   "decompress_mbps": 560.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1985375,
+   "ratio": 0.2996,
+   "compress_mbps": 73.59,
+   "decompress_mbps": 568.31
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1933775,
+   "ratio": 0.2918,
+   "compress_mbps": 51.74,
+   "decompress_mbps": 537.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1858103,
+   "ratio": 0.2804,
+   "compress_mbps": 21.93,
+   "decompress_mbps": 545.54
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1840414,
+   "ratio": 0.2777,
+   "compress_mbps": 15.07,
+   "decompress_mbps": 548.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1831679,
+   "ratio": 0.2764,
+   "compress_mbps": 11.71,
+   "decompress_mbps": 549.72
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1827137,
+   "ratio": 0.2757,
+   "compress_mbps": 10.12,
+   "decompress_mbps": 552.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 7089759,
+   "ratio": 0.3281,
+   "compress_mbps": 287.04,
+   "decompress_mbps": 569.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5966231,
+   "ratio": 0.2761,
+   "compress_mbps": 172.98,
+   "decompress_mbps": 636.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5611838,
+   "ratio": 0.2597,
+   "compress_mbps": 111.17,
+   "decompress_mbps": 664.17
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5535436,
+   "ratio": 0.2562,
+   "compress_mbps": 104.98,
+   "decompress_mbps": 685.69
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5480971,
+   "ratio": 0.2537,
+   "compress_mbps": 81.18,
+   "decompress_mbps": 694.96
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5437556,
+   "ratio": 0.2517,
+   "compress_mbps": 49.46,
+   "decompress_mbps": 708.44
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5432108,
+   "ratio": 0.2514,
+   "compress_mbps": 40.38,
+   "decompress_mbps": 711.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5428571,
+   "ratio": 0.2512,
+   "compress_mbps": 33.59,
+   "decompress_mbps": 712.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5425526,
+   "ratio": 0.2511,
+   "compress_mbps": 30.44,
+   "decompress_mbps": 715.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5900800,
+   "ratio": 0.8137,
+   "compress_mbps": 187.77,
+   "decompress_mbps": 313.02
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5523611,
+   "ratio": 0.7617,
+   "compress_mbps": 68.59,
+   "decompress_mbps": 330.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5393086,
+   "ratio": 0.7437,
+   "compress_mbps": 40.06,
+   "decompress_mbps": 339.57
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5401582,
+   "ratio": 0.7448,
+   "compress_mbps": 40.39,
+   "decompress_mbps": 353.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5371274,
+   "ratio": 0.7407,
+   "compress_mbps": 31.1,
+   "decompress_mbps": 345.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5330096,
+   "ratio": 0.735,
+   "compress_mbps": 20.73,
+   "decompress_mbps": 350.15
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5325437,
+   "ratio": 0.7343,
+   "compress_mbps": 18.95,
+   "decompress_mbps": 349.58
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5323934,
+   "ratio": 0.7341,
+   "compress_mbps": 18.0,
+   "decompress_mbps": 350.5
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5323621,
+   "ratio": 0.7341,
+   "compress_mbps": 17.72,
+   "decompress_mbps": 350.16
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 17587173,
+   "ratio": 0.4242,
+   "compress_mbps": 181.57,
+   "decompress_mbps": 387.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 14171707,
+   "ratio": 0.3418,
+   "compress_mbps": 147.21,
+   "decompress_mbps": 422.36
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12774851,
+   "ratio": 0.3081,
+   "compress_mbps": 85.63,
+   "decompress_mbps": 453.22
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12612554,
+   "ratio": 0.3042,
+   "compress_mbps": 75.62,
+   "decompress_mbps": 444.68
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12392339,
+   "ratio": 0.2989,
+   "compress_mbps": 57.71,
+   "decompress_mbps": 454.79
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12158314,
+   "ratio": 0.2933,
+   "compress_mbps": 34.28,
+   "decompress_mbps": 468.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12107840,
+   "ratio": 0.292,
+   "compress_mbps": 27.47,
+   "decompress_mbps": 468.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12081311,
+   "ratio": 0.2914,
+   "compress_mbps": 22.78,
+   "decompress_mbps": 469.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12081011,
+   "ratio": 0.2914,
+   "compress_mbps": 22.71,
+   "decompress_mbps": 477.7
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6527324,
+   "ratio": 0.7703,
+   "compress_mbps": 235.88,
+   "decompress_mbps": 331.36
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6051483,
+   "ratio": 0.7141,
+   "compress_mbps": 75.09,
+   "decompress_mbps": 332.98
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6010123,
+   "ratio": 0.7092,
+   "compress_mbps": 51.89,
+   "decompress_mbps": 336.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6024815,
+   "ratio": 0.711,
+   "compress_mbps": 44.26,
+   "decompress_mbps": 288.94
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6005181,
+   "ratio": 0.7086,
+   "compress_mbps": 40.26,
+   "decompress_mbps": 295.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5997508,
+   "ratio": 0.7077,
+   "compress_mbps": 37.69,
+   "decompress_mbps": 299.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.62,
+   "decompress_mbps": 298.2
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.72,
+   "decompress_mbps": 300.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.74,
+   "decompress_mbps": 299.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 1147652,
+   "ratio": 0.2147,
+   "compress_mbps": 382.79,
+   "decompress_mbps": 788.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 919639,
+   "ratio": 0.172,
+   "compress_mbps": 260.74,
+   "decompress_mbps": 978.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 752341,
+   "ratio": 0.1407,
+   "compress_mbps": 167.23,
+   "decompress_mbps": 1090.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 735537,
+   "ratio": 0.1376,
+   "compress_mbps": 160.57,
+   "decompress_mbps": 1058.77
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 706789,
+   "ratio": 0.1322,
+   "compress_mbps": 123.29,
+   "decompress_mbps": 1150.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 676279,
+   "ratio": 0.1265,
+   "compress_mbps": 69.46,
+   "decompress_mbps": 1228.58
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 668772,
+   "ratio": 0.1251,
+   "compress_mbps": 56.03,
+   "decompress_mbps": 1249.19
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 665340,
+   "ratio": 0.1245,
+   "compress_mbps": 47.57,
+   "decompress_mbps": 1238.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 664273,
+   "ratio": 0.1243,
+   "compress_mbps": 45.76,
+   "decompress_mbps": 1237.77
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4217525,
+   "ratio": 0.4138,
+   "compress_mbps": 242.99,
+   "decompress_mbps": 818.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4053259,
+   "ratio": 0.3977,
+   "compress_mbps": 169.62,
+   "decompress_mbps": 871.55
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3989875,
+   "ratio": 0.3915,
+   "compress_mbps": 139.67,
+   "decompress_mbps": 951.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3972869,
+   "ratio": 0.3898,
+   "compress_mbps": 127.73,
+   "decompress_mbps": 829.14
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3894026,
+   "ratio": 0.3821,
+   "compress_mbps": 99.4,
+   "decompress_mbps": 809.01
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3859436,
+   "ratio": 0.3787,
+   "compress_mbps": 75.53,
+   "decompress_mbps": 835.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3837515,
+   "ratio": 0.3765,
+   "compress_mbps": 55.75,
+   "decompress_mbps": 836.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3811467,
+   "ratio": 0.374,
+   "compress_mbps": 35.98,
+   "decompress_mbps": 829.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3810354,
+   "ratio": 0.3738,
+   "compress_mbps": 32.71,
+   "decompress_mbps": 830.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20192961,
+   "ratio": 0.3942,
+   "compress_mbps": 240.89,
+   "decompress_mbps": 713.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19374226,
+   "ratio": 0.3783,
+   "compress_mbps": 187.26,
+   "decompress_mbps": 726.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19234937,
+   "ratio": 0.3755,
+   "compress_mbps": 174.61,
+   "decompress_mbps": 741.38
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19145385,
+   "ratio": 0.3738,
+   "compress_mbps": 163.5,
+   "decompress_mbps": 743.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 18878875,
+   "ratio": 0.3686,
+   "compress_mbps": 144.02,
+   "decompress_mbps": 761.16
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 18805391,
+   "ratio": 0.3671,
+   "compress_mbps": 120.78,
+   "decompress_mbps": 768.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 18749947,
+   "ratio": 0.3661,
+   "compress_mbps": 87.76,
+   "decompress_mbps": 767.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 18718540,
+   "ratio": 0.3655,
+   "compress_mbps": 47.48,
+   "decompress_mbps": 762.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 18713659,
+   "ratio": 0.3654,
+   "compress_mbps": 33.6,
+   "decompress_mbps": 770.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3740775,
+   "ratio": 0.3752,
+   "compress_mbps": 293.8,
+   "decompress_mbps": 764.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3707407,
+   "ratio": 0.3718,
+   "compress_mbps": 216.83,
+   "decompress_mbps": 788.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3672389,
+   "ratio": 0.3683,
+   "compress_mbps": 184.51,
+   "decompress_mbps": 816.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3660011,
+   "ratio": 0.3671,
+   "compress_mbps": 170.65,
+   "decompress_mbps": 749.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3664245,
+   "ratio": 0.3675,
+   "compress_mbps": 140.57,
+   "decompress_mbps": 708.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3648644,
+   "ratio": 0.3659,
+   "compress_mbps": 106.69,
+   "decompress_mbps": 738.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3635323,
+   "ratio": 0.3646,
+   "compress_mbps": 68.38,
+   "decompress_mbps": 746.64
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3624778,
+   "ratio": 0.3635,
+   "compress_mbps": 43.1,
+   "decompress_mbps": 766.56
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3625176,
+   "ratio": 0.3636,
+   "compress_mbps": 38.91,
+   "decompress_mbps": 754.84
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3837577,
+   "ratio": 0.1144,
+   "compress_mbps": 609.63,
+   "decompress_mbps": 1525.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3714632,
+   "ratio": 0.1107,
+   "compress_mbps": 463.51,
+   "decompress_mbps": 1822.41
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3599455,
+   "ratio": 0.1073,
+   "compress_mbps": 428.22,
+   "decompress_mbps": 1889.16
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3431843,
+   "ratio": 0.1023,
+   "compress_mbps": 388.47,
+   "decompress_mbps": 1855.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3268188,
+   "ratio": 0.0974,
+   "compress_mbps": 347.32,
+   "decompress_mbps": 1750.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3091741,
+   "ratio": 0.0921,
+   "compress_mbps": 264.67,
+   "decompress_mbps": 1842.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3032499,
+   "ratio": 0.0904,
+   "compress_mbps": 186.26,
+   "decompress_mbps": 1809.44
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2949097,
+   "ratio": 0.0879,
+   "compress_mbps": 97.52,
+   "decompress_mbps": 1788.33
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2925243,
+   "ratio": 0.0872,
+   "compress_mbps": 69.09,
+   "decompress_mbps": 1844.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3275124,
+   "ratio": 0.5324,
+   "compress_mbps": 166.43,
+   "decompress_mbps": 463.32
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3150806,
+   "ratio": 0.5121,
+   "compress_mbps": 127.91,
+   "decompress_mbps": 493.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3137061,
+   "ratio": 0.5099,
+   "compress_mbps": 121.99,
+   "decompress_mbps": 505.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3129676,
+   "ratio": 0.5087,
+   "compress_mbps": 118.35,
+   "decompress_mbps": 510.19
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3079277,
+   "ratio": 0.5005,
+   "compress_mbps": 99.95,
+   "decompress_mbps": 527.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3072378,
+   "ratio": 0.4994,
+   "compress_mbps": 88.97,
+   "decompress_mbps": 544.41
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3068123,
+   "ratio": 0.4987,
+   "compress_mbps": 76.13,
+   "decompress_mbps": 535.41
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3067299,
+   "ratio": 0.4986,
+   "compress_mbps": 55.45,
+   "decompress_mbps": 539.41
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3066968,
+   "ratio": 0.4985,
+   "compress_mbps": 50.13,
+   "decompress_mbps": 528.48
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3868663,
+   "ratio": 0.3836,
+   "compress_mbps": 287.22,
+   "decompress_mbps": 772.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3839158,
+   "ratio": 0.3807,
+   "compress_mbps": 212.88,
+   "decompress_mbps": 912.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3818964,
+   "ratio": 0.3787,
+   "compress_mbps": 197.38,
+   "decompress_mbps": 933.64
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3789325,
+   "ratio": 0.3757,
+   "compress_mbps": 179.54,
+   "decompress_mbps": 957.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3666476,
+   "ratio": 0.3635,
+   "compress_mbps": 156.54,
+   "decompress_mbps": 953.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3660266,
+   "ratio": 0.3629,
+   "compress_mbps": 141.18,
+   "decompress_mbps": 1000.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3659491,
+   "ratio": 0.3628,
+   "compress_mbps": 134.42,
+   "decompress_mbps": 1001.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3654863,
+   "ratio": 0.3624,
+   "compress_mbps": 114.88,
+   "decompress_mbps": 1014.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3654860,
+   "ratio": 0.3624,
+   "compress_mbps": 115.03,
+   "decompress_mbps": 997.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2197055,
+   "ratio": 0.3315,
+   "compress_mbps": 301.19,
+   "decompress_mbps": 882.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2082309,
+   "ratio": 0.3142,
+   "compress_mbps": 213.98,
+   "decompress_mbps": 1112.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2021047,
+   "ratio": 0.305,
+   "compress_mbps": 178.28,
+   "decompress_mbps": 1247.02
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1990952,
+   "ratio": 0.3004,
+   "compress_mbps": 158.5,
+   "decompress_mbps": 1172.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1921113,
+   "ratio": 0.2899,
+   "compress_mbps": 127.85,
+   "decompress_mbps": 1100.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1876257,
+   "ratio": 0.2831,
+   "compress_mbps": 87.16,
+   "decompress_mbps": 1098.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1832695,
+   "ratio": 0.2765,
+   "compress_mbps": 46.51,
+   "decompress_mbps": 1112.02
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1809967,
+   "ratio": 0.2731,
+   "compress_mbps": 24.22,
+   "decompress_mbps": 1069.25
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1806374,
+   "ratio": 0.2726,
+   "compress_mbps": 19.81,
+   "decompress_mbps": 1095.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 5866517,
+   "ratio": 0.2715,
+   "compress_mbps": 340.25,
+   "decompress_mbps": 913.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5695942,
+   "ratio": 0.2636,
+   "compress_mbps": 258.87,
+   "decompress_mbps": 1066.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5605878,
+   "ratio": 0.2595,
+   "compress_mbps": 235.77,
+   "decompress_mbps": 1112.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5553432,
+   "ratio": 0.257,
+   "compress_mbps": 218.44,
+   "decompress_mbps": 1099.73
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5416713,
+   "ratio": 0.2507,
+   "compress_mbps": 186.56,
+   "decompress_mbps": 1093.56
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5337149,
+   "ratio": 0.247,
+   "compress_mbps": 143.73,
+   "decompress_mbps": 1112.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5310181,
+   "ratio": 0.2458,
+   "compress_mbps": 100.22,
+   "decompress_mbps": 1086.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5272761,
+   "ratio": 0.244,
+   "compress_mbps": 62.28,
+   "decompress_mbps": 1105.35
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5270405,
+   "ratio": 0.2439,
+   "compress_mbps": 50.01,
+   "decompress_mbps": 1102.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5575128,
+   "ratio": 0.7688,
+   "compress_mbps": 162.61,
+   "decompress_mbps": 486.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5417142,
+   "ratio": 0.747,
+   "compress_mbps": 117.06,
+   "decompress_mbps": 514.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5397999,
+   "ratio": 0.7444,
+   "compress_mbps": 105.54,
+   "decompress_mbps": 528.01
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5391125,
+   "ratio": 0.7434,
+   "compress_mbps": 99.63,
+   "decompress_mbps": 538.68
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5352212,
+   "ratio": 0.738,
+   "compress_mbps": 86.74,
+   "decompress_mbps": 512.9
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5335405,
+   "ratio": 0.7357,
+   "compress_mbps": 73.38,
+   "decompress_mbps": 532.08
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5325697,
+   "ratio": 0.7344,
+   "compress_mbps": 63.24,
+   "decompress_mbps": 529.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5324004,
+   "ratio": 0.7341,
+   "compress_mbps": 52.63,
+   "decompress_mbps": 530.0
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5323197,
+   "ratio": 0.734,
+   "compress_mbps": 50.8,
+   "decompress_mbps": 535.0
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 13550569,
+   "ratio": 0.3268,
+   "compress_mbps": 267.32,
+   "decompress_mbps": 828.33
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13130705,
+   "ratio": 0.3167,
+   "compress_mbps": 201.17,
+   "decompress_mbps": 977.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12839361,
+   "ratio": 0.3097,
+   "compress_mbps": 178.79,
+   "decompress_mbps": 1037.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12601933,
+   "ratio": 0.304,
+   "compress_mbps": 163.54,
+   "decompress_mbps": 923.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12310776,
+   "ratio": 0.2969,
+   "compress_mbps": 132.79,
+   "decompress_mbps": 882.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12140474,
+   "ratio": 0.2928,
+   "compress_mbps": 104.66,
+   "decompress_mbps": 894.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12025296,
+   "ratio": 0.2901,
+   "compress_mbps": 72.39,
+   "decompress_mbps": 907.96
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 11893824,
+   "ratio": 0.2869,
+   "compress_mbps": 45.96,
+   "decompress_mbps": 891.22
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11882496,
+   "ratio": 0.2866,
+   "compress_mbps": 39.48,
+   "decompress_mbps": 899.94
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6293390,
+   "ratio": 0.7426,
+   "compress_mbps": 146.95,
+   "decompress_mbps": 521.91
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6058412,
+   "ratio": 0.7149,
+   "compress_mbps": 119.59,
+   "decompress_mbps": 529.24
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6058381,
+   "ratio": 0.7149,
+   "compress_mbps": 120.02,
+   "decompress_mbps": 541.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6058363,
+   "ratio": 0.7149,
+   "compress_mbps": 119.96,
+   "decompress_mbps": 431.91
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 5998400,
+   "ratio": 0.7078,
+   "compress_mbps": 106.11,
+   "decompress_mbps": 455.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5998438,
+   "ratio": 0.7078,
+   "compress_mbps": 106.4,
+   "decompress_mbps": 459.47
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5998439,
+   "ratio": 0.7078,
+   "compress_mbps": 106.38,
+   "decompress_mbps": 462.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5986859,
+   "ratio": 0.7065,
+   "compress_mbps": 89.81,
+   "decompress_mbps": 460.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5986859,
+   "ratio": 0.7065,
+   "compress_mbps": 89.94,
+   "decompress_mbps": 455.68
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 887708,
+   "ratio": 0.1661,
+   "compress_mbps": 488.17,
+   "decompress_mbps": 1435.22
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 843475,
+   "ratio": 0.1578,
+   "compress_mbps": 360.78,
+   "decompress_mbps": 1807.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 793388,
+   "ratio": 0.1484,
+   "compress_mbps": 335.82,
+   "decompress_mbps": 1924.87
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 747602,
+   "ratio": 0.1399,
+   "compress_mbps": 302.16,
+   "decompress_mbps": 1812.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 718615,
+   "ratio": 0.1344,
+   "compress_mbps": 261.18,
+   "decompress_mbps": 1822.06
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 684405,
+   "ratio": 0.128,
+   "compress_mbps": 205.14,
+   "decompress_mbps": 1905.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 664859,
+   "ratio": 0.1244,
+   "compress_mbps": 142.19,
+   "decompress_mbps": 1863.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 650835,
+   "ratio": 0.1218,
+   "compress_mbps": 84.32,
+   "decompress_mbps": 1894.64
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 649494,
+   "ratio": 0.1215,
+   "compress_mbps": 68.05,
+   "decompress_mbps": 1897.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 65708,
+   "ratio": 0.432,
+   "compress_mbps": 42.56,
+   "decompress_mbps": 61.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 60259,
+   "ratio": 0.3962,
+   "compress_mbps": 26.21,
+   "decompress_mbps": 68.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 58544,
+   "ratio": 0.3849,
+   "compress_mbps": 21.92,
+   "decompress_mbps": 69.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56238,
+   "ratio": 0.3698,
+   "compress_mbps": 21.46,
+   "decompress_mbps": 70.96
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54764,
+   "ratio": 0.3601,
+   "compress_mbps": 16.16,
+   "decompress_mbps": 71.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54311,
+   "ratio": 0.3571,
+   "compress_mbps": 10.7,
+   "decompress_mbps": 71.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54262,
+   "ratio": 0.3568,
+   "compress_mbps": 9.8,
+   "decompress_mbps": 72.02
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54247,
+   "ratio": 0.3567,
+   "compress_mbps": 9.57,
+   "decompress_mbps": 72.02
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54247,
+   "ratio": 0.3567,
+   "compress_mbps": 9.65,
+   "decompress_mbps": 72.57
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 56882,
+   "ratio": 0.4544,
+   "compress_mbps": 37.25,
+   "decompress_mbps": 55.92
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 52826,
+   "ratio": 0.422,
+   "compress_mbps": 23.05,
+   "decompress_mbps": 62.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51625,
+   "ratio": 0.4124,
+   "compress_mbps": 22.69,
+   "decompress_mbps": 65.27
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50034,
+   "ratio": 0.3997,
+   "compress_mbps": 22.5,
+   "decompress_mbps": 65.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48912,
+   "ratio": 0.3907,
+   "compress_mbps": 12.62,
+   "decompress_mbps": 65.42
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48738,
+   "ratio": 0.3893,
+   "compress_mbps": 11.77,
+   "decompress_mbps": 65.61
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48719,
+   "ratio": 0.3892,
+   "compress_mbps": 9.97,
+   "decompress_mbps": 65.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48716,
+   "ratio": 0.3892,
+   "compress_mbps": 9.9,
+   "decompress_mbps": 68.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48716,
+   "ratio": 0.3892,
+   "compress_mbps": 12.58,
+   "decompress_mbps": 64.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8988,
+   "ratio": 0.3653,
+   "compress_mbps": 36.94,
+   "decompress_mbps": 103.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8564,
+   "ratio": 0.3481,
+   "compress_mbps": 43.51,
+   "decompress_mbps": 102.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8390,
+   "ratio": 0.341,
+   "compress_mbps": 28.97,
+   "decompress_mbps": 97.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8167,
+   "ratio": 0.332,
+   "compress_mbps": 37.49,
+   "decompress_mbps": 98.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7965,
+   "ratio": 0.3237,
+   "compress_mbps": 28.72,
+   "decompress_mbps": 88.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 22.76,
+   "decompress_mbps": 104.8
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 21.67,
+   "decompress_mbps": 85.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 20.13,
+   "decompress_mbps": 105.7
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 27.55,
+   "decompress_mbps": 92.8
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3731,
+   "ratio": 0.3346,
+   "compress_mbps": 18.9,
+   "decompress_mbps": 80.13
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3491,
+   "ratio": 0.3131,
+   "compress_mbps": 23.63,
+   "decompress_mbps": 84.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3384,
+   "ratio": 0.3035,
+   "compress_mbps": 22.04,
+   "decompress_mbps": 89.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3220,
+   "ratio": 0.2888,
+   "compress_mbps": 21.08,
+   "decompress_mbps": 86.53
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3138,
+   "ratio": 0.2814,
+   "compress_mbps": 17.11,
+   "decompress_mbps": 93.05
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3118,
+   "ratio": 0.2796,
+   "compress_mbps": 15.03,
+   "decompress_mbps": 100.03
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 14.26,
+   "decompress_mbps": 96.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 14.4,
+   "decompress_mbps": 104.06
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 15.81,
+   "decompress_mbps": 101.86
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1352,
+   "ratio": 0.3633,
+   "compress_mbps": 8.47,
+   "decompress_mbps": 63.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1287,
+   "ratio": 0.3459,
+   "compress_mbps": 11.63,
+   "decompress_mbps": 60.62
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1284,
+   "ratio": 0.3451,
+   "compress_mbps": 11.67,
+   "decompress_mbps": 62.5
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1226,
+   "ratio": 0.3295,
+   "compress_mbps": 11.31,
+   "decompress_mbps": 66.96
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 9.84,
+   "decompress_mbps": 63.24
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 10.84,
+   "decompress_mbps": 63.7
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 10.02,
+   "decompress_mbps": 64.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 10.74,
+   "decompress_mbps": 80.94
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 11.17,
+   "decompress_mbps": 63.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 245423,
+   "ratio": 0.2383,
+   "compress_mbps": 123.71,
+   "decompress_mbps": 127.4
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 229642,
+   "ratio": 0.223,
+   "compress_mbps": 92.84,
+   "decompress_mbps": 151.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 225678,
+   "ratio": 0.2192,
+   "compress_mbps": 109.83,
+   "decompress_mbps": 153.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 218218,
+   "ratio": 0.2119,
+   "compress_mbps": 99.82,
+   "decompress_mbps": 163.61
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 210550,
+   "ratio": 0.2045,
+   "compress_mbps": 48.7,
+   "decompress_mbps": 154.12
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 207949,
+   "ratio": 0.2019,
+   "compress_mbps": 27.88,
+   "decompress_mbps": 168.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 207413,
+   "ratio": 0.2014,
+   "compress_mbps": 18.82,
+   "decompress_mbps": 151.74
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 207478,
+   "ratio": 0.2015,
+   "compress_mbps": 6.77,
+   "decompress_mbps": 153.16
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 207482,
+   "ratio": 0.2015,
+   "compress_mbps": 3.56,
+   "decompress_mbps": 157.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 175980,
+   "ratio": 0.4124,
+   "compress_mbps": 43.31,
+   "decompress_mbps": 64.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 160455,
+   "ratio": 0.376,
+   "compress_mbps": 70.41,
+   "decompress_mbps": 72.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 156690,
+   "ratio": 0.3672,
+   "compress_mbps": 32.21,
+   "decompress_mbps": 74.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 149064,
+   "ratio": 0.3493,
+   "compress_mbps": 36.48,
+   "decompress_mbps": 75.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145616,
+   "ratio": 0.3412,
+   "compress_mbps": 20.01,
+   "decompress_mbps": 76.95
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144773,
+   "ratio": 0.3392,
+   "compress_mbps": 17.53,
+   "decompress_mbps": 76.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144603,
+   "ratio": 0.3388,
+   "compress_mbps": 19.93,
+   "decompress_mbps": 75.91
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144573,
+   "ratio": 0.3388,
+   "compress_mbps": 16.49,
+   "decompress_mbps": 80.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144570,
+   "ratio": 0.3388,
+   "compress_mbps": 15.68,
+   "decompress_mbps": 75.93
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 228837,
+   "ratio": 0.4749,
+   "compress_mbps": 35.31,
+   "decompress_mbps": 54.63
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 211248,
+   "ratio": 0.4384,
+   "compress_mbps": 31.57,
+   "decompress_mbps": 61.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 205619,
+   "ratio": 0.4267,
+   "compress_mbps": 25.52,
+   "decompress_mbps": 67.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 200595,
+   "ratio": 0.4163,
+   "compress_mbps": 34.86,
+   "decompress_mbps": 66.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 195418,
+   "ratio": 0.4055,
+   "compress_mbps": 18.88,
+   "decompress_mbps": 65.35
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 194148,
+   "ratio": 0.4029,
+   "compress_mbps": 15.2,
+   "decompress_mbps": 66.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 193994,
+   "ratio": 0.4026,
+   "compress_mbps": 16.61,
+   "decompress_mbps": 66.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 193991,
+   "ratio": 0.4026,
+   "compress_mbps": 14.97,
+   "decompress_mbps": 65.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 193991,
+   "ratio": 0.4026,
+   "compress_mbps": 14.75,
+   "decompress_mbps": 80.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60990,
+   "ratio": 0.1188,
+   "compress_mbps": 240.46,
+   "decompress_mbps": 173.43
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 61650,
+   "ratio": 0.1201,
+   "compress_mbps": 103.12,
+   "decompress_mbps": 188.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 60035,
+   "ratio": 0.117,
+   "compress_mbps": 90.48,
+   "decompress_mbps": 205.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57005,
+   "ratio": 0.1111,
+   "compress_mbps": 91.56,
+   "decompress_mbps": 195.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 55779,
+   "ratio": 0.1087,
+   "compress_mbps": 81.64,
+   "decompress_mbps": 263.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 54970,
+   "ratio": 0.1071,
+   "compress_mbps": 69.16,
+   "decompress_mbps": 204.84
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 53922,
+   "ratio": 0.1051,
+   "compress_mbps": 76.91,
+   "decompress_mbps": 217.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 51977,
+   "ratio": 0.1013,
+   "compress_mbps": 17.63,
+   "decompress_mbps": 275.85
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51474,
+   "ratio": 0.1003,
+   "compress_mbps": 6.71,
+   "decompress_mbps": 239.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14783,
+   "ratio": 0.3866,
+   "compress_mbps": 32.71,
+   "decompress_mbps": 70.98
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 14101,
+   "ratio": 0.3688,
+   "compress_mbps": 33.16,
+   "decompress_mbps": 78.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13975,
+   "ratio": 0.3655,
+   "compress_mbps": 28.17,
+   "decompress_mbps": 75.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13632,
+   "ratio": 0.3565,
+   "compress_mbps": 30.93,
+   "decompress_mbps": 100.62
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13302,
+   "ratio": 0.3479,
+   "compress_mbps": 25.78,
+   "decompress_mbps": 79.98
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13279,
+   "ratio": 0.3473,
+   "compress_mbps": 21.9,
+   "decompress_mbps": 77.99
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13274,
+   "ratio": 0.3471,
+   "compress_mbps": 19.14,
+   "decompress_mbps": 84.74
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13260,
+   "ratio": 0.3468,
+   "compress_mbps": 7.15,
+   "decompress_mbps": 80.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13260,
+   "ratio": 0.3468,
+   "compress_mbps": 4.57,
+   "decompress_mbps": 79.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1862,
+   "ratio": 0.4405,
+   "compress_mbps": 9.05,
+   "decompress_mbps": 61.67
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1803,
+   "ratio": 0.4265,
+   "compress_mbps": 12.61,
+   "decompress_mbps": 58.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1791,
+   "ratio": 0.4237,
+   "compress_mbps": 12.87,
+   "decompress_mbps": 60.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1746,
+   "ratio": 0.4131,
+   "compress_mbps": 12.23,
+   "decompress_mbps": 60.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 10.95,
+   "decompress_mbps": 59.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 11.32,
+   "decompress_mbps": 59.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 10.98,
+   "decompress_mbps": 65.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 11.09,
+   "decompress_mbps": 61.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 11.55,
+   "decompress_mbps": 61.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4623589,
+   "ratio": 0.4536,
+   "compress_mbps": 87.88,
+   "decompress_mbps": 121.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4241525,
+   "ratio": 0.4161,
+   "compress_mbps": 59.05,
+   "decompress_mbps": 124.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4123202,
+   "ratio": 0.4045,
+   "compress_mbps": 61.06,
+   "decompress_mbps": 116.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3985937,
+   "ratio": 0.3911,
+   "compress_mbps": 60.91,
+   "decompress_mbps": 204.23
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3883839,
+   "ratio": 0.3811,
+   "compress_mbps": 35.59,
+   "decompress_mbps": 119.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3860437,
+   "ratio": 0.3788,
+   "compress_mbps": 27.93,
+   "decompress_mbps": 202.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3857076,
+   "ratio": 0.3784,
+   "compress_mbps": 25.13,
+   "decompress_mbps": 126.89
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3856651,
+   "ratio": 0.3784,
+   "compress_mbps": 24.66,
+   "decompress_mbps": 202.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3856651,
+   "ratio": 0.3784,
+   "compress_mbps": 24.68,
+   "decompress_mbps": 116.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 21508211,
+   "ratio": 0.4199,
+   "compress_mbps": 143.1,
+   "decompress_mbps": 239.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20538783,
+   "ratio": 0.401,
+   "compress_mbps": 103.18,
+   "decompress_mbps": 229.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 20334352,
+   "ratio": 0.397,
+   "compress_mbps": 88.51,
+   "decompress_mbps": 208.07
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19886937,
+   "ratio": 0.3883,
+   "compress_mbps": 86.76,
+   "decompress_mbps": 244.41
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19582363,
+   "ratio": 0.3823,
+   "compress_mbps": 65.59,
+   "decompress_mbps": 239.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19512479,
+   "ratio": 0.381,
+   "compress_mbps": 43.56,
+   "decompress_mbps": 220.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19489160,
+   "ratio": 0.3805,
+   "compress_mbps": 32.93,
+   "decompress_mbps": 227.82
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19475109,
+   "ratio": 0.3802,
+   "compress_mbps": 18.63,
+   "decompress_mbps": 225.38
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19476276,
+   "ratio": 0.3802,
+   "compress_mbps": 10.28,
+   "decompress_mbps": 247.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3967718,
+   "ratio": 0.3979,
+   "compress_mbps": 146.76,
+   "decompress_mbps": 172.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3773274,
+   "ratio": 0.3784,
+   "compress_mbps": 105.47,
+   "decompress_mbps": 124.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3670460,
+   "ratio": 0.3681,
+   "compress_mbps": 77.56,
+   "decompress_mbps": 182.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3655100,
+   "ratio": 0.3666,
+   "compress_mbps": 87.36,
+   "decompress_mbps": 107.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3620881,
+   "ratio": 0.3632,
+   "compress_mbps": 51.01,
+   "decompress_mbps": 125.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3606626,
+   "ratio": 0.3617,
+   "compress_mbps": 33.83,
+   "decompress_mbps": 183.58
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3605405,
+   "ratio": 0.3616,
+   "compress_mbps": 31.23,
+   "decompress_mbps": 130.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3601635,
+   "ratio": 0.3612,
+   "compress_mbps": 26.28,
+   "decompress_mbps": 133.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3601151,
+   "ratio": 0.3612,
+   "compress_mbps": 19.51,
+   "decompress_mbps": 120.72
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4501482,
+   "ratio": 0.1342,
+   "compress_mbps": 294.72,
+   "decompress_mbps": 451.24
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3875891,
+   "ratio": 0.1155,
+   "compress_mbps": 315.51,
+   "decompress_mbps": 356.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3731525,
+   "ratio": 0.1112,
+   "compress_mbps": 288.4,
+   "decompress_mbps": 372.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3542242,
+   "ratio": 0.1056,
+   "compress_mbps": 236.86,
+   "decompress_mbps": 484.44
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3239184,
+   "ratio": 0.0965,
+   "compress_mbps": 175.14,
+   "decompress_mbps": 539.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3113927,
+   "ratio": 0.0928,
+   "compress_mbps": 120.53,
+   "decompress_mbps": 330.65
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3063520,
+   "ratio": 0.0913,
+   "compress_mbps": 84.76,
+   "decompress_mbps": 331.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2961320,
+   "ratio": 0.0883,
+   "compress_mbps": 29.61,
+   "decompress_mbps": 401.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2940087,
+   "ratio": 0.0876,
+   "compress_mbps": 20.54,
+   "decompress_mbps": 474.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3462708,
+   "ratio": 0.5628,
+   "compress_mbps": 65.77,
+   "decompress_mbps": 109.92
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3327399,
+   "ratio": 0.5408,
+   "compress_mbps": 71.78,
+   "decompress_mbps": 84.48
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3297422,
+   "ratio": 0.536,
+   "compress_mbps": 66.06,
+   "decompress_mbps": 89.69
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3249485,
+   "ratio": 0.5282,
+   "compress_mbps": 64.02,
+   "decompress_mbps": 122.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3220046,
+   "ratio": 0.5234,
+   "compress_mbps": 49.81,
+   "decompress_mbps": 90.58
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3213239,
+   "ratio": 0.5223,
+   "compress_mbps": 43.12,
+   "decompress_mbps": 91.3
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3212009,
+   "ratio": 0.5221,
+   "compress_mbps": 39.44,
+   "decompress_mbps": 177.12
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3211575,
+   "ratio": 0.522,
+   "compress_mbps": 27.92,
+   "decompress_mbps": 92.84
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3211561,
+   "ratio": 0.522,
+   "compress_mbps": 29.68,
+   "decompress_mbps": 92.12
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4334497,
+   "ratio": 0.4298,
+   "compress_mbps": 130.93,
+   "decompress_mbps": 133.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3900156,
+   "ratio": 0.3867,
+   "compress_mbps": 131.77,
+   "decompress_mbps": 116.9
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3876099,
+   "ratio": 0.3843,
+   "compress_mbps": 122.94,
+   "decompress_mbps": 133.81
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3782364,
+   "ratio": 0.375,
+   "compress_mbps": 110.84,
+   "decompress_mbps": 135.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3679310,
+   "ratio": 0.3648,
+   "compress_mbps": 89.42,
+   "decompress_mbps": 136.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3679424,
+   "ratio": 0.3648,
+   "compress_mbps": 87.41,
+   "decompress_mbps": 128.99
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3679163,
+   "ratio": 0.3648,
+   "compress_mbps": 83.39,
+   "decompress_mbps": 141.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3679169,
+   "ratio": 0.3648,
+   "compress_mbps": 82.21,
+   "decompress_mbps": 140.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3679169,
+   "ratio": 0.3648,
+   "compress_mbps": 81.84,
+   "decompress_mbps": 196.94
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2496363,
+   "ratio": 0.3767,
+   "compress_mbps": 96.93,
+   "decompress_mbps": 111.19
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2202601,
+   "ratio": 0.3324,
+   "compress_mbps": 92.65,
+   "decompress_mbps": 102.3
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2103089,
+   "ratio": 0.3173,
+   "compress_mbps": 49.73,
+   "decompress_mbps": 242.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1999697,
+   "ratio": 0.3017,
+   "compress_mbps": 75.29,
+   "decompress_mbps": 121.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1892143,
+   "ratio": 0.2855,
+   "compress_mbps": 37.29,
+   "decompress_mbps": 108.65
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1838372,
+   "ratio": 0.2774,
+   "compress_mbps": 20.3,
+   "decompress_mbps": 108.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1828850,
+   "ratio": 0.276,
+   "compress_mbps": 15.87,
+   "decompress_mbps": 115.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1823159,
+   "ratio": 0.2751,
+   "compress_mbps": 12.46,
+   "decompress_mbps": 114.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1823159,
+   "ratio": 0.2751,
+   "compress_mbps": 12.53,
+   "decompress_mbps": 97.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6447290,
+   "ratio": 0.2984,
+   "compress_mbps": 187.76,
+   "decompress_mbps": 292.5
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6030257,
+   "ratio": 0.2791,
+   "compress_mbps": 147.85,
+   "decompress_mbps": 241.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5928121,
+   "ratio": 0.2744,
+   "compress_mbps": 128.5,
+   "decompress_mbps": 269.87
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5615804,
+   "ratio": 0.2599,
+   "compress_mbps": 121.57,
+   "decompress_mbps": 280.75
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5496738,
+   "ratio": 0.2544,
+   "compress_mbps": 80.22,
+   "decompress_mbps": 336.14
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5464184,
+   "ratio": 0.2529,
+   "compress_mbps": 62.73,
+   "decompress_mbps": 195.35
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5429645,
+   "ratio": 0.2513,
+   "compress_mbps": 47.93,
+   "decompress_mbps": 214.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5418135,
+   "ratio": 0.2508,
+   "compress_mbps": 36.65,
+   "decompress_mbps": 241.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5416628,
+   "ratio": 0.2507,
+   "compress_mbps": 33.67,
+   "decompress_mbps": 233.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5759187,
+   "ratio": 0.7942,
+   "compress_mbps": 91.27,
+   "decompress_mbps": 158.91
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5619390,
+   "ratio": 0.7749,
+   "compress_mbps": 49.54,
+   "decompress_mbps": 94.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5560914,
+   "ratio": 0.7668,
+   "compress_mbps": 43.81,
+   "decompress_mbps": 115.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5544069,
+   "ratio": 0.7645,
+   "compress_mbps": 44.58,
+   "decompress_mbps": 94.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5518257,
+   "ratio": 0.7609,
+   "compress_mbps": 36.73,
+   "decompress_mbps": 163.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5508662,
+   "ratio": 0.7596,
+   "compress_mbps": 33.77,
+   "decompress_mbps": 95.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5507534,
+   "ratio": 0.7595,
+   "compress_mbps": 35.09,
+   "decompress_mbps": 95.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5507183,
+   "ratio": 0.7594,
+   "compress_mbps": 32.41,
+   "decompress_mbps": 94.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5507183,
+   "ratio": 0.7594,
+   "compress_mbps": 32.5,
+   "decompress_mbps": 117.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 15230651,
+   "ratio": 0.3674,
+   "compress_mbps": 123.36,
+   "decompress_mbps": 184.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13822040,
+   "ratio": 0.3334,
+   "compress_mbps": 96.36,
+   "decompress_mbps": 194.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13397592,
+   "ratio": 0.3232,
+   "compress_mbps": 83.62,
+   "decompress_mbps": 202.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12759940,
+   "ratio": 0.3078,
+   "compress_mbps": 80.4,
+   "decompress_mbps": 223.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12274278,
+   "ratio": 0.2961,
+   "compress_mbps": 54.6,
+   "decompress_mbps": 216.16
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12131738,
+   "ratio": 0.2926,
+   "compress_mbps": 40.41,
+   "decompress_mbps": 218.2
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12060450,
+   "ratio": 0.2909,
+   "compress_mbps": 33.43,
+   "decompress_mbps": 203.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12036900,
+   "ratio": 0.2903,
+   "compress_mbps": 29.91,
+   "decompress_mbps": 206.04
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12036900,
+   "ratio": 0.2903,
+   "compress_mbps": 30.01,
+   "decompress_mbps": 223.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6653052,
+   "ratio": 0.7851,
+   "compress_mbps": 124.38,
+   "decompress_mbps": 152.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6305035,
+   "ratio": 0.744,
+   "compress_mbps": 53.84,
+   "decompress_mbps": 154.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6302730,
+   "ratio": 0.7438,
+   "compress_mbps": 52.94,
+   "decompress_mbps": 119.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6299134,
+   "ratio": 0.7433,
+   "compress_mbps": 52.14,
+   "decompress_mbps": 156.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6289022,
+   "ratio": 0.7421,
+   "compress_mbps": 64.63,
+   "decompress_mbps": 159.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6289013,
+   "ratio": 0.7421,
+   "compress_mbps": 50.64,
+   "decompress_mbps": 156.7
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6289013,
+   "ratio": 0.7421,
+   "compress_mbps": 50.91,
+   "decompress_mbps": 165.38
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6289012,
+   "ratio": 0.7421,
+   "compress_mbps": 64.4,
+   "decompress_mbps": 157.39
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6289012,
+   "ratio": 0.7421,
+   "compress_mbps": 64.37,
+   "decompress_mbps": 98.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 989456,
+   "ratio": 0.1851,
+   "compress_mbps": 243.16,
+   "decompress_mbps": 153.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 839766,
+   "ratio": 0.1571,
+   "compress_mbps": 178.46,
+   "decompress_mbps": 169.75
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 800619,
+   "ratio": 0.1498,
+   "compress_mbps": 181.16,
+   "decompress_mbps": 178.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 776397,
+   "ratio": 0.1452,
+   "compress_mbps": 149.67,
+   "decompress_mbps": 185.03
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 712679,
+   "ratio": 0.1333,
+   "compress_mbps": 103.54,
+   "decompress_mbps": 199.06
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 683707,
+   "ratio": 0.1279,
+   "compress_mbps": 93.5,
+   "decompress_mbps": 512.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 668601,
+   "ratio": 0.1251,
+   "compress_mbps": 70.7,
+   "decompress_mbps": 209.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 659106,
+   "ratio": 0.1233,
+   "compress_mbps": 42.04,
+   "decompress_mbps": 216.57
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 658920,
+   "ratio": 0.1233,
+   "compress_mbps": 42.13,
+   "decompress_mbps": 256.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 62797,
+   "ratio": 0.4129,
+   "compress_mbps": 75.96,
+   "decompress_mbps": 132.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 59605,
+   "ratio": 0.3919,
+   "compress_mbps": 62.87,
+   "decompress_mbps": 131.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 57675,
+   "ratio": 0.3792,
+   "compress_mbps": 53.89,
+   "decompress_mbps": 124.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56500,
+   "ratio": 0.3715,
+   "compress_mbps": 38.93,
+   "decompress_mbps": 131.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 56440,
+   "ratio": 0.3711,
+   "compress_mbps": 38.82,
+   "decompress_mbps": 130.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 55443,
+   "ratio": 0.3645,
+   "compress_mbps": 32.14,
+   "decompress_mbps": 146.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 55373,
+   "ratio": 0.3641,
+   "compress_mbps": 31.65,
+   "decompress_mbps": 130.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 55352,
+   "ratio": 0.3639,
+   "compress_mbps": 31.32,
+   "decompress_mbps": 136.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 55352,
+   "ratio": 0.3639,
+   "compress_mbps": 31.37,
+   "decompress_mbps": 135.72
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 55063,
+   "ratio": 0.4399,
+   "compress_mbps": 74.97,
+   "decompress_mbps": 117.68
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 52932,
+   "ratio": 0.4229,
+   "compress_mbps": 60.75,
+   "decompress_mbps": 116.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51597,
+   "ratio": 0.4122,
+   "compress_mbps": 44.1,
+   "decompress_mbps": 116.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50780,
+   "ratio": 0.4057,
+   "compress_mbps": 43.18,
+   "decompress_mbps": 120.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 50767,
+   "ratio": 0.4056,
+   "compress_mbps": 42.85,
+   "decompress_mbps": 122.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 50160,
+   "ratio": 0.4007,
+   "compress_mbps": 33.03,
+   "decompress_mbps": 128.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 31.52,
+   "decompress_mbps": 124.51
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 32.14,
+   "decompress_mbps": 125.83
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 35.79,
+   "decompress_mbps": 124.35
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8730,
+   "ratio": 0.3548,
+   "compress_mbps": 46.94,
+   "decompress_mbps": 123.4
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8457,
+   "ratio": 0.3437,
+   "compress_mbps": 43.65,
+   "decompress_mbps": 119.12
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8353,
+   "ratio": 0.3395,
+   "compress_mbps": 64.98,
+   "decompress_mbps": 109.7
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8301,
+   "ratio": 0.3374,
+   "compress_mbps": 42.45,
+   "decompress_mbps": 124.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8212,
+   "ratio": 0.3338,
+   "compress_mbps": 58.84,
+   "decompress_mbps": 103.81
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 8172,
+   "ratio": 0.3322,
+   "compress_mbps": 48.55,
+   "decompress_mbps": 108.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 50.28,
+   "decompress_mbps": 109.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 49.23,
+   "decompress_mbps": 109.09
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 53.75,
+   "decompress_mbps": 109.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3475,
+   "ratio": 0.3117,
+   "compress_mbps": 109.11,
+   "decompress_mbps": 96.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3305,
+   "ratio": 0.2964,
+   "compress_mbps": 102.67,
+   "decompress_mbps": 101.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3225,
+   "ratio": 0.2892,
+   "compress_mbps": 91.21,
+   "decompress_mbps": 104.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3192,
+   "ratio": 0.2863,
+   "compress_mbps": 100.3,
+   "decompress_mbps": 104.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3180,
+   "ratio": 0.2852,
+   "compress_mbps": 100.47,
+   "decompress_mbps": 98.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 94.55,
+   "decompress_mbps": 99.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 95.62,
+   "decompress_mbps": 95.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 91.52,
+   "decompress_mbps": 121.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 83.09,
+   "decompress_mbps": 95.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1275,
+   "ratio": 0.3426,
+   "compress_mbps": 59.58,
+   "decompress_mbps": 44.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1247,
+   "ratio": 0.3351,
+   "compress_mbps": 59.47,
+   "decompress_mbps": 52.13
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1239,
+   "ratio": 0.333,
+   "compress_mbps": 56.69,
+   "decompress_mbps": 51.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1238,
+   "ratio": 0.3327,
+   "compress_mbps": 58.55,
+   "decompress_mbps": 50.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1239,
+   "ratio": 0.333,
+   "compress_mbps": 48.99,
+   "decompress_mbps": 51.01
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 56.51,
+   "decompress_mbps": 50.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 55.71,
+   "decompress_mbps": 51.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 50.22,
+   "decompress_mbps": 48.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 55.39,
+   "decompress_mbps": 48.56
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 226284,
+   "ratio": 0.2197,
+   "compress_mbps": 113.28,
+   "decompress_mbps": 183.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 221369,
+   "ratio": 0.215,
+   "compress_mbps": 90.24,
+   "decompress_mbps": 255.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 218607,
+   "ratio": 0.2123,
+   "compress_mbps": 78.67,
+   "decompress_mbps": 187.61
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 217919,
+   "ratio": 0.2116,
+   "compress_mbps": 69.94,
+   "decompress_mbps": 195.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 217919,
+   "ratio": 0.2116,
+   "compress_mbps": 70.92,
+   "decompress_mbps": 195.59
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 217312,
+   "ratio": 0.211,
+   "compress_mbps": 44.09,
+   "decompress_mbps": 191.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 215966,
+   "ratio": 0.2097,
+   "compress_mbps": 31.15,
+   "decompress_mbps": 191.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 215930,
+   "ratio": 0.2097,
+   "compress_mbps": 14.32,
+   "decompress_mbps": 194.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 215912,
+   "ratio": 0.2097,
+   "compress_mbps": 11.1,
+   "decompress_mbps": 210.59
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 167622,
+   "ratio": 0.3928,
+   "compress_mbps": 64.39,
+   "decompress_mbps": 116.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 158003,
+   "ratio": 0.3702,
+   "compress_mbps": 64.34,
+   "decompress_mbps": 139.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 152928,
+   "ratio": 0.3584,
+   "compress_mbps": 46.67,
+   "decompress_mbps": 141.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 149886,
+   "ratio": 0.3512,
+   "compress_mbps": 33.71,
+   "decompress_mbps": 136.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 149767,
+   "ratio": 0.3509,
+   "compress_mbps": 39.31,
+   "decompress_mbps": 138
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 147818,
+   "ratio": 0.3464,
+   "compress_mbps": 33.18,
+   "decompress_mbps": 150.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 147733,
+   "ratio": 0.3462,
+   "compress_mbps": 32.42,
+   "decompress_mbps": 154.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 147709,
+   "ratio": 0.3461,
+   "compress_mbps": 32.15,
+   "decompress_mbps": 151.45
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 147705,
+   "ratio": 0.3461,
+   "compress_mbps": 32.65,
+   "decompress_mbps": 138.19
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 222866,
+   "ratio": 0.4625,
+   "compress_mbps": 58.92,
+   "decompress_mbps": 105.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 212925,
+   "ratio": 0.4419,
+   "compress_mbps": 49.52,
+   "decompress_mbps": 118.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 206913,
+   "ratio": 0.4294,
+   "compress_mbps": 40.5,
+   "decompress_mbps": 116.88
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 202875,
+   "ratio": 0.421,
+   "compress_mbps": 33.54,
+   "decompress_mbps": 111.31
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 202867,
+   "ratio": 0.421,
+   "compress_mbps": 33.57,
+   "decompress_mbps": 117.4
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 199818,
+   "ratio": 0.4147,
+   "compress_mbps": 28.4,
+   "decompress_mbps": 114.8
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 199664,
+   "ratio": 0.4144,
+   "compress_mbps": 27.76,
+   "decompress_mbps": 105.02
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 199634,
+   "ratio": 0.4143,
+   "compress_mbps": 28.19,
+   "decompress_mbps": 106.5
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 199634,
+   "ratio": 0.4143,
+   "compress_mbps": 27.99,
+   "decompress_mbps": 121
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60580,
+   "ratio": 0.118,
+   "compress_mbps": 118.15,
+   "decompress_mbps": 253.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 59663,
+   "ratio": 0.1163,
+   "compress_mbps": 131.11,
+   "decompress_mbps": 295.73
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 59465,
+   "ratio": 0.1159,
+   "compress_mbps": 100.74,
+   "decompress_mbps": 295.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 59353,
+   "ratio": 0.1156,
+   "compress_mbps": 95.09,
+   "decompress_mbps": 302.88
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 58830,
+   "ratio": 0.1146,
+   "compress_mbps": 107.76,
+   "decompress_mbps": 221.47
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 57884,
+   "ratio": 0.1128,
+   "compress_mbps": 56.85,
+   "decompress_mbps": 285.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 57206,
+   "ratio": 0.1115,
+   "compress_mbps": 46.17,
+   "decompress_mbps": 299.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 56545,
+   "ratio": 0.1102,
+   "compress_mbps": 23.09,
+   "decompress_mbps": 280.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 56454,
+   "ratio": 0.11,
+   "compress_mbps": 9.11,
+   "decompress_mbps": 300.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14194,
+   "ratio": 0.3712,
+   "compress_mbps": 83.27,
+   "decompress_mbps": 134.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13770,
+   "ratio": 0.3601,
+   "compress_mbps": 74.14,
+   "decompress_mbps": 116.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13611,
+   "ratio": 0.3559,
+   "compress_mbps": 66.24,
+   "decompress_mbps": 115.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13534,
+   "ratio": 0.3539,
+   "compress_mbps": 61.31,
+   "decompress_mbps": 117.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13527,
+   "ratio": 0.3537,
+   "compress_mbps": 61.97,
+   "decompress_mbps": 148.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13438,
+   "ratio": 0.3514,
+   "compress_mbps": 51.17,
+   "decompress_mbps": 142.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13419,
+   "ratio": 0.3509,
+   "compress_mbps": 47.83,
+   "decompress_mbps": 125.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13404,
+   "ratio": 0.3505,
+   "compress_mbps": 41.2,
+   "decompress_mbps": 118.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13390,
+   "ratio": 0.3502,
+   "compress_mbps": 35.78,
+   "decompress_mbps": 116.99
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1832,
+   "ratio": 0.4334,
+   "compress_mbps": 41.01,
+   "decompress_mbps": 45
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1776,
+   "ratio": 0.4202,
+   "compress_mbps": 58.71,
+   "decompress_mbps": 64.9
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1764,
+   "ratio": 0.4173,
+   "compress_mbps": 57.37,
+   "decompress_mbps": 62.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1763,
+   "ratio": 0.4171,
+   "compress_mbps": 56.88,
+   "decompress_mbps": 53.28
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 59.36,
+   "decompress_mbps": 48.79
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 40.25,
+   "decompress_mbps": 47.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 57.06,
+   "decompress_mbps": 48.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 58.67,
+   "decompress_mbps": 52.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 58.3,
+   "decompress_mbps": 62.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4462632,
+   "ratio": 0.4378,
+   "compress_mbps": 61.62,
+   "decompress_mbps": 170.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4244833,
+   "ratio": 0.4165,
+   "compress_mbps": 50.24,
+   "decompress_mbps": 201.42
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4112285,
+   "ratio": 0.4035,
+   "compress_mbps": 42.04,
+   "decompress_mbps": 178.21
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4020435,
+   "ratio": 0.3945,
+   "compress_mbps": 35.5,
+   "decompress_mbps": 142.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 4019177,
+   "ratio": 0.3943,
+   "compress_mbps": 35.31,
+   "decompress_mbps": 170.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3956464,
+   "ratio": 0.3882,
+   "compress_mbps": 28.75,
+   "decompress_mbps": 164.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3953310,
+   "ratio": 0.3879,
+   "compress_mbps": 28.47,
+   "decompress_mbps": 198.87
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3952872,
+   "ratio": 0.3878,
+   "compress_mbps": 29.08,
+   "decompress_mbps": 220.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3952872,
+   "ratio": 0.3878,
+   "compress_mbps": 29.21,
+   "decompress_mbps": 218.12
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20177423,
+   "ratio": 0.3939,
+   "compress_mbps": 72.68,
+   "decompress_mbps": 209.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19759467,
+   "ratio": 0.3858,
+   "compress_mbps": 63.85,
+   "decompress_mbps": 193.45
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19583171,
+   "ratio": 0.3823,
+   "compress_mbps": 57.14,
+   "decompress_mbps": 206.47
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19479125,
+   "ratio": 0.3803,
+   "compress_mbps": 51.03,
+   "decompress_mbps": 205.14
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19423693,
+   "ratio": 0.3792,
+   "compress_mbps": 49.13,
+   "decompress_mbps": 200.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19337683,
+   "ratio": 0.3775,
+   "compress_mbps": 36.05,
+   "decompress_mbps": 188.48
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19323922,
+   "ratio": 0.3773,
+   "compress_mbps": 29.08,
+   "decompress_mbps": 193.94
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19314797,
+   "ratio": 0.3771,
+   "compress_mbps": 19.5,
+   "decompress_mbps": 225.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19312663,
+   "ratio": 0.377,
+   "compress_mbps": 11.12,
+   "decompress_mbps": 219.23
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3762978,
+   "ratio": 0.3774,
+   "compress_mbps": 78.68,
+   "decompress_mbps": 163.86
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3711615,
+   "ratio": 0.3723,
+   "compress_mbps": 68.1,
+   "decompress_mbps": 196.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3663131,
+   "ratio": 0.3674,
+   "compress_mbps": 57.01,
+   "decompress_mbps": 241.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3631512,
+   "ratio": 0.3642,
+   "compress_mbps": 49.21,
+   "decompress_mbps": 221.03
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3630867,
+   "ratio": 0.3642,
+   "compress_mbps": 48.78,
+   "decompress_mbps": 216.62
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3615953,
+   "ratio": 0.3627,
+   "compress_mbps": 37.72,
+   "decompress_mbps": 247.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3615518,
+   "ratio": 0.3626,
+   "compress_mbps": 35.3,
+   "decompress_mbps": 189.82
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3613845,
+   "ratio": 0.3625,
+   "compress_mbps": 30.03,
+   "decompress_mbps": 255.34
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3614283,
+   "ratio": 0.3625,
+   "compress_mbps": 26.24,
+   "decompress_mbps": 222.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4418800,
+   "ratio": 0.1317,
+   "compress_mbps": 133,
+   "decompress_mbps": 338.57
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4026774,
+   "ratio": 0.12,
+   "compress_mbps": 123.44,
+   "decompress_mbps": 339.7
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3837798,
+   "ratio": 0.1144,
+   "compress_mbps": 116.34,
+   "decompress_mbps": 370.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3751023,
+   "ratio": 0.1118,
+   "compress_mbps": 110.1,
+   "decompress_mbps": 361.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3643468,
+   "ratio": 0.1086,
+   "compress_mbps": 101.98,
+   "decompress_mbps": 371.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3379481,
+   "ratio": 0.1007,
+   "compress_mbps": 68.99,
+   "decompress_mbps": 366.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3354082,
+   "ratio": 0.1,
+   "compress_mbps": 61.49,
+   "decompress_mbps": 366.51
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3330028,
+   "ratio": 0.0992,
+   "compress_mbps": 49.65,
+   "decompress_mbps": 396.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3327482,
+   "ratio": 0.0992,
+   "compress_mbps": 37.41,
+   "decompress_mbps": 367.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3233790,
+   "ratio": 0.5256,
+   "compress_mbps": 52.65,
+   "decompress_mbps": 141.02
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3184644,
+   "ratio": 0.5176,
+   "compress_mbps": 48.35,
+   "decompress_mbps": 141.34
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3160521,
+   "ratio": 0.5137,
+   "compress_mbps": 44.16,
+   "decompress_mbps": 134.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3141929,
+   "ratio": 0.5107,
+   "compress_mbps": 40.04,
+   "decompress_mbps": 150.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3138514,
+   "ratio": 0.5101,
+   "compress_mbps": 39.11,
+   "decompress_mbps": 134.68
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3126843,
+   "ratio": 0.5082,
+   "compress_mbps": 32.81,
+   "decompress_mbps": 149.93
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3126796,
+   "ratio": 0.5082,
+   "compress_mbps": 30.63,
+   "decompress_mbps": 145.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3126322,
+   "ratio": 0.5082,
+   "compress_mbps": 27.28,
+   "decompress_mbps": 153.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3126286,
+   "ratio": 0.5082,
+   "compress_mbps": 23.43,
+   "decompress_mbps": 154.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4076349,
+   "ratio": 0.4042,
+   "compress_mbps": 79.56,
+   "decompress_mbps": 217.72
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3914739,
+   "ratio": 0.3881,
+   "compress_mbps": 72.11,
+   "decompress_mbps": 235.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3845160,
+   "ratio": 0.3812,
+   "compress_mbps": 68.92,
+   "decompress_mbps": 265.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3822047,
+   "ratio": 0.379,
+   "compress_mbps": 65.9,
+   "decompress_mbps": 249.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3799472,
+   "ratio": 0.3767,
+   "compress_mbps": 60.47,
+   "decompress_mbps": 196.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3783861,
+   "ratio": 0.3752,
+   "compress_mbps": 59.24,
+   "decompress_mbps": 206.2
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3783432,
+   "ratio": 0.3751,
+   "compress_mbps": 57.5,
+   "decompress_mbps": 276.55
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3783342,
+   "ratio": 0.3751,
+   "compress_mbps": 57.79,
+   "decompress_mbps": 278.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3783342,
+   "ratio": 0.3751,
+   "compress_mbps": 57.86,
+   "decompress_mbps": 279.64
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2261112,
+   "ratio": 0.3412,
+   "compress_mbps": 71.4,
+   "decompress_mbps": 216.97
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2128691,
+   "ratio": 0.3212,
+   "compress_mbps": 58.57,
+   "decompress_mbps": 197.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2049023,
+   "ratio": 0.3092,
+   "compress_mbps": 48.53,
+   "decompress_mbps": 209.61
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1990249,
+   "ratio": 0.3003,
+   "compress_mbps": 41.12,
+   "decompress_mbps": 207.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1975224,
+   "ratio": 0.298,
+   "compress_mbps": 39.61,
+   "decompress_mbps": 151.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1910262,
+   "ratio": 0.2882,
+   "compress_mbps": 28.21,
+   "decompress_mbps": 164.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1902923,
+   "ratio": 0.2871,
+   "compress_mbps": 25.04,
+   "decompress_mbps": 221.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1900964,
+   "ratio": 0.2868,
+   "compress_mbps": 23.45,
+   "decompress_mbps": 227.66
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1900958,
+   "ratio": 0.2868,
+   "compress_mbps": 24.4,
+   "decompress_mbps": 207.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6016919,
+   "ratio": 0.2785,
+   "compress_mbps": 92.31,
+   "decompress_mbps": 250.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5767272,
+   "ratio": 0.2669,
+   "compress_mbps": 81.02,
+   "decompress_mbps": 287.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5669548,
+   "ratio": 0.2624,
+   "compress_mbps": 75.87,
+   "decompress_mbps": 211.21
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5619947,
+   "ratio": 0.2601,
+   "compress_mbps": 68.8,
+   "decompress_mbps": 271.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5586034,
+   "ratio": 0.2585,
+   "compress_mbps": 64.77,
+   "decompress_mbps": 270.13
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5540130,
+   "ratio": 0.2564,
+   "compress_mbps": 50.72,
+   "decompress_mbps": 269.04
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5537271,
+   "ratio": 0.2563,
+   "compress_mbps": 45.58,
+   "decompress_mbps": 209.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5530686,
+   "ratio": 0.256,
+   "compress_mbps": 35.75,
+   "decompress_mbps": 303.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5529823,
+   "ratio": 0.2559,
+   "compress_mbps": 31.59,
+   "decompress_mbps": 227.31
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5602819,
+   "ratio": 0.7726,
+   "compress_mbps": 47.72,
+   "decompress_mbps": 166.89
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5504019,
+   "ratio": 0.759,
+   "compress_mbps": 42.76,
+   "decompress_mbps": 153.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5452816,
+   "ratio": 0.7519,
+   "compress_mbps": 38.01,
+   "decompress_mbps": 153.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5425752,
+   "ratio": 0.7482,
+   "compress_mbps": 35.6,
+   "decompress_mbps": 177.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5425752,
+   "ratio": 0.7482,
+   "compress_mbps": 36.17,
+   "decompress_mbps": 176.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5407602,
+   "ratio": 0.7457,
+   "compress_mbps": 30.72,
+   "decompress_mbps": 153.42
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5406417,
+   "ratio": 0.7455,
+   "compress_mbps": 30.08,
+   "decompress_mbps": 155.44
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5406380,
+   "ratio": 0.7455,
+   "compress_mbps": 30.76,
+   "decompress_mbps": 154.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5406380,
+   "ratio": 0.7455,
+   "compress_mbps": 30.68,
+   "decompress_mbps": 117.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 14342407,
+   "ratio": 0.3459,
+   "compress_mbps": 73.52,
+   "decompress_mbps": 197.71
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13424966,
+   "ratio": 0.3238,
+   "compress_mbps": 63.27,
+   "decompress_mbps": 213.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13061399,
+   "ratio": 0.315,
+   "compress_mbps": 56.27,
+   "decompress_mbps": 222.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12877207,
+   "ratio": 0.3106,
+   "compress_mbps": 49.84,
+   "decompress_mbps": 208.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12671090,
+   "ratio": 0.3056,
+   "compress_mbps": 47.71,
+   "decompress_mbps": 209.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12511088,
+   "ratio": 0.3018,
+   "compress_mbps": 40.67,
+   "decompress_mbps": 235.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12503313,
+   "ratio": 0.3016,
+   "compress_mbps": 39.02,
+   "decompress_mbps": 224.89
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12502263,
+   "ratio": 0.3016,
+   "compress_mbps": 39.56,
+   "decompress_mbps": 227.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12502263,
+   "ratio": 0.3016,
+   "compress_mbps": 39.56,
+   "decompress_mbps": 225.48
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6022390,
+   "ratio": 0.7107,
+   "compress_mbps": 54.31,
+   "decompress_mbps": 145.97
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 5997124,
+   "ratio": 0.7077,
+   "compress_mbps": 48.84,
+   "decompress_mbps": 145.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 5979254,
+   "ratio": 0.7056,
+   "compress_mbps": 43.2,
+   "decompress_mbps": 149.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 5967955,
+   "ratio": 0.7042,
+   "compress_mbps": 42.03,
+   "decompress_mbps": 178.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 5967953,
+   "ratio": 0.7042,
+   "compress_mbps": 42.1,
+   "decompress_mbps": 155.23
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5965386,
+   "ratio": 0.7039,
+   "compress_mbps": 41.26,
+   "decompress_mbps": 150.17
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 41,
+   "decompress_mbps": 152.03
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 40.8,
+   "decompress_mbps": 151.14
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 41.86,
+   "decompress_mbps": 155
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 985606,
+   "ratio": 0.1844,
+   "compress_mbps": 111.12,
+   "decompress_mbps": 305.94
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 852636,
+   "ratio": 0.1595,
+   "compress_mbps": 102.74,
+   "decompress_mbps": 250.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 814293,
+   "ratio": 0.1523,
+   "compress_mbps": 96.19,
+   "decompress_mbps": 221.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 788388,
+   "ratio": 0.1475,
+   "compress_mbps": 89.39,
+   "decompress_mbps": 250.71
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 749390,
+   "ratio": 0.1402,
+   "compress_mbps": 83.47,
+   "decompress_mbps": 304.92
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 706892,
+   "ratio": 0.1322,
+   "compress_mbps": 64.12,
+   "decompress_mbps": 266.99
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 705695,
+   "ratio": 0.132,
+   "compress_mbps": 64.27,
+   "decompress_mbps": 329.56
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 703904,
+   "ratio": 0.1317,
+   "compress_mbps": 61.16,
+   "decompress_mbps": 268.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 703900,
+   "ratio": 0.1317,
+   "compress_mbps": 60.89,
+   "decompress_mbps": 396.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.44,
+   "decompress_mbps": 310.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 87.92,
+   "decompress_mbps": 310.59
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.84,
+   "decompress_mbps": 310.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.64,
+   "decompress_mbps": 314.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54531,
+   "ratio": 0.3585,
+   "compress_mbps": 55.46,
+   "decompress_mbps": 303.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54068,
+   "ratio": 0.3555,
+   "compress_mbps": 42.11,
+   "decompress_mbps": 310.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54003,
+   "ratio": 0.3551,
+   "compress_mbps": 37.45,
+   "decompress_mbps": 307.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 53974,
+   "ratio": 0.3549,
+   "compress_mbps": 33.15,
+   "decompress_mbps": 306.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 53974,
+   "ratio": 0.3549,
+   "compress_mbps": 33.03,
+   "decompress_mbps": 307.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 82.91,
+   "decompress_mbps": 273.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 83.46,
+   "decompress_mbps": 272.35
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 84.13,
+   "decompress_mbps": 272.98
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 83.95,
+   "decompress_mbps": 268.75
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48753,
+   "ratio": 0.3895,
+   "compress_mbps": 50.79,
+   "decompress_mbps": 277.44
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48557,
+   "ratio": 0.3879,
+   "compress_mbps": 40.8,
+   "decompress_mbps": 274.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48523,
+   "ratio": 0.3876,
+   "compress_mbps": 38.65,
+   "decompress_mbps": 273.33
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48522,
+   "ratio": 0.3876,
+   "compress_mbps": 37.86,
+   "decompress_mbps": 276.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48522,
+   "ratio": 0.3876,
+   "compress_mbps": 37.9,
+   "decompress_mbps": 276.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 164.27,
+   "decompress_mbps": 279.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 172.17,
+   "decompress_mbps": 279.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 171.79,
+   "decompress_mbps": 279.43
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 170.54,
+   "decompress_mbps": 279.22
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7965,
+   "ratio": 0.3237,
+   "compress_mbps": 110.55,
+   "decompress_mbps": 288.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7914,
+   "ratio": 0.3217,
+   "compress_mbps": 87.16,
+   "decompress_mbps": 290.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7895,
+   "ratio": 0.3209,
+   "compress_mbps": 80.21,
+   "decompress_mbps": 290.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7896,
+   "ratio": 0.3209,
+   "compress_mbps": 73.83,
+   "decompress_mbps": 287.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7896,
+   "ratio": 0.3209,
+   "compress_mbps": 74.8,
+   "decompress_mbps": 285.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 167.43,
+   "decompress_mbps": 252.93
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 171.07,
+   "decompress_mbps": 257.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 171.82,
+   "decompress_mbps": 258.29
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 166.85,
+   "decompress_mbps": 256.2
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3136,
+   "ratio": 0.2813,
+   "compress_mbps": 143.33,
+   "decompress_mbps": 259.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3115,
+   "ratio": 0.2794,
+   "compress_mbps": 126.88,
+   "decompress_mbps": 263.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 116.0,
+   "decompress_mbps": 266.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 105.81,
+   "decompress_mbps": 262.03
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 108.16,
+   "decompress_mbps": 263.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 119.04,
+   "decompress_mbps": 119.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 114.29,
+   "decompress_mbps": 121.57
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 111.93,
+   "decompress_mbps": 114.91
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 113.37,
+   "decompress_mbps": 116.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 104.47,
+   "decompress_mbps": 117.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 101.17,
+   "decompress_mbps": 116.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 99.01,
+   "decompress_mbps": 115.26
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 100.66,
+   "decompress_mbps": 116.17
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 100.75,
+   "decompress_mbps": 117.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 226.33,
+   "decompress_mbps": 462.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 232.22,
+   "decompress_mbps": 461.76
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 226.95,
+   "decompress_mbps": 462.59
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 231.82,
+   "decompress_mbps": 462.46
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 218313,
+   "ratio": 0.212,
+   "compress_mbps": 163.75,
+   "decompress_mbps": 447.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 215095,
+   "ratio": 0.2089,
+   "compress_mbps": 107.22,
+   "decompress_mbps": 448.7
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 213213,
+   "ratio": 0.2071,
+   "compress_mbps": 73.07,
+   "decompress_mbps": 450.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 210955,
+   "ratio": 0.2049,
+   "compress_mbps": 9.42,
+   "decompress_mbps": 452.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 210981,
+   "ratio": 0.2049,
+   "compress_mbps": 4.64,
+   "decompress_mbps": 454.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.55,
+   "decompress_mbps": 304.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.89,
+   "decompress_mbps": 306.86
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.22,
+   "decompress_mbps": 306.2
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.33,
+   "decompress_mbps": 304.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145024,
+   "ratio": 0.3398,
+   "compress_mbps": 57.83,
+   "decompress_mbps": 305.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144159,
+   "ratio": 0.3378,
+   "compress_mbps": 44.56,
+   "decompress_mbps": 304.1
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 143991,
+   "ratio": 0.3374,
+   "compress_mbps": 40.14,
+   "decompress_mbps": 306.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 143941,
+   "ratio": 0.3373,
+   "compress_mbps": 36.87,
+   "decompress_mbps": 306.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 143939,
+   "ratio": 0.3373,
+   "compress_mbps": 37.03,
+   "decompress_mbps": 305.69
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 81.26,
+   "decompress_mbps": 255.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 80.9,
+   "decompress_mbps": 255.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 81.21,
+   "decompress_mbps": 255.67
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 81.07,
+   "decompress_mbps": 256.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 194496,
+   "ratio": 0.4036,
+   "compress_mbps": 46.0,
+   "decompress_mbps": 247.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 193176,
+   "ratio": 0.4009,
+   "compress_mbps": 34.56,
+   "decompress_mbps": 253.55
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 192991,
+   "ratio": 0.4005,
+   "compress_mbps": 31.43,
+   "decompress_mbps": 250.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 192980,
+   "ratio": 0.4005,
+   "compress_mbps": 29.91,
+   "decompress_mbps": 251.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 192980,
+   "ratio": 0.4005,
+   "compress_mbps": 29.82,
+   "decompress_mbps": 253.98
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 294.39,
+   "decompress_mbps": 724.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 294.6,
+   "decompress_mbps": 721.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 294.93,
+   "decompress_mbps": 721.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 295.58,
+   "decompress_mbps": 727.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 56050,
+   "ratio": 0.1092,
+   "compress_mbps": 229.82,
+   "decompress_mbps": 759.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55292,
+   "ratio": 0.1077,
+   "compress_mbps": 153.4,
+   "decompress_mbps": 778.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 54651,
+   "ratio": 0.1065,
+   "compress_mbps": 124.47,
+   "decompress_mbps": 790.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52583,
+   "ratio": 0.1025,
+   "compress_mbps": 46.92,
+   "decompress_mbps": 823.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51816,
+   "ratio": 0.101,
+   "compress_mbps": 15.63,
+   "decompress_mbps": 833.02
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 119.63,
+   "decompress_mbps": 301.35
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 118.87,
+   "decompress_mbps": 304.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 120.64,
+   "decompress_mbps": 303.05
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 118.25,
+   "decompress_mbps": 303.27
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13290,
+   "ratio": 0.3475,
+   "compress_mbps": 89.99,
+   "decompress_mbps": 316.05
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13258,
+   "ratio": 0.3467,
+   "compress_mbps": 68.72,
+   "decompress_mbps": 317.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13246,
+   "ratio": 0.3464,
+   "compress_mbps": 57.01,
+   "decompress_mbps": 319.69
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13236,
+   "ratio": 0.3461,
+   "compress_mbps": 25.4,
+   "decompress_mbps": 320.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13233,
+   "ratio": 0.3461,
+   "compress_mbps": 16.12,
+   "decompress_mbps": 322.36
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 95.7,
+   "decompress_mbps": 132.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 98.31,
+   "decompress_mbps": 133.01
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 97.54,
+   "decompress_mbps": 132.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 100.39,
+   "decompress_mbps": 132.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.29,
+   "decompress_mbps": 132.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.54,
+   "decompress_mbps": 134.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 93.18,
+   "decompress_mbps": 133.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.09,
+   "decompress_mbps": 134.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 92.21,
+   "decompress_mbps": 134.59
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 84.07,
+   "decompress_mbps": 273.96
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 84.3,
+   "decompress_mbps": 273.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 83.99,
+   "decompress_mbps": 274.36
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 84.24,
+   "decompress_mbps": 272.3
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3863846,
+   "ratio": 0.3791,
+   "compress_mbps": 49.03,
+   "decompress_mbps": 267.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3838854,
+   "ratio": 0.3766,
+   "compress_mbps": 37.71,
+   "decompress_mbps": 272.4
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3835182,
+   "ratio": 0.3763,
+   "compress_mbps": 33.64,
+   "decompress_mbps": 271.15
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3834518,
+   "ratio": 0.3762,
+   "compress_mbps": 31.63,
+   "decompress_mbps": 269.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3834518,
+   "ratio": 0.3762,
+   "compress_mbps": 31.46,
+   "decompress_mbps": 270.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.55,
+   "decompress_mbps": 250.87
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.76,
+   "decompress_mbps": 251.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.86,
+   "decompress_mbps": 251.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.63,
+   "decompress_mbps": 251.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19578840,
+   "ratio": 0.3822,
+   "compress_mbps": 78.52,
+   "decompress_mbps": 258.92
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19492445,
+   "ratio": 0.3806,
+   "compress_mbps": 58.0,
+   "decompress_mbps": 261.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19463481,
+   "ratio": 0.38,
+   "compress_mbps": 46.5,
+   "decompress_mbps": 263.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19444704,
+   "ratio": 0.3796,
+   "compress_mbps": 22.81,
+   "decompress_mbps": 262.15
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19440748,
+   "ratio": 0.3796,
+   "compress_mbps": 13.07,
+   "decompress_mbps": 263.2
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.24,
+   "decompress_mbps": 259.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.65,
+   "decompress_mbps": 260.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 111.43,
+   "decompress_mbps": 257.26
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.43,
+   "decompress_mbps": 258.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3637736,
+   "ratio": 0.3648,
+   "compress_mbps": 65.79,
+   "decompress_mbps": 267.17
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3621530,
+   "ratio": 0.3632,
+   "compress_mbps": 46.42,
+   "decompress_mbps": 268.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3623924,
+   "ratio": 0.3635,
+   "compress_mbps": 42.48,
+   "decompress_mbps": 270.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3623112,
+   "ratio": 0.3634,
+   "compress_mbps": 33.07,
+   "decompress_mbps": 270.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3623382,
+   "ratio": 0.3634,
+   "compress_mbps": 24.87,
+   "decompress_mbps": 268.67
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 306.93,
+   "decompress_mbps": 882.12
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 309.49,
+   "decompress_mbps": 879.51
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 306.65,
+   "decompress_mbps": 865.76
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 309.44,
+   "decompress_mbps": 876.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3268887,
+   "ratio": 0.0974,
+   "compress_mbps": 229.13,
+   "decompress_mbps": 923.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3131445,
+   "ratio": 0.0933,
+   "compress_mbps": 163.5,
+   "decompress_mbps": 955.29
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3080217,
+   "ratio": 0.0918,
+   "compress_mbps": 129.46,
+   "decompress_mbps": 960.33
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2978354,
+   "ratio": 0.0888,
+   "compress_mbps": 57.16,
+   "decompress_mbps": 973.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2947971,
+   "ratio": 0.0879,
+   "compress_mbps": 34.51,
+   "decompress_mbps": 973.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.44,
+   "decompress_mbps": 182.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.2,
+   "decompress_mbps": 182.46
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.32,
+   "decompress_mbps": 182.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.36,
+   "decompress_mbps": 183.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3178914,
+   "ratio": 0.5167,
+   "compress_mbps": 55.82,
+   "decompress_mbps": 189.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3174170,
+   "ratio": 0.5159,
+   "compress_mbps": 49.39,
+   "decompress_mbps": 191.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3172734,
+   "ratio": 0.5157,
+   "compress_mbps": 45.82,
+   "decompress_mbps": 191.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3171353,
+   "ratio": 0.5155,
+   "compress_mbps": 38.64,
+   "decompress_mbps": 191.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3171299,
+   "ratio": 0.5155,
+   "compress_mbps": 34.82,
+   "decompress_mbps": 191.12
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 123.34,
+   "decompress_mbps": 273.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 122.2,
+   "decompress_mbps": 272.47
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 121.33,
+   "decompress_mbps": 269.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 122.45,
+   "decompress_mbps": 274.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3654027,
+   "ratio": 0.3623,
+   "compress_mbps": 95.52,
+   "decompress_mbps": 276.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3652732,
+   "ratio": 0.3622,
+   "compress_mbps": 91.8,
+   "decompress_mbps": 276.29
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3652496,
+   "ratio": 0.3621,
+   "compress_mbps": 87.07,
+   "decompress_mbps": 275.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3652505,
+   "ratio": 0.3621,
+   "compress_mbps": 87.05,
+   "decompress_mbps": 277.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3652505,
+   "ratio": 0.3621,
+   "compress_mbps": 87.07,
+   "decompress_mbps": 276.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 100.62,
+   "decompress_mbps": 354.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 100.0,
+   "decompress_mbps": 353.82
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 99.59,
+   "decompress_mbps": 351.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 99.81,
+   "decompress_mbps": 354.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1892183,
+   "ratio": 0.2855,
+   "compress_mbps": 53.63,
+   "decompress_mbps": 353.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1837957,
+   "ratio": 0.2773,
+   "compress_mbps": 30.64,
+   "decompress_mbps": 360.81
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1826603,
+   "ratio": 0.2756,
+   "compress_mbps": 24.41,
+   "decompress_mbps": 362.4
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1818702,
+   "ratio": 0.2744,
+   "compress_mbps": 16.09,
+   "decompress_mbps": 362.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1818702,
+   "ratio": 0.2744,
+   "compress_mbps": 15.95,
+   "decompress_mbps": 359.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 146.11,
+   "decompress_mbps": 399.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 145.88,
+   "decompress_mbps": 400.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 146.06,
+   "decompress_mbps": 396.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 144.39,
+   "decompress_mbps": 379.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5501344,
+   "ratio": 0.2546,
+   "compress_mbps": 103.33,
+   "decompress_mbps": 402.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5464646,
+   "ratio": 0.2529,
+   "compress_mbps": 79.54,
+   "decompress_mbps": 407.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5429975,
+   "ratio": 0.2513,
+   "compress_mbps": 66.81,
+   "decompress_mbps": 408.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5419566,
+   "ratio": 0.2508,
+   "compress_mbps": 49.41,
+   "decompress_mbps": 410.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5417952,
+   "ratio": 0.2508,
+   "compress_mbps": 45.54,
+   "decompress_mbps": 407.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.47,
+   "decompress_mbps": 161.38
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.25,
+   "decompress_mbps": 161.25
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.34,
+   "decompress_mbps": 161.47
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.28,
+   "decompress_mbps": 159.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5450496,
+   "ratio": 0.7516,
+   "compress_mbps": 46.56,
+   "decompress_mbps": 163.89
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5440281,
+   "ratio": 0.7502,
+   "compress_mbps": 42.07,
+   "decompress_mbps": 164.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5439077,
+   "ratio": 0.75,
+   "compress_mbps": 40.6,
+   "decompress_mbps": 164.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5438787,
+   "ratio": 0.75,
+   "compress_mbps": 39.98,
+   "decompress_mbps": 163.79
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5438787,
+   "ratio": 0.75,
+   "compress_mbps": 39.92,
+   "decompress_mbps": 165.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.43,
+   "decompress_mbps": 313.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.96,
+   "decompress_mbps": 316.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.45,
+   "decompress_mbps": 312.18
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.89,
+   "decompress_mbps": 315.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12238874,
+   "ratio": 0.2952,
+   "compress_mbps": 72.34,
+   "decompress_mbps": 317.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12086531,
+   "ratio": 0.2915,
+   "compress_mbps": 53.58,
+   "decompress_mbps": 323.18
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12020742,
+   "ratio": 0.2899,
+   "compress_mbps": 46.37,
+   "decompress_mbps": 319.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 11987253,
+   "ratio": 0.2891,
+   "compress_mbps": 38.17,
+   "decompress_mbps": 322.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11987245,
+   "ratio": 0.2891,
+   "compress_mbps": 38.15,
+   "decompress_mbps": 319.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.53,
+   "decompress_mbps": 146.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.39,
+   "decompress_mbps": 146.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.11,
+   "decompress_mbps": 146.99
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.42,
+   "decompress_mbps": 146.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6244483,
+   "ratio": 0.7369,
+   "compress_mbps": 55.4,
+   "decompress_mbps": 148.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6244482,
+   "ratio": 0.7369,
+   "compress_mbps": 55.47,
+   "decompress_mbps": 148.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6244482,
+   "ratio": 0.7369,
+   "compress_mbps": 55.08,
+   "decompress_mbps": 147.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6244480,
+   "ratio": 0.7369,
+   "compress_mbps": 55.49,
+   "decompress_mbps": 148.22
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6244480,
+   "ratio": 0.7369,
+   "compress_mbps": 55.43,
+   "decompress_mbps": 147.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.66,
+   "decompress_mbps": 673.8
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.52,
+   "decompress_mbps": 670.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 231.93,
+   "decompress_mbps": 669.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.28,
+   "decompress_mbps": 671.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 716461,
+   "ratio": 0.134,
+   "compress_mbps": 166.09,
+   "decompress_mbps": 710.38
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 687053,
+   "ratio": 0.1285,
+   "compress_mbps": 124.29,
+   "decompress_mbps": 733.86
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 673597,
+   "ratio": 0.126,
+   "compress_mbps": 100.95,
+   "decompress_mbps": 744.02
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 662156,
+   "ratio": 0.1239,
+   "compress_mbps": 65.08,
+   "decompress_mbps": 750.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 661610,
+   "ratio": 0.1238,
+   "compress_mbps": 61.06,
+   "decompress_mbps": 754.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 73589,
+   "ratio": 0.4839,
+   "compress_mbps": 33.76,
+   "decompress_mbps": 57.05
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 69878,
+   "ratio": 0.4595,
+   "compress_mbps": 32.08,
+   "decompress_mbps": 58.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 66917,
+   "ratio": 0.44,
+   "compress_mbps": 26.68,
+   "decompress_mbps": 66.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 59388,
+   "ratio": 0.3905,
+   "compress_mbps": 31.26,
+   "decompress_mbps": 80.36
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 57062,
+   "ratio": 0.3752,
+   "compress_mbps": 22.77,
+   "decompress_mbps": 80.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 55472,
+   "ratio": 0.3647,
+   "compress_mbps": 16.23,
+   "decompress_mbps": 79.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 55265,
+   "ratio": 0.3634,
+   "compress_mbps": 14.29,
+   "decompress_mbps": 79.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 55168,
+   "ratio": 0.3627,
+   "compress_mbps": 11.91,
+   "decompress_mbps": 78.92
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 55168,
+   "ratio": 0.3627,
+   "compress_mbps": 11.93,
+   "decompress_mbps": 78.52
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 64551,
+   "ratio": 0.5157,
+   "compress_mbps": 31.89,
+   "decompress_mbps": 53.82
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 62089,
+   "ratio": 0.496,
+   "compress_mbps": 30.15,
+   "decompress_mbps": 57.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 58690,
+   "ratio": 0.4688,
+   "compress_mbps": 24.34,
+   "decompress_mbps": 59.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 53521,
+   "ratio": 0.4276,
+   "compress_mbps": 30.1,
+   "decompress_mbps": 79.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 51677,
+   "ratio": 0.4128,
+   "compress_mbps": 20.89,
+   "decompress_mbps": 78.97
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 50638,
+   "ratio": 0.4045,
+   "compress_mbps": 14.85,
+   "decompress_mbps": 82.68
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 50501,
+   "ratio": 0.4034,
+   "compress_mbps": 13.53,
+   "decompress_mbps": 79.57
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 50452,
+   "ratio": 0.403,
+   "compress_mbps": 12.59,
+   "decompress_mbps": 81.82
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 50452,
+   "ratio": 0.403,
+   "compress_mbps": 12.59,
+   "decompress_mbps": 81.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 9859,
+   "ratio": 0.4007,
+   "compress_mbps": 43.03,
+   "decompress_mbps": 111.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 10473,
+   "ratio": 0.4257,
+   "compress_mbps": 47.23,
+   "decompress_mbps": 149.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 10172,
+   "ratio": 0.4134,
+   "compress_mbps": 42.85,
+   "decompress_mbps": 148.23
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8692,
+   "ratio": 0.3533,
+   "compress_mbps": 40.47,
+   "decompress_mbps": 152.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8440,
+   "ratio": 0.343,
+   "compress_mbps": 36.18,
+   "decompress_mbps": 157.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 8385,
+   "ratio": 0.3408,
+   "compress_mbps": 31.88,
+   "decompress_mbps": 158.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 8366,
+   "ratio": 0.34,
+   "compress_mbps": 29.95,
+   "decompress_mbps": 158.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 8367,
+   "ratio": 0.3401,
+   "compress_mbps": 28.71,
+   "decompress_mbps": 157.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 8367,
+   "ratio": 0.3401,
+   "compress_mbps": 28.72,
+   "decompress_mbps": 156.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 4822,
+   "ratio": 0.4325,
+   "compress_mbps": 54.35,
+   "decompress_mbps": 187.68
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 4593,
+   "ratio": 0.4119,
+   "compress_mbps": 52.8,
+   "decompress_mbps": 193.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 4381,
+   "ratio": 0.3929,
+   "compress_mbps": 49.8,
+   "decompress_mbps": 200.8
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3725,
+   "ratio": 0.3341,
+   "compress_mbps": 51.8,
+   "decompress_mbps": 202.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3614,
+   "ratio": 0.3241,
+   "compress_mbps": 43.83,
+   "decompress_mbps": 208.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3578,
+   "ratio": 0.3209,
+   "compress_mbps": 39.35,
+   "decompress_mbps": 209.91
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3572,
+   "ratio": 0.3204,
+   "compress_mbps": 36.83,
+   "decompress_mbps": 210.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3568,
+   "ratio": 0.32,
+   "compress_mbps": 34.7,
+   "decompress_mbps": 208.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3568,
+   "ratio": 0.32,
+   "compress_mbps": 33.66,
+   "decompress_mbps": 206.14
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1738,
+   "ratio": 0.4671,
+   "compress_mbps": 30.09,
+   "decompress_mbps": 176.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1709,
+   "ratio": 0.4593,
+   "compress_mbps": 30.1,
+   "decompress_mbps": 174.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1694,
+   "ratio": 0.4553,
+   "compress_mbps": 31.7,
+   "decompress_mbps": 180.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1458,
+   "ratio": 0.3918,
+   "compress_mbps": 29.73,
+   "decompress_mbps": 187.58
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1441,
+   "ratio": 0.3873,
+   "compress_mbps": 28.44,
+   "decompress_mbps": 189.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.18,
+   "decompress_mbps": 189.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.68,
+   "decompress_mbps": 190.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 26.12,
+   "decompress_mbps": 189.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.78,
+   "decompress_mbps": 191.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 260073,
+   "ratio": 0.2526,
+   "compress_mbps": 52.45,
+   "decompress_mbps": 56.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 296764,
+   "ratio": 0.2882,
+   "compress_mbps": 48.94,
+   "decompress_mbps": 76.97
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 288989,
+   "ratio": 0.2806,
+   "compress_mbps": 37.59,
+   "decompress_mbps": 77.33
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 246442,
+   "ratio": 0.2393,
+   "compress_mbps": 54.71,
+   "decompress_mbps": 83.32
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 218888,
+   "ratio": 0.2126,
+   "compress_mbps": 40.79,
+   "decompress_mbps": 76.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 217830,
+   "ratio": 0.2115,
+   "compress_mbps": 24.16,
+   "decompress_mbps": 88.24
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 221437,
+   "ratio": 0.215,
+   "compress_mbps": 19.26,
+   "decompress_mbps": 86.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 219666,
+   "ratio": 0.2133,
+   "compress_mbps": 5.49,
+   "decompress_mbps": 86.51
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 219921,
+   "ratio": 0.2136,
+   "compress_mbps": 2.77,
+   "decompress_mbps": 85.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 194588,
+   "ratio": 0.456,
+   "compress_mbps": 34.47,
+   "decompress_mbps": 51.9
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 185757,
+   "ratio": 0.4353,
+   "compress_mbps": 32.92,
+   "decompress_mbps": 49.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 175850,
+   "ratio": 0.4121,
+   "compress_mbps": 27.11,
+   "decompress_mbps": 59.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 155951,
+   "ratio": 0.3654,
+   "compress_mbps": 31.95,
+   "decompress_mbps": 73.02
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 150274,
+   "ratio": 0.3521,
+   "compress_mbps": 23.12,
+   "decompress_mbps": 71.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 147958,
+   "ratio": 0.3467,
+   "compress_mbps": 16.73,
+   "decompress_mbps": 72.74
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 147522,
+   "ratio": 0.3457,
+   "compress_mbps": 14.93,
+   "decompress_mbps": 70.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 147331,
+   "ratio": 0.3452,
+   "compress_mbps": 13.5,
+   "decompress_mbps": 68.78
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 147328,
+   "ratio": 0.3452,
+   "compress_mbps": 13.48,
+   "decompress_mbps": 70.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 256904,
+   "ratio": 0.5331,
+   "compress_mbps": 29.73,
+   "decompress_mbps": 46.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 245675,
+   "ratio": 0.5098,
+   "compress_mbps": 28.42,
+   "decompress_mbps": 50.05
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 231519,
+   "ratio": 0.4805,
+   "compress_mbps": 22.58,
+   "decompress_mbps": 56.23
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 210028,
+   "ratio": 0.4359,
+   "compress_mbps": 27.54,
+   "decompress_mbps": 64.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 203312,
+   "ratio": 0.4219,
+   "compress_mbps": 18.52,
+   "decompress_mbps": 61.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 199287,
+   "ratio": 0.4136,
+   "compress_mbps": 12.88,
+   "decompress_mbps": 65.73
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 198474,
+   "ratio": 0.4119,
+   "compress_mbps": 11.21,
+   "decompress_mbps": 66.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 198080,
+   "ratio": 0.4111,
+   "compress_mbps": 8.88,
+   "decompress_mbps": 65.36
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 198080,
+   "ratio": 0.4111,
+   "compress_mbps": 8.84,
+   "decompress_mbps": 65.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 71229,
+   "ratio": 0.1388,
+   "compress_mbps": 82.96,
+   "decompress_mbps": 136.59
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 69946,
+   "ratio": 0.1363,
+   "compress_mbps": 78.92,
+   "decompress_mbps": 137.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 68538,
+   "ratio": 0.1335,
+   "compress_mbps": 69.23,
+   "decompress_mbps": 151.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 61320,
+   "ratio": 0.1195,
+   "compress_mbps": 65.87,
+   "decompress_mbps": 164.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 59993,
+   "ratio": 0.1169,
+   "compress_mbps": 57.15,
+   "decompress_mbps": 169.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 58637,
+   "ratio": 0.1143,
+   "compress_mbps": 41.42,
+   "decompress_mbps": 166.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 58209,
+   "ratio": 0.1134,
+   "compress_mbps": 35.38,
+   "decompress_mbps": 173.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 55749,
+   "ratio": 0.1086,
+   "compress_mbps": 19.35,
+   "decompress_mbps": 176.71
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 54927,
+   "ratio": 0.107,
+   "compress_mbps": 7.52,
+   "decompress_mbps": 176.17
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 16399,
+   "ratio": 0.4288,
+   "compress_mbps": 36.37,
+   "decompress_mbps": 86.67
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 15933,
+   "ratio": 0.4167,
+   "compress_mbps": 33.72,
+   "decompress_mbps": 88.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 15739,
+   "ratio": 0.4116,
+   "compress_mbps": 28.05,
+   "decompress_mbps": 87.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13834,
+   "ratio": 0.3618,
+   "compress_mbps": 31.73,
+   "decompress_mbps": 108.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13463,
+   "ratio": 0.3521,
+   "compress_mbps": 25.96,
+   "decompress_mbps": 111.56
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13353,
+   "ratio": 0.3492,
+   "compress_mbps": 18.86,
+   "decompress_mbps": 111.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13317,
+   "ratio": 0.3482,
+   "compress_mbps": 15.93,
+   "decompress_mbps": 113.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13255,
+   "ratio": 0.3466,
+   "compress_mbps": 8.38,
+   "decompress_mbps": 110.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13171,
+   "ratio": 0.3444,
+   "compress_mbps": 4.16,
+   "decompress_mbps": 114.39
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 2512,
+   "ratio": 0.5943,
+   "compress_mbps": 29.63,
+   "decompress_mbps": 155.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 2477,
+   "ratio": 0.586,
+   "compress_mbps": 29.51,
+   "decompress_mbps": 158.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 2452,
+   "ratio": 0.5801,
+   "compress_mbps": 30.37,
+   "decompress_mbps": 157.34
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 2110,
+   "ratio": 0.4992,
+   "compress_mbps": 29.99,
+   "decompress_mbps": 162.81
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.87,
+   "decompress_mbps": 169.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.86,
+   "decompress_mbps": 167.98
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.5,
+   "decompress_mbps": 169.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 27.54,
+   "decompress_mbps": 169.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.63,
+   "decompress_mbps": 169.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 5183792,
+   "ratio": 0.5086,
+   "compress_mbps": 31.31,
+   "decompress_mbps": 40.47
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4956750,
+   "ratio": 0.4863,
+   "compress_mbps": 29.97,
+   "decompress_mbps": 43.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4644095,
+   "ratio": 0.4556,
+   "compress_mbps": 24.06,
+   "decompress_mbps": 47.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4178564,
+   "ratio": 0.41,
+   "compress_mbps": 29.06,
+   "decompress_mbps": 61.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 4034632,
+   "ratio": 0.3958,
+   "compress_mbps": 19.92,
+   "decompress_mbps": 61.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3952244,
+   "ratio": 0.3878,
+   "compress_mbps": 13.83,
+   "decompress_mbps": 61.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3938822,
+   "ratio": 0.3864,
+   "compress_mbps": 12.23,
+   "decompress_mbps": 62.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3935171,
+   "ratio": 0.3861,
+   "compress_mbps": 10.76,
+   "decompress_mbps": 60.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3935171,
+   "ratio": 0.3861,
+   "compress_mbps": 10.72,
+   "decompress_mbps": 60.89
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 25320013,
+   "ratio": 0.4943,
+   "compress_mbps": 31.71,
+   "decompress_mbps": 34.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 24804084,
+   "ratio": 0.4843,
+   "compress_mbps": 30.3,
+   "decompress_mbps": 36.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 24241121,
+   "ratio": 0.4733,
+   "compress_mbps": 25.73,
+   "decompress_mbps": 37.97
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 20950547,
+   "ratio": 0.409,
+   "compress_mbps": 28.84,
+   "decompress_mbps": 44.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 20592289,
+   "ratio": 0.402,
+   "compress_mbps": 24.29,
+   "decompress_mbps": 46.14
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 20445232,
+   "ratio": 0.3992,
+   "compress_mbps": 18.69,
+   "decompress_mbps": 46.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 20407676,
+   "ratio": 0.3984,
+   "compress_mbps": 15.95,
+   "decompress_mbps": 46.63
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 20389473,
+   "ratio": 0.3981,
+   "compress_mbps": 10.13,
+   "decompress_mbps": 45.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 20386824,
+   "ratio": 0.398,
+   "compress_mbps": 6.82,
+   "decompress_mbps": 46.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3964698,
+   "ratio": 0.3976,
+   "compress_mbps": 37.98,
+   "decompress_mbps": 48.02
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3936391,
+   "ratio": 0.3948,
+   "compress_mbps": 35.52,
+   "decompress_mbps": 47.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3823540,
+   "ratio": 0.3835,
+   "compress_mbps": 27.78,
+   "decompress_mbps": 51.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3799601,
+   "ratio": 0.3811,
+   "compress_mbps": 33.02,
+   "decompress_mbps": 63.69
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3830938,
+   "ratio": 0.3842,
+   "compress_mbps": 22.58,
+   "decompress_mbps": 58.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3808303,
+   "ratio": 0.382,
+   "compress_mbps": 14.79,
+   "decompress_mbps": 57.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3802814,
+   "ratio": 0.3814,
+   "compress_mbps": 12.14,
+   "decompress_mbps": 57.87
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3800355,
+   "ratio": 0.3812,
+   "compress_mbps": 6.76,
+   "decompress_mbps": 59.01
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3799676,
+   "ratio": 0.3811,
+   "compress_mbps": 6.05,
+   "decompress_mbps": 59.07
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4899547,
+   "ratio": 0.146,
+   "compress_mbps": 95.3,
+   "decompress_mbps": 131.63
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4587004,
+   "ratio": 0.1367,
+   "compress_mbps": 94.92,
+   "decompress_mbps": 142.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 4229035,
+   "ratio": 0.126,
+   "compress_mbps": 90.43,
+   "decompress_mbps": 152.33
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3791322,
+   "ratio": 0.113,
+   "compress_mbps": 81.61,
+   "decompress_mbps": 160.66
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3449193,
+   "ratio": 0.1028,
+   "compress_mbps": 72.81,
+   "decompress_mbps": 168.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3269452,
+   "ratio": 0.0974,
+   "compress_mbps": 58.66,
+   "decompress_mbps": 173.37
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3211286,
+   "ratio": 0.0957,
+   "compress_mbps": 50.59,
+   "decompress_mbps": 173.62
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3101534,
+   "ratio": 0.0924,
+   "compress_mbps": 27.5,
+   "decompress_mbps": 174.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3058177,
+   "ratio": 0.0911,
+   "compress_mbps": 16.6,
+   "decompress_mbps": 177.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 4024327,
+   "ratio": 0.6541,
+   "compress_mbps": 22.81,
+   "decompress_mbps": 29.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3953722,
+   "ratio": 0.6427,
+   "compress_mbps": 21.66,
+   "decompress_mbps": 30.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3887921,
+   "ratio": 0.632,
+   "compress_mbps": 18.47,
+   "decompress_mbps": 31.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3320440,
+   "ratio": 0.5397,
+   "compress_mbps": 21.3,
+   "decompress_mbps": 37.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3279338,
+   "ratio": 0.533,
+   "compress_mbps": 17.83,
+   "decompress_mbps": 38.07
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3254309,
+   "ratio": 0.529,
+   "compress_mbps": 14.0,
+   "decompress_mbps": 37.9
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3250139,
+   "ratio": 0.5283,
+   "compress_mbps": 12.22,
+   "decompress_mbps": 38.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3247018,
+   "ratio": 0.5278,
+   "compress_mbps": 10.17,
+   "decompress_mbps": 38.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3246865,
+   "ratio": 0.5278,
+   "compress_mbps": 9.51,
+   "decompress_mbps": 38.0
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4471091,
+   "ratio": 0.4433,
+   "compress_mbps": 34.91,
+   "decompress_mbps": 69.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 4372105,
+   "ratio": 0.4335,
+   "compress_mbps": 33.82,
+   "decompress_mbps": 71.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 4305270,
+   "ratio": 0.4269,
+   "compress_mbps": 30.7,
+   "decompress_mbps": 73.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3920495,
+   "ratio": 0.3887,
+   "compress_mbps": 30.3,
+   "decompress_mbps": 64.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3853177,
+   "ratio": 0.382,
+   "compress_mbps": 26.63,
+   "decompress_mbps": 63.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3780878,
+   "ratio": 0.3749,
+   "compress_mbps": 23.38,
+   "decompress_mbps": 64.31
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3763880,
+   "ratio": 0.3732,
+   "compress_mbps": 20.2,
+   "decompress_mbps": 72.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3757719,
+   "ratio": 0.3726,
+   "compress_mbps": 18.3,
+   "decompress_mbps": 73.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3757719,
+   "ratio": 0.3726,
+   "compress_mbps": 18.25,
+   "decompress_mbps": 72.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2722387,
+   "ratio": 0.4108,
+   "compress_mbps": 38.01,
+   "decompress_mbps": 64.73
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2572544,
+   "ratio": 0.3882,
+   "compress_mbps": 36.87,
+   "decompress_mbps": 70.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2384328,
+   "ratio": 0.3598,
+   "compress_mbps": 29.15,
+   "decompress_mbps": 78.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2112060,
+   "ratio": 0.3187,
+   "compress_mbps": 36.42,
+   "decompress_mbps": 85.62
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1991581,
+   "ratio": 0.3005,
+   "compress_mbps": 25.34,
+   "decompress_mbps": 91.01
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1917866,
+   "ratio": 0.2894,
+   "compress_mbps": 15.03,
+   "decompress_mbps": 90.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1895353,
+   "ratio": 0.286,
+   "compress_mbps": 11.08,
+   "decompress_mbps": 90.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1880740,
+   "ratio": 0.2838,
+   "compress_mbps": 5.59,
+   "decompress_mbps": 90.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1880711,
+   "ratio": 0.2838,
+   "compress_mbps": 5.56,
+   "decompress_mbps": 92.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 7441483,
+   "ratio": 0.3444,
+   "compress_mbps": 43.78,
+   "decompress_mbps": 66.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 7229248,
+   "ratio": 0.3346,
+   "compress_mbps": 43.14,
+   "decompress_mbps": 69.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 7083451,
+   "ratio": 0.3278,
+   "compress_mbps": 38.92,
+   "decompress_mbps": 71.31
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 6189639,
+   "ratio": 0.2865,
+   "compress_mbps": 42.2,
+   "decompress_mbps": 92.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 6053058,
+   "ratio": 0.2802,
+   "compress_mbps": 35.08,
+   "decompress_mbps": 96.18
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5988137,
+   "ratio": 0.2771,
+   "compress_mbps": 28.51,
+   "decompress_mbps": 101.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5949908,
+   "ratio": 0.2754,
+   "compress_mbps": 25.19,
+   "decompress_mbps": 103.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5936656,
+   "ratio": 0.2748,
+   "compress_mbps": 19.22,
+   "decompress_mbps": 106.46
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5934701,
+   "ratio": 0.2747,
+   "compress_mbps": 17.98,
+   "decompress_mbps": 105.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 6335542,
+   "ratio": 0.8736,
+   "compress_mbps": 18.44,
+   "decompress_mbps": 31.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 6247260,
+   "ratio": 0.8615,
+   "compress_mbps": 17.59,
+   "decompress_mbps": 48.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 6064713,
+   "ratio": 0.8363,
+   "compress_mbps": 15.15,
+   "decompress_mbps": 56.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5568111,
+   "ratio": 0.7678,
+   "compress_mbps": 17.55,
+   "decompress_mbps": 58.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5544524,
+   "ratio": 0.7646,
+   "compress_mbps": 14.42,
+   "decompress_mbps": 64.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5513056,
+   "ratio": 0.7602,
+   "compress_mbps": 11.94,
+   "decompress_mbps": 62.87
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5508915,
+   "ratio": 0.7596,
+   "compress_mbps": 11.32,
+   "decompress_mbps": 64.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5508365,
+   "ratio": 0.7596,
+   "compress_mbps": 10.52,
+   "decompress_mbps": 65.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5508365,
+   "ratio": 0.7596,
+   "compress_mbps": 10.57,
+   "decompress_mbps": 64.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 16776095,
+   "ratio": 0.4046,
+   "compress_mbps": 37.73,
+   "decompress_mbps": 50.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 16032651,
+   "ratio": 0.3867,
+   "compress_mbps": 36.24,
+   "decompress_mbps": 54.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 15180334,
+   "ratio": 0.3662,
+   "compress_mbps": 31.28,
+   "decompress_mbps": 51.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 13261924,
+   "ratio": 0.3199,
+   "compress_mbps": 35.24,
+   "decompress_mbps": 68.67
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12706028,
+   "ratio": 0.3065,
+   "compress_mbps": 27.63,
+   "decompress_mbps": 70.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12464158,
+   "ratio": 0.3006,
+   "compress_mbps": 21.0,
+   "decompress_mbps": 70.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12375954,
+   "ratio": 0.2985,
+   "compress_mbps": 18.31,
+   "decompress_mbps": 73.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12321552,
+   "ratio": 0.2972,
+   "compress_mbps": 14.45,
+   "decompress_mbps": 70.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12320276,
+   "ratio": 0.2972,
+   "compress_mbps": 14.41,
+   "decompress_mbps": 70.34
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6799201,
+   "ratio": 0.8023,
+   "compress_mbps": 18.34,
+   "decompress_mbps": 18.29
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6800500,
+   "ratio": 0.8025,
+   "compress_mbps": 16.95,
+   "decompress_mbps": 18.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6803212,
+   "ratio": 0.8028,
+   "compress_mbps": 14.91,
+   "decompress_mbps": 18.44
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6264611,
+   "ratio": 0.7393,
+   "compress_mbps": 17.32,
+   "decompress_mbps": 24.91
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6217901,
+   "ratio": 0.7337,
+   "compress_mbps": 15.76,
+   "decompress_mbps": 25.36
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6201999,
+   "ratio": 0.7319,
+   "compress_mbps": 15.32,
+   "decompress_mbps": 25.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6201883,
+   "ratio": 0.7319,
+   "compress_mbps": 15.24,
+   "decompress_mbps": 25.06
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6201887,
+   "ratio": 0.7319,
+   "compress_mbps": 15.22,
+   "decompress_mbps": 24.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6201887,
+   "ratio": 0.7319,
+   "compress_mbps": 15.3,
+   "decompress_mbps": 24.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 1081679,
+   "ratio": 0.2024,
+   "compress_mbps": 74.26,
+   "decompress_mbps": 106.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 1001890,
+   "ratio": 0.1874,
+   "compress_mbps": 74.05,
+   "decompress_mbps": 118.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 921722,
+   "ratio": 0.1724,
+   "compress_mbps": 67.22,
+   "decompress_mbps": 127.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 849263,
+   "ratio": 0.1589,
+   "compress_mbps": 64.23,
+   "decompress_mbps": 142.53
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 771964,
+   "ratio": 0.1444,
+   "compress_mbps": 54.81,
+   "decompress_mbps": 144.22
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 728098,
+   "ratio": 0.1362,
+   "compress_mbps": 43.49,
+   "decompress_mbps": 150.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 713635,
+   "ratio": 0.1335,
+   "compress_mbps": 37.23,
+   "decompress_mbps": 154.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 699093,
+   "ratio": 0.1308,
+   "compress_mbps": 27.08,
+   "decompress_mbps": 146.56
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 698459,
+   "ratio": 0.1307,
+   "compress_mbps": 25.17,
+   "decompress_mbps": 148.81
+  }
+ ]
 }


### PR DESCRIPTION
This PR adds a `goodMatch` threshold to the lazy (deflate_slow) LZ77 matcher so the second `pos+1` chain walk is skipped once the first match is at least `goodMatch` bytes long. A long first match is rarely improved by deferring, so the lookahead is wasted work there. Per-level policy: L4-L6 use `goodMatch = 8`, L7+ use `259` (off). The mid levels gain speed; the high-ratio tier (L7-L8, and L9 which runs the optimal-parse DP) is preserved byte-identical. `goodMatch = 259` (> the 258-byte max match) restores the ungated matcher exactly, so the gate nests inside the existing lookahead branch and leaves the near-end-of-buffer path untouched.

Unlike the match prefilter, this is a ratio spend rather than byte-identical: skipping a deferral changes which valid matches are emitted. It is proven valid DEFLATE instead of iso-output. The gate is threaded through all three lazy matchers (`lz77ChainLazy`, `lz77ChainLazyIter`, `lz77ChainLazyIterP`) in lockstep so the equality pipeline stays structural (one extra `split`), and `lz77ChainLazy_mainLoop_valid`/`_encodable` extend with a single branch: the gated emission is a `chainWalk_spec`-verified match exactly like the existing emit-M cases. 0 sorries, full test suite green.

Measured on 2 MB Silesia slices versus gate-off: text +8-10% compress speed at +0.03% output size (free), binary +2-3% (free), repetitive +20-40% at +2.5% size. The win is free on the dominant text/binary content; the ratio cost lands on repetitive data, where native already trails the fast pack, so it surrenders no ratio lead it holds (native's ratio advantage lives at L9). L7-L8 stay byte-identical.

Stacked on #2618 (match prefilter); review/merge that first.

🤖 Prepared with Claude Code