### PR TITLE
perf: 4-byte hash for the LZ77 chain matcher (W8)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -401,7 +401,9 @@ where
     let a := (data[pos]'(by omega)).toUInt32
     let b := (data[pos + 1]'(by omega)).toUInt32
     let c := (data[pos + 2]'(by omega)).toUInt32
-    ((a ^^^ (b <<< 5) ^^^ (c <<< 10)).toNat % hashSize)
+    let d := if h3 : pos + 3 < data.size then (data[pos + 3]'h3).toUInt32 else 0
+    let word := a ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24)
+    (((word * 2654435761) >>> 16).toNat % hashSize)
   countMatch (data : ByteArray) (p1 p2 maxLen : Nat)
       (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) : Nat :=
     -- P1a: when the buffer is `USize`-addressable (always true at runtime; the
@@ -530,7 +532,9 @@ where
     let a := (data[pos]'(by omega)).toUInt32
     let b := (data[pos + 1]'(by omega)).toUInt32
     let c := (data[pos + 2]'(by omega)).toUInt32
-    ((a ^^^ (b <<< 5) ^^^ (c <<< 10)).toNat % hashSize)
+    let d := if h3 : pos + 3 < data.size then (data[pos + 3]'h3).toUInt32 else 0
+    let word := a ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24)
+    (((word * 2654435761) >>> 16).toNat % hashSize)
   countMatch (data : ByteArray) (p1 p2 maxLen : Nat)
       (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) : Nat :=
     go data p1 p2 0 maxLen h1 h2
@@ -1392,7 +1396,9 @@ where
     let a := (data[pos]'(by omega)).toUInt32
     let b := (data[pos + 1]'(by omega)).toUInt32
     let c := (data[pos + 2]'(by omega)).toUInt32
-    ((a ^^^ (b <<< 5) ^^^ (c <<< 10)).toNat % hashSize)
+    let d := if h3 : pos + 3 < data.size then (data[pos + 3]'h3).toUInt32 else 0
+    let word := a ||| (b <<< 8) ||| (c <<< 16) ||| (d <<< 24)
+    (((word * 2654435761) >>> 16).toNat % hashSize)
   countMatch (data : ByteArray) (p1 p2 maxLen : Nat)
       (h1 : p1 + maxLen ≤ data.size) (h2 : p2 + maxLen ≤ data.size) : Nat :=
     go data p1 p2 0 maxLen h1 h2

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p32f15071d6)">
+   <g clip-path="url(#p4b69dadfe4)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEElEQVR4nO3YsY6cVx2HYc/u2gRrZQUkYrBQChRR0SIqbiAtN0LNZXAHSEipUlO4pOAWEBIUkWwstNibZT1ebybz0dEneo/+ZPQ8V/AbnU9H75zd8cvPtgd8t9zdTi9Y5+5mesES21f30xOW2T35aHrCGt97PL1gnd3Z9II17vfTC9Y50TPb3rycnrDMaZ4YAMAggQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAELv4Yvd6esMS77/eT09Y5icf/mx6wjKX24+nJyyx219PT1jmz/u/Tk9Y4qePPpqesMzheD89YYmbw+ne+4ftOD1hiV89+Xh6wjJesAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2u3n/+TY9YoV3h9vpCcv86Ph4esI6h/vpBWvcXk0vWOfpz6cXLHG77acnLPP2cDM9YYmn25PpCcu8fPB6esISz66upycs4wULACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYheXb66mNyxxefFoesI6d6+mFyyz3X45PWGN43F6wTK7x/+anrDE5cMPpicsc3n+4fSENR6d7pk9e3c/PWGJbf/P6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIhdbFevpjfwTR2P0wvgf7YX/5iesMaZ/5/fOe5G/o+4QQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACB28durL6Y3LHF99/X0hGX+8uJmesIyf/rNr6cnLPH0+x9PT1jmF3/44/SEJT795IfTE5b527/fTU9Y4vyEnwyeP//79IQl3v7+d9MTljnhzxEAYIbAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI7Q7H59v0iBW27Tg9gW/h/G4/PWGN84vpBeu8fT29YInjD55NT1jmVO/H8xN+M/hqO0xPWOLh4TR/14MHXrAAAHICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdnF2/Wp6A9/U/np6wTLb/j/TE9Y4HKYXLLP75JfTE5Y4e/NyesI6ZxfTC9Y4O903g4fv99MTltiuXkxPWOZ0v0YAgCECCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAg9l+Lhor1UAga2AAAAABJRU5ErkJggg==" id="image1462b9d9f9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3Yz4rkZxmG4aqemiEMzaBC/jiIiKC4cO8ix+DGA/EIPIscgSC4ciuiS3cegiQigpMQm2kz6fSUPTX1c+c+cH+8priuI3iKor+6+92fv/jttuOb5Xg3vWCd46vpBUtsbx6mJyyzf/be9IQ1Hr8zvWCdq6vpBWu8OU4vWGd/md/ZdvtiesIyl/mNAQAMElgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHD33c30xuWeHM+Tk9Y5rvf+uH0hGWutw+mJyyx/+rl9IRl/vz6r9MTlvjek/emJyxzOj9MT1ji7u3lvvsP59P0hCV+9uz70xOWccECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7Vf363TY9Y4fXpbnrCMu+en05PWOf0ML1gjbub6QXrvP/j6QVL3G330xOWudT38d3tenrCMi92L6cnLPH85t/TE5ZxwQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY4fr2ZnrDEteHJ9MT1jl+Nr1gme3ui+kJa5zP0wuW2T/9fHrCEpf8hlwfnk1PWOPJO9MLlnn++mF6whLb/afTE5ZxwQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiB22m8+mN/B1nc/TC+B/tn/+bXrCGlf+//zG8Tbyf8QLAgAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHDL//1j+kNS9we305PWOYvL15NT1jm97/4cHrCEh88/cH0hGV++uvfTE9Y4uc/+s70hGU+uT1OT+Br+sMfP56esMT9R7+anrCMCxYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE9qfzn7bpESu8PZ+mJyxztb/cLn50vJ+esMajw/SCdb56Ob1gifO3n09PWGbbztMTlnh0wTeDN9tl/qY9Pl3m59rtXLAAAHICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdrg6naY3LHH16DA9YZ3PP55esMz25e30hDUu9O9st9vt9j/5cHrCElenh+kJ61zq+3i8m16wzOOH++kJS2yffjI9YRkXLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIj9FxIzjP9A0U/LAAAAAElFTkSuQmCC" id="image0b4041b398" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m44cd03d600" d="M 0 0 
+       <path id="m3736ae2aff" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m44cd03d600" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m44cd03d600" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m44cd03d600" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m44cd03d600" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m44cd03d600" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m44cd03d600" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m44cd03d600" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m44cd03d600" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m44cd03d600" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m44cd03d600" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m44cd03d600" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3736ae2aff" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m1e6952e8d7" d="M 0 0 
+       <path id="maccf141ffd" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1e6952e8d7" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maccf141ffd" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m1e6952e8d7" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maccf141ffd" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1e6952e8d7" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maccf141ffd" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m1e6952e8d7" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maccf141ffd" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1e6952e8d7" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maccf141ffd" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m1e6952e8d7" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maccf141ffd" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1e6952e8d7" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maccf141ffd" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m1e6952e8d7" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maccf141ffd" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,44 +1303,22 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -41 -->
+    <!-- -11 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- -40 -->
-    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
+    <!-- -5 -->
+    <g transform="translate(151.312096 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -68 -->
+    <!-- -61 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
@@ -1373,6 +1351,16 @@ Q 2619 4750 2861 4703
 Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -87 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1412,46 +1400,84 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -88 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -9 -->
+    <!-- -2 -->
     <g transform="translate(308.31529 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -46 -->
+    <!-- -10 -->
     <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- -38 -->
-    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
+    <!-- -4 -->
+    <g transform="translate(386.816887 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -22 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -39 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1488,23 +1514,7 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -35 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -52 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1516,7 +1526,7 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- +3 -->
+    <!-- +4 -->
     <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1536,14 +1546,15 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- +9 -->
-    <g transform="translate(149.761237 104.25537) scale(0.065 -0.065)">
+    <!-- +10 -->
+    <g transform="translate(147.693424 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1562,11 +1573,11 @@ z
     </g>
    </g>
    <g id="text_35">
-    <!-- -16 -->
+    <!-- -17 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_36">
@@ -1578,17 +1589,17 @@ z
     </g>
    </g>
    <g id="text_37">
-    <!-- +5 -->
+    <!-- +6 -->
     <g transform="translate(346.015229 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- +8 -->
+    <!-- +9 -->
     <g transform="translate(385.266027 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_39">
@@ -1599,49 +1610,37 @@ z
     </g>
    </g>
    <g id="text_40">
-    <!-- +11 -->
+    <!-- +12 -->
     <g transform="translate(461.699812 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- -16 -->
+    <!-- -17 -->
     <g transform="translate(502.50147 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_42">
-    <!-- +227 -->
+    <!-- +229 -->
     <g transform="translate(106.374813 139.606222) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_43">
-    <!-- +245 -->
+    <!-- +249 -->
     <g transform="translate(145.625612 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_44">
@@ -1654,11 +1653,11 @@ z
     </g>
    </g>
    <g id="text_45">
-    <!-- +73 -->
+    <!-- +74 -->
     <g transform="translate(226.195021 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_46">
@@ -1679,47 +1678,47 @@ z
     </g>
    </g>
    <g id="text_48">
-    <!-- +233 -->
+    <!-- +230 -->
     <g transform="translate(341.879604 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +271 -->
+    <!-- +267 -->
     <g transform="translate(381.130402 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +268 -->
+    <!-- +267 -->
     <g transform="translate(420.381201 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +393 -->
+    <!-- +394 -->
     <g transform="translate(459.631999 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
-    <!-- +20 -->
+    <!-- +18 -->
     <g transform="translate(500.95061 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_53">
@@ -1825,11 +1824,11 @@ z
     </g>
    </g>
    <g id="text_65">
-    <!-- -49 -->
+    <!-- -48 -->
     <g transform="translate(149.244284 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_66">
@@ -1881,11 +1880,11 @@ z
     </g>
    </g>
    <g id="text_72">
-    <!-- -10 -->
+    <!-- -11 -->
     <g transform="translate(423.999873 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_73">
@@ -1905,19 +1904,19 @@ z
     </g>
    </g>
    <g id="text_75">
-    <!-- +25 -->
+    <!-- +26 -->
     <g transform="translate(108.442626 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_76">
-    <!-- +44 -->
+    <!-- +45 -->
     <g transform="translate(147.693424 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_77">
@@ -1953,11 +1952,11 @@ z
     </g>
    </g>
    <g id="text_81">
-    <!-- +26 -->
+    <!-- +25 -->
     <g transform="translate(343.947416 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_82">
@@ -1969,11 +1968,11 @@ z
     </g>
    </g>
    <g id="text_83">
-    <!-- -26 -->
+    <!-- -27 -->
     <g transform="translate(423.999873 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_84">
@@ -1993,19 +1992,19 @@ z
     </g>
    </g>
    <g id="text_86">
-    <!-- +64 -->
+    <!-- +65 -->
     <g transform="translate(108.442626 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_87">
-    <!-- +78 -->
+    <!-- +79 -->
     <g transform="translate(147.693424 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_88">
@@ -2042,27 +2041,27 @@ z
     </g>
    </g>
    <g id="text_92">
-    <!-- +69 -->
+    <!-- +68 -->
     <g transform="translate(343.947416 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_93">
-    <!-- +78 -->
-    <g transform="translate(383.198215 281.009626) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_93">
+    <!-- +77 -->
+    <g transform="translate(383.198215 281.009626) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_94">
-    <!-- +99 -->
+    <!-- +97 -->
     <g transform="translate(422.449013 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
@@ -2075,19 +2074,19 @@ z
     </g>
    </g>
    <g id="text_96">
-    <!-- -51 -->
+    <!-- -52 -->
     <g transform="translate(502.50147 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_97">
-    <!-- -37 -->
+    <!-- -36 -->
     <g transform="translate(109.993485 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_98">
@@ -2147,11 +2146,11 @@ z
     </g>
    </g>
    <g id="text_105">
-    <!-- -46 -->
+    <!-- -47 -->
     <g transform="translate(423.999873 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_106">
@@ -2163,11 +2162,11 @@ z
     </g>
    </g>
    <g id="text_107">
-    <!-- -85 -->
+    <!-- -86 -->
     <g transform="translate(502.50147 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2181,23 +2180,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageb8f4930334" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imagec8a3b8a0ef" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mb40d318cf5" d="M 0 0 
+       <path id="m85572f4037" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb40d318cf5" x="547.779688" y="277.020043" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85572f4037" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
       <!-- −3 -->
-      <g transform="translate(554.779688 280.819262) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 280.800792) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2215,12 +2214,12 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mb40d318cf5" x="547.779688" y="248.292997" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85572f4037" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
       <!-- −2 -->
-      <g transform="translate(554.779688 252.092216) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 252.079903) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2229,12 +2228,12 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb40d318cf5" x="547.779688" y="219.565951" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85572f4037" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
       <!-- −1 -->
-      <g transform="translate(554.779688 223.36517) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 223.359013) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2243,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mb40d318cf5" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85572f4037" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2256,12 +2255,12 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb40d318cf5" x="547.779688" y="162.111858" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85572f4037" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
       <!-- 1 -->
-      <g transform="translate(554.779688 165.911077) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 165.917234) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2269,12 +2268,12 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mb40d318cf5" x="547.779688" y="133.384812" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85572f4037" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
       <!-- 2 -->
-      <g transform="translate(554.779688 137.184031) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 137.196344) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2282,12 +2281,12 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb40d318cf5" x="547.779688" y="104.657766" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85572f4037" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
       <!-- 3 -->
-      <g transform="translate(554.779688 108.456985) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 108.475455) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2943,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.763672 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T05:12:18Z  ·  Linux chungus x86_64  ·  commit 3c05ffff  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(22.88875 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3014,13 +3013,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3059,109 +3058,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3324.511719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3359.716797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3394.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3426.708984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3458.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3490.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3522.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3553.857422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3581.640625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3643.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3704.443359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3767.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3831.298828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3870.162109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3931.34375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3990.523438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4052.046875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4093.160156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4126.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4154.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4216.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4277.4375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4340.816406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4404.439453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4438.130859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4497.310547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4560.933594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4592.720703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4656.34375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4719.966797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4751.753906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4815.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4851.460938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4890.324219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4945.304688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5008.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5040.714844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5072.501953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5104.289062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5136.076172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5167.863281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5207.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5270.451172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5309.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5370.496094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5433.875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5497.351562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5560.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5624.207031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5726.794922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5758.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5874.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5971.570312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6033.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6096.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6185.632812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6249.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6280.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6332.898438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6457.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6521.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6573.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6697.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6736.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6770.59375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6802.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6843.494141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6904.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6943.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6971.765625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7032.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7064.734375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7092.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.617188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7176.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7239.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7301.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7340.613281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7402.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7441.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7538.912109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7566.695312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.074219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7657.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7709.957031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7749.166016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7776.949219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p32f15071d6">
+  <clipPath id="p4b69dadfe4">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m94b0f14fe0" d="M 0 0 
+       <path id="m775d47c08f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m94b0f14fe0" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m775d47c08f" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m94b0f14fe0" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m775d47c08f" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m94b0f14fe0" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m775d47c08f" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m94b0f14fe0" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m775d47c08f" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m94b0f14fe0" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m775d47c08f" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m94b0f14fe0" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m775d47c08f" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m94b0f14fe0" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m775d47c08f" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -852,23 +852,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 347.783657 
-L 637.2 347.783657 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 347.796763 
+L 637.2 347.796763 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m7adcc23853" d="M 0 0 
+       <path id="m7b467d7cfb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7adcc23853" x="49.078125" y="347.783657" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b467d7cfb" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 351.582876) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 351.595982) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -893,18 +893,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 238.637426 
-L 637.2 238.637426 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 238.680056 
+L 637.2 238.680056 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m7adcc23853" x="49.078125" y="238.637426" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b467d7cfb" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 242.436645) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 242.479274) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -913,18 +913,18 @@ L 637.2 238.637426
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 129.491195 
-L 637.2 129.491195 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 129.563348 
+L 637.2 129.563348 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7adcc23853" x="49.078125" y="129.491195" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7b467d7cfb" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 133.290413) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 133.362567) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -933,330 +933,330 @@ L 637.2 129.491195
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 404.853901 
-L 637.2 404.853901 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 404.851571 
+L 637.2 404.851571 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="md6ec43c425" d="M 0 0 
+       <path id="m44a0056db5" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="404.853901" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 391.217309 
-L 637.2 391.217309 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.218667 
+L 637.2 391.218667 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="391.217309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 380.639947 
-L 637.2 380.639947 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.644165 
+L 637.2 380.644165 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="380.639947" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 371.997612 
-L 637.2 371.997612 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 372.004168 
+L 637.2 372.004168 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="371.997612" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 364.690622 
-L 637.2 364.690622 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 364.699155 
+L 637.2 364.699155 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="364.690622" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 358.36102 
-L 637.2 358.36102 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 358.371265 
+L 637.2 358.371265 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="358.36102" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 352.777915 
-L 637.2 352.777915 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 352.78967 
+L 637.2 352.78967 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="352.777915" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 314.927368 
-L 637.2 314.927368 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 314.949361 
+L 637.2 314.949361 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="314.927368" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 295.70767 
-L 637.2 295.70767 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 295.734863 
+L 637.2 295.734863 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="295.70767" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 282.071078 
-L 637.2 282.071078 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 282.101959 
+L 637.2 282.101959 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="282.071078" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 271.493715 
-L 637.2 271.493715 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.527458 
+L 637.2 271.527458 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="271.493715" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 262.851381 
-L 637.2 262.851381 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.887461 
+L 637.2 262.887461 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="262.851381" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 255.544391 
-L 637.2 255.544391 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.582447 
+L 637.2 255.582447 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="255.544391" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 249.214789 
-L 637.2 249.214789 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.254557 
+L 637.2 249.254557 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="249.214789" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 243.631683 
-L 637.2 243.631683 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.672962 
+L 637.2 243.672962 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="243.631683" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 205.781136 
-L 637.2 205.781136 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.832653 
+L 637.2 205.832653 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="205.781136" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 186.561439 
-L 637.2 186.561439 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 186.618155 
+L 637.2 186.618155 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="186.561439" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 172.924847 
-L 637.2 172.924847 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 172.985251 
+L 637.2 172.985251 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="172.924847" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 162.347484 
-L 637.2 162.347484 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 162.41075 
+L 637.2 162.41075 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="162.347484" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 153.70515 
-L 637.2 153.70515 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 153.770753 
+L 637.2 153.770753 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="153.70515" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 146.39816 
-L 637.2 146.39816 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.46574 
+L 637.2 146.46574 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="146.39816" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 140.068557 
-L 637.2 140.068557 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 140.137849 
+L 637.2 140.137849 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="140.068557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 134.485452 
-L 637.2 134.485452 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 134.556255 
+L 637.2 134.556255 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="134.485452" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 49.078125 96.634905 
-L 637.2 96.634905 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 96.715946 
+L 637.2 96.715946 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="96.634905" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 49.078125 77.415208 
-L 637.2 77.415208 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 77.501447 
+L 637.2 77.501447 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="77.415208" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 49.078125 63.778616 
-L 637.2 63.778616 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 63.868544 
+L 637.2 63.868544 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="63.778616" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 49.078125 53.201253 
-L 637.2 53.201253 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 53.294042 
+L 637.2 53.294042 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#md6ec43c425" x="49.078125" y="53.201253" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44a0056db5" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(271.439833 185.056733) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 181.385749) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 343.911412) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(106.798311 333.680572) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1739,124 +1739,124 @@ z
     </g>
    </g>
    <g id="line2d_75">
-    <path d="M 355.479835 95.427628 
-L 308.273931 102.74725 
-L 271.230161 116.393477 
-L 217.83458 119.920971 
-L 177.077692 138.382232 
-L 162.880539 157.725182 
-L 160.741445 165.158146 
-L 153.966678 183.397753 
-L 151.589614 194.498928 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 355.479835 95.25942 
+L 308.273931 102.64095 
+L 271.230161 116.240058 
+L 217.83458 119.978674 
+L 177.077692 138.359262 
+L 162.880539 157.659557 
+L 160.741445 165.081439 
+L 153.966678 183.30847 
+L 151.589614 194.354473 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2a7a5b2555" d="M -2.5 2.5 
+     <path id="m106a41e0e8" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7e314c3807)">
-     <use xlink:href="#m2a7a5b2555" x="355.479835" y="95.427628" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2a7a5b2555" x="308.273931" y="102.74725" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2a7a5b2555" x="271.230161" y="116.393477" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2a7a5b2555" x="217.83458" y="119.920971" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2a7a5b2555" x="177.077692" y="138.382232" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2a7a5b2555" x="162.880539" y="157.725182" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2a7a5b2555" x="160.741445" y="165.158146" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2a7a5b2555" x="153.966678" y="183.397753" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2a7a5b2555" x="151.589614" y="194.498928" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p11ac66e169)">
+     <use xlink:href="#m106a41e0e8" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106a41e0e8" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106a41e0e8" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106a41e0e8" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106a41e0e8" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106a41e0e8" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106a41e0e8" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106a41e0e8" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m106a41e0e8" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
-    <path d="M 531.649087 76.276797 
-L 283.721324 99.171114 
-L 218.882044 120.99437 
-L 187.447228 127.133273 
-L 176.342474 138.440747 
-L 163.054314 161.369521 
-L 162.210539 168.860456 
-L 159.303811 175.80223 
-L 157.793928 179.622924 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 531.649087 75.906758 
+L 283.721324 98.757435 
+L 218.882044 120.902897 
+L 187.447228 126.710903 
+L 176.342474 138.212475 
+L 163.054314 161.207386 
+L 162.210539 168.678909 
+L 159.303811 175.634901 
+L 157.793928 179.408171 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7faf17c897" d="M 0 -2.5 
+     <path id="m1b8793c9ea" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7e314c3807)">
-     <use xlink:href="#m7faf17c897" x="531.649087" y="76.276797" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7faf17c897" x="283.721324" y="99.171114" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7faf17c897" x="218.882044" y="120.99437" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7faf17c897" x="187.447228" y="127.133273" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7faf17c897" x="176.342474" y="138.440747" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7faf17c897" x="163.054314" y="161.369521" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7faf17c897" x="162.210539" y="168.860456" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7faf17c897" x="159.303811" y="175.80223" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7faf17c897" x="157.793928" y="179.622924" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p11ac66e169)">
+     <use xlink:href="#m1b8793c9ea" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1b8793c9ea" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1b8793c9ea" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1b8793c9ea" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1b8793c9ea" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1b8793c9ea" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1b8793c9ea" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1b8793c9ea" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1b8793c9ea" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
     <path d="M 251.559581 64.890426 
-L 203.775848 81.783807 
-L 186.982691 88.406737 
-L 179.779306 91.089504 
-L 157.610419 99.330616 
-L 148.722526 107.797685 
-L 144.388162 121.168591 
-L 127.071247 144.590753 
-L 124.491988 152.069294 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 203.775848 81.892474 
+L 186.982691 88.798621 
+L 179.779306 91.094902 
+L 157.610419 99.337194 
+L 148.722526 107.793132 
+L 144.388162 121.197738 
+L 127.071247 144.456083 
+L 124.491988 152.059912 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m41d36ca341" d="M -0 3.535534 
+     <path id="m8aca75149e" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7e314c3807)">
-     <use xlink:href="#m41d36ca341" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m41d36ca341" x="203.775848" y="81.783807" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m41d36ca341" x="186.982691" y="88.406737" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m41d36ca341" x="179.779306" y="91.089504" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m41d36ca341" x="157.610419" y="99.330616" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m41d36ca341" x="148.722526" y="107.797685" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m41d36ca341" x="144.388162" y="121.168591" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m41d36ca341" x="127.071247" y="144.590753" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m41d36ca341" x="124.491988" y="152.069294" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p11ac66e169)">
+     <use xlink:href="#m8aca75149e" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8aca75149e" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8aca75149e" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8aca75149e" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8aca75149e" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8aca75149e" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8aca75149e" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8aca75149e" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8aca75149e" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mac3b85aca3" d="M -0 2.5 
+     <path id="m2b9a4867d2" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7e314c3807)">
-     <use xlink:href="#mac3b85aca3" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p11ac66e169)">
+     <use xlink:href="#m2b9a4867d2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
-    <path d="M 362.865999 178.098648 
-L 278.798176 181.007352 
-L 251.17632 188.624476 
-L 200.806828 186.265365 
-L 169.803221 202.705412 
-L 161.916638 211.108915 
-L 158.697104 213.992296 
-L 154.26679 230.319702 
-L 153.096464 236.294519 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 362.865999 178.157653 
+L 278.798176 181.06557 
+L 251.17632 188.680634 
+L 200.806828 186.322161 
+L 169.803221 202.757761 
+L 161.916638 211.158991 
+L 158.697104 214.041592 
+L 154.26679 230.364582 
+L 153.096464 236.337782 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf9019b91fc" d="M -0.833333 2.5 
+     <path id="md23089d9d9" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,31 +1871,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7e314c3807)">
-     <use xlink:href="#mf9019b91fc" x="362.865999" y="178.098648" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9019b91fc" x="278.798176" y="181.007352" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9019b91fc" x="251.17632" y="188.624476" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9019b91fc" x="200.806828" y="186.265365" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9019b91fc" x="169.803221" y="202.705412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9019b91fc" x="161.916638" y="211.108915" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9019b91fc" x="158.697104" y="213.992296" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9019b91fc" x="154.26679" y="230.319702" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf9019b91fc" x="153.096464" y="236.294519" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p11ac66e169)">
+     <use xlink:href="#md23089d9d9" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md23089d9d9" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md23089d9d9" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md23089d9d9" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md23089d9d9" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md23089d9d9" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md23089d9d9" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md23089d9d9" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md23089d9d9" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
-    <path d="M 301.619021 144.582873 
-L 250.236474 147.125487 
-L 225.418659 152.733542 
-L 212.328936 158.852069 
-L 209.030149 156.756132 
-L 197.547749 167.920818 
-L 194.819287 169.42959 
-L 193.12279 176.94553 
-L 192.79794 181.795347 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 301.619021 144.650944 
+L 250.236474 147.192871 
+L 225.418659 152.799409 
+L 212.328936 158.91628 
+L 209.030149 156.82091 
+L 197.547749 167.982576 
+L 194.819287 169.49094 
+L 193.12279 177.004847 
+L 192.79794 181.853352 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf2da31bec6" d="M -1.25 2.5 
+     <path id="m18b4f12f53" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,31 +1910,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7e314c3807)">
-     <use xlink:href="#mf2da31bec6" x="301.619021" y="144.582873" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2da31bec6" x="250.236474" y="147.125487" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2da31bec6" x="225.418659" y="152.733542" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2da31bec6" x="212.328936" y="158.852069" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2da31bec6" x="209.030149" y="156.756132" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2da31bec6" x="197.547749" y="167.920818" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2da31bec6" x="194.819287" y="169.42959" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2da31bec6" x="193.12279" y="176.94553" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2da31bec6" x="192.79794" y="181.795347" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p11ac66e169)">
+     <use xlink:href="#m18b4f12f53" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18b4f12f53" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18b4f12f53" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18b4f12f53" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18b4f12f53" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18b4f12f53" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18b4f12f53" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18b4f12f53" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18b4f12f53" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
-    <path d="M 206.45578 118.189494 
-L 206.45578 117.867861 
-L 206.45578 117.948133 
-L 206.45578 117.933386 
-L 171.767499 133.43666 
-L 163.54283 144.328176 
-L 160.174881 150.229314 
-L 154.179217 168.534313 
-L 152.4406 178.265247 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.264704 
+L 206.45578 117.943158 
+L 206.45578 118.023409 
+L 206.45578 118.008666 
+L 171.767499 133.507746 
+L 163.54283 144.396316 
+L 160.174881 150.295858 
+L 154.179217 168.595905 
+L 152.4406 178.324207 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb77c71c18f" d="M 0 -2.5 
+     <path id="mef854ce8c7" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,31 +1947,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p7e314c3807)">
-     <use xlink:href="#mb77c71c18f" x="206.45578" y="118.189494" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb77c71c18f" x="206.45578" y="117.867861" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb77c71c18f" x="206.45578" y="117.948133" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb77c71c18f" x="206.45578" y="117.933386" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb77c71c18f" x="171.767499" y="133.43666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb77c71c18f" x="163.54283" y="144.328176" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb77c71c18f" x="160.174881" y="150.229314" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb77c71c18f" x="154.179217" y="168.534313" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb77c71c18f" x="152.4406" y="178.265247" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p11ac66e169)">
+     <use xlink:href="#mef854ce8c7" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mef854ce8c7" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mef854ce8c7" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mef854ce8c7" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mef854ce8c7" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mef854ce8c7" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mef854ce8c7" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mef854ce8c7" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mef854ce8c7" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
-    <path d="M 610.467188 173.53492 
-L 592.067397 174.968145 
-L 534.807821 181.332245 
-L 327.802209 176.643864 
-L 275.83761 186.987233 
-L 258.25125 199.103527 
-L 256.777056 204.055585 
-L 248.769854 218.20246 
-L 246.264594 227.956461 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467188 173.595159 
+L 592.067397 175.027997 
+L 534.807821 181.390376 
+L 327.802209 176.703263 
+L 275.83761 187.043834 
+L 258.25125 199.15685 
+L 256.777056 204.107569 
+L 248.769854 218.250617 
+L 246.264594 228.00198 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc8af8d89ef" d="M 0 -2.5 
+     <path id="mfeb925fdb7" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7e314c3807)">
-     <use xlink:href="#mc8af8d89ef" x="610.467188" y="173.53492" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8af8d89ef" x="592.067397" y="174.968145" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8af8d89ef" x="534.807821" y="181.332245" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8af8d89ef" x="327.802209" y="176.643864" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8af8d89ef" x="275.83761" y="186.987233" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8af8d89ef" x="258.25125" y="199.103527" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8af8d89ef" x="256.777056" y="204.055585" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8af8d89ef" x="248.769854" y="218.20246" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc8af8d89ef" x="246.264594" y="227.956461" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p11ac66e169)">
+     <use xlink:href="#mfeb925fdb7" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfeb925fdb7" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfeb925fdb7" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfeb925fdb7" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfeb925fdb7" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfeb925fdb7" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfeb925fdb7" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfeb925fdb7" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfeb925fdb7" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="mac3c49926e" d="M 0 3.5 
+      <path id="m547d96cb43" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mac3c49926e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m547d96cb43" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2a7a5b2555" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m106a41e0e8" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7faf17c897" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1b8793c9ea" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m41d36ca341" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8aca75149e" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mac3b85aca3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2b9a4867d2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf9019b91fc" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md23089d9d9" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf2da31bec6" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m18b4f12f53" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb77c71c18f" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mef854ce8c7" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc8af8d89ef" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfeb925fdb7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 266.439833 190.056733 
-L 243.627793 193.366201 
-L 229.515893 196.783234 
-L 202.113895 205.249239 
-L 199.119619 207.210552 
-L 194.929393 211.166016 
-L 162.683902 258.092244 
-L 160.786938 260.752071 
-L 98.348822 348.911412 
-" clip-path="url(#p7e314c3807)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p7e314c3807)">
-     <use xlink:href="#mac3c49926e" x="266.439833" y="190.056733" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mac3c49926e" x="243.627793" y="193.366201" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mac3c49926e" x="229.515893" y="196.783234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mac3c49926e" x="202.113895" y="205.249239" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mac3c49926e" x="199.119619" y="207.210552" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mac3c49926e" x="194.929393" y="211.166016" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mac3c49926e" x="162.683902" y="258.092244" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mac3c49926e" x="160.786938" y="260.752071" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mac3c49926e" x="98.348822" y="348.911412" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 186.385749 
+L 214.084819 188.806016 
+L 206.266533 191.119295 
+L 187.75787 196.645158 
+L 186.58897 197.537684 
+L 184.505355 199.588975 
+L 152.30308 250.61665 
+L 150.950891 252.505576 
+L 101.798311 338.680572 
+" clip-path="url(#p11ac66e169)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p11ac66e169)">
+     <use xlink:href="#m547d96cb43" x="226.647908" y="186.385749" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m547d96cb43" x="214.084819" y="188.806016" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m547d96cb43" x="206.266533" y="191.119295" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m547d96cb43" x="187.75787" y="196.645158" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m547d96cb43" x="186.58897" y="197.537684" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m547d96cb43" x="184.505355" y="199.588975" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m547d96cb43" x="152.30308" y="250.61665" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m547d96cb43" x="150.950891" y="252.505576" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m547d96cb43" x="101.798311" y="338.680572" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.763672 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-16T05:12:18Z  ·  Linux chungus x86_64  ·  commit 3c05ffff  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(49.88875 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2903,6 +2903,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2975,31 +3000,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3041,13 +3041,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3086,109 +3086,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3324.511719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3359.716797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3394.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3426.708984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3458.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3490.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3522.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3553.857422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3581.640625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3643.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3704.443359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3767.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3831.298828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3870.162109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3931.34375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3990.523438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4052.046875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4093.160156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4126.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4154.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4216.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4277.4375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4340.816406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4404.439453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4438.130859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4497.310547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4560.933594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4592.720703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4656.34375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4719.966797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4751.753906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4815.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4851.460938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4890.324219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4945.304688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5008.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5040.714844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5072.501953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5104.289062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5136.076172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5167.863281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5207.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5270.451172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5309.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5370.496094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5433.875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5497.351562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5560.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5624.207031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5726.794922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5758.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5874.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5971.570312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6033.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6096.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6185.632812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6249.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6280.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6332.898438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6457.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6521.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6573.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6697.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6736.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6770.59375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6802.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6843.494141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6904.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6943.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6971.765625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7032.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7064.734375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7092.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.617188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7176.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7239.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7301.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7340.613281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7402.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7441.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7538.912109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7566.695312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.074219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7657.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7709.957031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7749.166016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7776.949219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7e314c3807">
+  <clipPath id="p11ac66e169">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pf60e885d76)">
+   <g clip-path="url(#p9e1a9bfa67)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAJAElEQVR4nO3YsaqdWR2H4b2Tc44n0QkoUYcpLAamk2GKaUwj2Hkn0wuWYi9ehnoDgojMNOJgYyN2YiODhDATx5iEc072+baXkAhL/rLf57mC31d8a72s/fbPXxx3p+b559MLljp+cVrfs9vtdp/9+NfTE5b6259fTE9Y7vu//OH0hOX2H3w4PWGt/Z3pBes9ezy9YL3LB9MLlvrVt382PWG5E/yTAADenBgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbXx9+c5wesdpxt01PWGp/gs16fudiesJSN9vV9ITlzv/yx+kJyx2++2h6wlKH7WZ6wnIvDs+mJyz38MSOh1cPHk5PWO70blkAgP+CGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASDs7f/Hl9Ib1rl9OL1jruE0vWO/eg+kFS11MD/gfOD57MT1hufN/P52esNT5dpiesNy9Uzzvrp5PL1jq/Oz0TjwvQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbH7bfHadHrHY8btMTltpO7Ht2u93u/M7F9ISlbo+H6QnL3X3+dHrCem99a3rBUq+2m+kJy31x9Y/pCcu9fX02PWGp7evvTE9YzssQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB29qcnf5jesNyd3X56wlLfvP9wesJyt9thesJSF3cvpycs99Env5+esNxPv/fe9ISlDsdtesJyP/n0r9MTlnv0zlenJyz10fuPpics52UIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftXt789To9Y7eb2anrCUvf2l9MTeI2b/WF6wnL/uv58esJy37h8e3rCUttxm56w3JfXT6YnLPf0+vH0hKXeffD+9ITlvAwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgbb9tHx+nRwD/hw430wvWO7uYXsBrXN2+nJ6w3OXd+9MTeA0vQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEg7210/n96w3u1hesFa+xNs1rOL6QVrHbfpBct98p0fTU9Y7gd///n0hLVeXU0vWO7yK1+bnrDeqd1JNy+nFyx3grcsAMCbE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn/AXlXiw4LA/k9AAAAAElFTkSuQmCC" id="image6872edb5cb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image4c9727aae2" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mb80566baca" d="M 0 0 
+       <path id="m9c54705384" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb80566baca" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mb80566baca" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mb80566baca" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb80566baca" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb80566baca" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb80566baca" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mb80566baca" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb80566baca" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mb80566baca" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb80566baca" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mb80566baca" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c54705384" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="md4c08cb802" d="M 0 0 
+       <path id="m11836f0fa2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md4c08cb802" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11836f0fa2" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#md4c08cb802" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11836f0fa2" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md4c08cb802" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11836f0fa2" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md4c08cb802" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11836f0fa2" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md4c08cb802" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11836f0fa2" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md4c08cb802" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11836f0fa2" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md4c08cb802" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11836f0fa2" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md4c08cb802" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11836f0fa2" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,7 +1303,7 @@ L 512.247548 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- +1 -->
+    <!-- +0 -->
     <g transform="translate(109.820098 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1323,21 +1323,21 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- +1 -->
+    <!-- +0 -->
     <g transform="translate(147.690216 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- +1 -->
-    <g transform="translate(185.560334 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(187.111194 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_23">
@@ -1348,53 +1348,99 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- +1 -->
-    <g transform="translate(261.30057 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(262.85143 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +19 -->
+    <!-- +17 -->
     <g transform="translate(297.102876 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +1 -->
-    <g transform="translate(337.040806 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +1 -->
-    <g transform="translate(374.910924 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- +1 -->
-    <g transform="translate(412.781042 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
     <!-- +0 -->
-    <g transform="translate(450.65116 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(337.040806 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
+   <g id="text_27">
+    <!-- -0 -->
+    <g transform="translate(376.461784 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -2 -->
+    <g transform="translate(414.331902 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +3 -->
+    <g transform="translate(450.65116 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
    <g id="text_30">
-    <!-- +1 -->
+    <!-- +0 -->
     <g transform="translate(488.521278 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_31">
@@ -1589,40 +1635,6 @@ z
    <g id="text_55">
     <!-- -3 -->
     <g transform="translate(187.111194 174.957073) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -1833,18 +1845,6 @@ z
    <g id="text_80">
     <!-- +7 -->
     <g transform="translate(299.170688 245.658775) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagecd8dbe4bbb" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image3e7c243547" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m82d512bf08" d="M 0 0 
+       <path id="m6e606e3b6a" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m82d512bf08" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e606e3b6a" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m82d512bf08" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e606e3b6a" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m82d512bf08" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e606e3b6a" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m82d512bf08" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e606e3b6a" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m82d512bf08" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e606e3b6a" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m82d512bf08" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e606e3b6a" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m82d512bf08" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e606e3b6a" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m82d512bf08" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e606e3b6a" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m82d512bf08" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6e606e3b6a" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.763672 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T05:12:18Z  ·  Linux chungus x86_64  ·  commit 3c05ffff  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(22.88875 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2954,13 +2954,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3324.511719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3359.716797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3394.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3426.708984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3458.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3490.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3522.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3553.857422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3581.640625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3643.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3704.443359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3767.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3831.298828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3870.162109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3931.34375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3990.523438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4052.046875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4093.160156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4126.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4154.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4216.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4277.4375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4340.816406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4404.439453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4438.130859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4497.310547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4560.933594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4592.720703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4656.34375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4719.966797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4751.753906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4815.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4851.460938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4890.324219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4945.304688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5008.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5040.714844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5072.501953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5104.289062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5136.076172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5167.863281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5207.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5270.451172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5309.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5370.496094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5433.875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5497.351562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5560.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5624.207031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5726.794922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5758.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5874.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5971.570312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6033.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6096.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6185.632812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6249.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6280.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6332.898438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6457.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6521.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6573.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6697.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6736.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6770.59375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6802.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6843.494141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6904.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6943.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6971.765625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7032.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7064.734375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7092.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.617188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7176.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7239.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7301.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7340.613281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7402.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7441.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7538.912109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7566.695312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.074219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7657.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7709.957031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7749.166016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7776.949219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf60e885d76">
+  <clipPath id="p9e1a9bfa67">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.872656pt" height="386.202469pt" viewBox="0 0 570.872656 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="562.6225pt" height="386.202469pt" viewBox="0 0 562.6225 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.872656 386.202469 
-L 570.872656 0 
+L 562.6225 386.202469 
+L 562.6225 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.561328 104.1264 
-L 292.186328 104.1264 
-L 292.186328 74.7432 
-L 187.561328 74.7432 
+    <path d="M 183.43625 104.1264 
+L 288.06125 104.1264 
+L 288.06125 74.7432 
+L 183.43625 74.7432 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.186328 104.1264 
-L 396.811328 104.1264 
-L 396.811328 74.7432 
-L 292.186328 74.7432 
+    <path d="M 288.06125 104.1264 
+L 392.68625 104.1264 
+L 392.68625 74.7432 
+L 288.06125 74.7432 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.811328 104.1264 
-L 501.436328 104.1264 
-L 501.436328 74.7432 
-L 396.811328 74.7432 
+    <path d="M 392.68625 104.1264 
+L 497.31125 104.1264 
+L 497.31125 74.7432 
+L 392.68625 74.7432 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.561328 133.5096 
-L 292.186328 133.5096 
-L 292.186328 104.1264 
-L 187.561328 104.1264 
+    <path d="M 183.43625 133.5096 
+L 288.06125 133.5096 
+L 288.06125 104.1264 
+L 183.43625 104.1264 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.186328 133.5096 
-L 396.811328 133.5096 
-L 396.811328 104.1264 
-L 292.186328 104.1264 
+    <path d="M 288.06125 133.5096 
+L 392.68625 133.5096 
+L 392.68625 104.1264 
+L 288.06125 104.1264 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #fff7b2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.811328 133.5096 
-L 501.436328 133.5096 
-L 501.436328 104.1264 
-L 396.811328 104.1264 
+    <path d="M 392.68625 133.5096 
+L 497.31125 133.5096 
+L 497.31125 104.1264 
+L 392.68625 104.1264 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.561328 162.8928 
-L 292.186328 162.8928 
-L 292.186328 133.5096 
-L 187.561328 133.5096 
+    <path d="M 183.43625 162.8928 
+L 288.06125 162.8928 
+L 288.06125 133.5096 
+L 183.43625 133.5096 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.186328 162.8928 
-L 396.811328 162.8928 
-L 396.811328 133.5096 
-L 292.186328 133.5096 
+    <path d="M 288.06125 162.8928 
+L 392.68625 162.8928 
+L 392.68625 133.5096 
+L 288.06125 133.5096 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.811328 162.8928 
-L 501.436328 162.8928 
-L 501.436328 133.5096 
-L 396.811328 133.5096 
+    <path d="M 392.68625 162.8928 
+L 497.31125 162.8928 
+L 497.31125 133.5096 
+L 392.68625 133.5096 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #bfe47a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.561328 192.276 
-L 292.186328 192.276 
-L 292.186328 162.8928 
-L 187.561328 162.8928 
+    <path d="M 183.43625 192.276 
+L 288.06125 192.276 
+L 288.06125 162.8928 
+L 183.43625 162.8928 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.186328 192.276 
-L 396.811328 192.276 
-L 396.811328 162.8928 
-L 292.186328 162.8928 
+    <path d="M 288.06125 192.276 
+L 392.68625 192.276 
+L 392.68625 162.8928 
+L 288.06125 162.8928 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.811328 192.276 
-L 501.436328 192.276 
-L 501.436328 162.8928 
-L 396.811328 162.8928 
+    <path d="M 392.68625 192.276 
+L 497.31125 192.276 
+L 497.31125 162.8928 
+L 392.68625 162.8928 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.561328 221.6592 
-L 292.186328 221.6592 
-L 292.186328 192.276 
-L 187.561328 192.276 
+    <path d="M 183.43625 221.6592 
+L 288.06125 221.6592 
+L 288.06125 192.276 
+L 183.43625 192.276 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.186328 221.6592 
-L 396.811328 221.6592 
-L 396.811328 192.276 
-L 292.186328 192.276 
+    <path d="M 288.06125 221.6592 
+L 392.68625 221.6592 
+L 392.68625 192.276 
+L 288.06125 192.276 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.811328 221.6592 
-L 501.436328 221.6592 
-L 501.436328 192.276 
-L 396.811328 192.276 
+    <path d="M 392.68625 221.6592 
+L 497.31125 221.6592 
+L 497.31125 192.276 
+L 392.68625 192.276 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.561328 251.0424 
-L 292.186328 251.0424 
-L 292.186328 221.6592 
-L 187.561328 221.6592 
+    <path d="M 183.43625 251.0424 
+L 288.06125 251.0424 
+L 288.06125 221.6592 
+L 183.43625 221.6592 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.186328 251.0424 
-L 396.811328 251.0424 
-L 396.811328 221.6592 
-L 292.186328 221.6592 
+    <path d="M 288.06125 251.0424 
+L 392.68625 251.0424 
+L 392.68625 221.6592 
+L 288.06125 221.6592 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.811328 251.0424 
-L 501.436328 251.0424 
-L 501.436328 221.6592 
-L 396.811328 221.6592 
+    <path d="M 392.68625 251.0424 
+L 497.31125 251.0424 
+L 497.31125 221.6592 
+L 392.68625 221.6592 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.561328 280.4256 
-L 292.186328 280.4256 
-L 292.186328 251.0424 
-L 187.561328 251.0424 
+    <path d="M 183.43625 280.4256 
+L 288.06125 280.4256 
+L 288.06125 251.0424 
+L 183.43625 251.0424 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.186328 280.4256 
-L 396.811328 280.4256 
-L 396.811328 251.0424 
-L 292.186328 251.0424 
+    <path d="M 288.06125 280.4256 
+L 392.68625 280.4256 
+L 392.68625 251.0424 
+L 288.06125 251.0424 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.811328 280.4256 
-L 501.436328 280.4256 
-L 501.436328 251.0424 
-L 396.811328 251.0424 
+    <path d="M 392.68625 280.4256 
+L 497.31125 280.4256 
+L 497.31125 251.0424 
+L 392.68625 251.0424 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #e65036; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.561328 309.8088 
-L 292.186328 309.8088 
-L 292.186328 280.4256 
-L 187.561328 280.4256 
+    <path d="M 183.43625 309.8088 
+L 288.06125 309.8088 
+L 288.06125 280.4256 
+L 183.43625 280.4256 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.186328 309.8088 
-L 396.811328 309.8088 
-L 396.811328 280.4256 
-L 292.186328 280.4256 
+    <path d="M 288.06125 309.8088 
+L 392.68625 309.8088 
+L 392.68625 280.4256 
+L 288.06125 280.4256 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.811328 309.8088 
-L 501.436328 309.8088 
-L 501.436328 280.4256 
-L 396.811328 280.4256 
+    <path d="M 392.68625 309.8088 
+L 497.31125 309.8088 
+L 497.31125 280.4256 
+L 392.68625 280.4256 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #e65036; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.561328 339.192 
-L 292.186328 339.192 
-L 292.186328 309.8088 
-L 187.561328 309.8088 
+    <path d="M 183.43625 339.192 
+L 288.06125 339.192 
+L 288.06125 309.8088 
+L 183.43625 309.8088 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.186328 339.192 
-L 396.811328 339.192 
-L 396.811328 309.8088 
-L 292.186328 309.8088 
+    <path d="M 288.06125 339.192 
+L 392.68625 339.192 
+L 392.68625 309.8088 
+L 288.06125 309.8088 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.811328 339.192 
-L 501.436328 339.192 
-L 501.436328 309.8088 
-L 396.811328 309.8088 
+    <path d="M 392.68625 339.192 
+L 497.31125 339.192 
+L 497.31125 309.8088 
+L 392.68625 309.8088 
 z
-" clip-path="url(#p54e78dd682)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8cdfae67f8)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.548594 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(116.423516 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.832812 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(223.707734 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.404922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(302.279844 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.756641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(400.631563 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.486328 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(112.36125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.422578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.863828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(332.73875 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1033,50 +1033,16 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 931 -->
-    <g transform="translate(441.488828 91.6423) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 925 -->
+    <g transform="translate(437.36375 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.124453 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(106.999375 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1175,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.422578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1185,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.408828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(335.28375 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1197,6 +1163,38 @@ L 525 4134
 L 525 4666 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
@@ -1204,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.488828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(437.36375 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1212,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.387578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(124.2625 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1236,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.422578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1246,22 +1244,22 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.408828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(335.28375 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 693 -->
-    <g transform="translate(441.488828 150.4087) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+    <!-- 700 -->
+    <g transform="translate(437.36375 150.4087) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-37"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.693828 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(107.56875 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1371,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.422578 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1381,22 +1379,22 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.408828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(335.28375 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 733 -->
-    <g transform="translate(441.488828 179.7919) scale(0.08 -0.08)">
+    <!-- 730 -->
+    <g transform="translate(437.36375 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.850078 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(115.725 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1456,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.422578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1466,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(339.408828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(335.28375 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1494,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.488828 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(437.36375 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1502,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- OCaml decompress -->
-    <g transform="translate(96.310703 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(92.185625 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1631,7 +1629,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.321 -->
-    <g transform="translate(228.422578 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1641,102 +1639,22 @@ z
    </g>
    <g id="text_27">
     <!-- 23 -->
-    <g transform="translate(339.408828 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(335.28375 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 117 -->
-    <g transform="translate(441.488828 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(437.36375 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- Go compress/flate -->
-    <g transform="translate(98.817578 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-47"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(77.490234 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(138.671875 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(170.458984 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(225.439453 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(286.621094 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(384.033203 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(447.509766 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(486.373047 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(547.896484 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(599.996094 0)"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(652.095703 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(685.787109 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(720.992188 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(748.775391 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(810.054688 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 0.299 -->
-    <g transform="translate(228.422578 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 18 -->
-    <g transform="translate(339.408828 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 88 -->
-    <g transform="translate(444.033828 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.195703 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(94.070625 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1843,9 +1761,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_34">
-    <!-- 0.307 -->
-    <g transform="translate(227.221953 297.3247) scale(0.08 -0.08)">
+   <g id="text_30">
+    <!-- 0.304 -->
+    <g transform="translate(223.096875 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1907,14 +1825,23 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1922,74 +1849,43 @@ z
      <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(246.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- 18 -->
-    <g transform="translate(338.932578 297.3247) scale(0.08 -0.08)">
+   <g id="text_31">
+    <!-- 23 -->
+    <g transform="translate(334.8075 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
-z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
     </g>
    </g>
-   <g id="text_36">
-    <!-- 92 -->
-    <g transform="translate(443.557578 297.3247) scale(0.08 -0.08)">
+   <g id="text_32">
+    <!-- 93 -->
+    <g transform="translate(439.4325 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -2021,36 +1917,94 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-32" d="M 1844 884 
-L 3897 884 
-L 3897 0 
-L 506 0 
-L 506 884 
-L 2209 2388 
-Q 2438 2594 2547 2791 
-Q 2656 2988 2656 3200 
-Q 2656 3528 2436 3728 
-Q 2216 3928 1850 3928 
-Q 1569 3928 1234 3808 
-Q 900 3688 519 3450 
-L 519 4475 
-Q 925 4609 1322 4679 
-Q 1719 4750 2100 4750 
-Q 2938 4750 3402 4381 
-Q 3866 4013 3866 3353 
-Q 3866 2972 3669 2642 
-Q 3472 2313 2841 1759 
-L 1844 884 
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-39"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- Go compress/flate -->
+    <g transform="translate(94.6925 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-39"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-47"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(77.490234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(138.671875 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(170.458984 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(225.439453 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(286.621094 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(384.033203 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(447.509766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(486.373047 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(547.896484 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(599.996094 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(652.095703 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(685.787109 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(720.992188 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(748.775391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(810.054688 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 0.299 -->
+    <g transform="translate(224.2975 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 18 -->
+    <g transform="translate(335.28375 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 88 -->
+    <g transform="translate(439.90875 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.531953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(120.406875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2061,7 +2015,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.422578 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2071,13 +2025,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.953828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(337.82875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.123828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(440.99875 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2093,7 +2047,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.945078 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(130.82 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2306,7 +2260,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-16T05:12:18Z  ·  Linux chungus x86_64  ·  commit 3c05ffff  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2448,13 +2402,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2493,110 +2447,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3324.511719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3359.716797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3394.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3426.708984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3458.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3490.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3522.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3553.857422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3581.640625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3643.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3704.443359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3767.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3831.298828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3870.162109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3931.34375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3990.523438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4052.046875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4093.160156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4126.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4154.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4216.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4277.4375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4340.816406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4404.439453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4438.130859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4497.310547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4560.933594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4592.720703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4656.34375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4719.966797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4751.753906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4815.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4851.460938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4890.324219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4945.304688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5008.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5040.714844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5072.501953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5104.289062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5136.076172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5167.863281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5207.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5270.451172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5309.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5370.496094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5433.875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5497.351562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5560.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5624.207031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5726.794922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5758.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5874.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5971.570312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6033.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6096.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6185.632812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6249.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6280.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6332.898438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6457.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6521.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6573.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6697.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6736.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6770.59375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6802.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6843.494141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6904.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6943.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6971.765625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7032.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7064.734375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7092.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.617188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7176.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7239.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7301.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7340.613281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7402.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7441.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7538.912109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7566.695312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.074219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7657.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7709.957031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7749.166016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7776.949219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p54e78dd682">
-   <rect x="82.936328" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p8cdfae67f8">
+   <rect x="78.81125" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p26b8072c30)">
+   <g clip-path="url(#pb380823ac0)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ+ElEQVR4nO3YTY6lZR2H4T5Vp6uLQpqPJtgBYxwYHTEwsgJX4EIYMWQD7MGZI1fgwJGJEwaEhJlONK0mBgE/wLaoPlV9yhUwIs/9L99c1wp+yfN+3O+7O/7jl7f3tuxwOb1grd3J9IK1jjfTC9ba+vndHKYXrHXxyvSCtZ49nV7At3F6Nr1gra1fn2cX0wuW2vjbDwCAu0aAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2n98/WR6w1Ln98+mJyx1dXOYnrDU45ceT09Y6slXf52esNTJ6ba/cX94/sr0hKWePzifnrDUn//zl+kJS735wrafn8/OjtMTltrtLqcnLLXttwMAAHeOAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7b/30venNyz1+vmb0xOW+vTyyfSEpd76ej89YanvPHp7esJSp7ttn9/x3nF6wlIP711MT1jq9OG2r8+XH7w+PWGp6+NhesJSLx62/XzxBxQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtT/d7ac3LPXV4Z/TE5a62D+cnrDU80evTU9Y6tMvP5mesNTTw9X0hKV++uo70xOWOpxOL1jr6tnl9ISlXp4esNi/n302PWGtB29ML1jKH1AAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1O757967nR6x1PE4vQC+2YlvQO6wrT8/t37/Ob//bxs/v42fHgAAd40ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtf/uR3+Y3rDUyX7bjf3Z7z+fnrDUL979yfSEpT748O/TE5b62Q9enZ6w1K9++6fpCUu9//MfTU9Y6td//HJ6wlI/fnQxPWGpz/97PT1hqXcevzA9Yalt1xkAAHeOAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7a6f/+Z2esRKp9eH6Qlr3T+fXrDW4XJ6wVpnF9ML1tpt/Bv39ji9YK3rq+kFa239+jzZTy9Y6nq37fvv/s3N9ISlNn73AQBw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS+9N//W16w1rH4/SCtU42/g1xuJxesNb+fHrBUrdPv5iesNTu4RvTE9a6ejq9YK3jzfSCtc4uphcsdf924+/3jdt4vQAAcNcIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUv8DXtR4oM4hskwAAAAASUVORK5CYII=" id="imagef7163c67df" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7klEQVR4nO3Xv47mZR2H4X1nXmZxgbDCskRINsREqCAhUtl4BhYehqWtvaW1LT0nQAWhMjFGOuwkQKFLNLCs6+y8s+94BFab5/7O/nJdR/BJfn+e+9kd//Xh1Y0tO5xPL+BpHC+nF6y1O5lesNblxfSCtW7dnl6w1uOH0wvWOj2bXsDT2Pr7eXZresFSGz/9AAC4bgQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/V8OX05vWGp/cjo9Yanj1dX0hKXuvnR3esJSXz74enrCWhu/4r79/O3pCUsdbp5NT1jqr/e/mJ6w1Ht3fjY9YanHZ8fpCUvtdo+mJyy18eMBAIDrRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPb3XnpresNSt2/enZ6w1Lfn30xPWOqNR9u+I7346rvTE5Y63e2nJyx1vHGcnrDUazfuTE9Y6vLOxfSEpV6/dW96wlKH47af3wsX2/6/bPt0BwDg2hGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9rvdthv0h8O/pycs9aPTF6cnLPXk1VemJyz1j+8/n56w1MOL8+kJS/38xx9MT1jq4nR6wVr/OfwwPYGn8N3j+9MT1rp5d3rBUtuuTwAArh0BCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAavfks99eTY9Y6nicXgD/34k74DPN/+XZtvXvb+vvp+f3TNv40wMA4LoRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPav//lv0xuWOtlvu7Hvf/Ht9ISl/vib96cnLPX7P/1zesJSv7z38vSEpT769O/TE5b63a/fmZ6w1B8++Wp6wlK/ev8n0xOW+ur7x9MTlvrFmy9MT1hq23UGAMC1I0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUrvDk4+vpkesdHp5OT1hrZP99IK1Ls+nF6x1dmt6wVq7jd9xr47TC9Y6+P6eaU+2ff4ddtv+/p7beL9s/HQAAOC6EaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT2p7v99Ia1dsfpBWudbPwO8eD+9IK1Xvvp9IK1/vtgesFaW//+zh9OL1jq/HR6wVrPn59PT1jquf3Z9IS1Hn03vWCpjf89AQC4bgQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/wGFdHmssBcbMAAAAABJRU5ErkJggg==" id="image0681134e22" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m74533dfd73" d="M 0 0 
+       <path id="mcbaa106f4e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m74533dfd73" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m74533dfd73" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m74533dfd73" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m74533dfd73" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m74533dfd73" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m74533dfd73" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m74533dfd73" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m74533dfd73" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m74533dfd73" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m74533dfd73" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m74533dfd73" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m74533dfd73" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcbaa106f4e" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m1abe87e6a1" d="M 0 0 
+       <path id="md84bce5a60" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1abe87e6a1" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md84bce5a60" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1abe87e6a1" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md84bce5a60" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m1abe87e6a1" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md84bce5a60" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1abe87e6a1" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md84bce5a60" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m1abe87e6a1" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md84bce5a60" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1abe87e6a1" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md84bce5a60" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m1abe87e6a1" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md84bce5a60" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m1abe87e6a1" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md84bce5a60" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,41 +1138,120 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- -38 -->
-    <g transform="translate(110.506785 69.553235) scale(0.065 -0.065)">
+    <!-- -2 -->
+    <g transform="translate(112.574598 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -7 -->
+    <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -4 -->
+    <g transform="translate(193.129395 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -41 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -1 -->
+    <g transform="translate(273.684192 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -18 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1214,121 +1293,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_22">
-    <!-- -39 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -38 -->
-    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -49 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -40 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -64 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+   <g id="text_27">
+    <!-- -16 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1362,33 +1333,117 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- -37 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+   <g id="text_28">
+    <!-- -30 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- -50 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+   <g id="text_29">
+    <!-- +12 -->
+    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -22 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -16 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -35 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1417,95 +1472,30 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -55 -->
-    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_30">
-    <!-- -44 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -46 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -47 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
    <g id="text_33">
-    <!-- +7 -->
+    <!-- +6 -->
     <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_34">
-    <!-- -14 -->
+    <!-- -11 -->
     <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_35">
-    <!-- -4 -->
+    <!-- -6 -->
     <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_36">
@@ -1517,24 +1507,24 @@ z
     </g>
    </g>
    <g id="text_37">
-    <!-- -4 -->
+    <!-- -5 -->
     <g transform="translate(273.684192 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- +0 -->
+    <!-- +1 -->
     <g transform="translate(312.410731 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- -4 -->
+    <!-- -3 -->
     <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_40">
@@ -1546,11 +1536,10 @@ z
     </g>
    </g>
    <g id="text_41">
-    <!-- -10 -->
-    <g transform="translate(432.725974 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    <!-- +1 -->
+    <g transform="translate(433.242927 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_42">
@@ -1561,53 +1550,59 @@ z
     </g>
    </g>
    <g id="text_43">
-    <!-- +8 -->
+    <!-- +9 -->
     <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_44">
     <!-- -12 -->
     <g transform="translate(553.558169 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +257 -->
+    <!-- +256 -->
     <g transform="translate(106.888113 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_46">
@@ -1647,66 +1642,66 @@ z
     </g>
    </g>
    <g id="text_50">
-    <!-- +186 -->
+    <!-- +189 -->
     <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_51">
+    <!-- +281 -->
+    <g transform="translate(348.552505 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_52">
+    <!-- +152 -->
+    <g transform="translate(388.829903 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_53">
+    <!-- +259 -->
+    <g transform="translate(429.107302 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_54">
+    <!-- +186 -->
+    <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
-   <g id="text_51">
-    <!-- +280 -->
-    <g transform="translate(348.552505 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_52">
-    <!-- +153 -->
-    <g transform="translate(388.829903 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_53">
-    <!-- +219 -->
-    <g transform="translate(429.107302 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_54">
-    <!-- +187 -->
-    <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
    <g id="text_55">
-    <!-- +205 -->
+    <!-- +210 -->
     <g transform="translate(509.662099 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_56">
-    <!-- +159 -->
+    <!-- +160 -->
     <g transform="translate(549.939498 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_57">
@@ -1775,11 +1770,11 @@ z
     </g>
    </g>
    <g id="text_65">
-    <!-- -97 -->
+    <!-- -96 -->
     <g transform="translate(432.725974 180.060583) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_66">
@@ -1807,34 +1802,34 @@ z
     </g>
    </g>
    <g id="text_69">
-    <!-- +32 -->
+    <!-- +31 -->
     <g transform="translate(108.955926 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_70">
-    <!-- +27 -->
+    <!-- +30 -->
     <g transform="translate(149.233324 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
-    <!-- +29 -->
+    <!-- +28 -->
     <g transform="translate(189.510723 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_72">
-    <!-- +6 -->
+    <!-- +7 -->
     <g transform="translate(231.855934 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_73">
@@ -1846,11 +1841,11 @@ z
     </g>
    </g>
    <g id="text_74">
-    <!-- +77 -->
+    <!-- +78 -->
     <g transform="translate(310.342919 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_75">
@@ -1862,19 +1857,19 @@ z
     </g>
    </g>
    <g id="text_76">
-    <!-- +10 -->
+    <!-- +11 -->
     <g transform="translate(390.897716 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_77">
-    <!-- +47 -->
+    <!-- +64 -->
     <g transform="translate(431.175114 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_78">
@@ -1902,18 +1897,18 @@ z
     </g>
    </g>
    <g id="text_81">
-    <!-- +36 -->
+    <!-- +35 -->
     <g transform="translate(108.955926 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_82">
-    <!-- +5 -->
+    <!-- +8 -->
     <g transform="translate(151.301137 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_83">
@@ -1949,27 +1944,27 @@ z
     </g>
    </g>
    <g id="text_87">
-    <!-- +23 -->
+    <!-- +24 -->
     <g transform="translate(350.620317 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_88">
-    <!-- -11 -->
+    <!-- -10 -->
     <g transform="translate(392.448575 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_89">
-    <!-- +34 -->
+    <!-- +50 -->
     <g transform="translate(431.175114 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_90">
@@ -2005,11 +2000,11 @@ z
     </g>
    </g>
    <g id="text_94">
-    <!-- +69 -->
+    <!-- +73 -->
     <g transform="translate(149.233324 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
@@ -2029,19 +2024,19 @@ z
     </g>
    </g>
    <g id="text_97">
-    <!-- +87 -->
+    <!-- +88 -->
     <g transform="translate(270.06552 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_98">
-    <!-- +86 -->
+    <!-- +87 -->
     <g transform="translate(310.342919 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_99">
@@ -2053,19 +2048,20 @@ z
     </g>
    </g>
    <g id="text_100">
-    <!-- +40 -->
+    <!-- +41 -->
     <g transform="translate(390.897716 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_101">
-    <!-- +83 -->
-    <g transform="translate(431.175114 290.567931) scale(0.065 -0.065)">
+    <!-- +105 -->
+    <g transform="translate(429.107302 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_102">
@@ -2101,11 +2097,11 @@ z
     </g>
    </g>
    <g id="text_106">
-    <!-- -46 -->
+    <!-- -44 -->
     <g transform="translate(150.784184 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_107">
@@ -2133,11 +2129,11 @@ z
     </g>
    </g>
    <g id="text_110">
-    <!-- -53 -->
+    <!-- -52 -->
     <g transform="translate(311.893778 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_111">
@@ -2157,19 +2153,19 @@ z
     </g>
    </g>
    <g id="text_113">
-    <!-- -48 -->
+    <!-- -42 -->
     <g transform="translate(432.725974 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_114">
-    <!-- -42 -->
+    <!-- -43 -->
     <g transform="translate(473.003372 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_115">
@@ -2199,23 +2195,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image6930ffc5bb" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image01013ccecf" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m9ca4d7886c" d="M 0 0 
+       <path id="m41000c4b52" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9ca4d7886c" x="601.779688" y="320.990988" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41000c4b52" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
       <!-- −3 -->
-      <g transform="translate(608.779688 324.790207) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 325.122218) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2233,12 +2229,12 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m9ca4d7886c" x="601.779688" y="279.555619" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41000c4b52" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
       <!-- −2 -->
-      <g transform="translate(608.779688 283.354838) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 283.576178) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2247,12 +2243,12 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m9ca4d7886c" x="601.779688" y="238.12025" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41000c4b52" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
       <!-- −1 -->
-      <g transform="translate(608.779688 241.919469) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 242.030139) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2261,7 +2257,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m9ca4d7886c" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41000c4b52" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2274,12 +2270,12 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m9ca4d7886c" x="601.779688" y="155.249512" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41000c4b52" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
       <!-- 1 -->
-      <g transform="translate(608.779688 159.04873) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 158.93806) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2287,12 +2283,12 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m9ca4d7886c" x="601.779688" y="113.814142" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41000c4b52" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
       <!-- 2 -->
-      <g transform="translate(608.779688 117.613361) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 117.392021) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2300,12 +2296,12 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m9ca4d7886c" x="601.779688" y="72.378773" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m41000c4b52" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
       <!-- 3 -->
-      <g transform="translate(608.779688 76.177992) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 75.845981) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2916,8 +2912,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.763672 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T05:12:18Z  ·  Linux chungus x86_64  ·  commit 3c05ffff  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(49.88875 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3009,13 +3005,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3054,109 +3050,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3324.511719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3359.716797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3394.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3426.708984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3458.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3490.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3522.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3553.857422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3581.640625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3643.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3704.443359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3767.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3831.298828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3870.162109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3931.34375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3990.523438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4052.046875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4093.160156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4126.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4154.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4216.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4277.4375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4340.816406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4404.439453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4438.130859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4497.310547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4560.933594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4592.720703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4656.34375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4719.966797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4751.753906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4815.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4851.460938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4890.324219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4945.304688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5008.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5040.714844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5072.501953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5104.289062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5136.076172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5167.863281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5207.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5270.451172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5309.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5370.496094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5433.875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5497.351562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5560.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5624.207031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5726.794922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5758.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5874.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5971.570312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6033.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6096.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6185.632812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6249.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6280.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6332.898438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6457.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6521.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6573.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6697.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6736.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6770.59375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6802.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6843.494141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6904.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6943.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6971.765625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7032.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7064.734375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7092.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.617188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7176.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7239.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7301.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7340.613281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7402.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7441.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7538.912109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7566.695312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.074219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7657.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7709.957031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7749.166016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7776.949219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p26b8072c30">
+  <clipPath id="pb380823ac0">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m9f8a5260db" d="M 0 0 
+       <path id="mffda126c52" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9f8a5260db" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mffda126c52" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9f8a5260db" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mffda126c52" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9f8a5260db" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mffda126c52" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9f8a5260db" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mffda126c52" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9f8a5260db" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mffda126c52" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9f8a5260db" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mffda126c52" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9f8a5260db" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mffda126c52" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,23 +854,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 368.094456 
-L 637.2 368.094456 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 368.088255 
+L 637.2 368.088255 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="med1f71fa97" d="M 0 0 
+       <path id="m4af61a4130" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#med1f71fa97" x="49.078125" y="368.094456" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4af61a4130" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 371.893674) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 371.887474) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -895,18 +895,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 243.509386 
-L 637.2 243.509386 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.475737 
+L 637.2 243.475737 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#med1f71fa97" x="49.078125" y="243.509386" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4af61a4130" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 247.308605) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 247.274956) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -915,18 +915,18 @@ L 637.2 243.509386
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 118.924317 
-L 637.2 118.924317 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 118.863219 
+L 637.2 118.863219 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#med1f71fa97" x="49.078125" y="118.924317" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4af61a4130" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 122.723536) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 122.662438) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -935,282 +935,282 @@ L 637.2 118.924317
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 405.598299 
-L 637.2 405.598299 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 405.600361 
+L 637.2 405.600361 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m0a3d7e3679" d="M 0 0 
+       <path id="mf78d0610af" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="405.598299" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 395.733497 
-L 637.2 395.733497 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 395.733387 
+L 637.2 395.733387 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="395.733497" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 387.392927 
-L 637.2 387.392927 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 387.390979 
+L 637.2 387.390979 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="387.392927" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 380.167996 
-L 637.2 380.167996 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.164456 
+L 637.2 380.164456 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="380.167996" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 373.795156 
-L 637.2 373.795156 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 373.790211 
+L 637.2 373.790211 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="373.795156" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 330.590613 
-L 637.2 330.590613 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.57615 
+L 637.2 330.57615 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="330.590613" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 308.652271 
-L 637.2 308.652271 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 308.632974 
+L 637.2 308.632974 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="308.652271" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 293.08677 
-L 637.2 293.08677 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 293.064044 
+L 637.2 293.064044 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="293.08677" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 281.013229 
-L 637.2 281.013229 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 280.987843 
+L 637.2 280.987843 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="281.013229" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 271.148428 
-L 637.2 271.148428 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.120868 
+L 637.2 271.120868 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="271.148428" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 262.807858 
-L 637.2 262.807858 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.77846 
+L 637.2 262.77846 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="262.807858" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 255.582927 
-L 637.2 255.582927 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.551938 
+L 637.2 255.551938 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="255.582927" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 249.210086 
-L 637.2 249.210086 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.177693 
+L 637.2 249.177693 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="249.210086" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 206.005543 
-L 637.2 206.005543 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.963631 
+L 637.2 205.963631 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="206.005543" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 184.067202 
-L 637.2 184.067202 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 184.020456 
+L 637.2 184.020456 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="184.067202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 168.5017 
-L 637.2 168.5017 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 168.451525 
+L 637.2 168.451525 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="168.5017" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 156.42816 
-L 637.2 156.42816 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 156.375325 
+L 637.2 156.375325 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="156.42816" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 146.563359 
-L 637.2 146.563359 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.50835 
+L 637.2 146.50835 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="146.563359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 138.222788 
-L 637.2 138.222788 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 138.165942 
+L 637.2 138.165942 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="138.222788" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 130.997857 
-L 637.2 130.997857 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 130.93942 
+L 637.2 130.93942 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="130.997857" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 124.625017 
-L 637.2 124.625017 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 124.565175 
+L 637.2 124.565175 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="124.625017" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 81.420474 
-L 637.2 81.420474 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 81.351113 
+L 637.2 81.351113 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="81.420474" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 59.482132 
-L 637.2 59.482132 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 59.407938 
+L 637.2 59.407938 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m0a3d7e3679" x="49.078125" y="59.482132" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf78d0610af" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(292.62732 162.051943) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 156.028639) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 371.184435) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(113.682818 359.641788) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1693,124 +1693,124 @@ z
     </g>
    </g>
    <g id="line2d_67">
-    <path d="M 377.110281 104.911856 
-L 323.801439 110.575431 
-L 272.665744 126.520079 
-L 235.168828 128.081722 
-L 186.228265 149.433593 
-L 158.303164 171.536947 
-L 149.489547 182.243656 
-L 140.563162 202.555128 
-L 138.984853 209.414141 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 377.110281 107.572658 
+L 323.801439 112.143178 
+L 272.665744 128.289861 
+L 235.168828 129.778148 
+L 186.228265 150.062022 
+L 158.303164 172.157864 
+L 149.489547 182.173164 
+L 140.563162 202.575355 
+L 138.984853 209.263476 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6c2c128fa1" d="M -2.5 2.5 
+     <path id="m5c6b26cd21" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5533f3772f)">
-     <use xlink:href="#m6c2c128fa1" x="377.110281" y="104.911856" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c2c128fa1" x="323.801439" y="110.575431" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c2c128fa1" x="272.665744" y="126.520079" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c2c128fa1" x="235.168828" y="128.081722" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c2c128fa1" x="186.228265" y="149.433593" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c2c128fa1" x="158.303164" y="171.536947" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c2c128fa1" x="149.489547" y="182.243656" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c2c128fa1" x="140.563162" y="202.555128" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c2c128fa1" x="138.984853" y="209.414141" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e70d99370)">
+     <use xlink:href="#m5c6b26cd21" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c6b26cd21" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c6b26cd21" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c6b26cd21" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c6b26cd21" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c6b26cd21" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c6b26cd21" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c6b26cd21" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5c6b26cd21" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 610.467187 72.783769 
-L 319.880958 101.93596 
-L 210.281253 129.848445 
-L 196.287076 133.742413 
-L 176.054419 147.544128 
-L 152.161413 174.89224 
-L 146.720208 186.684946 
-L 143.994022 196.417999 
-L 142.666037 200.286049 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467187 71.829514 
+L 319.880958 101.654884 
+L 210.281253 129.793447 
+L 196.287076 133.571842 
+L 176.054419 147.433896 
+L 152.161413 174.830826 
+L 146.720208 186.628416 
+L 143.994022 196.353927 
+L 142.666037 200.270771 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me8bf5921a5" d="M 0 -2.5 
+     <path id="mec9c4894a1" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5533f3772f)">
-     <use xlink:href="#me8bf5921a5" x="610.467187" y="72.783769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8bf5921a5" x="319.880958" y="101.93596" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8bf5921a5" x="210.281253" y="129.848445" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8bf5921a5" x="196.287076" y="133.742413" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8bf5921a5" x="176.054419" y="147.544128" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8bf5921a5" x="152.161413" y="174.89224" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8bf5921a5" x="146.720208" y="186.684946" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8bf5921a5" x="143.994022" y="196.417999" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8bf5921a5" x="142.666037" y="200.286049" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e70d99370)">
+     <use xlink:href="#mec9c4894a1" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec9c4894a1" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec9c4894a1" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec9c4894a1" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec9c4894a1" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec9c4894a1" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec9c4894a1" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec9c4894a1" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mec9c4894a1" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <path d="M 292.033351 64.890426 
-L 242.839153 80.619559 
-L 218.251194 86.000655 
-L 197.814984 90.069865 
-L 166.378359 98.986137 
-L 145.830392 110.284604 
-L 134.598477 126.051516 
-L 124.077268 149.014931 
-L 122.462976 157.16811 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 242.839153 80.520583 
+L 218.251194 86.060539 
+L 197.814984 90.141422 
+L 166.378359 98.767475 
+L 145.830392 110.20084 
+L 134.598477 125.76687 
+L 124.077268 149.129162 
+L 122.462976 157.203722 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mea3ea56ac0" d="M -0 3.535534 
+     <path id="m4885493221" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5533f3772f)">
-     <use xlink:href="#mea3ea56ac0" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3ea56ac0" x="242.839153" y="80.619559" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3ea56ac0" x="218.251194" y="86.000655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3ea56ac0" x="197.814984" y="90.069865" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3ea56ac0" x="166.378359" y="98.986137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3ea56ac0" x="145.830392" y="110.284604" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3ea56ac0" x="134.598477" y="126.051516" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3ea56ac0" x="124.077268" y="149.014931" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mea3ea56ac0" x="122.462976" y="157.16811" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e70d99370)">
+     <use xlink:href="#m4885493221" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4885493221" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4885493221" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4885493221" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4885493221" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4885493221" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4885493221" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4885493221" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4885493221" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma8dc9e0875" d="M -0 2.5 
+     <path id="m53db167dc3" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5533f3772f)">
-     <use xlink:href="#ma8dc9e0875" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e70d99370)">
+     <use xlink:href="#m53db167dc3" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
-    <path d="M 432.495268 103.737185 
-L 300.62247 118.083959 
-L 266.967623 125.742596 
-L 226.040946 126.211606 
-L 180.985721 144.136302 
-L 164.441833 158.510263 
-L 157.761315 167.052311 
-L 151.269082 181.292165 
-L 150.327087 187.028288 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 432.495268 103.672741 
+L 300.62247 118.022676 
+L 266.967623 125.683 
+L 226.040946 126.152114 
+L 180.985721 144.080759 
+L 164.441833 158.457887 
+L 157.761315 167.001817 
+L 151.269082 181.244808 
+L 150.327087 186.982195 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m3abe6d6fcc" d="M -0.833333 2.5 
+     <path id="m33a24adfa1" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,31 +1825,31 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5533f3772f)">
-     <use xlink:href="#m3abe6d6fcc" x="432.495268" y="103.737185" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3abe6d6fcc" x="300.62247" y="118.083959" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3abe6d6fcc" x="266.967623" y="125.742596" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3abe6d6fcc" x="226.040946" y="126.211606" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3abe6d6fcc" x="180.985721" y="144.136302" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3abe6d6fcc" x="164.441833" y="158.510263" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3abe6d6fcc" x="157.761315" y="167.052311" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3abe6d6fcc" x="151.269082" y="181.292165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3abe6d6fcc" x="150.327087" y="187.028288" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e70d99370)">
+     <use xlink:href="#m33a24adfa1" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33a24adfa1" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33a24adfa1" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33a24adfa1" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33a24adfa1" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33a24adfa1" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33a24adfa1" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33a24adfa1" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33a24adfa1" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
-    <path d="M 345.030867 135.144559 
-L 273.364924 141.949468 
-L 240.719951 147.988703 
-L 221.353978 153.301573 
-L 207.129625 155.243167 
-L 181.064802 166.740869 
-L 179.282169 170.33495 
-L 177.719335 175.708221 
-L 177.643939 181.080484 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 345.030867 135.087035 
+L 273.364924 141.893443 
+L 240.719951 147.934009 
+L 221.353978 153.24805 
+L 207.129625 155.190071 
+L 181.064802 166.690306 
+L 179.282169 170.285179 
+L 177.719335 175.659634 
+L 177.643939 181.03308 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m43c4855600" d="M -1.25 2.5 
+     <path id="m5750b4a378" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,31 +1864,31 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5533f3772f)">
-     <use xlink:href="#m43c4855600" x="345.030867" y="135.144559" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m43c4855600" x="273.364924" y="141.949468" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m43c4855600" x="240.719951" y="147.988703" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m43c4855600" x="221.353978" y="153.301573" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m43c4855600" x="207.129625" y="155.243167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m43c4855600" x="181.064802" y="166.740869" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m43c4855600" x="179.282169" y="170.33495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m43c4855600" x="177.719335" y="175.708221" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m43c4855600" x="177.643939" y="181.080484" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e70d99370)">
+     <use xlink:href="#m5750b4a378" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5750b4a378" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5750b4a378" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5750b4a378" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5750b4a378" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5750b4a378" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5750b4a378" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5750b4a378" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5750b4a378" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
-    <path d="M 226.871027 113.1409 
-L 226.871027 113.164985 
-L 226.871027 113.313492 
-L 226.871027 113.22217 
-L 177.768423 132.156838 
-L 160.37503 145.347429 
-L 153.995779 152.481042 
-L 147.106887 167.687381 
-L 145.871703 174.959641 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 226.871027 113.078527 
+L 226.871027 113.102618 
+L 226.871027 113.251157 
+L 226.871027 113.159816 
+L 177.768423 132.098656 
+L 160.37503 145.292152 
+L 153.995779 152.427338 
+L 147.106887 167.637027 
+L 145.871703 174.910889 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m8de2f032c6" d="M 0 -2.5 
+     <path id="m509bd12934" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,31 +1901,31 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p5533f3772f)">
-     <use xlink:href="#m8de2f032c6" x="226.871027" y="113.1409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8de2f032c6" x="226.871027" y="113.164985" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8de2f032c6" x="226.871027" y="113.313492" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8de2f032c6" x="226.871027" y="113.22217" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8de2f032c6" x="177.768423" y="132.156838" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8de2f032c6" x="160.37503" y="145.347429" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8de2f032c6" x="153.995779" y="152.481042" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8de2f032c6" x="147.106887" y="167.687381" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8de2f032c6" x="145.871703" y="174.959641" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p5e70d99370)">
+     <use xlink:href="#m509bd12934" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m509bd12934" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m509bd12934" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m509bd12934" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m509bd12934" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m509bd12934" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m509bd12934" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m509bd12934" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m509bd12934" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
-    <path d="M 585.66883 174.423041 
-L 527.144592 176.48787 
-L 457.339427 184.571799 
-L 292.124837 179.266215 
-L 243.129344 190.947125 
-L 213.541392 204.882385 
-L 204.551957 212.49732 
-L 195.860087 228.926857 
-L 194.019853 234.441004 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 585.66883 174.374171 
+L 527.144592 176.439455 
+L 457.339427 184.525165 
+L 292.124837 179.218412 
+L 243.129344 190.901895 
+L 213.541392 204.840226 
+L 204.551957 212.456838 
+L 195.860087 228.889995 
+L 194.019853 234.405357 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf96895c333" d="M 0 -2.5 
+     <path id="mccc9ca63ac" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5533f3772f)">
-     <use xlink:href="#mf96895c333" x="585.66883" y="174.423041" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf96895c333" x="527.144592" y="176.48787" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf96895c333" x="457.339427" y="184.571799" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf96895c333" x="292.124837" y="179.266215" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf96895c333" x="243.129344" y="190.947125" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf96895c333" x="213.541392" y="204.882385" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf96895c333" x="204.551957" y="212.49732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf96895c333" x="195.860087" y="228.926857" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf96895c333" x="194.019853" y="234.441004" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p5e70d99370)">
+     <use xlink:href="#mccc9ca63ac" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mccc9ca63ac" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mccc9ca63ac" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mccc9ca63ac" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mccc9ca63ac" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mccc9ca63ac" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mccc9ca63ac" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mccc9ca63ac" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mccc9ca63ac" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m2ccfa4ff70" d="M 0 3.5 
+      <path id="m0502d6aead" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m2ccfa4ff70" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m0502d6aead" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6c2c128fa1" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5c6b26cd21" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me8bf5921a5" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mec9c4894a1" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mea3ea56ac0" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4885493221" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma8dc9e0875" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m53db167dc3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m3abe6d6fcc" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m33a24adfa1" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m43c4855600" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5750b4a378" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m8de2f032c6" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m509bd12934" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf96895c333" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mccc9ca63ac" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 287.62732 167.051943 
-L 253.661767 175.8127 
-L 230.111105 180.539221 
-L 201.85576 192.323346 
-L 197.114151 194.8929 
-L 189.167523 205.247277 
-L 155.420659 255.586582 
-L 153.649656 262.02238 
-L 95.319203 376.184435 
-" clip-path="url(#p5533f3772f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p5533f3772f)">
-     <use xlink:href="#m2ccfa4ff70" x="287.62732" y="167.051943" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2ccfa4ff70" x="253.661767" y="175.8127" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2ccfa4ff70" x="230.111105" y="180.539221" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2ccfa4ff70" x="201.85576" y="192.323346" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2ccfa4ff70" x="197.114151" y="194.8929" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2ccfa4ff70" x="189.167523" y="205.247277" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2ccfa4ff70" x="155.420659" y="255.586582" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2ccfa4ff70" x="153.649656" y="262.02238" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2ccfa4ff70" x="95.319203" y="376.184435" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 161.028639 
+L 236.23654 164.575027 
+L 222.073314 168.130956 
+L 202.315941 176.597495 
+L 199.905291 178.397776 
+L 195.893147 181.817762 
+L 157.982343 244.890218 
+L 157.246106 247.251651 
+L 108.682818 364.641788 
+" clip-path="url(#p5e70d99370)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p5e70d99370)">
+     <use xlink:href="#m0502d6aead" x="257.531237" y="161.028639" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0502d6aead" x="236.23654" y="164.575027" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0502d6aead" x="222.073314" y="168.130956" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0502d6aead" x="202.315941" y="176.597495" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0502d6aead" x="199.905291" y="178.397776" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0502d6aead" x="195.893147" y="181.817762" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0502d6aead" x="157.982343" y="244.890218" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0502d6aead" x="157.246106" y="247.251651" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0502d6aead" x="108.682818" y="364.641788" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.763672 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-16T05:12:18Z  ·  Linux chungus x86_64  ·  commit 3c05ffff  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(49.88875 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2815,6 +2815,31 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2887,31 +2912,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -2953,13 +2953,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2998,109 +2998,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3324.511719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3359.716797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3394.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3426.708984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3458.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3490.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3522.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3553.857422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3581.640625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3643.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3704.443359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3767.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3831.298828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3870.162109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3931.34375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3990.523438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4052.046875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4093.160156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4126.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4154.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4216.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4277.4375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4340.816406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4404.439453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4438.130859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4497.310547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4560.933594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4592.720703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4656.34375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4719.966797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4751.753906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4815.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4851.460938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4890.324219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4945.304688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5008.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5040.714844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5072.501953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5104.289062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5136.076172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5167.863281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5207.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5270.451172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5309.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5370.496094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5433.875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5497.351562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5560.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5624.207031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5726.794922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5758.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5874.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5971.570312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6033.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6096.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6185.632812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6249.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6280.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6332.898438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6457.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6521.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6573.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6697.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6736.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6770.59375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6802.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6843.494141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6904.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6943.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6971.765625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7032.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7064.734375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7092.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.617188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7176.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7239.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7301.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7340.613281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7402.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7441.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7538.912109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7566.695312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.074219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7657.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7709.957031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7749.166016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7776.949219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5533f3772f">
+  <clipPath id="p5e70d99370">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pcb12790487)">
+   <g clip-path="url(#p2464dfa602)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKAElEQVR4nO3Yu45eVx2H4ZnMOLY8jse2wEQEFCmOaEKgQUIBQZUKQcE1IC4ACioqxB1Q0VDSoSgFhZuURAFiIFRECQdxkDXY+IBl7PF4Pq7gLVC09EefnucKftLeWvvda/f05o83O1vo+KfXpycsceb1V6cnLLN79ZPTE5bY/PZ30xOW2P3cK9MTltg8vD89YZmj770xPWGJqz/8+vSEJXavfGJ6whrHD6cXLHP6y+0875+ZHgAAwP8vsQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQNr99/Ebm+kRKxz862h6whK3Lp6fnrDMf04eTE9Y4tP3jqcnLHHv489PT1jidHM6PWGZy/tXpiescfvP0wuWuH95O5/Xc3/6w/SEZTaf+eL0hCXcLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPYPbt+c3rDG+UvTC5bYbI6nJyzzqbd+PT1hjde/Nr1gicNb/5iesMbpyfSCdQ629Pw4e2F6wRIX/7md3+c7L16bnrDM5b++Nz1hCTeLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQNp98vT6ZnrECntHf5yesMTN556dnrDMgyd3pycsce0vd6cnLHHy2S9NT1ji4cn96QnLHO5dmp6wxObDX01PWOLRS69OT1ji3HvvTE9Y5vHnX5uesISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDtvvnhdzbTI1a4cu5gesIS79+9PT1hmW/96Mb0hCV+84NvTE9Y4vDs4fSEJb7/i3enJyzz1RfOTU9Y4pvXXpuesMRbf3tnesISF85s53u4s7Oz87MP7kxPWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2nzy9vpkescKdx0fTE5Y42L84PWGZ9+/+fnrCEi9femV6whKbzen0hCUunGzvP/TfT7fzXHzh4OXpCUs8evpwesIS23p27Ozs7Ow9sz89YYntPRUBAPjIxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQ9vd296c3LPGxvSvTE9bYe3Z6wTKHZw+nJyxxsH9xesISTzcn0xOWOD2zvf/Qz2/OT0/gf7Ct3+fjzaPpCcvcf3w0PWGJ7T0VAQD4yMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABpf+fBrekNS2xuvD09YYndL3xlesIyL777wfSENb780vSCJfZOT6YnrHHv5vSCZR7/5OfTE5bY++63pycsceb44fSEJR6cOZ2esMzVt29MT1jCzSIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQ/gunYJutB18TSwAAAABJRU5ErkJggg==" id="imaged85a415faf" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="imagedcea578b0b" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mf18e863ea9" d="M 0 0 
+       <path id="m85176b06a8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf18e863ea9" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mf18e863ea9" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mf18e863ea9" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf18e863ea9" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mf18e863ea9" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf18e863ea9" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mf18e863ea9" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf18e863ea9" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mf18e863ea9" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf18e863ea9" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mf18e863ea9" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf18e863ea9" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m85176b06a8" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m69433dd2c6" d="M 0 0 
+       <path id="m18e0f5abe7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m69433dd2c6" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18e0f5abe7" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m69433dd2c6" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18e0f5abe7" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m69433dd2c6" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18e0f5abe7" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m69433dd2c6" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18e0f5abe7" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m69433dd2c6" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18e0f5abe7" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m69433dd2c6" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18e0f5abe7" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m69433dd2c6" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18e0f5abe7" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m69433dd2c6" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m18e0f5abe7" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 563.817548 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +1 -->
+    <!-- +0 -->
     <g transform="translate(110.390926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,6 +1156,55 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- +7 -->
+    <g transform="translate(149.402701 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +1 -->
+    <g transform="translate(188.414476 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
 L 1825 4091 
@@ -1175,9 +1224,154 @@ z
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_22">
+   <g id="text_24">
+    <!-- +0 -->
+    <g transform="translate(227.426251 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +4 -->
+    <g transform="translate(266.438026 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +0 -->
+    <g transform="translate(305.449801 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +1 -->
+    <g transform="translate(344.461576 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- +8 -->
+    <g transform="translate(383.473351 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +3 -->
+    <g transform="translate(422.485125 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -0 -->
+    <g transform="translate(463.04776 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
     <!-- +5 -->
-    <g transform="translate(149.402701 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(500.508675 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1209,37 +1403,37 @@ z
      <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- +1 -->
-    <g transform="translate(188.414476 69.553235) scale(0.065 -0.065)">
+   <g id="text_32">
+    <!-- +4 -->
+    <g transform="translate(539.52045 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_24">
-    <!-- +5 -->
-    <g transform="translate(227.426251 69.553235) scale(0.065 -0.065)">
+   <g id="text_33">
+    <!-- +0 -->
+    <g transform="translate(110.390926 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- +1 -->
-    <g transform="translate(266.438026 69.553235) scale(0.065 -0.065)">
+   <g id="text_34">
+    <!-- +0 -->
+    <g transform="translate(149.402701 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- +1 -->
-    <g transform="translate(305.449801 69.553235) scale(0.065 -0.065)">
+   <g id="text_35">
+    <!-- +0 -->
+    <g transform="translate(188.414476 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- +2 -->
-    <g transform="translate(344.461576 69.553235) scale(0.065 -0.065)">
+   <g id="text_36">
+    <!-- -2 -->
+    <g transform="translate(228.97711 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1266,104 +1460,6 @@ Q 1991 1309 1228 531
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- +7 -->
-    <g transform="translate(383.473351 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +1 -->
-    <g transform="translate(422.485125 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- +1 -->
-    <g transform="translate(461.4969 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -1 -->
-    <g transform="translate(502.059535 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- +5 -->
-    <g transform="translate(539.52045 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +0 -->
-    <g transform="translate(110.390926 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- +0 -->
-    <g transform="translate(149.402701 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- +0 -->
-    <g transform="translate(188.414476 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -2 -->
-    <g transform="translate(228.97711 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
@@ -1448,40 +1544,6 @@ z
    <g id="text_48">
     <!-- -3 -->
     <g transform="translate(228.97711 143.2248) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -1552,27 +1614,6 @@ z
    <g id="text_58">
     <!-- -4 -->
     <g transform="translate(150.953561 180.060583) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
@@ -2060,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image44afe5d8c1" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image95e505e39a" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m910be63ca4" d="M 0 0 
+       <path id="m562fdd8274" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m910be63ca4" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m562fdd8274" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m910be63ca4" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m562fdd8274" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m910be63ca4" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m562fdd8274" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m910be63ca4" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m562fdd8274" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m910be63ca4" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m562fdd8274" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.763672 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-16T05:12:18Z  ·  Linux chungus x86_64  ·  commit 3c05ffff  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(49.88875 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2764,45 +2805,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2871,13 +2873,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2916,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3324.511719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3359.716797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3394.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3426.708984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3458.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3490.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3522.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3553.857422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3581.640625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3643.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3704.443359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3767.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3831.298828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3870.162109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3931.34375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3990.523438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4052.046875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4093.160156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4126.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4154.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4216.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4277.4375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4340.816406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4404.439453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4438.130859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4497.310547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4560.933594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4592.720703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4656.34375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4719.966797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4751.753906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4815.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4851.460938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4890.324219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4945.304688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5008.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5040.714844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5072.501953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5104.289062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5136.076172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5167.863281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5207.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5270.451172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5309.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5370.496094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5433.875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5497.351562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5560.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5624.207031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5726.794922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5758.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5874.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5971.570312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6033.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6096.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6185.632812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6249.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6280.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6332.898438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6457.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6521.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6573.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6697.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6736.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6770.59375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6802.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6843.494141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6904.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6943.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6971.765625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7032.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7064.734375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7092.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.617188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7176.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7239.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7301.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7340.613281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7402.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7441.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7538.912109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7566.695312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.074219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7657.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7709.957031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7749.166016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7776.949219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pcb12790487">
+  <clipPath id="p2464dfa602">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.872656pt" height="386.202469pt" viewBox="0 0 570.872656 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="562.6225pt" height="386.202469pt" viewBox="0 0 562.6225 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.872656 386.202469 
-L 570.872656 0 
+L 562.6225 386.202469 
+L 562.6225 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.561328 104.1264 
-L 292.186328 104.1264 
-L 292.186328 74.7432 
-L 187.561328 74.7432 
+    <path d="M 183.43625 104.1264 
+L 288.06125 104.1264 
+L 288.06125 74.7432 
+L 183.43625 74.7432 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.186328 104.1264 
-L 396.811328 104.1264 
-L 396.811328 74.7432 
-L 292.186328 74.7432 
+    <path d="M 288.06125 104.1264 
+L 392.68625 104.1264 
+L 392.68625 74.7432 
+L 288.06125 74.7432 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.811328 104.1264 
-L 501.436328 104.1264 
-L 501.436328 74.7432 
-L 396.811328 74.7432 
+    <path d="M 392.68625 104.1264 
+L 497.31125 104.1264 
+L 497.31125 74.7432 
+L 392.68625 74.7432 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.561328 133.5096 
-L 292.186328 133.5096 
-L 292.186328 104.1264 
-L 187.561328 104.1264 
+    <path d="M 183.43625 133.5096 
+L 288.06125 133.5096 
+L 288.06125 104.1264 
+L 183.43625 104.1264 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.186328 133.5096 
-L 396.811328 133.5096 
-L 396.811328 104.1264 
-L 292.186328 104.1264 
+    <path d="M 288.06125 133.5096 
+L 392.68625 133.5096 
+L 392.68625 104.1264 
+L 288.06125 104.1264 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.811328 133.5096 
-L 501.436328 133.5096 
-L 501.436328 104.1264 
-L 396.811328 104.1264 
+    <path d="M 392.68625 133.5096 
+L 497.31125 133.5096 
+L 497.31125 104.1264 
+L 392.68625 104.1264 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #feca79; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.561328 162.8928 
-L 292.186328 162.8928 
-L 292.186328 133.5096 
-L 187.561328 133.5096 
+    <path d="M 183.43625 162.8928 
+L 288.06125 162.8928 
+L 288.06125 133.5096 
+L 183.43625 133.5096 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.186328 162.8928 
-L 396.811328 162.8928 
-L 396.811328 133.5096 
-L 292.186328 133.5096 
+    <path d="M 288.06125 162.8928 
+L 392.68625 162.8928 
+L 392.68625 133.5096 
+L 288.06125 133.5096 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.811328 162.8928 
-L 501.436328 162.8928 
-L 501.436328 133.5096 
-L 396.811328 133.5096 
+    <path d="M 392.68625 162.8928 
+L 497.31125 162.8928 
+L 497.31125 133.5096 
+L 392.68625 133.5096 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.561328 192.276 
-L 292.186328 192.276 
-L 292.186328 162.8928 
-L 187.561328 162.8928 
+    <path d="M 183.43625 192.276 
+L 288.06125 192.276 
+L 288.06125 162.8928 
+L 183.43625 162.8928 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.186328 192.276 
-L 396.811328 192.276 
-L 396.811328 162.8928 
-L 292.186328 162.8928 
+    <path d="M 288.06125 192.276 
+L 392.68625 192.276 
+L 392.68625 162.8928 
+L 288.06125 162.8928 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.811328 192.276 
-L 501.436328 192.276 
-L 501.436328 162.8928 
-L 396.811328 162.8928 
+    <path d="M 392.68625 192.276 
+L 497.31125 192.276 
+L 497.31125 162.8928 
+L 392.68625 162.8928 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.561328 221.6592 
-L 292.186328 221.6592 
-L 292.186328 192.276 
-L 187.561328 192.276 
+    <path d="M 183.43625 221.6592 
+L 288.06125 221.6592 
+L 288.06125 192.276 
+L 183.43625 192.276 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.186328 221.6592 
-L 396.811328 221.6592 
-L 396.811328 192.276 
-L 292.186328 192.276 
+    <path d="M 288.06125 221.6592 
+L 392.68625 221.6592 
+L 392.68625 192.276 
+L 288.06125 192.276 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.811328 221.6592 
-L 501.436328 221.6592 
-L 501.436328 192.276 
-L 396.811328 192.276 
+    <path d="M 392.68625 221.6592 
+L 497.31125 221.6592 
+L 497.31125 192.276 
+L 392.68625 192.276 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fff8b4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.561328 251.0424 
-L 292.186328 251.0424 
-L 292.186328 221.6592 
-L 187.561328 221.6592 
+    <path d="M 183.43625 251.0424 
+L 288.06125 251.0424 
+L 288.06125 221.6592 
+L 183.43625 221.6592 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.186328 251.0424 
-L 396.811328 251.0424 
-L 396.811328 221.6592 
-L 292.186328 221.6592 
+    <path d="M 288.06125 251.0424 
+L 392.68625 251.0424 
+L 392.68625 221.6592 
+L 288.06125 221.6592 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.811328 251.0424 
-L 501.436328 251.0424 
-L 501.436328 221.6592 
-L 396.811328 221.6592 
+    <path d="M 392.68625 251.0424 
+L 497.31125 251.0424 
+L 497.31125 221.6592 
+L 392.68625 221.6592 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.561328 280.4256 
-L 292.186328 280.4256 
-L 292.186328 251.0424 
-L 187.561328 251.0424 
+    <path d="M 183.43625 280.4256 
+L 288.06125 280.4256 
+L 288.06125 251.0424 
+L 183.43625 251.0424 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.186328 280.4256 
-L 396.811328 280.4256 
-L 396.811328 251.0424 
-L 292.186328 251.0424 
+    <path d="M 288.06125 280.4256 
+L 392.68625 280.4256 
+L 392.68625 251.0424 
+L 288.06125 251.0424 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.811328 280.4256 
-L 501.436328 280.4256 
-L 501.436328 251.0424 
-L 396.811328 251.0424 
+    <path d="M 392.68625 280.4256 
+L 497.31125 280.4256 
+L 497.31125 251.0424 
+L 392.68625 251.0424 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.561328 309.8088 
-L 292.186328 309.8088 
-L 292.186328 280.4256 
-L 187.561328 280.4256 
+    <path d="M 183.43625 309.8088 
+L 288.06125 309.8088 
+L 288.06125 280.4256 
+L 183.43625 280.4256 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fb9d59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.186328 309.8088 
-L 396.811328 309.8088 
-L 396.811328 280.4256 
-L 292.186328 280.4256 
+    <path d="M 288.06125 309.8088 
+L 392.68625 309.8088 
+L 392.68625 280.4256 
+L 288.06125 280.4256 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.811328 309.8088 
-L 501.436328 309.8088 
-L 501.436328 280.4256 
-L 396.811328 280.4256 
+    <path d="M 392.68625 309.8088 
+L 497.31125 309.8088 
+L 497.31125 280.4256 
+L 392.68625 280.4256 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #ed5f3c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.561328 339.192 
-L 292.186328 339.192 
-L 292.186328 309.8088 
-L 187.561328 309.8088 
+    <path d="M 183.43625 339.192 
+L 288.06125 339.192 
+L 288.06125 309.8088 
+L 183.43625 309.8088 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.186328 339.192 
-L 396.811328 339.192 
-L 396.811328 309.8088 
-L 292.186328 309.8088 
+    <path d="M 288.06125 339.192 
+L 392.68625 339.192 
+L 392.68625 309.8088 
+L 288.06125 309.8088 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.811328 339.192 
-L 501.436328 339.192 
-L 501.436328 309.8088 
-L 396.811328 309.8088 
+    <path d="M 392.68625 339.192 
+L 497.31125 339.192 
+L 497.31125 309.8088 
+L 392.68625 309.8088 
 z
-" clip-path="url(#p7a6707cffe)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p0bd005c3b7)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.548594 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(116.423516 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.832812 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(223.707734 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.404922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(302.279844 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.756641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(400.631563 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.486328 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(112.36125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.422578 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.863828 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(332.73875 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -951,8 +951,8 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 889 -->
-    <g transform="translate(441.488828 91.6423) scale(0.08 -0.08)">
+    <!-- 878 -->
+    <g transform="translate(437.36375 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -993,45 +993,15 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.124453 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(106.999375 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1130,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.422578 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1161,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.408828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(335.28375 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1200,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.488828 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(437.36375 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1208,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.817578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(94.6925 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1379,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.422578 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1416,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(339.408828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(335.28375 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(441.488828 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(437.36375 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1431,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.850078 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(115.725 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1491,7 +1461,39 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.422578 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 179.7919) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1501,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.408828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(335.28375 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(441.488828 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(437.36375 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1516,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.387578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(124.2625 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.422578 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1549,23 +1551,23 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- 38 -->
-    <g transform="translate(339.408828 209.1751) scale(0.08 -0.08)">
+    <!-- 37 -->
+    <g transform="translate(335.28375 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 454 -->
-    <g transform="translate(441.488828 209.1751) scale(0.08 -0.08)">
+    <!-- 451 -->
+    <g transform="translate(437.36375 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.693828 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(107.56875 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.422578 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,111 +1636,22 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(339.408828 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(335.28375 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 539 -->
-    <g transform="translate(441.488828 238.5583) scale(0.08 -0.08)">
+    <!-- 532 -->
+    <g transform="translate(437.36375 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- OCaml decompress -->
-    <g transform="translate(96.310703 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-4f" d="M 2522 4238 
-Q 1834 4238 1429 3725 
-Q 1025 3213 1025 2328 
-Q 1025 1447 1429 934 
-Q 1834 422 2522 422 
-Q 3209 422 3611 934 
-Q 4013 1447 4013 2328 
-Q 4013 3213 3611 3725 
-Q 3209 4238 2522 4238 
-z
-M 2522 4750 
-Q 3503 4750 4090 4092 
-Q 4678 3434 4678 2328 
-Q 4678 1225 4090 567 
-Q 3503 -91 2522 -91 
-Q 1538 -91 948 565 
-Q 359 1222 359 2328 
-Q 359 3434 948 4092 
-Q 1538 4750 2522 4750 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-4f"/>
-     <use xlink:href="#DejaVuSans-43" transform="translate(78.710938 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(148.535156 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(209.814453 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(307.226562 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(335.009766 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(366.796875 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(430.273438 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(491.796875 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(546.777344 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(607.958984 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(705.371094 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(768.847656 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(807.710938 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(869.234375 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(921.333984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 0.336 -->
-    <g transform="translate(228.422578 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 20 -->
-    <g transform="translate(339.408828 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 68 -->
-    <g transform="translate(444.033828 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.195703 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(94.070625 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1845,9 +1758,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_34">
-    <!-- 0.330 -->
-    <g transform="translate(227.221953 297.3247) scale(0.08 -0.08)">
+   <g id="text_30">
+    <!-- 0.332 -->
+    <g transform="translate(223.096875 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1909,18 +1822,6 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-30"/>
-     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(177.148438 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(246.728516 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 20 -->
-    <g transform="translate(338.932578 297.3247) scale(0.08 -0.08)">
-     <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
 L 3897 0 
@@ -1944,13 +1845,16 @@ L 1844 884
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_36">
-    <!-- 100 -->
-    <g transform="translate(440.774453 297.3247) scale(0.08 -0.08)">
+   <g id="text_31">
+    <!-- 31 -->
+    <g transform="translate(334.8075 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1967,14 +1871,131 @@ L 750 831
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 104 -->
+    <g transform="translate(436.649375 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- OCaml decompress -->
+    <g transform="translate(92.185625 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-43" transform="translate(78.710938 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(148.535156 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(209.814453 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(307.226562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(335.009766 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(366.796875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(430.273438 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(491.796875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(546.777344 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(607.958984 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(705.371094 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(768.847656 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(807.710938 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(869.234375 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(921.333984 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 0.336 -->
+    <g transform="translate(224.2975 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 20 -->
+    <g transform="translate(335.28375 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 68 -->
+    <g transform="translate(439.90875 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.531953 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(120.406875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -1985,7 +2006,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.422578 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(224.2975 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1995,13 +2016,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.953828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(337.82875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.123828 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(440.99875 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2017,7 +2038,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(152.038047 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(147.912969 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2161,7 +2182,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-16T04:08:01Z  ·  Linux chungus x86_64  ·  commit e22d5e5d  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-16T05:12:18Z  ·  Linux chungus x86_64  ·  commit 3c05ffff  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2303,13 +2324,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2348,110 +2369,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3260.498047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3324.121094 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3385.644531 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3449.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.744141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.53125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.318359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.105469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.679688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.462891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3760.986328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.265625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.644531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3987.984375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.166016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.345703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.869141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4210.982422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.673828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.457031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4333.980469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.259766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.638672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.261719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4555.953125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.755859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.542969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.166016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.789062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.576172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.199219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.283203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.146484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.126953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.537109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.324219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.111328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.898438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.894531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.273438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.318359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.697266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.173828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.552734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.408203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.617188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.404297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.193359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5991.980469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.392578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.916016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.392578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.175781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.833984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.621094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.720703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.099609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.378906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.855469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6690.955078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.515625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.724609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.416016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.203125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.316406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.595703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.804688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.587891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.769531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.556641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.339844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.439453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.703125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.226562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.435547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7519.958984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.322266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.734375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.896484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.779297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7866.988281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.771484 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3289.306641 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3324.511719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3359.716797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3394.921875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3426.708984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3458.496094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3490.283203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3522.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3553.857422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3581.640625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3643.164062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3704.443359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3767.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3831.298828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3870.162109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(3931.34375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3990.523438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4052.046875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4093.160156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4126.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4154.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4216.158203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4277.4375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4340.816406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4404.439453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4438.130859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4497.310547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4560.933594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4592.720703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4656.34375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4719.966797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4751.753906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4815.376953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4851.460938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4890.324219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4945.304688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5008.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5040.714844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5072.501953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5104.289062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5136.076172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5167.863281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5207.072266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5270.451172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5309.314453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5370.496094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5433.875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5497.351562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5560.730469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5624.207031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5687.585938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5726.794922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5758.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5842.371094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5874.158203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5971.570312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6033.09375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6096.570312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6185.632812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6249.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6280.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6332.898438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6396.277344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6457.556641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6521.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6573.132812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6636.511719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6697.693359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6736.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6770.59375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6802.380859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6843.494141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6904.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6943.982422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6971.765625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7032.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7064.734375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7092.517578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7144.617188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7176.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7239.880859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7301.404297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7340.613281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7402.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7441.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7538.912109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7566.695312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.074219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7657.857422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7709.957031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7749.166016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7776.949219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7a6707cffe">
-   <rect x="82.936328" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p0bd005c3b7">
+   <rect x="78.81125" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-16T04:08:01Z",
+  "date": "2026-06-16T05:12:18Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "e22d5e5d",
+  "git_commit": "3c05ffff",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -12,909 +12,909 @@
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 1,
-   "out_size": 59545,
-   "ratio": 0.3915,
-   "compress_mbps": 31.02,
-   "decompress_mbps": 86.4
+   "out_size": 56868,
+   "ratio": 0.3739,
+   "compress_mbps": 34.75,
+   "decompress_mbps": 86.71
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 2,
-   "out_size": 57936,
-   "ratio": 0.3809,
-   "compress_mbps": 27.8,
-   "decompress_mbps": 94.41
+   "out_size": 56050,
+   "ratio": 0.3685,
+   "compress_mbps": 32.09,
+   "decompress_mbps": 94.78
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 3,
-   "out_size": 56891,
-   "ratio": 0.3741,
-   "compress_mbps": 24.7,
-   "decompress_mbps": 103.96
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 55596,
-   "ratio": 0.3655,
-   "compress_mbps": 18.22,
+   "out_size": 55543,
+   "ratio": 0.3652,
+   "compress_mbps": 30.17,
    "decompress_mbps": 104.09
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
+   "level": 4,
+   "out_size": 54765,
+   "ratio": 0.3601,
+   "compress_mbps": 24.98,
+   "decompress_mbps": 103.6
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
    "level": 5,
-   "out_size": 55337,
-   "ratio": 0.3638,
-   "compress_mbps": 17.22,
-   "decompress_mbps": 106.71
+   "out_size": 54681,
+   "ratio": 0.3595,
+   "compress_mbps": 24.21,
+   "decompress_mbps": 105.73
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 6,
-   "out_size": 54954,
-   "ratio": 0.3613,
-   "compress_mbps": 15.14,
-   "decompress_mbps": 111.67
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54533,
+   "out_size": 54535,
    "ratio": 0.3586,
+   "compress_mbps": 22.68,
+   "decompress_mbps": 110.06
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54140,
+   "ratio": 0.356,
+   "compress_mbps": 9.05,
+   "decompress_mbps": 109.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54127,
+   "ratio": 0.3559,
+   "compress_mbps": 8.91,
+   "decompress_mbps": 108.95
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 52022,
+   "ratio": 0.342,
+   "compress_mbps": 1.4,
+   "decompress_mbps": 109.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 50489,
+   "ratio": 0.4033,
+   "compress_mbps": 32.38,
+   "decompress_mbps": 81.87
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50023,
+   "ratio": 0.3996,
+   "compress_mbps": 30.25,
+   "decompress_mbps": 86.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 49768,
+   "ratio": 0.3976,
+   "compress_mbps": 28.56,
+   "decompress_mbps": 92.92
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 49034,
+   "ratio": 0.3917,
+   "compress_mbps": 23.07,
+   "decompress_mbps": 93.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48992,
+   "ratio": 0.3914,
+   "compress_mbps": 22.54,
+   "decompress_mbps": 95.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48934,
+   "ratio": 0.3909,
+   "compress_mbps": 21.65,
+   "decompress_mbps": 97.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48634,
+   "ratio": 0.3885,
+   "compress_mbps": 8.65,
+   "decompress_mbps": 97.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48634,
+   "ratio": 0.3885,
+   "compress_mbps": 8.6,
+   "decompress_mbps": 97.71
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 46817,
+   "ratio": 0.374,
+   "compress_mbps": 1.64,
+   "decompress_mbps": 98.91
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8199,
+   "ratio": 0.3333,
+   "compress_mbps": 30.71,
+   "decompress_mbps": 85.73
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8112,
+   "ratio": 0.3297,
+   "compress_mbps": 29.91,
+   "decompress_mbps": 89.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8053,
+   "ratio": 0.3273,
+   "compress_mbps": 29.6,
+   "decompress_mbps": 91.53
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 7968,
+   "ratio": 0.3239,
+   "compress_mbps": 28.17,
+   "decompress_mbps": 90.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7961,
+   "ratio": 0.3236,
+   "compress_mbps": 27.85,
+   "decompress_mbps": 93.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7949,
+   "ratio": 0.3231,
+   "compress_mbps": 27.13,
+   "decompress_mbps": 92.58
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7929,
+   "ratio": 0.3223,
+   "compress_mbps": 9.51,
+   "decompress_mbps": 93.06
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7929,
+   "ratio": 0.3223,
+   "compress_mbps": 9.52,
+   "decompress_mbps": 93.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7731,
+   "ratio": 0.3142,
+   "compress_mbps": 1.48,
+   "decompress_mbps": 92.91
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3282,
+   "ratio": 0.2943,
+   "compress_mbps": 21.71,
+   "decompress_mbps": 75.39
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3227,
+   "ratio": 0.2894,
+   "compress_mbps": 21.25,
+   "decompress_mbps": 77.72
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3183,
+   "ratio": 0.2855,
+   "compress_mbps": 21.01,
+   "decompress_mbps": 79.89
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3147,
+   "ratio": 0.2822,
+   "compress_mbps": 20.17,
+   "decompress_mbps": 81.37
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3141,
+   "ratio": 0.2817,
+   "compress_mbps": 20.04,
+   "decompress_mbps": 82.39
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3133,
+   "ratio": 0.281,
+   "compress_mbps": 19.74,
+   "decompress_mbps": 83.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3128,
+   "ratio": 0.2805,
    "compress_mbps": 7.0,
-   "decompress_mbps": 109.34
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 54492,
-   "ratio": 0.3583,
-   "compress_mbps": 6.6,
-   "decompress_mbps": 109.96
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 52111,
-   "ratio": 0.3426,
-   "compress_mbps": 0.97,
-   "decompress_mbps": 109.51
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 52768,
-   "ratio": 0.4215,
-   "compress_mbps": 29.21,
-   "decompress_mbps": 81.47
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 51760,
-   "ratio": 0.4135,
-   "compress_mbps": 26.15,
-   "decompress_mbps": 86.12
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 51056,
-   "ratio": 0.4079,
-   "compress_mbps": 23.11,
-   "decompress_mbps": 92.34
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 49986,
-   "ratio": 0.3993,
-   "compress_mbps": 16.41,
-   "decompress_mbps": 93.27
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 49809,
-   "ratio": 0.3979,
-   "compress_mbps": 15.45,
-   "decompress_mbps": 96.48
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 49570,
-   "ratio": 0.396,
-   "compress_mbps": 13.71,
-   "decompress_mbps": 97.96
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 49161,
-   "ratio": 0.3927,
-   "compress_mbps": 6.59,
-   "decompress_mbps": 98.17
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 49153,
-   "ratio": 0.3927,
-   "compress_mbps": 6.49,
-   "decompress_mbps": 98.93
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 46881,
-   "ratio": 0.3745,
-   "compress_mbps": 1.11,
-   "decompress_mbps": 98.25
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8430,
-   "ratio": 0.3426,
-   "compress_mbps": 27.63,
-   "decompress_mbps": 84.5
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8297,
-   "ratio": 0.3372,
-   "compress_mbps": 26.69,
-   "decompress_mbps": 88.29
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8218,
-   "ratio": 0.334,
-   "compress_mbps": 26.02,
-   "decompress_mbps": 90.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8072,
-   "ratio": 0.3281,
-   "compress_mbps": 23.53,
-   "decompress_mbps": 89.48
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 8066,
-   "ratio": 0.3278,
-   "compress_mbps": 23.24,
-   "decompress_mbps": 91.96
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 8056,
-   "ratio": 0.3274,
-   "compress_mbps": 22.4,
-   "decompress_mbps": 91.62
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 8038,
-   "ratio": 0.3267,
-   "compress_mbps": 8.32,
-   "decompress_mbps": 92.71
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 8038,
-   "ratio": 0.3267,
-   "compress_mbps": 8.29,
-   "decompress_mbps": 92.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7727,
-   "ratio": 0.3141,
-   "compress_mbps": 1.27,
-   "decompress_mbps": 92.23
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3325,
-   "ratio": 0.2982,
-   "compress_mbps": 20.72,
-   "decompress_mbps": 75.08
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3251,
-   "ratio": 0.2916,
-   "compress_mbps": 20.21,
-   "decompress_mbps": 77.43
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3202,
-   "ratio": 0.2872,
-   "compress_mbps": 19.79,
-   "decompress_mbps": 79.5
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3153,
-   "ratio": 0.2828,
-   "compress_mbps": 18.46,
-   "decompress_mbps": 81.19
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3143,
-   "ratio": 0.2819,
-   "compress_mbps": 18.37,
-   "decompress_mbps": 82.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3139,
-   "ratio": 0.2815,
-   "compress_mbps": 17.97,
-   "decompress_mbps": 82.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3134,
-   "ratio": 0.2811,
-   "compress_mbps": 6.37,
-   "decompress_mbps": 82.17
+   "decompress_mbps": 82.87
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 8,
-   "out_size": 3134,
-   "ratio": 0.2811,
-   "compress_mbps": 6.36,
-   "decompress_mbps": 83.16
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 7.0,
+   "decompress_mbps": 82.98
   },
   {
    "compressor": "native",
    "pattern": "canterbury/fields.c",
    "size": 11150,
    "level": 9,
-   "out_size": 3027,
-   "ratio": 0.2715,
-   "compress_mbps": 1.35,
-   "decompress_mbps": 82.34
+   "out_size": 3036,
+   "ratio": 0.2723,
+   "compress_mbps": 1.61,
+   "decompress_mbps": 82.41
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
    "level": 1,
-   "out_size": 1251,
-   "ratio": 0.3362,
-   "compress_mbps": 10.44,
-   "decompress_mbps": 41.89
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1241,
-   "ratio": 0.3335,
-   "compress_mbps": 10.38,
-   "decompress_mbps": 42.28
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1241,
-   "ratio": 0.3335,
-   "compress_mbps": 10.27,
-   "decompress_mbps": 42.52
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 10.08,
-   "decompress_mbps": 43.3
+   "compress_mbps": 10.78,
+   "decompress_mbps": 42.13
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
-   "level": 5,
-   "out_size": 1227,
-   "ratio": 0.3298,
-   "compress_mbps": 10.13,
+   "level": 2,
+   "out_size": 1223,
+   "ratio": 0.3287,
+   "compress_mbps": 10.7,
+   "decompress_mbps": 42.53
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1222,
+   "ratio": 0.3284,
+   "compress_mbps": 10.64,
+   "decompress_mbps": 42.87
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1213,
+   "ratio": 0.326,
+   "compress_mbps": 10.54,
    "decompress_mbps": 43.56
   },
   {
    "compressor": "native",
    "pattern": "canterbury/grammar.lsp",
    "size": 3721,
-   "level": 6,
-   "out_size": 1227,
-   "ratio": 0.3298,
-   "compress_mbps": 10.1,
-   "decompress_mbps": 43.48
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1224,
-   "ratio": 0.3289,
-   "compress_mbps": 3.61,
-   "decompress_mbps": 43.41
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1224,
-   "ratio": 0.3289,
-   "compress_mbps": 3.6,
-   "decompress_mbps": 43.45
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1190,
-   "ratio": 0.3198,
-   "compress_mbps": 1.13,
-   "decompress_mbps": 43.95
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 248840,
-   "ratio": 0.2417,
-   "compress_mbps": 61.39,
-   "decompress_mbps": 129.7
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 247429,
-   "ratio": 0.2403,
-   "compress_mbps": 56.84,
-   "decompress_mbps": 149.26
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 246442,
-   "ratio": 0.2393,
-   "compress_mbps": 54.75,
-   "decompress_mbps": 157.25
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 242288,
-   "ratio": 0.2353,
-   "compress_mbps": 51.81,
-   "decompress_mbps": 162.88
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
    "level": 5,
-   "out_size": 242066,
-   "ratio": 0.2351,
-   "compress_mbps": 50.24,
-   "decompress_mbps": 130.44
+   "out_size": 1213,
+   "ratio": 0.326,
+   "compress_mbps": 10.52,
+   "decompress_mbps": 43.39
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
    "level": 6,
-   "out_size": 241736,
-   "ratio": 0.2348,
-   "compress_mbps": 45.33,
-   "decompress_mbps": 131.33
+   "out_size": 1213,
+   "ratio": 0.326,
+   "compress_mbps": 10.54,
+   "decompress_mbps": 43.91
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
    "level": 7,
-   "out_size": 201296,
-   "ratio": 0.1955,
-   "compress_mbps": 9.4,
-   "decompress_mbps": 122.37
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 201458,
-   "ratio": 0.1956,
-   "compress_mbps": 7.56,
-   "decompress_mbps": 120.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 178311,
-   "ratio": 0.1732,
-   "compress_mbps": 0.72,
-   "decompress_mbps": 120.42
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 158127,
-   "ratio": 0.3705,
-   "compress_mbps": 33.54,
-   "decompress_mbps": 89.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 153708,
-   "ratio": 0.3602,
-   "compress_mbps": 29.85,
-   "decompress_mbps": 96.21
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 150718,
-   "ratio": 0.3532,
-   "compress_mbps": 26.02,
-   "decompress_mbps": 106.13
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 147584,
-   "ratio": 0.3458,
-   "compress_mbps": 19.28,
-   "decompress_mbps": 106.83
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 146956,
-   "ratio": 0.3444,
-   "compress_mbps": 16.51,
-   "decompress_mbps": 92.09
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 146218,
-   "ratio": 0.3426,
-   "compress_mbps": 14.28,
-   "decompress_mbps": 96.86
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 145400,
-   "ratio": 0.3407,
-   "compress_mbps": 6.47,
-   "decompress_mbps": 96.64
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 145324,
-   "ratio": 0.3405,
-   "compress_mbps": 6.19,
-   "decompress_mbps": 94.08
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 138661,
+   "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 0.97,
-   "decompress_mbps": 113.78
+   "compress_mbps": 3.8,
+   "decompress_mbps": 43.64
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 212305,
-   "ratio": 0.4406,
-   "compress_mbps": 28.44,
-   "decompress_mbps": 78.6
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 207350,
-   "ratio": 0.4303,
-   "compress_mbps": 24.8,
-   "decompress_mbps": 85.1
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 203699,
-   "ratio": 0.4227,
-   "compress_mbps": 21.47,
-   "decompress_mbps": 90.62
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 200095,
-   "ratio": 0.4153,
-   "compress_mbps": 14.79,
-   "decompress_mbps": 91.1
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 199269,
-   "ratio": 0.4135,
-   "compress_mbps": 13.83,
-   "decompress_mbps": 94.27
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 198081,
-   "ratio": 0.4111,
-   "compress_mbps": 11.97,
-   "decompress_mbps": 96.46
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 197186,
-   "ratio": 0.4092,
-   "compress_mbps": 6.02,
-   "decompress_mbps": 96.81
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
    "level": 8,
-   "out_size": 197001,
-   "ratio": 0.4088,
-   "compress_mbps": 5.62,
-   "decompress_mbps": 97.45
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 3.8,
+   "decompress_mbps": 43.32
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
    "level": 9,
-   "out_size": 186472,
-   "ratio": 0.387,
-   "compress_mbps": 0.99,
-   "decompress_mbps": 97.31
+   "out_size": 1191,
+   "ratio": 0.3201,
+   "compress_mbps": 1.28,
+   "decompress_mbps": 43.87
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
    "level": 1,
-   "out_size": 60352,
-   "ratio": 0.1176,
-   "compress_mbps": 96.74,
-   "decompress_mbps": 240.7
+   "out_size": 243674,
+   "ratio": 0.2366,
+   "compress_mbps": 61.58,
+   "decompress_mbps": 128.2
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
    "level": 2,
-   "out_size": 59696,
-   "ratio": 0.1163,
-   "compress_mbps": 86.52,
-   "decompress_mbps": 251.8
+   "out_size": 242564,
+   "ratio": 0.2356,
+   "compress_mbps": 57.32,
+   "decompress_mbps": 148.92
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
    "level": 3,
-   "out_size": 59069,
-   "ratio": 0.1151,
-   "compress_mbps": 75.44,
-   "decompress_mbps": 266.09
+   "out_size": 242532,
+   "ratio": 0.2355,
+   "compress_mbps": 52.38,
+   "decompress_mbps": 155.2
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
    "level": 4,
-   "out_size": 57047,
-   "ratio": 0.1112,
-   "compress_mbps": 59.15,
-   "decompress_mbps": 242.05
+   "out_size": 239898,
+   "ratio": 0.233,
+   "compress_mbps": 52.47,
+   "decompress_mbps": 160.54
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
    "level": 5,
-   "out_size": 56965,
-   "ratio": 0.111,
-   "compress_mbps": 56.5,
-   "decompress_mbps": 254.62
+   "out_size": 239804,
+   "ratio": 0.2329,
+   "compress_mbps": 51.75,
+   "decompress_mbps": 129.17
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
    "level": 6,
-   "out_size": 56766,
-   "ratio": 0.1106,
-   "compress_mbps": 49.78,
-   "decompress_mbps": 268.72
+   "out_size": 239606,
+   "ratio": 0.2327,
+   "compress_mbps": 49.09,
+   "decompress_mbps": 128.66
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
    "level": 7,
-   "out_size": 54820,
-   "ratio": 0.1068,
-   "compress_mbps": 17.29,
-   "decompress_mbps": 280.81
+   "out_size": 200711,
+   "ratio": 0.1949,
+   "compress_mbps": 9.5,
+   "decompress_mbps": 122.68
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
    "level": 8,
-   "out_size": 54111,
-   "ratio": 0.1054,
-   "compress_mbps": 15.38,
-   "decompress_mbps": 290.69
+   "out_size": 200719,
+   "ratio": 0.1949,
+   "compress_mbps": 7.55,
+   "decompress_mbps": 118.09
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
    "level": 9,
-   "out_size": 51490,
-   "ratio": 0.1003,
-   "compress_mbps": 0.42,
-   "decompress_mbps": 295.85
+   "out_size": 179506,
+   "ratio": 0.1743,
+   "compress_mbps": 0.77,
+   "decompress_mbps": 118.05
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
    "level": 1,
-   "out_size": 13725,
-   "ratio": 0.3589,
-   "compress_mbps": 22.37,
-   "decompress_mbps": 65.57
+   "out_size": 150916,
+   "ratio": 0.3536,
+   "compress_mbps": 37.45,
+   "decompress_mbps": 90.39
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
    "level": 2,
-   "out_size": 13615,
-   "ratio": 0.356,
-   "compress_mbps": 21.6,
-   "decompress_mbps": 69.11
+   "out_size": 148848,
+   "ratio": 0.3488,
+   "compress_mbps": 34.64,
+   "decompress_mbps": 96.74
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
    "level": 3,
-   "out_size": 13548,
-   "ratio": 0.3543,
-   "compress_mbps": 20.83,
-   "decompress_mbps": 72.24
+   "out_size": 147739,
+   "ratio": 0.3462,
+   "compress_mbps": 32.16,
+   "decompress_mbps": 106.54
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
    "level": 4,
-   "out_size": 13098,
-   "ratio": 0.3425,
-   "compress_mbps": 18.02,
-   "decompress_mbps": 70.3
+   "out_size": 145779,
+   "ratio": 0.3416,
+   "compress_mbps": 26.44,
+   "decompress_mbps": 107.99
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
    "level": 5,
-   "out_size": 13080,
-   "ratio": 0.3421,
-   "compress_mbps": 17.52,
-   "decompress_mbps": 74.01
+   "out_size": 145631,
+   "ratio": 0.3413,
+   "compress_mbps": 25.4,
+   "decompress_mbps": 111.58
   },
   {
    "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
    "level": 6,
-   "out_size": 13027,
+   "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 16.03,
-   "decompress_mbps": 75.06
+   "compress_mbps": 23.78,
+   "decompress_mbps": 113.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144554,
+   "ratio": 0.3387,
+   "compress_mbps": 9.53,
+   "decompress_mbps": 113.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144540,
+   "ratio": 0.3387,
+   "compress_mbps": 9.45,
+   "decompress_mbps": 113.79
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 138791,
+   "ratio": 0.3252,
+   "compress_mbps": 1.39,
+   "decompress_mbps": 113.63
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 202083,
+   "ratio": 0.4194,
+   "compress_mbps": 32.28,
+   "decompress_mbps": 78.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 199922,
+   "ratio": 0.4149,
+   "compress_mbps": 29.8,
+   "decompress_mbps": 85.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 198538,
+   "ratio": 0.412,
+   "compress_mbps": 27.63,
+   "decompress_mbps": 90.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 195796,
+   "ratio": 0.4063,
+   "compress_mbps": 20.8,
+   "decompress_mbps": 91.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 195460,
+   "ratio": 0.4056,
+   "compress_mbps": 20.12,
+   "decompress_mbps": 93.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 194965,
+   "ratio": 0.4046,
+   "compress_mbps": 18.76,
+   "decompress_mbps": 96.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194385,
+   "ratio": 0.4034,
+   "compress_mbps": 8.1,
+   "decompress_mbps": 97.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194380,
+   "ratio": 0.4034,
+   "compress_mbps": 8.09,
+   "decompress_mbps": 97.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 185549,
+   "ratio": 0.3851,
+   "compress_mbps": 1.48,
+   "decompress_mbps": 97.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 58252,
+   "ratio": 0.1135,
+   "compress_mbps": 109.02,
+   "decompress_mbps": 240.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 57685,
+   "ratio": 0.1124,
+   "compress_mbps": 98.21,
+   "decompress_mbps": 253.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 57118,
+   "ratio": 0.1113,
+   "compress_mbps": 85.82,
+   "decompress_mbps": 268.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 55724,
+   "ratio": 0.1086,
+   "compress_mbps": 68.76,
+   "decompress_mbps": 243.61
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 55673,
+   "ratio": 0.1085,
+   "compress_mbps": 66.62,
+   "decompress_mbps": 257.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55441,
+   "ratio": 0.108,
+   "compress_mbps": 60.43,
+   "decompress_mbps": 270.33
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 53495,
+   "ratio": 0.1042,
+   "compress_mbps": 18.56,
+   "decompress_mbps": 279.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52897,
+   "ratio": 0.1031,
+   "compress_mbps": 16.48,
+   "decompress_mbps": 291.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51139,
+   "ratio": 0.0996,
+   "compress_mbps": 0.42,
+   "decompress_mbps": 297.32
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 13822,
+   "ratio": 0.3615,
+   "compress_mbps": 24.08,
+   "decompress_mbps": 65.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13760,
+   "ratio": 0.3598,
+   "compress_mbps": 23.67,
+   "decompress_mbps": 68.54
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13727,
+   "ratio": 0.359,
+   "compress_mbps": 23.07,
+   "decompress_mbps": 71.68
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13371,
+   "ratio": 0.3497,
+   "compress_mbps": 21.53,
+   "decompress_mbps": 69.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13366,
+   "ratio": 0.3495,
+   "compress_mbps": 21.23,
+   "decompress_mbps": 73.18
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13369,
+   "ratio": 0.3496,
+   "compress_mbps": 20.33,
+   "decompress_mbps": 74.13
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 7,
-   "out_size": 12823,
-   "ratio": 0.3353,
-   "compress_mbps": 5.05,
-   "decompress_mbps": 74.17
+   "out_size": 13035,
+   "ratio": 0.3409,
+   "compress_mbps": 5.68,
+   "decompress_mbps": 72.86
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 8,
-   "out_size": 12811,
-   "ratio": 0.335,
-   "compress_mbps": 4.64,
-   "decompress_mbps": 77.78
+   "out_size": 13028,
+   "ratio": 0.3407,
+   "compress_mbps": 5.35,
+   "decompress_mbps": 76.12
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 9,
-   "out_size": 12278,
-   "ratio": 0.3211,
-   "compress_mbps": 0.97,
-   "decompress_mbps": 75.9
+   "out_size": 12674,
+   "ratio": 0.3314,
+   "compress_mbps": 1.22,
+   "decompress_mbps": 73.87
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 1,
-   "out_size": 1781,
-   "ratio": 0.4213,
-   "compress_mbps": 11.47,
+   "out_size": 1747,
+   "ratio": 0.4133,
+   "compress_mbps": 11.83,
    "decompress_mbps": 42.07
   },
   {
@@ -922,80 +922,80 @@
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 2,
-   "out_size": 1764,
-   "ratio": 0.4173,
-   "compress_mbps": 11.41,
-   "decompress_mbps": 42.88
+   "out_size": 1741,
+   "ratio": 0.4119,
+   "compress_mbps": 11.74,
+   "decompress_mbps": 42.91
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 3,
-   "out_size": 1765,
-   "ratio": 0.4176,
-   "compress_mbps": 11.39,
-   "decompress_mbps": 42.97
+   "out_size": 1740,
+   "ratio": 0.4116,
+   "compress_mbps": 11.86,
+   "decompress_mbps": 42.98
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 4,
-   "out_size": 1750,
-   "ratio": 0.414,
-   "compress_mbps": 11.24,
-   "decompress_mbps": 43.81
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 11.72,
+   "decompress_mbps": 43.77
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 5,
-   "out_size": 1750,
-   "ratio": 0.414,
-   "compress_mbps": 11.25,
-   "decompress_mbps": 43.67
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1750,
-   "ratio": 0.414,
-   "compress_mbps": 11.25,
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 11.72,
    "decompress_mbps": 43.81
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
+   "level": 6,
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 11.7,
+   "decompress_mbps": 43.77
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
    "level": 7,
-   "out_size": 1747,
-   "ratio": 0.4133,
-   "compress_mbps": 3.88,
-   "decompress_mbps": 43.47
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 4.09,
+   "decompress_mbps": 43.5
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 8,
-   "out_size": 1747,
-   "ratio": 0.4133,
-   "compress_mbps": 3.87,
-   "decompress_mbps": 43.54
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 4.09,
+   "decompress_mbps": 43.59
   },
   {
    "compressor": "native",
    "pattern": "canterbury/xargs.1",
    "size": 4227,
    "level": 9,
-   "out_size": 1696,
-   "ratio": 0.4012,
-   "compress_mbps": 1.31,
-   "decompress_mbps": 43.45
+   "out_size": 1700,
+   "ratio": 0.4022,
+   "compress_mbps": 1.46,
+   "decompress_mbps": 43.34
   },
   {
    "compressor": "zlib",
@@ -1004,8 +1004,8 @@
    "level": 1,
    "out_size": 65130,
    "ratio": 0.4282,
-   "compress_mbps": 118.8,
-   "decompress_mbps": 397.09
+   "compress_mbps": 118.84,
+   "decompress_mbps": 399.29
   },
   {
    "compressor": "zlib",
@@ -1014,8 +1014,8 @@
    "level": 2,
    "out_size": 62270,
    "ratio": 0.4094,
-   "compress_mbps": 102.02,
-   "decompress_mbps": 415.49
+   "compress_mbps": 101.78,
+   "decompress_mbps": 418.8
   },
   {
    "compressor": "zlib",
@@ -1024,8 +1024,8 @@
    "level": 3,
    "out_size": 59488,
    "ratio": 0.3911,
-   "compress_mbps": 67.28,
-   "decompress_mbps": 428.14
+   "compress_mbps": 67.0,
+   "decompress_mbps": 435.28
   },
   {
    "compressor": "zlib",
@@ -1034,8 +1034,8 @@
    "level": 4,
    "out_size": 57679,
    "ratio": 0.3792,
-   "compress_mbps": 72.14,
-   "decompress_mbps": 410.74
+   "compress_mbps": 71.67,
+   "decompress_mbps": 414.35
   },
   {
    "compressor": "zlib",
@@ -1044,8 +1044,8 @@
    "level": 5,
    "out_size": 55616,
    "ratio": 0.3657,
-   "compress_mbps": 42.19,
-   "decompress_mbps": 401.47
+   "compress_mbps": 41.81,
+   "decompress_mbps": 408.93
   },
   {
    "compressor": "zlib",
@@ -1054,8 +1054,8 @@
    "level": 6,
    "out_size": 54398,
    "ratio": 0.3577,
-   "compress_mbps": 25.62,
-   "decompress_mbps": 415.51
+   "compress_mbps": 25.53,
+   "decompress_mbps": 421.51
   },
   {
    "compressor": "zlib",
@@ -1064,8 +1064,8 @@
    "level": 7,
    "out_size": 54253,
    "ratio": 0.3567,
-   "compress_mbps": 21.49,
-   "decompress_mbps": 416.57
+   "compress_mbps": 21.45,
+   "decompress_mbps": 423.73
   },
   {
    "compressor": "zlib",
@@ -1074,8 +1074,8 @@
    "level": 8,
    "out_size": 54164,
    "ratio": 0.3561,
-   "compress_mbps": 17.06,
-   "decompress_mbps": 416.96
+   "compress_mbps": 16.99,
+   "decompress_mbps": 425.54
   },
   {
    "compressor": "zlib",
@@ -1084,8 +1084,8 @@
    "level": 9,
    "out_size": 54164,
    "ratio": 0.3561,
-   "compress_mbps": 17.04,
-   "decompress_mbps": 416.51
+   "compress_mbps": 16.98,
+   "decompress_mbps": 423.92
   },
   {
    "compressor": "zlib",
@@ -1094,8 +1094,8 @@
    "level": 1,
    "out_size": 56791,
    "ratio": 0.4537,
-   "compress_mbps": 115.9,
-   "decompress_mbps": 388.54
+   "compress_mbps": 115.6,
+   "decompress_mbps": 394.7
   },
   {
    "compressor": "zlib",
@@ -1104,8 +1104,8 @@
    "level": 2,
    "out_size": 54652,
    "ratio": 0.4366,
-   "compress_mbps": 98.11,
-   "decompress_mbps": 403.21
+   "compress_mbps": 97.78,
+   "decompress_mbps": 407.38
   },
   {
    "compressor": "zlib",
@@ -1114,8 +1114,8 @@
    "level": 3,
    "out_size": 52663,
    "ratio": 0.4207,
-   "compress_mbps": 62.56,
-   "decompress_mbps": 424.42
+   "compress_mbps": 62.36,
+   "decompress_mbps": 428.67
   },
   {
    "compressor": "zlib",
@@ -1124,8 +1124,8 @@
    "level": 4,
    "out_size": 51266,
    "ratio": 0.4095,
-   "compress_mbps": 67.99,
-   "decompress_mbps": 395.27
+   "compress_mbps": 67.4,
+   "decompress_mbps": 398.49
   },
   {
    "compressor": "zlib",
@@ -1134,8 +1134,8 @@
    "level": 5,
    "out_size": 49622,
    "ratio": 0.3964,
-   "compress_mbps": 37.63,
-   "decompress_mbps": 385.38
+   "compress_mbps": 37.32,
+   "decompress_mbps": 386.08
   },
   {
    "compressor": "zlib",
@@ -1144,8 +1144,8 @@
    "level": 6,
    "out_size": 48891,
    "ratio": 0.3906,
-   "compress_mbps": 22.92,
-   "decompress_mbps": 387.37
+   "compress_mbps": 22.81,
+   "decompress_mbps": 395.49
   },
   {
    "compressor": "zlib",
@@ -1154,8 +1154,8 @@
    "level": 7,
    "out_size": 48801,
    "ratio": 0.3898,
-   "compress_mbps": 20.1,
-   "decompress_mbps": 394.92
+   "compress_mbps": 20.02,
+   "decompress_mbps": 397.56
   },
   {
    "compressor": "zlib",
@@ -1164,8 +1164,8 @@
    "level": 8,
    "out_size": 48772,
    "ratio": 0.3896,
-   "compress_mbps": 18.19,
-   "decompress_mbps": 392.93
+   "compress_mbps": 18.15,
+   "decompress_mbps": 395.81
   },
   {
    "compressor": "zlib",
@@ -1174,8 +1174,8 @@
    "level": 9,
    "out_size": 48772,
    "ratio": 0.3896,
-   "compress_mbps": 18.2,
-   "decompress_mbps": 392.95
+   "compress_mbps": 18.14,
+   "decompress_mbps": 399.23
   },
   {
    "compressor": "zlib",
@@ -1184,8 +1184,8 @@
    "level": 1,
    "out_size": 9028,
    "ratio": 0.3669,
-   "compress_mbps": 412.21,
-   "decompress_mbps": 1045.04
+   "compress_mbps": 414.75,
+   "decompress_mbps": 1058.33
   },
   {
    "compressor": "zlib",
@@ -1194,8 +1194,8 @@
    "level": 2,
    "out_size": 8811,
    "ratio": 0.3581,
-   "compress_mbps": 217.23,
-   "decompress_mbps": 1072.07
+   "compress_mbps": 218.08,
+   "decompress_mbps": 1085.71
   },
   {
    "compressor": "zlib",
@@ -1204,8 +1204,8 @@
    "level": 3,
    "out_size": 8616,
    "ratio": 0.3502,
-   "compress_mbps": 160.24,
-   "decompress_mbps": 1099.14
+   "compress_mbps": 163.26,
+   "decompress_mbps": 1104.41
   },
   {
    "compressor": "zlib",
@@ -1214,8 +1214,8 @@
    "level": 4,
    "out_size": 8219,
    "ratio": 0.3341,
-   "compress_mbps": 117.35,
-   "decompress_mbps": 1111.63
+   "compress_mbps": 116.35,
+   "decompress_mbps": 1113.96
   },
   {
    "compressor": "zlib",
@@ -1224,8 +1224,8 @@
    "level": 5,
    "out_size": 8001,
    "ratio": 0.3252,
-   "compress_mbps": 85.23,
-   "decompress_mbps": 1142.93
+   "compress_mbps": 84.93,
+   "decompress_mbps": 1146.67
   },
   {
    "compressor": "zlib",
@@ -1234,8 +1234,8 @@
    "level": 6,
    "out_size": 7955,
    "ratio": 0.3233,
-   "compress_mbps": 68.93,
-   "decompress_mbps": 1144.77
+   "compress_mbps": 68.91,
+   "decompress_mbps": 1156.51
   },
   {
    "compressor": "zlib",
@@ -1244,8 +1244,8 @@
    "level": 7,
    "out_size": 7933,
    "ratio": 0.3224,
-   "compress_mbps": 63.18,
-   "decompress_mbps": 1154.46
+   "compress_mbps": 62.88,
+   "decompress_mbps": 1159.42
   },
   {
    "compressor": "zlib",
@@ -1254,8 +1254,8 @@
    "level": 8,
    "out_size": 7934,
    "ratio": 0.3225,
-   "compress_mbps": 58.33,
-   "decompress_mbps": 1154.23
+   "compress_mbps": 58.08,
+   "decompress_mbps": 1161.26
   },
   {
    "compressor": "zlib",
@@ -1264,8 +1264,8 @@
    "level": 9,
    "out_size": 7934,
    "ratio": 0.3225,
-   "compress_mbps": 58.22,
-   "decompress_mbps": 1150.95
+   "compress_mbps": 58.09,
+   "decompress_mbps": 1160.11
   },
   {
    "compressor": "zlib",
@@ -1274,8 +1274,8 @@
    "level": 1,
    "out_size": 3647,
    "ratio": 0.3271,
-   "compress_mbps": 425.03,
-   "decompress_mbps": 1057.22
+   "compress_mbps": 426.79,
+   "decompress_mbps": 1073.55
   },
   {
    "compressor": "zlib",
@@ -1284,8 +1284,8 @@
    "level": 2,
    "out_size": 3501,
    "ratio": 0.314,
-   "compress_mbps": 408.74,
-   "decompress_mbps": 1104.66
+   "compress_mbps": 408.84,
+   "decompress_mbps": 1117.67
   },
   {
    "compressor": "zlib",
@@ -1294,8 +1294,8 @@
    "level": 3,
    "out_size": 3393,
    "ratio": 0.3043,
-   "compress_mbps": 337.65,
-   "decompress_mbps": 1135.93
+   "compress_mbps": 338.35,
+   "decompress_mbps": 1147.08
   },
   {
    "compressor": "zlib",
@@ -1304,8 +1304,8 @@
    "level": 4,
    "out_size": 3215,
    "ratio": 0.2883,
-   "compress_mbps": 273.63,
-   "decompress_mbps": 1161.62
+   "compress_mbps": 271.93,
+   "decompress_mbps": 1175.75
   },
   {
    "compressor": "zlib",
@@ -1314,8 +1314,8 @@
    "level": 5,
    "out_size": 3140,
    "ratio": 0.2816,
-   "compress_mbps": 205.53,
-   "decompress_mbps": 1195.44
+   "compress_mbps": 205.2,
+   "decompress_mbps": 1205.2
   },
   {
    "compressor": "zlib",
@@ -1324,8 +1324,8 @@
    "level": 6,
    "out_size": 3116,
    "ratio": 0.2795,
-   "compress_mbps": 153.83,
-   "decompress_mbps": 1207.94
+   "compress_mbps": 154.1,
+   "decompress_mbps": 1215.53
   },
   {
    "compressor": "zlib",
@@ -1334,8 +1334,8 @@
    "level": 7,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 132.01,
-   "decompress_mbps": 1211.52
+   "compress_mbps": 131.87,
+   "decompress_mbps": 1216.78
   },
   {
    "compressor": "zlib",
@@ -1344,8 +1344,8 @@
    "level": 8,
    "out_size": 3109,
    "ratio": 0.2788,
-   "compress_mbps": 111.29,
-   "decompress_mbps": 1210.96
+   "compress_mbps": 111.18,
+   "decompress_mbps": 1216.5
   },
   {
    "compressor": "zlib",
@@ -1354,8 +1354,8 @@
    "level": 9,
    "out_size": 3109,
    "ratio": 0.2788,
-   "compress_mbps": 111.09,
-   "decompress_mbps": 1212.9
+   "compress_mbps": 110.92,
+   "decompress_mbps": 1220.83
   },
   {
    "compressor": "zlib",
@@ -1364,8 +1364,8 @@
    "level": 1,
    "out_size": 1326,
    "ratio": 0.3564,
-   "compress_mbps": 313.32,
-   "decompress_mbps": 771.1
+   "compress_mbps": 317.29,
+   "decompress_mbps": 787.88
   },
   {
    "compressor": "zlib",
@@ -1374,8 +1374,8 @@
    "level": 2,
    "out_size": 1306,
    "ratio": 0.351,
-   "compress_mbps": 306.47,
-   "decompress_mbps": 779.92
+   "compress_mbps": 310.71,
+   "decompress_mbps": 796.73
   },
   {
    "compressor": "zlib",
@@ -1384,8 +1384,8 @@
    "level": 3,
    "out_size": 1301,
    "ratio": 0.3496,
-   "compress_mbps": 289.28,
-   "decompress_mbps": 781.63
+   "compress_mbps": 291.04,
+   "decompress_mbps": 799.42
   },
   {
    "compressor": "zlib",
@@ -1394,8 +1394,8 @@
    "level": 4,
    "out_size": 1228,
    "ratio": 0.33,
-   "compress_mbps": 231.68,
-   "decompress_mbps": 821.25
+   "compress_mbps": 233.69,
+   "decompress_mbps": 825.26
   },
   {
    "compressor": "zlib",
@@ -1404,8 +1404,8 @@
    "level": 5,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 197.3,
-   "decompress_mbps": 810.0
+   "compress_mbps": 198.9,
+   "decompress_mbps": 831.06
   },
   {
    "compressor": "zlib",
@@ -1414,8 +1414,8 @@
    "level": 6,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 176.88,
-   "decompress_mbps": 813.9
+   "compress_mbps": 177.77,
+   "decompress_mbps": 832.23
   },
   {
    "compressor": "zlib",
@@ -1424,8 +1424,8 @@
    "level": 7,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 168.98,
-   "decompress_mbps": 812.04
+   "compress_mbps": 170.71,
+   "decompress_mbps": 821.82
   },
   {
    "compressor": "zlib",
@@ -1434,8 +1434,8 @@
    "level": 8,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 166.6,
-   "decompress_mbps": 811.3
+   "compress_mbps": 167.8,
+   "decompress_mbps": 826.61
   },
   {
    "compressor": "zlib",
@@ -1444,8 +1444,8 @@
    "level": 9,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 166.42,
-   "decompress_mbps": 810.56
+   "compress_mbps": 168.26,
+   "decompress_mbps": 828.73
   },
   {
    "compressor": "zlib",
@@ -1454,8 +1454,8 @@
    "level": 1,
    "out_size": 242293,
    "ratio": 0.2353,
-   "compress_mbps": 262.03,
-   "decompress_mbps": 839.95
+   "compress_mbps": 261.91,
+   "decompress_mbps": 834.71
   },
   {
    "compressor": "zlib",
@@ -1464,8 +1464,8 @@
    "level": 2,
    "out_size": 233553,
    "ratio": 0.2268,
-   "compress_mbps": 247.95,
-   "decompress_mbps": 991.27
+   "compress_mbps": 248.46,
+   "decompress_mbps": 990.64
   },
   {
    "compressor": "zlib",
@@ -1474,8 +1474,8 @@
    "level": 3,
    "out_size": 228222,
    "ratio": 0.2216,
-   "compress_mbps": 195.75,
-   "decompress_mbps": 1053.53
+   "compress_mbps": 195.71,
+   "decompress_mbps": 1047.56
   },
   {
    "compressor": "zlib",
@@ -1484,8 +1484,8 @@
    "level": 4,
    "out_size": 223668,
    "ratio": 0.2172,
-   "compress_mbps": 177.37,
-   "decompress_mbps": 1083.25
+   "compress_mbps": 177.25,
+   "decompress_mbps": 1079.08
   },
   {
    "compressor": "zlib",
@@ -1494,8 +1494,8 @@
    "level": 5,
    "out_size": 205994,
    "ratio": 0.2,
-   "compress_mbps": 110.05,
-   "decompress_mbps": 1042.06
+   "compress_mbps": 110.7,
+   "decompress_mbps": 1038.46
   },
   {
    "compressor": "zlib",
@@ -1504,8 +1504,8 @@
    "level": 6,
    "out_size": 203986,
    "ratio": 0.1981,
-   "compress_mbps": 50.02,
-   "decompress_mbps": 1042.68
+   "compress_mbps": 50.06,
+   "decompress_mbps": 1033.64
   },
   {
    "compressor": "zlib",
@@ -1514,8 +1514,8 @@
    "level": 7,
    "out_size": 207681,
    "ratio": 0.2017,
-   "compress_mbps": 37.04,
-   "decompress_mbps": 1036.03
+   "compress_mbps": 37.08,
+   "decompress_mbps": 1027.99
   },
   {
    "compressor": "zlib",
@@ -1524,8 +1524,8 @@
    "level": 8,
    "out_size": 206827,
    "ratio": 0.2009,
-   "compress_mbps": 7.28,
-   "decompress_mbps": 1013.69
+   "compress_mbps": 7.29,
+   "decompress_mbps": 1001.69
   },
   {
    "compressor": "zlib",
@@ -1534,8 +1534,8 @@
    "level": 9,
    "out_size": 207023,
    "ratio": 0.201,
-   "compress_mbps": 3.42,
-   "decompress_mbps": 1009.96
+   "compress_mbps": 3.43,
+   "decompress_mbps": 1007.49
   },
   {
    "compressor": "zlib",
@@ -1544,8 +1544,8 @@
    "level": 1,
    "out_size": 174124,
    "ratio": 0.408,
-   "compress_mbps": 123.96,
-   "decompress_mbps": 394.42
+   "compress_mbps": 124.52,
+   "decompress_mbps": 403.49
   },
   {
    "compressor": "zlib",
@@ -1554,8 +1554,8 @@
    "level": 2,
    "out_size": 166150,
    "ratio": 0.3893,
-   "compress_mbps": 105.1,
-   "decompress_mbps": 405.11
+   "compress_mbps": 105.75,
+   "decompress_mbps": 410.83
   },
   {
    "compressor": "zlib",
@@ -1564,8 +1564,8 @@
    "level": 3,
    "out_size": 158784,
    "ratio": 0.3721,
-   "compress_mbps": 70.47,
-   "decompress_mbps": 420.77
+   "compress_mbps": 70.62,
+   "decompress_mbps": 431.19
   },
   {
    "compressor": "zlib",
@@ -1574,8 +1574,8 @@
    "level": 4,
    "out_size": 152782,
    "ratio": 0.358,
-   "compress_mbps": 74.09,
-   "decompress_mbps": 410.19
+   "compress_mbps": 74.37,
+   "decompress_mbps": 417.63
   },
   {
    "compressor": "zlib",
@@ -1584,8 +1584,8 @@
    "level": 5,
    "out_size": 147196,
    "ratio": 0.3449,
-   "compress_mbps": 43.64,
-   "decompress_mbps": 405.47
+   "compress_mbps": 43.69,
+   "decompress_mbps": 412.43
   },
   {
    "compressor": "zlib",
@@ -1594,8 +1594,8 @@
    "level": 6,
    "out_size": 144898,
    "ratio": 0.3395,
-   "compress_mbps": 26.43,
-   "decompress_mbps": 416.56
+   "compress_mbps": 26.54,
+   "decompress_mbps": 422.22
   },
   {
    "compressor": "zlib",
@@ -1604,8 +1604,8 @@
    "level": 7,
    "out_size": 144589,
    "ratio": 0.3388,
-   "compress_mbps": 22.9,
-   "decompress_mbps": 416.56
+   "compress_mbps": 23.0,
+   "decompress_mbps": 422.54
   },
   {
    "compressor": "zlib",
@@ -1614,8 +1614,8 @@
    "level": 8,
    "out_size": 144436,
    "ratio": 0.3385,
-   "compress_mbps": 19.66,
-   "decompress_mbps": 418.82
+   "compress_mbps": 19.77,
+   "decompress_mbps": 426.62
   },
   {
    "compressor": "zlib",
@@ -1624,8 +1624,8 @@
    "level": 9,
    "out_size": 144433,
    "ratio": 0.3384,
-   "compress_mbps": 19.61,
-   "decompress_mbps": 419.14
+   "compress_mbps": 19.7,
+   "decompress_mbps": 427.06
   },
   {
    "compressor": "zlib",
@@ -1634,8 +1634,8 @@
    "level": 1,
    "out_size": 228883,
    "ratio": 0.475,
-   "compress_mbps": 107.9,
-   "decompress_mbps": 371.56
+   "compress_mbps": 108.85,
+   "decompress_mbps": 379.18
   },
   {
    "compressor": "zlib",
@@ -1644,8 +1644,8 @@
    "level": 2,
    "out_size": 219047,
    "ratio": 0.4546,
-   "compress_mbps": 90.9,
-   "decompress_mbps": 388.53
+   "compress_mbps": 91.35,
+   "decompress_mbps": 396.75
   },
   {
    "compressor": "zlib",
@@ -1654,8 +1654,8 @@
    "level": 3,
    "out_size": 209408,
    "ratio": 0.4346,
-   "compress_mbps": 55.55,
-   "decompress_mbps": 401.19
+   "compress_mbps": 55.73,
+   "decompress_mbps": 408.77
   },
   {
    "compressor": "zlib",
@@ -1664,8 +1664,8 @@
    "level": 4,
    "out_size": 205916,
    "ratio": 0.4273,
-   "compress_mbps": 62.66,
-   "decompress_mbps": 376.95
+   "compress_mbps": 62.79,
+   "decompress_mbps": 384.06
   },
   {
    "compressor": "zlib",
@@ -1674,8 +1674,8 @@
    "level": 5,
    "out_size": 199188,
    "ratio": 0.4134,
-   "compress_mbps": 33.11,
-   "decompress_mbps": 358.51
+   "compress_mbps": 33.23,
+   "decompress_mbps": 365.25
   },
   {
    "compressor": "zlib",
@@ -1684,8 +1684,8 @@
    "level": 6,
    "out_size": 195255,
    "ratio": 0.4052,
-   "compress_mbps": 19.41,
-   "decompress_mbps": 367.26
+   "compress_mbps": 19.51,
+   "decompress_mbps": 371.54
   },
   {
    "compressor": "zlib",
@@ -1694,8 +1694,8 @@
    "level": 7,
    "out_size": 194657,
    "ratio": 0.404,
-   "compress_mbps": 16.43,
-   "decompress_mbps": 369.33
+   "compress_mbps": 16.52,
+   "decompress_mbps": 368.04
   },
   {
    "compressor": "zlib",
@@ -1704,8 +1704,8 @@
    "level": 8,
    "out_size": 194326,
    "ratio": 0.4033,
-   "compress_mbps": 12.95,
-   "decompress_mbps": 368.52
+   "compress_mbps": 13.04,
+   "decompress_mbps": 372.62
   },
   {
    "compressor": "zlib",
@@ -1714,8 +1714,8 @@
    "level": 9,
    "out_size": 194326,
    "ratio": 0.4033,
-   "compress_mbps": 12.88,
-   "decompress_mbps": 367.51
+   "compress_mbps": 13.03,
+   "decompress_mbps": 376.86
   },
   {
    "compressor": "zlib",
@@ -1724,8 +1724,8 @@
    "level": 1,
    "out_size": 65553,
    "ratio": 0.1277,
-   "compress_mbps": 273.05,
-   "decompress_mbps": 889.95
+   "compress_mbps": 277.05,
+   "decompress_mbps": 898.35
   },
   {
    "compressor": "zlib",
@@ -1734,8 +1734,8 @@
    "level": 2,
    "out_size": 63891,
    "ratio": 0.1245,
-   "compress_mbps": 246.67,
-   "decompress_mbps": 920.25
+   "compress_mbps": 249.81,
+   "decompress_mbps": 925.37
   },
   {
    "compressor": "zlib",
@@ -1744,8 +1744,8 @@
    "level": 3,
    "out_size": 62515,
    "ratio": 0.1218,
-   "compress_mbps": 193.29,
-   "decompress_mbps": 975.32
+   "compress_mbps": 196.22,
+   "decompress_mbps": 996.47
   },
   {
    "compressor": "zlib",
@@ -1754,8 +1754,8 @@
    "level": 4,
    "out_size": 58451,
    "ratio": 0.1139,
-   "compress_mbps": 169.09,
-   "decompress_mbps": 696.08
+   "compress_mbps": 170.56,
+   "decompress_mbps": 705.74
   },
   {
    "compressor": "zlib",
@@ -1764,8 +1764,8 @@
    "level": 5,
    "out_size": 57410,
    "ratio": 0.1119,
-   "compress_mbps": 130.04,
-   "decompress_mbps": 730.28
+   "compress_mbps": 131.27,
+   "decompress_mbps": 733.83
   },
   {
    "compressor": "zlib",
@@ -1774,8 +1774,8 @@
    "level": 6,
    "out_size": 56459,
    "ratio": 0.11,
-   "compress_mbps": 77.17,
-   "decompress_mbps": 774.64
+   "compress_mbps": 77.73,
+   "decompress_mbps": 785.69
   },
   {
    "compressor": "zlib",
@@ -1784,8 +1784,8 @@
    "level": 7,
    "out_size": 55358,
    "ratio": 0.1079,
-   "compress_mbps": 60.41,
-   "decompress_mbps": 811.24
+   "compress_mbps": 60.89,
+   "decompress_mbps": 824.41
   },
   {
    "compressor": "zlib",
@@ -1794,8 +1794,8 @@
    "level": 8,
    "out_size": 52991,
    "ratio": 0.1033,
-   "compress_mbps": 27.55,
-   "decompress_mbps": 865.3
+   "compress_mbps": 27.8,
+   "decompress_mbps": 878.92
   },
   {
    "compressor": "zlib",
@@ -1804,8 +1804,8 @@
    "level": 9,
    "out_size": 52215,
    "ratio": 0.1017,
-   "compress_mbps": 9.82,
-   "decompress_mbps": 890.2
+   "compress_mbps": 9.91,
+   "decompress_mbps": 892.75
   },
   {
    "compressor": "zlib",
@@ -1814,8 +1814,8 @@
    "level": 1,
    "out_size": 14112,
    "ratio": 0.369,
-   "compress_mbps": 129.59,
-   "decompress_mbps": 932.67
+   "compress_mbps": 130.36,
+   "decompress_mbps": 944.12
   },
   {
    "compressor": "zlib",
@@ -1824,8 +1824,8 @@
    "level": 2,
    "out_size": 13815,
    "ratio": 0.3613,
-   "compress_mbps": 109.91,
-   "decompress_mbps": 964.65
+   "compress_mbps": 110.11,
+   "decompress_mbps": 978.68
   },
   {
    "compressor": "zlib",
@@ -1834,8 +1834,8 @@
    "level": 3,
    "out_size": 13795,
    "ratio": 0.3607,
-   "compress_mbps": 79.05,
-   "decompress_mbps": 1011.13
+   "compress_mbps": 79.64,
+   "decompress_mbps": 1014.48
   },
   {
    "compressor": "zlib",
@@ -1844,8 +1844,8 @@
    "level": 4,
    "out_size": 13375,
    "ratio": 0.3498,
-   "compress_mbps": 81.07,
-   "decompress_mbps": 996.24
+   "compress_mbps": 81.09,
+   "decompress_mbps": 997.82
   },
   {
    "compressor": "zlib",
@@ -1854,8 +1854,8 @@
    "level": 5,
    "out_size": 13062,
    "ratio": 0.3416,
-   "compress_mbps": 56.11,
-   "decompress_mbps": 1041.93
+   "compress_mbps": 56.15,
+   "decompress_mbps": 1040.2
   },
   {
    "compressor": "zlib",
@@ -1864,8 +1864,8 @@
    "level": 6,
    "out_size": 12984,
    "ratio": 0.3395,
-   "compress_mbps": 33.27,
-   "decompress_mbps": 1050.33
+   "compress_mbps": 33.24,
+   "decompress_mbps": 1062.14
   },
   {
    "compressor": "zlib",
@@ -1874,8 +1874,8 @@
    "level": 7,
    "out_size": 12949,
    "ratio": 0.3386,
-   "compress_mbps": 25.56,
-   "decompress_mbps": 1051.63
+   "compress_mbps": 25.62,
+   "decompress_mbps": 1070.49
   },
   {
    "compressor": "zlib",
@@ -1884,8 +1884,8 @@
    "level": 8,
    "out_size": 12894,
    "ratio": 0.3372,
-   "compress_mbps": 11.08,
-   "decompress_mbps": 1069.27
+   "compress_mbps": 11.1,
+   "decompress_mbps": 1080.36
   },
   {
    "compressor": "zlib",
@@ -1894,8 +1894,8 @@
    "level": 9,
    "out_size": 12832,
    "ratio": 0.3356,
-   "compress_mbps": 5.09,
-   "decompress_mbps": 1079.11
+   "compress_mbps": 5.1,
+   "decompress_mbps": 1081.93
   },
   {
    "compressor": "zlib",
@@ -1904,8 +1904,8 @@
    "level": 1,
    "out_size": 1846,
    "ratio": 0.4367,
-   "compress_mbps": 289.14,
-   "decompress_mbps": 707.85
+   "compress_mbps": 290.31,
+   "decompress_mbps": 710.34
   },
   {
    "compressor": "zlib",
@@ -1914,8 +1914,8 @@
    "level": 2,
    "out_size": 1820,
    "ratio": 0.4306,
-   "compress_mbps": 283.45,
-   "decompress_mbps": 713.86
+   "compress_mbps": 284.39,
+   "decompress_mbps": 723.73
   },
   {
    "compressor": "zlib",
@@ -1924,8 +1924,8 @@
    "level": 3,
    "out_size": 1808,
    "ratio": 0.4277,
-   "compress_mbps": 270.88,
-   "decompress_mbps": 729.49
+   "compress_mbps": 272.54,
+   "decompress_mbps": 726.34
   },
   {
    "compressor": "zlib",
@@ -1934,8 +1934,8 @@
    "level": 4,
    "out_size": 1749,
    "ratio": 0.4138,
-   "compress_mbps": 223.74,
-   "decompress_mbps": 744.45
+   "compress_mbps": 226.28,
+   "decompress_mbps": 749.43
   },
   {
    "compressor": "zlib",
@@ -1944,8 +1944,8 @@
    "level": 5,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 199.55,
-   "decompress_mbps": 747.07
+   "compress_mbps": 202.59,
+   "decompress_mbps": 753.91
   },
   {
    "compressor": "zlib",
@@ -1954,8 +1954,8 @@
    "level": 6,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 196.71,
-   "decompress_mbps": 748.32
+   "compress_mbps": 199.81,
+   "decompress_mbps": 754.2
   },
   {
    "compressor": "zlib",
@@ -1964,8 +1964,8 @@
    "level": 7,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 194.15,
-   "decompress_mbps": 751.67
+   "compress_mbps": 196.62,
+   "decompress_mbps": 753.91
   },
   {
    "compressor": "zlib",
@@ -1974,8 +1974,8 @@
    "level": 8,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 194.4,
-   "decompress_mbps": 749.43
+   "compress_mbps": 197.1,
+   "decompress_mbps": 754.2
   },
   {
    "compressor": "zlib",
@@ -1984,8 +1984,8 @@
    "level": 9,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 194.82,
-   "decompress_mbps": 749.01
+   "compress_mbps": 197.89,
+   "decompress_mbps": 752.93
   },
   {
    "compressor": "miniz_oxide",
@@ -1994,8 +1994,8 @@
    "level": 1,
    "out_size": 76470,
    "ratio": 0.5028,
-   "compress_mbps": 154.26,
-   "decompress_mbps": 454.01
+   "compress_mbps": 156.81,
+   "decompress_mbps": 442.0
   },
   {
    "compressor": "miniz_oxide",
@@ -2004,8 +2004,8 @@
    "level": 2,
    "out_size": 62765,
    "ratio": 0.4127,
-   "compress_mbps": 131.95,
-   "decompress_mbps": 508.28
+   "compress_mbps": 133.14,
+   "decompress_mbps": 491.57
   },
   {
    "compressor": "miniz_oxide",
@@ -2014,8 +2014,8 @@
    "level": 3,
    "out_size": 57162,
    "ratio": 0.3758,
-   "compress_mbps": 72.26,
-   "decompress_mbps": 564.0
+   "compress_mbps": 72.46,
+   "decompress_mbps": 549.38
   },
   {
    "compressor": "miniz_oxide",
@@ -2024,8 +2024,8 @@
    "level": 4,
    "out_size": 56826,
    "ratio": 0.3736,
-   "compress_mbps": 64.16,
-   "decompress_mbps": 547.78
+   "compress_mbps": 64.54,
+   "decompress_mbps": 540.99
   },
   {
    "compressor": "miniz_oxide",
@@ -2034,8 +2034,8 @@
    "level": 5,
    "out_size": 55696,
    "ratio": 0.3662,
-   "compress_mbps": 46.68,
-   "decompress_mbps": 537.55
+   "compress_mbps": 46.93,
+   "decompress_mbps": 528.35
   },
   {
    "compressor": "miniz_oxide",
@@ -2044,8 +2044,8 @@
    "level": 6,
    "out_size": 54440,
    "ratio": 0.3579,
-   "compress_mbps": 26.5,
-   "decompress_mbps": 552.53
+   "compress_mbps": 26.59,
+   "decompress_mbps": 545.39
   },
   {
    "compressor": "miniz_oxide",
@@ -2054,8 +2054,8 @@
    "level": 7,
    "out_size": 54283,
    "ratio": 0.3569,
-   "compress_mbps": 22.34,
-   "decompress_mbps": 553.98
+   "compress_mbps": 22.46,
+   "decompress_mbps": 546.21
   },
   {
    "compressor": "miniz_oxide",
@@ -2064,8 +2064,8 @@
    "level": 8,
    "out_size": 54221,
    "ratio": 0.3565,
-   "compress_mbps": 19.67,
-   "decompress_mbps": 553.32
+   "compress_mbps": 19.77,
+   "decompress_mbps": 546.31
   },
   {
    "compressor": "miniz_oxide",
@@ -2074,8 +2074,8 @@
    "level": 9,
    "out_size": 54217,
    "ratio": 0.3565,
-   "compress_mbps": 19.42,
-   "decompress_mbps": 553.28
+   "compress_mbps": 19.52,
+   "decompress_mbps": 546.07
   },
   {
    "compressor": "miniz_oxide",
@@ -2084,8 +2084,8 @@
    "level": 1,
    "out_size": 64926,
    "ratio": 0.5187,
-   "compress_mbps": 148.29,
-   "decompress_mbps": 433.02
+   "compress_mbps": 150.76,
+   "decompress_mbps": 420.61
   },
   {
    "compressor": "miniz_oxide",
@@ -2094,8 +2094,8 @@
    "level": 2,
    "out_size": 54985,
    "ratio": 0.4393,
-   "compress_mbps": 123.58,
-   "decompress_mbps": 482.39
+   "compress_mbps": 124.87,
+   "decompress_mbps": 468.91
   },
   {
    "compressor": "miniz_oxide",
@@ -2104,8 +2104,8 @@
    "level": 3,
    "out_size": 51148,
    "ratio": 0.4086,
-   "compress_mbps": 67.17,
-   "decompress_mbps": 545.13
+   "compress_mbps": 67.28,
+   "decompress_mbps": 536.64
   },
   {
    "compressor": "miniz_oxide",
@@ -2114,8 +2114,8 @@
    "level": 4,
    "out_size": 50599,
    "ratio": 0.4042,
-   "compress_mbps": 58.92,
-   "decompress_mbps": 529.12
+   "compress_mbps": 59.25,
+   "decompress_mbps": 526.29
   },
   {
    "compressor": "miniz_oxide",
@@ -2124,8 +2124,8 @@
    "level": 5,
    "out_size": 49775,
    "ratio": 0.3976,
-   "compress_mbps": 42.46,
-   "decompress_mbps": 517.64
+   "compress_mbps": 42.72,
+   "decompress_mbps": 513.76
   },
   {
    "compressor": "miniz_oxide",
@@ -2134,8 +2134,8 @@
    "level": 6,
    "out_size": 48967,
    "ratio": 0.3912,
-   "compress_mbps": 24.89,
-   "decompress_mbps": 529.56
+   "compress_mbps": 25.03,
+   "decompress_mbps": 524.3
   },
   {
    "compressor": "miniz_oxide",
@@ -2144,8 +2144,8 @@
    "level": 7,
    "out_size": 48870,
    "ratio": 0.3904,
-   "compress_mbps": 22.11,
-   "decompress_mbps": 533.55
+   "compress_mbps": 22.21,
+   "decompress_mbps": 523.8
   },
   {
    "compressor": "miniz_oxide",
@@ -2154,8 +2154,8 @@
    "level": 8,
    "out_size": 48845,
    "ratio": 0.3902,
-   "compress_mbps": 20.81,
-   "decompress_mbps": 529.55
+   "compress_mbps": 20.95,
+   "decompress_mbps": 522.13
   },
   {
    "compressor": "miniz_oxide",
@@ -2164,8 +2164,8 @@
    "level": 9,
    "out_size": 48845,
    "ratio": 0.3902,
-   "compress_mbps": 20.81,
-   "decompress_mbps": 530.67
+   "compress_mbps": 20.95,
+   "decompress_mbps": 524.0
   },
   {
    "compressor": "miniz_oxide",
@@ -2174,8 +2174,8 @@
    "level": 1,
    "out_size": 10024,
    "ratio": 0.4074,
-   "compress_mbps": 569.29,
-   "decompress_mbps": 904.07
+   "compress_mbps": 568.72,
+   "decompress_mbps": 906.86
   },
   {
    "compressor": "miniz_oxide",
@@ -2184,8 +2184,8 @@
    "level": 2,
    "out_size": 8577,
    "ratio": 0.3486,
-   "compress_mbps": 257.95,
-   "decompress_mbps": 932.15
+   "compress_mbps": 269.07,
+   "decompress_mbps": 929.83
   },
   {
    "compressor": "miniz_oxide",
@@ -2194,8 +2194,8 @@
    "level": 3,
    "out_size": 8168,
    "ratio": 0.332,
-   "compress_mbps": 154.5,
-   "decompress_mbps": 953.09
+   "compress_mbps": 155.49,
+   "decompress_mbps": 951.35
   },
   {
    "compressor": "miniz_oxide",
@@ -2204,8 +2204,8 @@
    "level": 4,
    "out_size": 8069,
    "ratio": 0.328,
-   "compress_mbps": 113.91,
-   "decompress_mbps": 968.76
+   "compress_mbps": 116.17,
+   "decompress_mbps": 969.68
   },
   {
    "compressor": "miniz_oxide",
@@ -2214,8 +2214,8 @@
    "level": 5,
    "out_size": 7997,
    "ratio": 0.325,
-   "compress_mbps": 100.0,
-   "decompress_mbps": 998.86
+   "compress_mbps": 100.13,
+   "decompress_mbps": 1001.46
   },
   {
    "compressor": "miniz_oxide",
@@ -2224,8 +2224,8 @@
    "level": 6,
    "out_size": 7952,
    "ratio": 0.3232,
-   "compress_mbps": 74.82,
-   "decompress_mbps": 1005.11
+   "compress_mbps": 74.99,
+   "decompress_mbps": 1003.47
   },
   {
    "compressor": "miniz_oxide",
@@ -2234,8 +2234,8 @@
    "level": 7,
    "out_size": 7947,
    "ratio": 0.323,
-   "compress_mbps": 72.03,
-   "decompress_mbps": 1010.08
+   "compress_mbps": 72.24,
+   "decompress_mbps": 1009.09
   },
   {
    "compressor": "miniz_oxide",
@@ -2244,8 +2244,8 @@
    "level": 8,
    "out_size": 7947,
    "ratio": 0.323,
-   "compress_mbps": 70.84,
-   "decompress_mbps": 1009.65
+   "compress_mbps": 71.2,
+   "decompress_mbps": 1009.52
   },
   {
    "compressor": "miniz_oxide",
@@ -2254,8 +2254,8 @@
    "level": 9,
    "out_size": 7947,
    "ratio": 0.323,
-   "compress_mbps": 70.97,
-   "decompress_mbps": 1009.74
+   "compress_mbps": 70.94,
+   "decompress_mbps": 1010.39
   },
   {
    "compressor": "miniz_oxide",
@@ -2264,8 +2264,8 @@
    "level": 1,
    "out_size": 4061,
    "ratio": 0.3642,
-   "compress_mbps": 507.39,
-   "decompress_mbps": 854.78
+   "compress_mbps": 505.27,
+   "decompress_mbps": 857.33
   },
   {
    "compressor": "miniz_oxide",
@@ -2274,8 +2274,8 @@
    "level": 2,
    "out_size": 3446,
    "ratio": 0.3091,
-   "compress_mbps": 303.49,
-   "decompress_mbps": 892.97
+   "compress_mbps": 303.09,
+   "decompress_mbps": 902.14
   },
   {
    "compressor": "miniz_oxide",
@@ -2284,8 +2284,8 @@
    "level": 3,
    "out_size": 3201,
    "ratio": 0.2871,
-   "compress_mbps": 235.54,
-   "decompress_mbps": 922.56
+   "compress_mbps": 235.32,
+   "decompress_mbps": 933.5
   },
   {
    "compressor": "miniz_oxide",
@@ -2294,8 +2294,8 @@
    "level": 4,
    "out_size": 3168,
    "ratio": 0.2841,
-   "compress_mbps": 193.62,
-   "decompress_mbps": 949.67
+   "compress_mbps": 196.56,
+   "decompress_mbps": 955.13
   },
   {
    "compressor": "miniz_oxide",
@@ -2304,8 +2304,8 @@
    "level": 5,
    "out_size": 3139,
    "ratio": 0.2815,
-   "compress_mbps": 162.3,
-   "decompress_mbps": 972.07
+   "compress_mbps": 162.35,
+   "decompress_mbps": 979.95
   },
   {
    "compressor": "miniz_oxide",
@@ -2314,8 +2314,8 @@
    "level": 6,
    "out_size": 3115,
    "ratio": 0.2794,
-   "compress_mbps": 116.79,
-   "decompress_mbps": 982.22
+   "compress_mbps": 116.87,
+   "decompress_mbps": 990.27
   },
   {
    "compressor": "miniz_oxide",
@@ -2324,8 +2324,8 @@
    "level": 7,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 106.23,
-   "decompress_mbps": 984.85
+   "compress_mbps": 106.87,
+   "decompress_mbps": 991.47
   },
   {
    "compressor": "miniz_oxide",
@@ -2334,8 +2334,8 @@
    "level": 8,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 103.57,
-   "decompress_mbps": 986.68
+   "compress_mbps": 103.44,
+   "decompress_mbps": 992.11
   },
   {
    "compressor": "miniz_oxide",
@@ -2344,8 +2344,8 @@
    "level": 9,
    "out_size": 3112,
    "ratio": 0.2791,
-   "compress_mbps": 103.48,
-   "decompress_mbps": 989.34
+   "compress_mbps": 103.35,
+   "decompress_mbps": 992.21
   },
   {
    "compressor": "miniz_oxide",
@@ -2354,8 +2354,8 @@
    "level": 1,
    "out_size": 1410,
    "ratio": 0.3789,
-   "compress_mbps": 365.42,
-   "decompress_mbps": 594.61
+   "compress_mbps": 365.35,
+   "decompress_mbps": 595.71
   },
   {
    "compressor": "miniz_oxide",
@@ -2364,8 +2364,8 @@
    "level": 2,
    "out_size": 1262,
    "ratio": 0.3392,
-   "compress_mbps": 234.67,
-   "decompress_mbps": 606.6
+   "compress_mbps": 234.59,
+   "decompress_mbps": 602.38
   },
   {
    "compressor": "miniz_oxide",
@@ -2374,8 +2374,8 @@
    "level": 3,
    "out_size": 1238,
    "ratio": 0.3327,
-   "compress_mbps": 203.21,
-   "decompress_mbps": 602.58
+   "compress_mbps": 206.3,
+   "decompress_mbps": 606.19
   },
   {
    "compressor": "miniz_oxide",
@@ -2384,8 +2384,8 @@
    "level": 4,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 175.23,
-   "decompress_mbps": 623.33
+   "compress_mbps": 178.27,
+   "decompress_mbps": 624.32
   },
   {
    "compressor": "miniz_oxide",
@@ -2394,8 +2394,8 @@
    "level": 5,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 161.11,
-   "decompress_mbps": 632.44
+   "compress_mbps": 163.31,
+   "decompress_mbps": 633.68
   },
   {
    "compressor": "miniz_oxide",
@@ -2404,8 +2404,8 @@
    "level": 6,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 148.18,
-   "decompress_mbps": 634.36
+   "compress_mbps": 147.91,
+   "decompress_mbps": 631.88
   },
   {
    "compressor": "miniz_oxide",
@@ -2414,8 +2414,8 @@
    "level": 7,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 147.32,
-   "decompress_mbps": 633.0
+   "compress_mbps": 147.05,
+   "decompress_mbps": 632.21
   },
   {
    "compressor": "miniz_oxide",
@@ -2424,8 +2424,8 @@
    "level": 8,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 148.12,
-   "decompress_mbps": 629.97
+   "compress_mbps": 147.52,
+   "decompress_mbps": 634.82
   },
   {
    "compressor": "miniz_oxide",
@@ -2434,8 +2434,8 @@
    "level": 9,
    "out_size": 1216,
    "ratio": 0.3268,
-   "compress_mbps": 147.52,
-   "decompress_mbps": 633.57
+   "compress_mbps": 147.39,
+   "decompress_mbps": 634.93
   },
   {
    "compressor": "miniz_oxide",
@@ -2444,8 +2444,8 @@
    "level": 1,
    "out_size": 274412,
    "ratio": 0.2665,
-   "compress_mbps": 443.65,
-   "decompress_mbps": 799.43
+   "compress_mbps": 452.12,
+   "decompress_mbps": 796.51
   },
   {
    "compressor": "miniz_oxide",
@@ -2454,8 +2454,8 @@
    "level": 2,
    "out_size": 213239,
    "ratio": 0.2071,
-   "compress_mbps": 272.38,
-   "decompress_mbps": 880.89
+   "compress_mbps": 274.72,
+   "decompress_mbps": 895.56
   },
   {
    "compressor": "miniz_oxide",
@@ -2464,8 +2464,8 @@
    "level": 3,
    "out_size": 232107,
    "ratio": 0.2254,
-   "compress_mbps": 136.69,
-   "decompress_mbps": 923.14
+   "compress_mbps": 137.22,
+   "decompress_mbps": 936.66
   },
   {
    "compressor": "miniz_oxide",
@@ -2474,8 +2474,8 @@
    "level": 4,
    "out_size": 202733,
    "ratio": 0.1969,
-   "compress_mbps": 129.43,
-   "decompress_mbps": 929.09
+   "compress_mbps": 130.42,
+   "decompress_mbps": 942.52
   },
   {
    "compressor": "miniz_oxide",
@@ -2484,8 +2484,8 @@
    "level": 5,
    "out_size": 207803,
    "ratio": 0.2018,
-   "compress_mbps": 84.08,
-   "decompress_mbps": 945.24
+   "compress_mbps": 84.44,
+   "decompress_mbps": 954.1
   },
   {
    "compressor": "miniz_oxide",
@@ -2494,8 +2494,8 @@
    "level": 6,
    "out_size": 205270,
    "ratio": 0.1993,
-   "compress_mbps": 27.21,
-   "decompress_mbps": 978.2
+   "compress_mbps": 27.28,
+   "decompress_mbps": 981.19
   },
   {
    "compressor": "miniz_oxide",
@@ -2504,8 +2504,8 @@
    "level": 7,
    "out_size": 209951,
    "ratio": 0.2039,
-   "compress_mbps": 19.25,
-   "decompress_mbps": 982.69
+   "compress_mbps": 19.33,
+   "decompress_mbps": 997.67
   },
   {
    "compressor": "miniz_oxide",
@@ -2514,8 +2514,8 @@
    "level": 8,
    "out_size": 209656,
    "ratio": 0.2036,
-   "compress_mbps": 12.1,
-   "decompress_mbps": 990.53
+   "compress_mbps": 12.25,
+   "decompress_mbps": 1008.86
   },
   {
    "compressor": "miniz_oxide",
@@ -2524,8 +2524,8 @@
    "level": 9,
    "out_size": 209189,
    "ratio": 0.2031,
-   "compress_mbps": 8.75,
-   "decompress_mbps": 998.24
+   "compress_mbps": 8.96,
+   "decompress_mbps": 1009.49
   },
   {
    "compressor": "miniz_oxide",
@@ -2534,8 +2534,8 @@
    "level": 1,
    "out_size": 208640,
    "ratio": 0.4889,
-   "compress_mbps": 153.87,
-   "decompress_mbps": 437.89
+   "compress_mbps": 157.34,
+   "decompress_mbps": 424.83
   },
   {
    "compressor": "miniz_oxide",
@@ -2544,8 +2544,8 @@
    "level": 2,
    "out_size": 167329,
    "ratio": 0.3921,
-   "compress_mbps": 136.94,
-   "decompress_mbps": 476.75
+   "compress_mbps": 138.54,
+   "decompress_mbps": 464.58
   },
   {
    "compressor": "miniz_oxide",
@@ -2554,8 +2554,8 @@
    "level": 3,
    "out_size": 151097,
    "ratio": 0.3541,
-   "compress_mbps": 73.3,
-   "decompress_mbps": 523.19
+   "compress_mbps": 73.57,
+   "decompress_mbps": 510.84
   },
   {
    "compressor": "miniz_oxide",
@@ -2564,8 +2564,8 @@
    "level": 4,
    "out_size": 150035,
    "ratio": 0.3516,
-   "compress_mbps": 65.88,
-   "decompress_mbps": 516.75
+   "compress_mbps": 66.59,
+   "decompress_mbps": 511.35
   },
   {
    "compressor": "miniz_oxide",
@@ -2574,8 +2574,8 @@
    "level": 5,
    "out_size": 147375,
    "ratio": 0.3453,
-   "compress_mbps": 47.75,
-   "decompress_mbps": 515.09
+   "compress_mbps": 48.11,
+   "decompress_mbps": 508.07
   },
   {
    "compressor": "miniz_oxide",
@@ -2584,8 +2584,8 @@
    "level": 6,
    "out_size": 144908,
    "ratio": 0.3396,
-   "compress_mbps": 27.87,
-   "decompress_mbps": 525.27
+   "compress_mbps": 28.06,
+   "decompress_mbps": 519.16
   },
   {
    "compressor": "miniz_oxide",
@@ -2594,8 +2594,8 @@
    "level": 7,
    "out_size": 144562,
    "ratio": 0.3387,
-   "compress_mbps": 24.45,
-   "decompress_mbps": 525.95
+   "compress_mbps": 24.64,
+   "decompress_mbps": 517.99
   },
   {
    "compressor": "miniz_oxide",
@@ -2604,8 +2604,8 @@
    "level": 8,
    "out_size": 144449,
    "ratio": 0.3385,
-   "compress_mbps": 22.28,
-   "decompress_mbps": 525.77
+   "compress_mbps": 22.41,
+   "decompress_mbps": 518.6
   },
   {
    "compressor": "miniz_oxide",
@@ -2614,8 +2614,8 @@
    "level": 9,
    "out_size": 144438,
    "ratio": 0.3385,
-   "compress_mbps": 22.15,
-   "decompress_mbps": 526.06
+   "compress_mbps": 22.31,
+   "decompress_mbps": 518.95
   },
   {
    "compressor": "miniz_oxide",
@@ -2624,8 +2624,8 @@
    "level": 1,
    "out_size": 264549,
    "ratio": 0.549,
-   "compress_mbps": 132.16,
-   "decompress_mbps": 389.54
+   "compress_mbps": 135.43,
+   "decompress_mbps": 376.95
   },
   {
    "compressor": "miniz_oxide",
@@ -2634,8 +2634,8 @@
    "level": 2,
    "out_size": 223724,
    "ratio": 0.4643,
-   "compress_mbps": 117.41,
-   "decompress_mbps": 434.23
+   "compress_mbps": 118.93,
+   "decompress_mbps": 422.83
   },
   {
    "compressor": "miniz_oxide",
@@ -2644,8 +2644,8 @@
    "level": 3,
    "out_size": 204825,
    "ratio": 0.4251,
-   "compress_mbps": 60.4,
-   "decompress_mbps": 488.71
+   "compress_mbps": 60.63,
+   "decompress_mbps": 478.39
   },
   {
    "compressor": "miniz_oxide",
@@ -2654,8 +2654,8 @@
    "level": 4,
    "out_size": 203945,
    "ratio": 0.4232,
-   "compress_mbps": 53.51,
-   "decompress_mbps": 478.05
+   "compress_mbps": 53.94,
+   "decompress_mbps": 474.47
   },
   {
    "compressor": "miniz_oxide",
@@ -2664,8 +2664,8 @@
    "level": 5,
    "out_size": 199780,
    "ratio": 0.4146,
-   "compress_mbps": 37.6,
-   "decompress_mbps": 460.47
+   "compress_mbps": 37.91,
+   "decompress_mbps": 457.62
   },
   {
    "compressor": "miniz_oxide",
@@ -2674,8 +2674,8 @@
    "level": 6,
    "out_size": 195417,
    "ratio": 0.4055,
-   "compress_mbps": 20.91,
-   "decompress_mbps": 468.06
+   "compress_mbps": 21.2,
+   "decompress_mbps": 468.93
   },
   {
    "compressor": "miniz_oxide",
@@ -2684,8 +2684,8 @@
    "level": 7,
    "out_size": 194796,
    "ratio": 0.4043,
-   "compress_mbps": 17.73,
-   "decompress_mbps": 472.19
+   "compress_mbps": 17.9,
+   "decompress_mbps": 467.61
   },
   {
    "compressor": "miniz_oxide",
@@ -2694,8 +2694,8 @@
    "level": 8,
    "out_size": 194543,
    "ratio": 0.4037,
-   "compress_mbps": 15.62,
-   "decompress_mbps": 471.47
+   "compress_mbps": 15.72,
+   "decompress_mbps": 467.24
   },
   {
    "compressor": "miniz_oxide",
@@ -2704,8 +2704,8 @@
    "level": 9,
    "out_size": 194460,
    "ratio": 0.4036,
-   "compress_mbps": 14.96,
-   "decompress_mbps": 471.89
+   "compress_mbps": 15.05,
+   "decompress_mbps": 468.35
   },
   {
    "compressor": "miniz_oxide",
@@ -2714,8 +2714,8 @@
    "level": 1,
    "out_size": 67436,
    "ratio": 0.1314,
-   "compress_mbps": 615.15,
-   "decompress_mbps": 1029.3
+   "compress_mbps": 627.54,
+   "decompress_mbps": 1004.41
   },
   {
    "compressor": "miniz_oxide",
@@ -2724,8 +2724,8 @@
    "level": 2,
    "out_size": 59257,
    "ratio": 0.1155,
-   "compress_mbps": 276.11,
-   "decompress_mbps": 1085.4
+   "compress_mbps": 278.61,
+   "decompress_mbps": 1060.4
   },
   {
    "compressor": "miniz_oxide",
@@ -2734,8 +2734,8 @@
    "level": 3,
    "out_size": 58316,
    "ratio": 0.1136,
-   "compress_mbps": 180.64,
-   "decompress_mbps": 1175.73
+   "compress_mbps": 181.72,
+   "decompress_mbps": 1145.04
   },
   {
    "compressor": "miniz_oxide",
@@ -2744,8 +2744,8 @@
    "level": 4,
    "out_size": 56291,
    "ratio": 0.1097,
-   "compress_mbps": 183.2,
-   "decompress_mbps": 1182.36
+   "compress_mbps": 185.03,
+   "decompress_mbps": 1154.82
   },
   {
    "compressor": "miniz_oxide",
@@ -2754,8 +2754,8 @@
    "level": 5,
    "out_size": 56220,
    "ratio": 0.1095,
-   "compress_mbps": 145.21,
-   "decompress_mbps": 1236.28
+   "compress_mbps": 146.23,
+   "decompress_mbps": 1207.72
   },
   {
    "compressor": "miniz_oxide",
@@ -2764,8 +2764,8 @@
    "level": 6,
    "out_size": 55972,
    "ratio": 0.1091,
-   "compress_mbps": 74.19,
-   "decompress_mbps": 1301.85
+   "compress_mbps": 74.5,
+   "decompress_mbps": 1263.85
   },
   {
    "compressor": "miniz_oxide",
@@ -2774,8 +2774,8 @@
    "level": 7,
    "out_size": 55121,
    "ratio": 0.1074,
-   "compress_mbps": 51.88,
-   "decompress_mbps": 1334.52
+   "compress_mbps": 52.14,
+   "decompress_mbps": 1305.51
   },
   {
    "compressor": "miniz_oxide",
@@ -2784,8 +2784,8 @@
    "level": 8,
    "out_size": 54124,
    "ratio": 0.1055,
-   "compress_mbps": 36.55,
-   "decompress_mbps": 1415.19
+   "compress_mbps": 36.7,
+   "decompress_mbps": 1378.02
   },
   {
    "compressor": "miniz_oxide",
@@ -2794,8 +2794,8 @@
    "level": 9,
    "out_size": 53699,
    "ratio": 0.1046,
-   "compress_mbps": 28.58,
-   "decompress_mbps": 1434.08
+   "compress_mbps": 28.66,
+   "decompress_mbps": 1411.67
   },
   {
    "compressor": "miniz_oxide",
@@ -2804,8 +2804,8 @@
    "level": 1,
    "out_size": 15612,
    "ratio": 0.4083,
-   "compress_mbps": 505.46,
-   "decompress_mbps": 849.63
+   "compress_mbps": 502.51,
+   "decompress_mbps": 850.6
   },
   {
    "compressor": "miniz_oxide",
@@ -2814,8 +2814,8 @@
    "level": 2,
    "out_size": 14133,
    "ratio": 0.3696,
-   "compress_mbps": 144.85,
-   "decompress_mbps": 881.61
+   "compress_mbps": 145.19,
+   "decompress_mbps": 890.56
   },
   {
    "compressor": "miniz_oxide",
@@ -2824,8 +2824,8 @@
    "level": 3,
    "out_size": 13341,
    "ratio": 0.3489,
-   "compress_mbps": 88.42,
-   "decompress_mbps": 911.78
+   "compress_mbps": 88.72,
+   "decompress_mbps": 911.51
   },
   {
    "compressor": "miniz_oxide",
@@ -2835,7 +2835,7 @@
    "out_size": 13289,
    "ratio": 0.3475,
    "compress_mbps": 83.64,
-   "decompress_mbps": 938.27
+   "decompress_mbps": 941.29
   },
   {
    "compressor": "miniz_oxide",
@@ -2844,8 +2844,8 @@
    "level": 5,
    "out_size": 13052,
    "ratio": 0.3413,
-   "compress_mbps": 66.5,
-   "decompress_mbps": 977.6
+   "compress_mbps": 66.83,
+   "decompress_mbps": 973.4
   },
   {
    "compressor": "miniz_oxide",
@@ -2854,8 +2854,8 @@
    "level": 6,
    "out_size": 12996,
    "ratio": 0.3399,
-   "compress_mbps": 37.02,
-   "decompress_mbps": 992.66
+   "compress_mbps": 37.14,
+   "decompress_mbps": 986.7
   },
   {
    "compressor": "miniz_oxide",
@@ -2864,8 +2864,8 @@
    "level": 7,
    "out_size": 12972,
    "ratio": 0.3392,
-   "compress_mbps": 27.11,
-   "decompress_mbps": 998.92
+   "compress_mbps": 27.2,
+   "decompress_mbps": 990.88
   },
   {
    "compressor": "miniz_oxide",
@@ -2874,8 +2874,8 @@
    "level": 8,
    "out_size": 12951,
    "ratio": 0.3387,
-   "compress_mbps": 18.98,
-   "decompress_mbps": 998.26
+   "compress_mbps": 19.04,
+   "decompress_mbps": 996.63
   },
   {
    "compressor": "miniz_oxide",
@@ -2884,8 +2884,8 @@
    "level": 9,
    "out_size": 12933,
    "ratio": 0.3382,
-   "compress_mbps": 14.81,
-   "decompress_mbps": 1001.94
+   "compress_mbps": 14.86,
+   "decompress_mbps": 1010.18
   },
   {
    "compressor": "miniz_oxide",
@@ -2894,8 +2894,8 @@
    "level": 1,
    "out_size": 1988,
    "ratio": 0.4703,
-   "compress_mbps": 340.62,
-   "decompress_mbps": 547.64
+   "compress_mbps": 340.18,
+   "decompress_mbps": 548.09
   },
   {
    "compressor": "miniz_oxide",
@@ -2904,8 +2904,8 @@
    "level": 2,
    "out_size": 1802,
    "ratio": 0.4263,
-   "compress_mbps": 216.68,
-   "decompress_mbps": 552.52
+   "compress_mbps": 218.94,
+   "decompress_mbps": 554.27
   },
   {
    "compressor": "miniz_oxide",
@@ -2914,8 +2914,8 @@
    "level": 3,
    "out_size": 1760,
    "ratio": 0.4164,
-   "compress_mbps": 207.05,
-   "decompress_mbps": 552.75
+   "compress_mbps": 205.58,
+   "decompress_mbps": 558.57
   },
   {
    "compressor": "miniz_oxide",
@@ -2924,8 +2924,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 169.21,
-   "decompress_mbps": 563.8
+   "compress_mbps": 171.81,
+   "decompress_mbps": 573.34
   },
   {
    "compressor": "miniz_oxide",
@@ -2934,8 +2934,8 @@
    "level": 5,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 165.89,
-   "decompress_mbps": 574.0
+   "compress_mbps": 167.66,
+   "decompress_mbps": 582.37
   },
   {
    "compressor": "miniz_oxide",
@@ -2944,8 +2944,8 @@
    "level": 6,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 164.72,
-   "decompress_mbps": 573.92
+   "compress_mbps": 166.66,
+   "decompress_mbps": 582.62
   },
   {
    "compressor": "miniz_oxide",
@@ -2954,8 +2954,8 @@
    "level": 7,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 164.83,
-   "decompress_mbps": 573.75
+   "compress_mbps": 166.44,
+   "decompress_mbps": 580.03
   },
   {
    "compressor": "miniz_oxide",
@@ -2964,8 +2964,8 @@
    "level": 8,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 165.54,
-   "decompress_mbps": 575.47
+   "compress_mbps": 167.1,
+   "decompress_mbps": 579.86
   },
   {
    "compressor": "miniz_oxide",
@@ -2974,8 +2974,8 @@
    "level": 9,
    "out_size": 1730,
    "ratio": 0.4093,
-   "compress_mbps": 164.96,
-   "decompress_mbps": 576.05
+   "compress_mbps": 166.8,
+   "decompress_mbps": 579.36
   },
   {
    "compressor": "libdeflate",
@@ -2984,8 +2984,8 @@
    "level": 1,
    "out_size": 59790,
    "ratio": 0.3931,
-   "compress_mbps": 260.81,
-   "decompress_mbps": 999.31
+   "compress_mbps": 262.72,
+   "decompress_mbps": 1002.92
   },
   {
    "compressor": "libdeflate",
@@ -2994,8 +2994,8 @@
    "level": 2,
    "out_size": 57173,
    "ratio": 0.3759,
-   "compress_mbps": 180.73,
-   "decompress_mbps": 1071.44
+   "compress_mbps": 181.24,
+   "decompress_mbps": 1076.37
   },
   {
    "compressor": "libdeflate",
@@ -3004,8 +3004,8 @@
    "level": 3,
    "out_size": 56189,
    "ratio": 0.3694,
-   "compress_mbps": 150.02,
-   "decompress_mbps": 1149.5
+   "compress_mbps": 150.83,
+   "decompress_mbps": 1150.52
   },
   {
    "compressor": "libdeflate",
@@ -3014,8 +3014,8 @@
    "level": 4,
    "out_size": 55816,
    "ratio": 0.367,
-   "compress_mbps": 137.21,
-   "decompress_mbps": 1184.79
+   "compress_mbps": 138.22,
+   "decompress_mbps": 1189.04
   },
   {
    "compressor": "libdeflate",
@@ -3024,8 +3024,8 @@
    "level": 5,
    "out_size": 54758,
    "ratio": 0.36,
-   "compress_mbps": 108.54,
-   "decompress_mbps": 1243.11
+   "compress_mbps": 109.12,
+   "decompress_mbps": 1241.07
   },
   {
    "compressor": "libdeflate",
@@ -3034,8 +3034,8 @@
    "level": 6,
    "out_size": 54220,
    "ratio": 0.3565,
-   "compress_mbps": 83.68,
-   "decompress_mbps": 1275.79
+   "compress_mbps": 84.01,
+   "decompress_mbps": 1281.1
   },
   {
    "compressor": "libdeflate",
@@ -3044,8 +3044,8 @@
    "level": 7,
    "out_size": 53801,
    "ratio": 0.3537,
-   "compress_mbps": 60.29,
-   "decompress_mbps": 1285.52
+   "compress_mbps": 61.34,
+   "decompress_mbps": 1284.1
   },
   {
    "compressor": "libdeflate",
@@ -3054,8 +3054,8 @@
    "level": 8,
    "out_size": 53573,
    "ratio": 0.3522,
-   "compress_mbps": 38.96,
-   "decompress_mbps": 1289.61
+   "compress_mbps": 38.99,
+   "decompress_mbps": 1281.45
   },
   {
    "compressor": "libdeflate",
@@ -3064,8 +3064,8 @@
    "level": 9,
    "out_size": 53546,
    "ratio": 0.3521,
-   "compress_mbps": 34.44,
-   "decompress_mbps": 1284.66
+   "compress_mbps": 34.49,
+   "decompress_mbps": 1286.38
   },
   {
    "compressor": "libdeflate",
@@ -3074,8 +3074,8 @@
    "level": 1,
    "out_size": 52276,
    "ratio": 0.4176,
-   "compress_mbps": 242.55,
-   "decompress_mbps": 943.26
+   "compress_mbps": 244.27,
+   "decompress_mbps": 941.62
   },
   {
    "compressor": "libdeflate",
@@ -3084,8 +3084,8 @@
    "level": 2,
    "out_size": 50534,
    "ratio": 0.4037,
-   "compress_mbps": 167.4,
-   "decompress_mbps": 991.68
+   "compress_mbps": 169.26,
+   "decompress_mbps": 994.53
   },
   {
    "compressor": "libdeflate",
@@ -3094,8 +3094,8 @@
    "level": 3,
    "out_size": 49919,
    "ratio": 0.3988,
-   "compress_mbps": 140.99,
-   "decompress_mbps": 1057.13
+   "compress_mbps": 142.29,
+   "decompress_mbps": 1056.87
   },
   {
    "compressor": "libdeflate",
@@ -3104,8 +3104,8 @@
    "level": 4,
    "out_size": 49715,
    "ratio": 0.3972,
-   "compress_mbps": 130.7,
-   "decompress_mbps": 1091.16
+   "compress_mbps": 131.62,
+   "decompress_mbps": 1092.43
   },
   {
    "compressor": "libdeflate",
@@ -3114,8 +3114,8 @@
    "level": 5,
    "out_size": 48735,
    "ratio": 0.3893,
-   "compress_mbps": 100.96,
-   "decompress_mbps": 1142.37
+   "compress_mbps": 101.28,
+   "decompress_mbps": 1138.39
   },
   {
    "compressor": "libdeflate",
@@ -3124,8 +3124,8 @@
    "level": 6,
    "out_size": 48422,
    "ratio": 0.3868,
-   "compress_mbps": 79.18,
-   "decompress_mbps": 1163.55
+   "compress_mbps": 79.56,
+   "decompress_mbps": 1159.77
   },
   {
    "compressor": "libdeflate",
@@ -3134,8 +3134,8 @@
    "level": 7,
    "out_size": 48249,
    "ratio": 0.3854,
-   "compress_mbps": 61.18,
-   "decompress_mbps": 1171.12
+   "compress_mbps": 61.42,
+   "decompress_mbps": 1167.2
   },
   {
    "compressor": "libdeflate",
@@ -3144,8 +3144,8 @@
    "level": 8,
    "out_size": 47977,
    "ratio": 0.3833,
-   "compress_mbps": 43.04,
-   "decompress_mbps": 1170.38
+   "compress_mbps": 43.01,
+   "decompress_mbps": 1163.26
   },
   {
    "compressor": "libdeflate",
@@ -3155,7 +3155,7 @@
    "out_size": 47971,
    "ratio": 0.3832,
    "compress_mbps": 41.05,
-   "decompress_mbps": 1171.39
+   "decompress_mbps": 1168.97
   },
   {
    "compressor": "libdeflate",
@@ -3164,8 +3164,8 @@
    "level": 1,
    "out_size": 8385,
    "ratio": 0.3408,
-   "compress_mbps": 692.66,
-   "decompress_mbps": 955.34
+   "compress_mbps": 694.12,
+   "decompress_mbps": 956.86
   },
   {
    "compressor": "libdeflate",
@@ -3174,8 +3174,8 @@
    "level": 2,
    "out_size": 8380,
    "ratio": 0.3406,
-   "compress_mbps": 443.72,
-   "decompress_mbps": 980.33
+   "compress_mbps": 439.72,
+   "decompress_mbps": 974.59
   },
   {
    "compressor": "libdeflate",
@@ -3184,8 +3184,8 @@
    "level": 3,
    "out_size": 8286,
    "ratio": 0.3368,
-   "compress_mbps": 406.67,
-   "decompress_mbps": 994.5
+   "compress_mbps": 403.73,
+   "decompress_mbps": 993.24
   },
   {
    "compressor": "libdeflate",
@@ -3194,8 +3194,8 @@
    "level": 4,
    "out_size": 8163,
    "ratio": 0.3318,
-   "compress_mbps": 377.97,
-   "decompress_mbps": 1008.69
+   "compress_mbps": 378.68,
+   "decompress_mbps": 1003.78
   },
   {
    "compressor": "libdeflate",
@@ -3204,8 +3204,8 @@
    "level": 5,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 339.17,
-   "decompress_mbps": 1022.19
+   "compress_mbps": 335.07,
+   "decompress_mbps": 1027.69
   },
   {
    "compressor": "libdeflate",
@@ -3214,8 +3214,8 @@
    "level": 6,
    "out_size": 7986,
    "ratio": 0.3246,
-   "compress_mbps": 277.85,
-   "decompress_mbps": 1031.31
+   "compress_mbps": 277.67,
+   "decompress_mbps": 1035.81
   },
   {
    "compressor": "libdeflate",
@@ -3224,8 +3224,8 @@
    "level": 7,
    "out_size": 7954,
    "ratio": 0.3233,
-   "compress_mbps": 192.36,
-   "decompress_mbps": 1034.22
+   "compress_mbps": 191.05,
+   "decompress_mbps": 1026.12
   },
   {
    "compressor": "libdeflate",
@@ -3234,8 +3234,8 @@
    "level": 8,
    "out_size": 7916,
    "ratio": 0.3217,
-   "compress_mbps": 125.45,
-   "decompress_mbps": 1037.19
+   "compress_mbps": 129.56,
+   "decompress_mbps": 1035.17
   },
   {
    "compressor": "libdeflate",
@@ -3244,8 +3244,8 @@
    "level": 9,
    "out_size": 7916,
    "ratio": 0.3217,
-   "compress_mbps": 125.34,
-   "decompress_mbps": 1037.6
+   "compress_mbps": 125.42,
+   "decompress_mbps": 1013.27
   },
   {
    "compressor": "libdeflate",
@@ -3254,8 +3254,8 @@
    "level": 1,
    "out_size": 3401,
    "ratio": 0.305,
-   "compress_mbps": 586.48,
-   "decompress_mbps": 778.55
+   "compress_mbps": 586.93,
+   "decompress_mbps": 768.98
   },
   {
    "compressor": "libdeflate",
@@ -3264,8 +3264,8 @@
    "level": 2,
    "out_size": 3307,
    "ratio": 0.2966,
-   "compress_mbps": 399.18,
-   "decompress_mbps": 803.19
+   "compress_mbps": 398.24,
+   "decompress_mbps": 792.95
   },
   {
    "compressor": "libdeflate",
@@ -3274,8 +3274,8 @@
    "level": 3,
    "out_size": 3242,
    "ratio": 0.2908,
-   "compress_mbps": 367.65,
-   "decompress_mbps": 815.14
+   "compress_mbps": 371.5,
+   "decompress_mbps": 810.66
   },
   {
    "compressor": "libdeflate",
@@ -3284,8 +3284,8 @@
    "level": 4,
    "out_size": 3205,
    "ratio": 0.2874,
-   "compress_mbps": 349.58,
-   "decompress_mbps": 826.54
+   "compress_mbps": 349.62,
+   "decompress_mbps": 821.62
   },
   {
    "compressor": "libdeflate",
@@ -3294,8 +3294,8 @@
    "level": 5,
    "out_size": 3150,
    "ratio": 0.2825,
-   "compress_mbps": 311.46,
-   "decompress_mbps": 835.7
+   "compress_mbps": 313.81,
+   "decompress_mbps": 837.48
   },
   {
    "compressor": "libdeflate",
@@ -3304,8 +3304,8 @@
    "level": 6,
    "out_size": 3126,
    "ratio": 0.2804,
-   "compress_mbps": 266.22,
-   "decompress_mbps": 840.99
+   "compress_mbps": 267.83,
+   "decompress_mbps": 842.46
   },
   {
    "compressor": "libdeflate",
@@ -3314,8 +3314,8 @@
    "level": 7,
    "out_size": 3106,
    "ratio": 0.2786,
-   "compress_mbps": 205.69,
-   "decompress_mbps": 842.39
+   "compress_mbps": 206.71,
+   "decompress_mbps": 846.01
   },
   {
    "compressor": "libdeflate",
@@ -3324,8 +3324,8 @@
    "level": 8,
    "out_size": 3102,
    "ratio": 0.2782,
-   "compress_mbps": 147.71,
-   "decompress_mbps": 847.09
+   "compress_mbps": 147.91,
+   "decompress_mbps": 842.39
   },
   {
    "compressor": "libdeflate",
@@ -3334,8 +3334,8 @@
    "level": 9,
    "out_size": 3102,
    "ratio": 0.2782,
-   "compress_mbps": 140.25,
-   "decompress_mbps": 842.79
+   "compress_mbps": 140.39,
+   "decompress_mbps": 846.34
   },
   {
    "compressor": "libdeflate",
@@ -3344,8 +3344,8 @@
    "level": 1,
    "out_size": 1251,
    "ratio": 0.3362,
-   "compress_mbps": 381.0,
-   "decompress_mbps": 430.61
+   "compress_mbps": 377.39,
+   "decompress_mbps": 426.98
   },
   {
    "compressor": "libdeflate",
@@ -3354,8 +3354,8 @@
    "level": 2,
    "out_size": 1228,
    "ratio": 0.33,
-   "compress_mbps": 268.94,
-   "decompress_mbps": 432.28
+   "compress_mbps": 267.66,
+   "decompress_mbps": 433.76
   },
   {
    "compressor": "libdeflate",
@@ -3364,8 +3364,8 @@
    "level": 3,
    "out_size": 1219,
    "ratio": 0.3276,
-   "compress_mbps": 260.68,
-   "decompress_mbps": 434.03
+   "compress_mbps": 258.72,
+   "decompress_mbps": 433.23
   },
   {
    "compressor": "libdeflate",
@@ -3374,8 +3374,8 @@
    "level": 4,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 254.4,
-   "decompress_mbps": 445.25
+   "compress_mbps": 253.94,
+   "decompress_mbps": 439.29
   },
   {
    "compressor": "libdeflate",
@@ -3384,8 +3384,8 @@
    "level": 5,
    "out_size": 1207,
    "ratio": 0.3244,
-   "compress_mbps": 239.14,
-   "decompress_mbps": 445.53
+   "compress_mbps": 240.44,
+   "decompress_mbps": 443.8
   },
   {
    "compressor": "libdeflate",
@@ -3394,8 +3394,8 @@
    "level": 6,
    "out_size": 1207,
    "ratio": 0.3244,
-   "compress_mbps": 220.64,
-   "decompress_mbps": 449.76
+   "compress_mbps": 222.65,
+   "decompress_mbps": 441.15
   },
   {
    "compressor": "libdeflate",
@@ -3404,8 +3404,8 @@
    "level": 7,
    "out_size": 1207,
    "ratio": 0.3244,
-   "compress_mbps": 201.89,
-   "decompress_mbps": 450.73
+   "compress_mbps": 203.53,
+   "decompress_mbps": 438.86
   },
   {
    "compressor": "libdeflate",
@@ -3414,8 +3414,8 @@
    "level": 8,
    "out_size": 1204,
    "ratio": 0.3236,
-   "compress_mbps": 168.55,
-   "decompress_mbps": 449.82
+   "compress_mbps": 169.68,
+   "decompress_mbps": 444.08
   },
   {
    "compressor": "libdeflate",
@@ -3424,8 +3424,8 @@
    "level": 9,
    "out_size": 1204,
    "ratio": 0.3236,
-   "compress_mbps": 169.25,
-   "decompress_mbps": 450.79
+   "compress_mbps": 169.88,
+   "decompress_mbps": 438.1
   },
   {
    "compressor": "libdeflate",
@@ -3434,8 +3434,8 @@
    "level": 1,
    "out_size": 221813,
    "ratio": 0.2154,
-   "compress_mbps": 589.05,
-   "decompress_mbps": 1008.2
+   "compress_mbps": 593.83,
+   "decompress_mbps": 1009.94
   },
   {
    "compressor": "libdeflate",
@@ -3444,8 +3444,8 @@
    "level": 2,
    "out_size": 199825,
    "ratio": 0.1941,
-   "compress_mbps": 405.32,
-   "decompress_mbps": 1440.65
+   "compress_mbps": 409.25,
+   "decompress_mbps": 1460.57
   },
   {
    "compressor": "libdeflate",
@@ -3454,8 +3454,8 @@
    "level": 3,
    "out_size": 195675,
    "ratio": 0.19,
-   "compress_mbps": 281.74,
-   "decompress_mbps": 1532.75
+   "compress_mbps": 283.23,
+   "decompress_mbps": 1526.64
   },
   {
    "compressor": "libdeflate",
@@ -3464,8 +3464,8 @@
    "level": 4,
    "out_size": 195664,
    "ratio": 0.19,
-   "compress_mbps": 278.71,
-   "decompress_mbps": 1533.21
+   "compress_mbps": 279.77,
+   "decompress_mbps": 1536.83
   },
   {
    "compressor": "libdeflate",
@@ -3474,8 +3474,8 @@
    "level": 5,
    "out_size": 198900,
    "ratio": 0.1932,
-   "compress_mbps": 239.27,
-   "decompress_mbps": 1130.77
+   "compress_mbps": 239.94,
+   "decompress_mbps": 1127.82
   },
   {
    "compressor": "libdeflate",
@@ -3484,8 +3484,8 @@
    "level": 6,
    "out_size": 199347,
    "ratio": 0.1936,
-   "compress_mbps": 204.42,
-   "decompress_mbps": 1130.09
+   "compress_mbps": 204.69,
+   "decompress_mbps": 1130.61
   },
   {
    "compressor": "libdeflate",
@@ -3494,8 +3494,8 @@
    "level": 7,
    "out_size": 199777,
    "ratio": 0.194,
-   "compress_mbps": 123.6,
-   "decompress_mbps": 1179.72
+   "compress_mbps": 123.53,
+   "decompress_mbps": 1190.54
   },
   {
    "compressor": "libdeflate",
@@ -3504,8 +3504,8 @@
    "level": 8,
    "out_size": 182094,
    "ratio": 0.1768,
-   "compress_mbps": 25.73,
-   "decompress_mbps": 1168.32
+   "compress_mbps": 25.66,
+   "decompress_mbps": 1169.78
   },
   {
    "compressor": "libdeflate",
@@ -3514,8 +3514,8 @@
    "level": 9,
    "out_size": 181451,
    "ratio": 0.1762,
-   "compress_mbps": 13.56,
-   "decompress_mbps": 1179.72
+   "compress_mbps": 13.61,
+   "decompress_mbps": 1173.47
   },
   {
    "compressor": "libdeflate",
@@ -3524,8 +3524,8 @@
    "level": 1,
    "out_size": 159063,
    "ratio": 0.3727,
-   "compress_mbps": 263.07,
-   "decompress_mbps": 1032.01
+   "compress_mbps": 263.86,
+   "decompress_mbps": 1029.34
   },
   {
    "compressor": "libdeflate",
@@ -3534,8 +3534,8 @@
    "level": 2,
    "out_size": 152115,
    "ratio": 0.3564,
-   "compress_mbps": 186.6,
-   "decompress_mbps": 1110.18
+   "compress_mbps": 187.44,
+   "decompress_mbps": 1105.52
   },
   {
    "compressor": "libdeflate",
@@ -3544,8 +3544,8 @@
    "level": 3,
    "out_size": 149162,
    "ratio": 0.3495,
-   "compress_mbps": 156.51,
-   "decompress_mbps": 1197.51
+   "compress_mbps": 156.82,
+   "decompress_mbps": 1189.07
   },
   {
    "compressor": "libdeflate",
@@ -3554,8 +3554,8 @@
    "level": 4,
    "out_size": 148359,
    "ratio": 0.3476,
-   "compress_mbps": 143.03,
-   "decompress_mbps": 1049.97
+   "compress_mbps": 142.61,
+   "decompress_mbps": 1033.04
   },
   {
    "compressor": "libdeflate",
@@ -3564,8 +3564,8 @@
    "level": 5,
    "out_size": 145353,
    "ratio": 0.3406,
-   "compress_mbps": 113.38,
-   "decompress_mbps": 1021.29
+   "compress_mbps": 113.35,
+   "decompress_mbps": 997.15
   },
   {
    "compressor": "libdeflate",
@@ -3574,8 +3574,8 @@
    "level": 6,
    "out_size": 144209,
    "ratio": 0.3379,
-   "compress_mbps": 87.88,
-   "decompress_mbps": 1050.93
+   "compress_mbps": 87.48,
+   "decompress_mbps": 1037.45
   },
   {
    "compressor": "libdeflate",
@@ -3584,8 +3584,8 @@
    "level": 7,
    "out_size": 143604,
    "ratio": 0.3365,
-   "compress_mbps": 66.56,
-   "decompress_mbps": 1057.84
+   "compress_mbps": 66.64,
+   "decompress_mbps": 1039.31
   },
   {
    "compressor": "libdeflate",
@@ -3594,8 +3594,8 @@
    "level": 8,
    "out_size": 142086,
    "ratio": 0.3329,
-   "compress_mbps": 44.23,
-   "decompress_mbps": 1060.89
+   "compress_mbps": 44.24,
+   "decompress_mbps": 1035.21
   },
   {
    "compressor": "libdeflate",
@@ -3604,8 +3604,8 @@
    "level": 9,
    "out_size": 142027,
    "ratio": 0.3328,
-   "compress_mbps": 40.4,
-   "decompress_mbps": 1062.13
+   "compress_mbps": 40.46,
+   "decompress_mbps": 1038.75
   },
   {
    "compressor": "libdeflate",
@@ -3614,8 +3614,8 @@
    "level": 1,
    "out_size": 210662,
    "ratio": 0.4372,
-   "compress_mbps": 228.42,
-   "decompress_mbps": 872.53
+   "compress_mbps": 228.71,
+   "decompress_mbps": 869.83
   },
   {
    "compressor": "libdeflate",
@@ -3624,8 +3624,8 @@
    "level": 2,
    "out_size": 202881,
    "ratio": 0.421,
-   "compress_mbps": 158.21,
-   "decompress_mbps": 939.7
+   "compress_mbps": 158.66,
+   "decompress_mbps": 939.95
   },
   {
    "compressor": "libdeflate",
@@ -3634,8 +3634,8 @@
    "level": 3,
    "out_size": 200409,
    "ratio": 0.4159,
-   "compress_mbps": 132.99,
-   "decompress_mbps": 1018.78
+   "compress_mbps": 132.96,
+   "decompress_mbps": 1019.12
   },
   {
    "compressor": "libdeflate",
@@ -3644,8 +3644,8 @@
    "level": 4,
    "out_size": 199678,
    "ratio": 0.4144,
-   "compress_mbps": 122.56,
-   "decompress_mbps": 860.05
+   "compress_mbps": 122.96,
+   "decompress_mbps": 839.63
   },
   {
    "compressor": "libdeflate",
@@ -3654,8 +3654,8 @@
    "level": 5,
    "out_size": 195798,
    "ratio": 0.4063,
-   "compress_mbps": 93.49,
-   "decompress_mbps": 811.85
+   "compress_mbps": 93.4,
+   "decompress_mbps": 789.36
   },
   {
    "compressor": "libdeflate",
@@ -3664,8 +3664,8 @@
    "level": 6,
    "out_size": 194029,
    "ratio": 0.4027,
-   "compress_mbps": 72.07,
-   "decompress_mbps": 837.28
+   "compress_mbps": 71.6,
+   "decompress_mbps": 813.1
   },
   {
    "compressor": "libdeflate",
@@ -3674,8 +3674,8 @@
    "level": 7,
    "out_size": 192773,
    "ratio": 0.4001,
-   "compress_mbps": 51.36,
-   "decompress_mbps": 838.03
+   "compress_mbps": 50.41,
+   "decompress_mbps": 835.88
   },
   {
    "compressor": "libdeflate",
@@ -3684,8 +3684,8 @@
    "level": 8,
    "out_size": 191739,
    "ratio": 0.3979,
-   "compress_mbps": 33.6,
-   "decompress_mbps": 841.75
+   "compress_mbps": 33.69,
+   "decompress_mbps": 841.06
   },
   {
    "compressor": "libdeflate",
@@ -3694,8 +3694,8 @@
    "level": 9,
    "out_size": 191676,
    "ratio": 0.3978,
-   "compress_mbps": 30.97,
-   "decompress_mbps": 842.22
+   "compress_mbps": 31.1,
+   "decompress_mbps": 839.65
   },
   {
    "compressor": "libdeflate",
@@ -3704,8 +3704,8 @@
    "level": 1,
    "out_size": 58079,
    "ratio": 0.1132,
-   "compress_mbps": 371.08,
-   "decompress_mbps": 1698.89
+   "compress_mbps": 373.38,
+   "decompress_mbps": 1687.98
   },
   {
    "compressor": "libdeflate",
@@ -3714,8 +3714,8 @@
    "level": 2,
    "out_size": 57838,
    "ratio": 0.1127,
-   "compress_mbps": 412.92,
-   "decompress_mbps": 1797.6
+   "compress_mbps": 413.69,
+   "decompress_mbps": 1800.72
   },
   {
    "compressor": "libdeflate",
@@ -3724,8 +3724,8 @@
    "level": 3,
    "out_size": 57554,
    "ratio": 0.1121,
-   "compress_mbps": 394.15,
-   "decompress_mbps": 1894.32
+   "compress_mbps": 394.76,
+   "decompress_mbps": 1899.42
   },
   {
    "compressor": "libdeflate",
@@ -3734,8 +3734,8 @@
    "level": 4,
    "out_size": 57064,
    "ratio": 0.1112,
-   "compress_mbps": 373.43,
-   "decompress_mbps": 1725.49
+   "compress_mbps": 374.05,
+   "decompress_mbps": 1741.26
   },
   {
    "compressor": "libdeflate",
@@ -3744,8 +3744,8 @@
    "level": 5,
    "out_size": 55743,
    "ratio": 0.1086,
-   "compress_mbps": 342.91,
-   "decompress_mbps": 1805.04
+   "compress_mbps": 343.45,
+   "decompress_mbps": 1793.36
   },
   {
    "compressor": "libdeflate",
@@ -3754,8 +3754,8 @@
    "level": 6,
    "out_size": 55102,
    "ratio": 0.1074,
-   "compress_mbps": 283.88,
-   "decompress_mbps": 1879.75
+   "compress_mbps": 285.08,
+   "decompress_mbps": 1869.89
   },
   {
    "compressor": "libdeflate",
@@ -3764,8 +3764,8 @@
    "level": 7,
    "out_size": 54742,
    "ratio": 0.1067,
-   "compress_mbps": 192.52,
-   "decompress_mbps": 1918.38
+   "compress_mbps": 193.03,
+   "decompress_mbps": 1929.26
   },
   {
    "compressor": "libdeflate",
@@ -3774,8 +3774,8 @@
    "level": 8,
    "out_size": 53133,
    "ratio": 0.1035,
-   "compress_mbps": 102.65,
-   "decompress_mbps": 1992.72
+   "compress_mbps": 102.77,
+   "decompress_mbps": 1996.36
   },
   {
    "compressor": "libdeflate",
@@ -3784,8 +3784,8 @@
    "level": 9,
    "out_size": 52186,
    "ratio": 0.1017,
-   "compress_mbps": 72.09,
-   "decompress_mbps": 2031.63
+   "compress_mbps": 72.32,
+   "decompress_mbps": 2031.74
   },
   {
    "compressor": "libdeflate",
@@ -3794,8 +3794,8 @@
    "level": 1,
    "out_size": 14122,
    "ratio": 0.3693,
-   "compress_mbps": 646.89,
-   "decompress_mbps": 831.23
+   "compress_mbps": 648.66,
+   "decompress_mbps": 823.66
   },
   {
    "compressor": "libdeflate",
@@ -3804,8 +3804,8 @@
    "level": 2,
    "out_size": 13374,
    "ratio": 0.3497,
-   "compress_mbps": 347.06,
-   "decompress_mbps": 878.51
+   "compress_mbps": 338.62,
+   "decompress_mbps": 879.23
   },
   {
    "compressor": "libdeflate",
@@ -3814,8 +3814,8 @@
    "level": 3,
    "out_size": 13293,
    "ratio": 0.3476,
-   "compress_mbps": 283.08,
-   "decompress_mbps": 963.27
+   "compress_mbps": 257.73,
+   "decompress_mbps": 960.76
   },
   {
    "compressor": "libdeflate",
@@ -3824,8 +3824,8 @@
    "level": 4,
    "out_size": 13259,
    "ratio": 0.3467,
-   "compress_mbps": 265.41,
-   "decompress_mbps": 958.01
+   "compress_mbps": 263.83,
+   "decompress_mbps": 960.86
   },
   {
    "compressor": "libdeflate",
@@ -3834,8 +3834,8 @@
    "level": 5,
    "out_size": 12641,
    "ratio": 0.3306,
-   "compress_mbps": 190.37,
-   "decompress_mbps": 983.35
+   "compress_mbps": 190.13,
+   "decompress_mbps": 990.29
   },
   {
    "compressor": "libdeflate",
@@ -3844,8 +3844,8 @@
    "level": 6,
    "out_size": 12432,
    "ratio": 0.3251,
-   "compress_mbps": 164.17,
-   "decompress_mbps": 1012.87
+   "compress_mbps": 164.05,
+   "decompress_mbps": 1006.67
   },
   {
    "compressor": "libdeflate",
@@ -3854,8 +3854,8 @@
    "level": 7,
    "out_size": 12439,
    "ratio": 0.3253,
-   "compress_mbps": 123.29,
-   "decompress_mbps": 1019.1
+   "compress_mbps": 122.43,
+   "decompress_mbps": 1013.21
   },
   {
    "compressor": "libdeflate",
@@ -3864,8 +3864,8 @@
    "level": 8,
    "out_size": 12579,
    "ratio": 0.3289,
-   "compress_mbps": 67.35,
-   "decompress_mbps": 1029.37
+   "compress_mbps": 67.61,
+   "decompress_mbps": 1025.92
   },
   {
    "compressor": "libdeflate",
@@ -3874,8 +3874,8 @@
    "level": 9,
    "out_size": 12574,
    "ratio": 0.3288,
-   "compress_mbps": 47.38,
-   "decompress_mbps": 1035.27
+   "compress_mbps": 47.47,
+   "decompress_mbps": 1031.58
   },
   {
    "compressor": "libdeflate",
@@ -3884,8 +3884,8 @@
    "level": 1,
    "out_size": 1777,
    "ratio": 0.4204,
-   "compress_mbps": 389.52,
-   "decompress_mbps": 401.71
+   "compress_mbps": 386.35,
+   "decompress_mbps": 403.24
   },
   {
    "compressor": "libdeflate",
@@ -3894,8 +3894,8 @@
    "level": 2,
    "out_size": 1756,
    "ratio": 0.4154,
-   "compress_mbps": 260.09,
-   "decompress_mbps": 404.66
+   "compress_mbps": 260.77,
+   "decompress_mbps": 408.51
   },
   {
    "compressor": "libdeflate",
@@ -3904,8 +3904,8 @@
    "level": 3,
    "out_size": 1746,
    "ratio": 0.4131,
-   "compress_mbps": 256.26,
-   "decompress_mbps": 408.97
+   "compress_mbps": 257.14,
+   "decompress_mbps": 410.93
   },
   {
    "compressor": "libdeflate",
@@ -3914,8 +3914,8 @@
    "level": 4,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 254.08,
-   "decompress_mbps": 411.05
+   "compress_mbps": 254.99,
+   "decompress_mbps": 414.73
   },
   {
    "compressor": "libdeflate",
@@ -3924,8 +3924,8 @@
    "level": 5,
    "out_size": 1722,
    "ratio": 0.4074,
-   "compress_mbps": 239.04,
-   "decompress_mbps": 415.16
+   "compress_mbps": 240.47,
+   "decompress_mbps": 415.2
   },
   {
    "compressor": "libdeflate",
@@ -3934,8 +3934,8 @@
    "level": 6,
    "out_size": 1721,
    "ratio": 0.4071,
-   "compress_mbps": 235.37,
-   "decompress_mbps": 415.54
+   "compress_mbps": 235.91,
+   "decompress_mbps": 415.29
   },
   {
    "compressor": "libdeflate",
@@ -3944,8 +3944,8 @@
    "level": 7,
    "out_size": 1720,
    "ratio": 0.4069,
-   "compress_mbps": 233.46,
-   "decompress_mbps": 414.56
+   "compress_mbps": 234.75,
+   "decompress_mbps": 415.41
   },
   {
    "compressor": "libdeflate",
@@ -3954,8 +3954,8 @@
    "level": 8,
    "out_size": 1717,
    "ratio": 0.4062,
-   "compress_mbps": 217.24,
-   "decompress_mbps": 409.13
+   "compress_mbps": 217.57,
+   "decompress_mbps": 417.83
   },
   {
    "compressor": "libdeflate",
@@ -3964,1088 +3964,1088 @@
    "level": 9,
    "out_size": 1717,
    "ratio": 0.4062,
-   "compress_mbps": 217.56,
-   "decompress_mbps": 408.88
+   "compress_mbps": 216.75,
+   "decompress_mbps": 416.19
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 1,
-   "out_size": 4231315,
-   "ratio": 0.4151,
-   "compress_mbps": 29.41,
-   "decompress_mbps": 80.34
+   "out_size": 4020171,
+   "ratio": 0.3944,
+   "compress_mbps": 32.0,
+   "decompress_mbps": 80.4
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 2,
-   "out_size": 4120658,
-   "ratio": 0.4043,
-   "compress_mbps": 26.35,
-   "decompress_mbps": 85.51
+   "out_size": 3970599,
+   "ratio": 0.3896,
+   "compress_mbps": 29.36,
+   "decompress_mbps": 85.84
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 3,
-   "out_size": 4037988,
-   "ratio": 0.3962,
-   "compress_mbps": 23.24,
-   "decompress_mbps": 91.75
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 3961310,
-   "ratio": 0.3887,
-   "compress_mbps": 16.1,
-   "decompress_mbps": 90.62
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3943365,
+   "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 15.16,
-   "decompress_mbps": 93.04
+   "compress_mbps": 28.64,
+   "decompress_mbps": 91.83
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3888008,
+   "ratio": 0.3815,
+   "compress_mbps": 22.95,
+   "decompress_mbps": 91.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3882303,
+   "ratio": 0.3809,
+   "compress_mbps": 22.29,
+   "decompress_mbps": 93.14
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 6,
-   "out_size": 3915657,
-   "ratio": 0.3842,
-   "compress_mbps": 13.1,
-   "decompress_mbps": 95.86
+   "out_size": 3873339,
+   "ratio": 0.38,
+   "compress_mbps": 20.9,
+   "decompress_mbps": 95.82
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 7,
-   "out_size": 3902484,
-   "ratio": 0.3829,
-   "compress_mbps": 6.42,
-   "decompress_mbps": 101.01
+   "out_size": 3865234,
+   "ratio": 0.3792,
+   "compress_mbps": 8.57,
+   "decompress_mbps": 99.99
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 8,
-   "out_size": 3899047,
-   "ratio": 0.3825,
-   "compress_mbps": 6.27,
-   "decompress_mbps": 98.48
+   "out_size": 3864805,
+   "ratio": 0.3792,
+   "compress_mbps": 8.69,
+   "decompress_mbps": 100.01
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 9,
-   "out_size": 3712344,
-   "ratio": 0.3642,
-   "compress_mbps": 1.0,
-   "decompress_mbps": 101.74
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20729473,
-   "ratio": 0.4047,
-   "compress_mbps": 40.64,
-   "decompress_mbps": 72.33
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 20500337,
-   "ratio": 0.4002,
-   "compress_mbps": 37.45,
-   "decompress_mbps": 75.28
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 20349978,
-   "ratio": 0.3973,
-   "compress_mbps": 34.46,
-   "decompress_mbps": 77.56
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 20049333,
-   "ratio": 0.3914,
-   "compress_mbps": 26.08,
-   "decompress_mbps": 79.22
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 20022052,
-   "ratio": 0.3909,
-   "compress_mbps": 24.58,
-   "decompress_mbps": 82.1
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19979491,
-   "ratio": 0.3901,
-   "compress_mbps": 20.98,
-   "decompress_mbps": 83.99
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 18841079,
-   "ratio": 0.3678,
-   "compress_mbps": 6.57,
-   "decompress_mbps": 84.38
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 18833163,
-   "ratio": 0.3677,
-   "compress_mbps": 5.98,
-   "decompress_mbps": 85.12
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18518350,
-   "ratio": 0.3615,
-   "compress_mbps": 0.88,
-   "decompress_mbps": 85.51
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3773613,
-   "ratio": 0.3785,
-   "compress_mbps": 42.85,
-   "decompress_mbps": 75.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3728325,
-   "ratio": 0.3739,
-   "compress_mbps": 38.65,
-   "decompress_mbps": 77.51
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3701126,
-   "ratio": 0.3712,
-   "compress_mbps": 33.57,
-   "decompress_mbps": 80.46
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3717412,
-   "ratio": 0.3728,
-   "compress_mbps": 22.46,
-   "decompress_mbps": 74.32
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3713907,
-   "ratio": 0.3725,
-   "compress_mbps": 20.56,
-   "decompress_mbps": 76.44
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3712342,
-   "ratio": 0.3723,
-   "compress_mbps": 16.43,
-   "decompress_mbps": 78.52
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3649251,
-   "ratio": 0.366,
-   "compress_mbps": 6.27,
-   "decompress_mbps": 76.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3648922,
-   "ratio": 0.366,
-   "compress_mbps": 5.29,
-   "decompress_mbps": 77.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3520112,
-   "ratio": 0.3531,
-   "compress_mbps": 0.36,
-   "decompress_mbps": 78.76
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3957304,
-   "ratio": 0.1179,
-   "compress_mbps": 101.14,
-   "decompress_mbps": 269.41
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 3769595,
-   "ratio": 0.1123,
-   "compress_mbps": 89.93,
-   "decompress_mbps": 297.5
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3594567,
-   "ratio": 0.1071,
-   "compress_mbps": 78.8,
-   "decompress_mbps": 325.85
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3423500,
-   "ratio": 0.102,
-   "compress_mbps": 68.23,
-   "decompress_mbps": 311.62
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3397370,
-   "ratio": 0.1013,
-   "compress_mbps": 65.0,
-   "decompress_mbps": 360.16
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3352804,
-   "ratio": 0.0999,
-   "compress_mbps": 58.0,
-   "decompress_mbps": 382.17
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3249135,
-   "ratio": 0.0968,
-   "compress_mbps": 22.22,
-   "decompress_mbps": 389.05
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3225205,
-   "ratio": 0.0961,
-   "compress_mbps": 18.42,
-   "decompress_mbps": 394.27
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2868751,
-   "ratio": 0.0855,
-   "compress_mbps": 0.53,
-   "decompress_mbps": 381.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3218639,
-   "ratio": 0.5232,
-   "compress_mbps": 28.22,
-   "decompress_mbps": 49.94
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3192732,
-   "ratio": 0.519,
-   "compress_mbps": 26.62,
-   "decompress_mbps": 51.56
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3174297,
-   "ratio": 0.516,
-   "compress_mbps": 24.66,
-   "decompress_mbps": 54.71
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3122783,
-   "ratio": 0.5076,
-   "compress_mbps": 18.87,
-   "decompress_mbps": 54.44
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3119358,
-   "ratio": 0.507,
-   "compress_mbps": 17.96,
-   "decompress_mbps": 55.69
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3113833,
-   "ratio": 0.5061,
-   "compress_mbps": 15.85,
-   "decompress_mbps": 56.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3072891,
-   "ratio": 0.4995,
-   "compress_mbps": 5.64,
-   "decompress_mbps": 56.67
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3071839,
-   "ratio": 0.4993,
-   "compress_mbps": 5.34,
-   "decompress_mbps": 58.24
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3017696,
-   "ratio": 0.4905,
-   "compress_mbps": 1.19,
-   "decompress_mbps": 57.17
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3889230,
-   "ratio": 0.3856,
-   "compress_mbps": 41.4,
-   "decompress_mbps": 68.79
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3811489,
-   "ratio": 0.3779,
-   "compress_mbps": 16.21,
-   "decompress_mbps": 32.86
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3789217,
-   "ratio": 0.3757,
-   "compress_mbps": 18.06,
-   "decompress_mbps": 37.79
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3742374,
-   "ratio": 0.3711,
-   "compress_mbps": 28.16,
-   "decompress_mbps": 72.75
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3734392,
-   "ratio": 0.3703,
-   "compress_mbps": 28.5,
-   "decompress_mbps": 73.0
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3723638,
-   "ratio": 0.3692,
-   "compress_mbps": 17.63,
-   "decompress_mbps": 70.4
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3723087,
-   "ratio": 0.3691,
-   "compress_mbps": 9.32,
-   "decompress_mbps": 72.54
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3723909,
-   "ratio": 0.3692,
-   "compress_mbps": 4.53,
-   "decompress_mbps": 32.87
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3647083,
-   "ratio": 0.3616,
+   "out_size": 3703324,
+   "ratio": 0.3633,
    "compress_mbps": 1.51,
-   "decompress_mbps": 72.44
+   "decompress_mbps": 102.18
   },
   {
    "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
    "level": 1,
-   "out_size": 2146953,
-   "ratio": 0.324,
+   "out_size": 20776195,
+   "ratio": 0.4056,
+   "compress_mbps": 46.87,
+   "decompress_mbps": 72.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20636431,
+   "ratio": 0.4029,
+   "compress_mbps": 45.01,
+   "decompress_mbps": 75.23
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 20554782,
+   "ratio": 0.4013,
+   "compress_mbps": 41.62,
+   "decompress_mbps": 77.73
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 20408622,
+   "ratio": 0.3984,
+   "compress_mbps": 36.15,
+   "decompress_mbps": 78.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 20393572,
+   "ratio": 0.3982,
+   "compress_mbps": 34.84,
+   "decompress_mbps": 81.25
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 20370310,
+   "ratio": 0.3977,
+   "compress_mbps": 30.98,
+   "decompress_mbps": 83.66
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19177172,
+   "ratio": 0.3744,
+   "compress_mbps": 7.4,
+   "decompress_mbps": 84.32
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19172591,
+   "ratio": 0.3743,
+   "compress_mbps": 6.81,
+   "decompress_mbps": 84.2
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19007884,
+   "ratio": 0.3711,
+   "compress_mbps": 1.05,
+   "decompress_mbps": 84.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3771859,
+   "ratio": 0.3783,
+   "compress_mbps": 44.46,
+   "decompress_mbps": 74.93
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3733442,
+   "ratio": 0.3744,
+   "compress_mbps": 41.13,
+   "decompress_mbps": 77.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3708043,
+   "ratio": 0.3719,
    "compress_mbps": 37.48,
-   "decompress_mbps": 97.58
+   "decompress_mbps": 79.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3713154,
+   "ratio": 0.3724,
+   "compress_mbps": 28.74,
+   "decompress_mbps": 73.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3707604,
+   "ratio": 0.3719,
+   "compress_mbps": 27.26,
+   "decompress_mbps": 74.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3701198,
+   "ratio": 0.3712,
+   "compress_mbps": 25.31,
+   "decompress_mbps": 77.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3609769,
+   "ratio": 0.362,
+   "compress_mbps": 8.01,
+   "decompress_mbps": 76.93
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3609490,
+   "ratio": 0.362,
+   "compress_mbps": 7.97,
+   "decompress_mbps": 75.87
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3502174,
+   "ratio": 0.3513,
+   "compress_mbps": 0.4,
+   "decompress_mbps": 78.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3555940,
+   "ratio": 0.106,
+   "compress_mbps": 106.34,
+   "decompress_mbps": 262.39
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3447001,
+   "ratio": 0.1027,
+   "compress_mbps": 93.63,
+   "decompress_mbps": 298.26
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3338834,
+   "ratio": 0.0995,
+   "compress_mbps": 82.17,
+   "decompress_mbps": 327.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3233721,
+   "ratio": 0.0964,
+   "compress_mbps": 73.69,
+   "decompress_mbps": 328.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3225450,
+   "ratio": 0.0961,
+   "compress_mbps": 72.26,
+   "decompress_mbps": 359.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3207256,
+   "ratio": 0.0956,
+   "compress_mbps": 66.84,
+   "decompress_mbps": 379.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3123611,
+   "ratio": 0.0931,
+   "compress_mbps": 25.18,
+   "decompress_mbps": 398.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3112207,
+   "ratio": 0.0928,
+   "compress_mbps": 22.39,
+   "decompress_mbps": 405.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2826301,
+   "ratio": 0.0842,
+   "compress_mbps": 0.53,
+   "decompress_mbps": 364.68
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3285977,
+   "ratio": 0.5341,
+   "compress_mbps": 33.33,
+   "decompress_mbps": 49.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3273720,
+   "ratio": 0.5321,
+   "compress_mbps": 32.16,
+   "decompress_mbps": 51.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3266820,
+   "ratio": 0.531,
+   "compress_mbps": 31.38,
+   "decompress_mbps": 54.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3238141,
+   "ratio": 0.5263,
+   "compress_mbps": 27.06,
+   "decompress_mbps": 53.82
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3237094,
+   "ratio": 0.5262,
+   "compress_mbps": 26.75,
+   "decompress_mbps": 55.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3235481,
+   "ratio": 0.5259,
+   "compress_mbps": 26.04,
+   "decompress_mbps": 57.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3165678,
+   "ratio": 0.5146,
+   "compress_mbps": 6.87,
+   "decompress_mbps": 57.18
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3165909,
+   "ratio": 0.5146,
+   "compress_mbps": 6.7,
+   "decompress_mbps": 57.57
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3123789,
+   "ratio": 0.5078,
+   "compress_mbps": 1.58,
+   "decompress_mbps": 57.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3788537,
+   "ratio": 0.3756,
+   "compress_mbps": 46.54,
+   "decompress_mbps": 68.05
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3760350,
+   "ratio": 0.3728,
+   "compress_mbps": 44.14,
+   "decompress_mbps": 71.37
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3754713,
+   "ratio": 0.3723,
+   "compress_mbps": 43.23,
+   "decompress_mbps": 72.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3707210,
+   "ratio": 0.3676,
+   "compress_mbps": 40.84,
+   "decompress_mbps": 73.55
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3706928,
+   "ratio": 0.3675,
+   "compress_mbps": 40.68,
+   "decompress_mbps": 71.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3706877,
+   "ratio": 0.3675,
+   "compress_mbps": 40.33,
+   "decompress_mbps": 72.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3706769,
+   "ratio": 0.3675,
+   "compress_mbps": 11.76,
+   "decompress_mbps": 70.83
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3706769,
+   "ratio": 0.3675,
+   "compress_mbps": 11.8,
+   "decompress_mbps": 72.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3645611,
+   "ratio": 0.3615,
+   "compress_mbps": 1.91,
+   "decompress_mbps": 72.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2075987,
+   "ratio": 0.3133,
+   "compress_mbps": 39.06,
+   "decompress_mbps": 97.99
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 2,
-   "out_size": 2072169,
-   "ratio": 0.3127,
-   "compress_mbps": 33.32,
-   "decompress_mbps": 105.59
+   "out_size": 2018042,
+   "ratio": 0.3045,
+   "compress_mbps": 36.56,
+   "decompress_mbps": 107.1
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 3,
-   "out_size": 2021398,
-   "ratio": 0.305,
-   "compress_mbps": 28.42,
-   "decompress_mbps": 54.71
+   "out_size": 1977555,
+   "ratio": 0.2984,
+   "compress_mbps": 32.37,
+   "decompress_mbps": 118.83
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 4,
-   "out_size": 1941481,
-   "ratio": 0.293,
-   "compress_mbps": 19.08,
-   "decompress_mbps": 112.97
+   "out_size": 1911442,
+   "ratio": 0.2884,
+   "compress_mbps": 24.5,
+   "decompress_mbps": 118.16
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 5,
-   "out_size": 1927150,
-   "ratio": 0.2908,
-   "compress_mbps": 18.66,
-   "decompress_mbps": 123.73
+   "out_size": 1901081,
+   "ratio": 0.2869,
+   "compress_mbps": 22.72,
+   "decompress_mbps": 122.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 6,
-   "out_size": 1899667,
-   "ratio": 0.2866,
-   "compress_mbps": 14.38,
-   "decompress_mbps": 128.74
+   "out_size": 1883325,
+   "ratio": 0.2842,
+   "compress_mbps": 19.18,
+   "decompress_mbps": 129.09
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 7,
-   "out_size": 1854694,
-   "ratio": 0.2799,
-   "compress_mbps": 6.1,
-   "decompress_mbps": 132.1
+   "out_size": 1843401,
+   "ratio": 0.2782,
+   "compress_mbps": 8.15,
+   "decompress_mbps": 133.03
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 8,
-   "out_size": 1849481,
-   "ratio": 0.2791,
-   "compress_mbps": 5.01,
-   "decompress_mbps": 138.2
+   "out_size": 1841388,
+   "ratio": 0.2779,
+   "compress_mbps": 7.54,
+   "decompress_mbps": 131.33
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 9,
-   "out_size": 1724560,
-   "ratio": 0.2602,
-   "compress_mbps": 0.65,
-   "decompress_mbps": 136.54
+   "out_size": 1718442,
+   "ratio": 0.2593,
+   "compress_mbps": 0.92,
+   "decompress_mbps": 138.13
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 1,
-   "out_size": 6185865,
-   "ratio": 0.2863,
-   "compress_mbps": 53.74,
-   "decompress_mbps": 128.13
+   "out_size": 6091028,
+   "ratio": 0.2819,
+   "compress_mbps": 59.17,
+   "decompress_mbps": 128.04
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 2,
-   "out_size": 6066146,
-   "ratio": 0.2808,
-   "compress_mbps": 48.96,
-   "decompress_mbps": 134.12
+   "out_size": 6008304,
+   "ratio": 0.2781,
+   "compress_mbps": 53.84,
+   "decompress_mbps": 134.14
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 3,
-   "out_size": 5993070,
-   "ratio": 0.2774,
-   "compress_mbps": 44.18,
-   "decompress_mbps": 138.98
+   "out_size": 5963161,
+   "ratio": 0.276,
+   "compress_mbps": 50.33,
+   "decompress_mbps": 139.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 4,
-   "out_size": 5880232,
+   "out_size": 5886640,
+   "ratio": 0.2724,
+   "compress_mbps": 43.58,
+   "decompress_mbps": 142.54
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 35.63,
-   "decompress_mbps": 143.02
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5869068,
-   "ratio": 0.2716,
-   "compress_mbps": 34.11,
-   "decompress_mbps": 145.98
+   "compress_mbps": 42.36,
+   "decompress_mbps": 147.35
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 6,
-   "out_size": 5854265,
-   "ratio": 0.271,
-   "compress_mbps": 28.21,
-   "decompress_mbps": 144.21
+   "out_size": 5873572,
+   "ratio": 0.2718,
+   "compress_mbps": 39.59,
+   "decompress_mbps": 149.95
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 7,
-   "out_size": 5422105,
-   "ratio": 0.2509,
-   "compress_mbps": 11.22,
-   "decompress_mbps": 146.26
+   "out_size": 5409010,
+   "ratio": 0.2503,
+   "compress_mbps": 13.01,
+   "decompress_mbps": 144.59
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 8,
-   "out_size": 5419419,
-   "ratio": 0.2508,
-   "compress_mbps": 10.82,
-   "decompress_mbps": 112.44
+   "out_size": 5407066,
+   "ratio": 0.2503,
+   "compress_mbps": 12.54,
+   "decompress_mbps": 145.84
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 9,
-   "out_size": 5169629,
-   "ratio": 0.2393,
-   "compress_mbps": 0.73,
-   "decompress_mbps": 144.9
+   "out_size": 5178935,
+   "ratio": 0.2397,
+   "compress_mbps": 0.91,
+   "decompress_mbps": 149.9
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 1,
-   "out_size": 5514155,
-   "ratio": 0.7604,
-   "compress_mbps": 25.55,
-   "decompress_mbps": 51.98
+   "out_size": 5553060,
+   "ratio": 0.7657,
+   "compress_mbps": 31.02,
+   "decompress_mbps": 52.49
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 2,
-   "out_size": 5472540,
-   "ratio": 0.7546,
-   "compress_mbps": 23.79,
-   "decompress_mbps": 53.04
+   "out_size": 5533873,
+   "ratio": 0.7631,
+   "compress_mbps": 29.05,
+   "decompress_mbps": 53.65
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 3,
-   "out_size": 5448811,
-   "ratio": 0.7514,
-   "compress_mbps": 22.16,
-   "decompress_mbps": 54.72
+   "out_size": 5522436,
+   "ratio": 0.7615,
+   "compress_mbps": 28.02,
+   "decompress_mbps": 54.95
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 4,
-   "out_size": 5376136,
-   "ratio": 0.7413,
-   "compress_mbps": 16.05,
-   "decompress_mbps": 55.07
+   "out_size": 5500073,
+   "ratio": 0.7584,
+   "compress_mbps": 23.95,
+   "decompress_mbps": 55.49
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 5,
-   "out_size": 5371177,
-   "ratio": 0.7407,
-   "compress_mbps": 14.93,
-   "decompress_mbps": 51.3
+   "out_size": 5498823,
+   "ratio": 0.7583,
+   "compress_mbps": 23.64,
+   "decompress_mbps": 55.53
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 6,
-   "out_size": 5362808,
+   "out_size": 5497402,
+   "ratio": 0.7581,
+   "compress_mbps": 23.02,
+   "decompress_mbps": 56.39
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5429379,
+   "ratio": 0.7487,
+   "compress_mbps": 6.08,
+   "decompress_mbps": 56.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5429363,
+   "ratio": 0.7487,
+   "compress_mbps": 6.17,
+   "decompress_mbps": 56.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5362653,
    "ratio": 0.7395,
-   "compress_mbps": 10.24,
-   "decompress_mbps": 35.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5349148,
-   "ratio": 0.7376,
-   "compress_mbps": 3.96,
-   "decompress_mbps": 33.65
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5348874,
-   "ratio": 0.7376,
-   "compress_mbps": 4.7,
-   "decompress_mbps": 51.64
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5261135,
-   "ratio": 0.7255,
-   "compress_mbps": 1.27,
-   "decompress_mbps": 56.34
+   "compress_mbps": 1.79,
+   "decompress_mbps": 56.31
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 1,
-   "out_size": 13389198,
-   "ratio": 0.323,
-   "compress_mbps": 38.12,
-   "decompress_mbps": 103.2
+   "out_size": 12821463,
+   "ratio": 0.3093,
+   "compress_mbps": 42.35,
+   "decompress_mbps": 103.07
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 2,
-   "out_size": 12991470,
-   "ratio": 0.3134,
-   "compress_mbps": 34.32,
-   "decompress_mbps": 109.52
+   "out_size": 12582079,
+   "ratio": 0.3035,
+   "compress_mbps": 40.39,
+   "decompress_mbps": 110.71
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 3,
-   "out_size": 12756198,
-   "ratio": 0.3077,
-   "compress_mbps": 31.26,
-   "decompress_mbps": 118.42
+   "out_size": 12448952,
+   "ratio": 0.3003,
+   "compress_mbps": 38.19,
+   "decompress_mbps": 115.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 4,
-   "out_size": 12487773,
-   "ratio": 0.3012,
-   "compress_mbps": 24.3,
-   "decompress_mbps": 118.79
+   "out_size": 12257878,
+   "ratio": 0.2957,
+   "compress_mbps": 32.62,
+   "decompress_mbps": 118.3
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 5,
-   "out_size": 12439753,
-   "ratio": 0.3001,
-   "compress_mbps": 22.79,
-   "decompress_mbps": 119.89
+   "out_size": 12229398,
+   "ratio": 0.295,
+   "compress_mbps": 31.36,
+   "decompress_mbps": 121.99
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 6,
-   "out_size": 12356447,
-   "ratio": 0.298,
-   "compress_mbps": 20.37,
-   "decompress_mbps": 125.22
+   "out_size": 12184501,
+   "ratio": 0.2939,
+   "compress_mbps": 28.57,
+   "decompress_mbps": 124.95
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 7,
-   "out_size": 12265937,
-   "ratio": 0.2959,
-   "compress_mbps": 8.03,
-   "decompress_mbps": 122.12
+   "out_size": 12109369,
+   "ratio": 0.2921,
+   "compress_mbps": 11.22,
+   "decompress_mbps": 125.39
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 8,
-   "out_size": 12249548,
-   "ratio": 0.2955,
-   "compress_mbps": 7.62,
-   "decompress_mbps": 121.55
+   "out_size": 12106058,
+   "ratio": 0.292,
+   "compress_mbps": 11.05,
+   "decompress_mbps": 126.85
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 9,
-   "out_size": 11638957,
-   "ratio": 0.2807,
-   "compress_mbps": 0.85,
-   "decompress_mbps": 126.16
+   "out_size": 11604192,
+   "ratio": 0.2799,
+   "compress_mbps": 1.01,
+   "decompress_mbps": 125.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 1,
-   "out_size": 6018712,
-   "ratio": 0.7102,
-   "compress_mbps": 25.67,
-   "decompress_mbps": 40.17
+   "out_size": 6392156,
+   "ratio": 0.7543,
+   "compress_mbps": 30.75,
+   "decompress_mbps": 40.89
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 2,
-   "out_size": 5998688,
-   "ratio": 0.7079,
-   "compress_mbps": 24.08,
-   "decompress_mbps": 43.05
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 5983501,
-   "ratio": 0.7061,
-   "compress_mbps": 23.22,
-   "decompress_mbps": 45.66
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 5965383,
-   "ratio": 0.7039,
-   "compress_mbps": 19.38,
-   "decompress_mbps": 42.74
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 5964823,
-   "ratio": 0.7039,
-   "compress_mbps": 19.05,
-   "decompress_mbps": 43.42
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5964656,
-   "ratio": 0.7039,
-   "compress_mbps": 18.78,
-   "decompress_mbps": 43.81
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 5937524,
-   "ratio": 0.7007,
-   "compress_mbps": 5.8,
+   "out_size": 6392125,
+   "ratio": 0.7543,
+   "compress_mbps": 30.64,
    "decompress_mbps": 43.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
+   "level": 3,
+   "out_size": 6392122,
+   "ratio": 0.7543,
+   "compress_mbps": 29.48,
+   "decompress_mbps": 45.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6368721,
+   "ratio": 0.7515,
+   "compress_mbps": 28.64,
+   "decompress_mbps": 42.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6368719,
+   "ratio": 0.7515,
+   "compress_mbps": 28.14,
+   "decompress_mbps": 43.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6368719,
+   "ratio": 0.7515,
+   "compress_mbps": 29.32,
+   "decompress_mbps": 43.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 4.66,
+   "decompress_mbps": 41.62
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
    "level": 8,
-   "out_size": 5937524,
-   "ratio": 0.7007,
-   "compress_mbps": 5.83,
-   "decompress_mbps": 43.95
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 4.11,
+   "decompress_mbps": 38.58
   },
   {
    "compressor": "native",
    "pattern": "silesia/x-ray",
    "size": 8474240,
    "level": 9,
-   "out_size": 5825680,
-   "ratio": 0.6875,
-   "compress_mbps": 1.63,
-   "decompress_mbps": 43.77
+   "out_size": 6259392,
+   "ratio": 0.7386,
+   "compress_mbps": 1.89,
+   "decompress_mbps": 43.78
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 1,
-   "out_size": 841047,
-   "ratio": 0.1573,
-   "compress_mbps": 75.93,
-   "decompress_mbps": 205.59
+   "out_size": 793301,
+   "ratio": 0.1484,
+   "compress_mbps": 84.72,
+   "decompress_mbps": 189.94
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 2,
-   "out_size": 796222,
-   "ratio": 0.149,
-   "compress_mbps": 69.84,
-   "decompress_mbps": 230.04
+   "out_size": 762011,
+   "ratio": 0.1426,
+   "compress_mbps": 77.52,
+   "decompress_mbps": 211.99
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 3,
-   "out_size": 765435,
-   "ratio": 0.1432,
-   "compress_mbps": 60.99,
-   "decompress_mbps": 252.72
+   "out_size": 743137,
+   "ratio": 0.139,
+   "compress_mbps": 70.38,
+   "decompress_mbps": 233.68
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 4,
-   "out_size": 739407,
-   "ratio": 0.1383,
-   "compress_mbps": 48.47,
-   "decompress_mbps": 248.49
+   "out_size": 725534,
+   "ratio": 0.1357,
+   "compress_mbps": 59.41,
+   "decompress_mbps": 243.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 5,
-   "out_size": 732214,
-   "ratio": 0.137,
-   "compress_mbps": 45.8,
-   "decompress_mbps": 271.43
+   "out_size": 721655,
+   "ratio": 0.135,
+   "compress_mbps": 55.32,
+   "decompress_mbps": 244.29
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 6,
-   "out_size": 721492,
-   "ratio": 0.135,
-   "compress_mbps": 41.67,
-   "decompress_mbps": 292.09
+   "out_size": 715547,
+   "ratio": 0.1339,
+   "compress_mbps": 51.42,
+   "decompress_mbps": 266.09
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 7,
-   "out_size": 682684,
-   "ratio": 0.1277,
-   "compress_mbps": 17.61,
-   "decompress_mbps": 277.14
+   "out_size": 675427,
+   "ratio": 0.1264,
+   "compress_mbps": 20.98,
+   "decompress_mbps": 271.6
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 8,
-   "out_size": 681103,
-   "ratio": 0.1274,
-   "compress_mbps": 16.47,
-   "decompress_mbps": 285.04
+   "out_size": 674362,
+   "ratio": 0.1262,
+   "compress_mbps": 19.57,
+   "decompress_mbps": 288.48
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 9,
-   "out_size": 637424,
-   "ratio": 0.1192,
-   "compress_mbps": 0.66,
-   "decompress_mbps": 274.69
+   "out_size": 636855,
+   "ratio": 0.1191,
+   "compress_mbps": 0.74,
+   "decompress_mbps": 278.43
   },
   {
    "compressor": "zlib",
@@ -5054,8 +5054,8 @@
    "level": 1,
    "out_size": 4585612,
    "ratio": 0.4499,
-   "compress_mbps": 112.42,
-   "decompress_mbps": 350.6
+   "compress_mbps": 113.67,
+   "decompress_mbps": 354.82
   },
   {
    "compressor": "zlib",
@@ -5064,8 +5064,8 @@
    "level": 2,
    "out_size": 4389474,
    "ratio": 0.4307,
-   "compress_mbps": 95.08,
-   "decompress_mbps": 361.4
+   "compress_mbps": 96.07,
+   "decompress_mbps": 375.93
   },
   {
    "compressor": "zlib",
@@ -5074,8 +5074,8 @@
    "level": 3,
    "out_size": 4192079,
    "ratio": 0.4113,
-   "compress_mbps": 59.1,
-   "decompress_mbps": 401.85
+   "compress_mbps": 59.36,
+   "decompress_mbps": 412.28
   },
   {
    "compressor": "zlib",
@@ -5084,8 +5084,8 @@
    "level": 4,
    "out_size": 4095021,
    "ratio": 0.4018,
-   "compress_mbps": 65.75,
-   "decompress_mbps": 383.13
+   "compress_mbps": 66.19,
+   "decompress_mbps": 389.42
   },
   {
    "compressor": "zlib",
@@ -5094,8 +5094,8 @@
    "level": 5,
    "out_size": 3949169,
    "ratio": 0.3875,
-   "compress_mbps": 35.72,
-   "decompress_mbps": 371.06
+   "compress_mbps": 35.97,
+   "decompress_mbps": 376.93
   },
   {
    "compressor": "zlib",
@@ -5104,8 +5104,8 @@
    "level": 6,
    "out_size": 3871628,
    "ratio": 0.3799,
-   "compress_mbps": 21.15,
-   "decompress_mbps": 379.61
+   "compress_mbps": 21.24,
+   "decompress_mbps": 384.89
   },
   {
    "compressor": "zlib",
@@ -5114,8 +5114,8 @@
    "level": 7,
    "out_size": 3858876,
    "ratio": 0.3786,
-   "compress_mbps": 17.64,
-   "decompress_mbps": 381.99
+   "compress_mbps": 17.58,
+   "decompress_mbps": 387.13
   },
   {
    "compressor": "zlib",
@@ -5124,8 +5124,8 @@
    "level": 8,
    "out_size": 3854729,
    "ratio": 0.3782,
-   "compress_mbps": 15.02,
-   "decompress_mbps": 364.85
+   "compress_mbps": 15.07,
+   "decompress_mbps": 385.46
   },
   {
    "compressor": "zlib",
@@ -5134,8 +5134,8 @@
    "level": 9,
    "out_size": 3854729,
    "ratio": 0.3782,
-   "compress_mbps": 15.01,
-   "decompress_mbps": 382.09
+   "compress_mbps": 15.07,
+   "decompress_mbps": 391.3
   },
   {
    "compressor": "zlib",
@@ -5144,8 +5144,8 @@
    "level": 1,
    "out_size": 20577220,
    "ratio": 0.4017,
-   "compress_mbps": 111.93,
-   "decompress_mbps": 349.28
+   "compress_mbps": 113.25,
+   "decompress_mbps": 364.49
   },
   {
    "compressor": "zlib",
@@ -5154,8 +5154,8 @@
    "level": 2,
    "out_size": 20247697,
    "ratio": 0.3953,
-   "compress_mbps": 100.14,
-   "decompress_mbps": 370.91
+   "compress_mbps": 100.51,
+   "decompress_mbps": 370.0
   },
   {
    "compressor": "zlib",
@@ -5164,8 +5164,8 @@
    "level": 3,
    "out_size": 19987880,
    "ratio": 0.3902,
-   "compress_mbps": 76.0,
-   "decompress_mbps": 377.96
+   "compress_mbps": 75.64,
+   "decompress_mbps": 340.24
   },
   {
    "compressor": "zlib",
@@ -5174,8 +5174,8 @@
    "level": 4,
    "out_size": 19512665,
    "ratio": 0.381,
-   "compress_mbps": 75.6,
-   "decompress_mbps": 367.97
+   "compress_mbps": 71.76,
+   "decompress_mbps": 363.34
   },
   {
    "compressor": "zlib",
@@ -5184,8 +5184,8 @@
    "level": 5,
    "out_size": 19213507,
    "ratio": 0.3751,
-   "compress_mbps": 53.26,
-   "decompress_mbps": 374.37
+   "compress_mbps": 51.35,
+   "decompress_mbps": 370.37
   },
   {
    "compressor": "zlib",
@@ -5194,8 +5194,8 @@
    "level": 6,
    "out_size": 19089118,
    "ratio": 0.3727,
-   "compress_mbps": 34.34,
-   "decompress_mbps": 379.81
+   "compress_mbps": 33.44,
+   "decompress_mbps": 376.59
   },
   {
    "compressor": "zlib",
@@ -5204,8 +5204,8 @@
    "level": 7,
    "out_size": 19061204,
    "ratio": 0.3721,
-   "compress_mbps": 27.28,
-   "decompress_mbps": 380.61
+   "compress_mbps": 27.31,
+   "decompress_mbps": 380.14
   },
   {
    "compressor": "zlib",
@@ -5214,8 +5214,8 @@
    "level": 8,
    "out_size": 19040998,
    "ratio": 0.3717,
-   "compress_mbps": 15.38,
-   "decompress_mbps": 388.07
+   "compress_mbps": 15.24,
+   "decompress_mbps": 379.76
   },
   {
    "compressor": "zlib",
@@ -5224,8 +5224,8 @@
    "level": 9,
    "out_size": 19044390,
    "ratio": 0.3718,
-   "compress_mbps": 9.53,
-   "decompress_mbps": 388.16
+   "compress_mbps": 9.54,
+   "decompress_mbps": 385.45
   },
   {
    "compressor": "zlib",
@@ -5234,8 +5234,8 @@
    "level": 1,
    "out_size": 3828360,
    "ratio": 0.384,
-   "compress_mbps": 143.56,
-   "decompress_mbps": 450.35
+   "compress_mbps": 144.91,
+   "decompress_mbps": 453.29
   },
   {
    "compressor": "zlib",
@@ -5244,8 +5244,8 @@
    "level": 2,
    "out_size": 3798539,
    "ratio": 0.381,
-   "compress_mbps": 127.44,
-   "decompress_mbps": 490.01
+   "compress_mbps": 128.29,
+   "decompress_mbps": 497.36
   },
   {
    "compressor": "zlib",
@@ -5254,8 +5254,8 @@
    "level": 3,
    "out_size": 3674568,
    "ratio": 0.3685,
-   "compress_mbps": 79.74,
-   "decompress_mbps": 511.38
+   "compress_mbps": 80.47,
+   "decompress_mbps": 515.99
   },
   {
    "compressor": "zlib",
@@ -5264,8 +5264,8 @@
    "level": 4,
    "out_size": 3680923,
    "ratio": 0.3692,
-   "compress_mbps": 89.18,
-   "decompress_mbps": 451.78
+   "compress_mbps": 89.36,
+   "decompress_mbps": 457.6
   },
   {
    "compressor": "zlib",
@@ -5274,8 +5274,8 @@
    "level": 5,
    "out_size": 3698707,
    "ratio": 0.371,
-   "compress_mbps": 47.85,
-   "decompress_mbps": 424.27
+   "compress_mbps": 48.13,
+   "decompress_mbps": 427.63
   },
   {
    "compressor": "zlib",
@@ -5284,8 +5284,8 @@
    "level": 6,
    "out_size": 3675935,
    "ratio": 0.3687,
-   "compress_mbps": 26.32,
-   "decompress_mbps": 438.57
+   "compress_mbps": 26.41,
+   "decompress_mbps": 437.75
   },
   {
    "compressor": "zlib",
@@ -5294,8 +5294,8 @@
    "level": 7,
    "out_size": 3670281,
    "ratio": 0.3681,
-   "compress_mbps": 20.77,
-   "decompress_mbps": 442.63
+   "compress_mbps": 20.84,
+   "decompress_mbps": 444.31
   },
   {
    "compressor": "zlib",
@@ -5304,8 +5304,8 @@
    "level": 8,
    "out_size": 3661103,
    "ratio": 0.3672,
-   "compress_mbps": 10.95,
-   "decompress_mbps": 452.72
+   "compress_mbps": 10.94,
+   "decompress_mbps": 458.18
   },
   {
    "compressor": "zlib",
@@ -5315,7 +5315,7 @@
    "out_size": 3660788,
    "ratio": 0.3672,
    "compress_mbps": 9.47,
-   "decompress_mbps": 451.14
+   "decompress_mbps": 459.79
   },
   {
    "compressor": "zlib",
@@ -5324,8 +5324,8 @@
    "level": 1,
    "out_size": 4624591,
    "ratio": 0.1378,
-   "compress_mbps": 331.64,
-   "decompress_mbps": 826.4
+   "compress_mbps": 332.0,
+   "decompress_mbps": 831.27
   },
   {
    "compressor": "zlib",
@@ -5334,8 +5334,8 @@
    "level": 2,
    "out_size": 4303176,
    "ratio": 0.1282,
-   "compress_mbps": 306.94,
-   "decompress_mbps": 852.6
+   "compress_mbps": 310.37,
+   "decompress_mbps": 841.9
   },
   {
    "compressor": "zlib",
@@ -5344,8 +5344,8 @@
    "level": 3,
    "out_size": 4010156,
    "ratio": 0.1195,
-   "compress_mbps": 256.69,
-   "decompress_mbps": 932.94
+   "compress_mbps": 257.47,
+   "decompress_mbps": 926.52
   },
   {
    "compressor": "zlib",
@@ -5354,8 +5354,8 @@
    "level": 4,
    "out_size": 3713866,
    "ratio": 0.1107,
-   "compress_mbps": 211.59,
-   "decompress_mbps": 908.17
+   "compress_mbps": 212.08,
+   "decompress_mbps": 896.37
   },
   {
    "compressor": "zlib",
@@ -5364,8 +5364,8 @@
    "level": 5,
    "out_size": 3378136,
    "ratio": 0.1007,
-   "compress_mbps": 165.04,
-   "decompress_mbps": 965.7
+   "compress_mbps": 166.1,
+   "decompress_mbps": 954.98
   },
   {
    "compressor": "zlib",
@@ -5374,8 +5374,8 @@
    "level": 6,
    "out_size": 3200182,
    "ratio": 0.0954,
-   "compress_mbps": 113.42,
-   "decompress_mbps": 1009.46
+   "compress_mbps": 113.17,
+   "decompress_mbps": 986.8
   },
   {
    "compressor": "zlib",
@@ -5384,8 +5384,8 @@
    "level": 7,
    "out_size": 3141278,
    "ratio": 0.0936,
-   "compress_mbps": 89.96,
-   "decompress_mbps": 1013.87
+   "compress_mbps": 90.33,
+   "decompress_mbps": 999.02
   },
   {
    "compressor": "zlib",
@@ -5394,8 +5394,8 @@
    "level": 8,
    "out_size": 3031199,
    "ratio": 0.0903,
-   "compress_mbps": 39.18,
-   "decompress_mbps": 1034.15
+   "compress_mbps": 39.16,
+   "decompress_mbps": 1017.12
   },
   {
    "compressor": "zlib",
@@ -5404,8 +5404,8 @@
    "level": 9,
    "out_size": 2987995,
    "ratio": 0.0891,
-   "compress_mbps": 21.34,
-   "decompress_mbps": 1029.51
+   "compress_mbps": 21.44,
+   "decompress_mbps": 1033.52
   },
   {
    "compressor": "zlib",
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 3290526,
    "ratio": 0.5349,
-   "compress_mbps": 78.22,
-   "decompress_mbps": 253.01
+   "compress_mbps": 79.06,
+   "decompress_mbps": 257.16
   },
   {
    "compressor": "zlib",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 3238282,
    "ratio": 0.5264,
-   "compress_mbps": 71.4,
-   "decompress_mbps": 258.77
+   "compress_mbps": 72.38,
+   "decompress_mbps": 263.21
   },
   {
    "compressor": "zlib",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 3193366,
    "ratio": 0.5191,
-   "compress_mbps": 56.41,
-   "decompress_mbps": 264.86
+   "compress_mbps": 57.0,
+   "decompress_mbps": 265.33
   },
   {
    "compressor": "zlib",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 3158012,
    "ratio": 0.5133,
-   "compress_mbps": 55.13,
-   "decompress_mbps": 266.28
+   "compress_mbps": 55.65,
+   "decompress_mbps": 268.5
   },
   {
    "compressor": "zlib",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 3115309,
    "ratio": 0.5064,
-   "compress_mbps": 38.95,
-   "decompress_mbps": 270.75
+   "compress_mbps": 39.25,
+   "decompress_mbps": 269.0
   },
   {
    "compressor": "zlib",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 3097288,
    "ratio": 0.5034,
-   "compress_mbps": 26.35,
-   "decompress_mbps": 273.83
+   "compress_mbps": 26.28,
+   "decompress_mbps": 264.86
   },
   {
    "compressor": "zlib",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 3094363,
    "ratio": 0.503,
-   "compress_mbps": 21.93,
-   "decompress_mbps": 274.27
+   "compress_mbps": 21.86,
+   "decompress_mbps": 268.09
   },
   {
    "compressor": "zlib",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 3093026,
    "ratio": 0.5028,
-   "compress_mbps": 17.11,
-   "decompress_mbps": 274.94
+   "compress_mbps": 16.97,
+   "decompress_mbps": 270.33
   },
   {
    "compressor": "zlib",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 3092920,
    "ratio": 0.5027,
-   "compress_mbps": 15.54,
-   "decompress_mbps": 274.77
+   "compress_mbps": 15.53,
+   "decompress_mbps": 269.1
   },
   {
    "compressor": "zlib",
@@ -5504,8 +5504,8 @@
    "level": 1,
    "out_size": 4076385,
    "ratio": 0.4042,
-   "compress_mbps": 126.69,
-   "decompress_mbps": 476.58
+   "compress_mbps": 125.81,
+   "decompress_mbps": 474.99
   },
   {
    "compressor": "zlib",
@@ -5514,8 +5514,8 @@
    "level": 2,
    "out_size": 3991014,
    "ratio": 0.3957,
-   "compress_mbps": 117.61,
-   "decompress_mbps": 498.31
+   "compress_mbps": 117.17,
+   "decompress_mbps": 494.44
   },
   {
    "compressor": "zlib",
@@ -5524,8 +5524,8 @@
    "level": 3,
    "out_size": 3934055,
    "ratio": 0.3901,
-   "compress_mbps": 93.62,
-   "decompress_mbps": 513.48
+   "compress_mbps": 93.6,
+   "decompress_mbps": 511.59
   },
   {
    "compressor": "zlib",
@@ -5534,8 +5534,8 @@
    "level": 4,
    "out_size": 3825092,
    "ratio": 0.3793,
-   "compress_mbps": 84.8,
-   "decompress_mbps": 511.06
+   "compress_mbps": 85.49,
+   "decompress_mbps": 513.7
   },
   {
    "compressor": "zlib",
@@ -5544,8 +5544,8 @@
    "level": 5,
    "out_size": 3752932,
    "ratio": 0.3721,
-   "compress_mbps": 64.64,
-   "decompress_mbps": 499.36
+   "compress_mbps": 64.41,
+   "decompress_mbps": 496.1
   },
   {
    "compressor": "zlib",
@@ -5554,8 +5554,8 @@
    "level": 6,
    "out_size": 3695164,
    "ratio": 0.3664,
-   "compress_mbps": 49.43,
-   "decompress_mbps": 510.55
+   "compress_mbps": 49.22,
+   "decompress_mbps": 507.36
   },
   {
    "compressor": "zlib",
@@ -5564,8 +5564,8 @@
    "level": 7,
    "out_size": 3676881,
    "ratio": 0.3646,
-   "compress_mbps": 38.12,
-   "decompress_mbps": 520.16
+   "compress_mbps": 38.17,
+   "decompress_mbps": 515.91
   },
   {
    "compressor": "zlib",
@@ -5574,8 +5574,8 @@
    "level": 8,
    "out_size": 3673171,
    "ratio": 0.3642,
-   "compress_mbps": 31.95,
-   "decompress_mbps": 522.73
+   "compress_mbps": 31.92,
+   "decompress_mbps": 519.6
   },
   {
    "compressor": "zlib",
@@ -5584,8 +5584,8 @@
    "level": 9,
    "out_size": 3673171,
    "ratio": 0.3642,
-   "compress_mbps": 31.91,
-   "decompress_mbps": 522.88
+   "compress_mbps": 31.92,
+   "decompress_mbps": 519.23
   },
   {
    "compressor": "zlib",
@@ -5594,8 +5594,8 @@
    "level": 1,
    "out_size": 2376424,
    "ratio": 0.3586,
-   "compress_mbps": 129.7,
-   "decompress_mbps": 396.67
+   "compress_mbps": 130.38,
+   "decompress_mbps": 393.75
   },
   {
    "compressor": "zlib",
@@ -5604,8 +5604,8 @@
    "level": 2,
    "out_size": 2259060,
    "ratio": 0.3409,
-   "compress_mbps": 111.68,
-   "decompress_mbps": 418.18
+   "compress_mbps": 112.03,
+   "decompress_mbps": 411.76
   },
   {
    "compressor": "zlib",
@@ -5614,8 +5614,8 @@
    "level": 3,
    "out_size": 2135664,
    "ratio": 0.3223,
-   "compress_mbps": 72.01,
-   "decompress_mbps": 430.73
+   "compress_mbps": 72.25,
+   "decompress_mbps": 435.29
   },
   {
    "compressor": "zlib",
@@ -5624,8 +5624,8 @@
    "level": 4,
    "out_size": 2052793,
    "ratio": 0.3098,
-   "compress_mbps": 81.07,
-   "decompress_mbps": 434.6
+   "compress_mbps": 81.67,
+   "decompress_mbps": 430.73
   },
   {
    "compressor": "zlib",
@@ -5634,8 +5634,8 @@
    "level": 5,
    "out_size": 1932127,
    "ratio": 0.2915,
-   "compress_mbps": 45.34,
-   "decompress_mbps": 442.84
+   "compress_mbps": 45.23,
+   "decompress_mbps": 432.43
   },
   {
    "compressor": "zlib",
@@ -5644,8 +5644,8 @@
    "level": 6,
    "out_size": 1860865,
    "ratio": 0.2808,
-   "compress_mbps": 22.93,
-   "decompress_mbps": 447.34
+   "compress_mbps": 22.82,
+   "decompress_mbps": 440.25
   },
   {
    "compressor": "zlib",
@@ -5654,8 +5654,8 @@
    "level": 7,
    "out_size": 1838671,
    "ratio": 0.2774,
-   "compress_mbps": 15.98,
-   "decompress_mbps": 441.79
+   "compress_mbps": 15.96,
+   "decompress_mbps": 441.72
   },
   {
    "compressor": "zlib",
@@ -5664,8 +5664,8 @@
    "level": 8,
    "out_size": 1823235,
    "ratio": 0.2751,
-   "compress_mbps": 8.14,
-   "decompress_mbps": 445.38
+   "compress_mbps": 8.12,
+   "decompress_mbps": 436.13
   },
   {
    "compressor": "zlib",
@@ -5674,8 +5674,8 @@
    "level": 9,
    "out_size": 1823190,
    "ratio": 0.2751,
-   "compress_mbps": 8.1,
-   "decompress_mbps": 446.32
+   "compress_mbps": 8.15,
+   "decompress_mbps": 439.5
   },
   {
    "compressor": "zlib",
@@ -5684,8 +5684,8 @@
    "level": 1,
    "out_size": 6329449,
    "ratio": 0.2929,
-   "compress_mbps": 169.67,
-   "decompress_mbps": 462.4
+   "compress_mbps": 169.74,
+   "decompress_mbps": 460.79
   },
   {
    "compressor": "zlib",
@@ -5694,8 +5694,8 @@
    "level": 2,
    "out_size": 6128866,
    "ratio": 0.2837,
-   "compress_mbps": 156.15,
-   "decompress_mbps": 555.76
+   "compress_mbps": 155.55,
+   "decompress_mbps": 557.06
   },
   {
    "compressor": "zlib",
@@ -5704,8 +5704,8 @@
    "level": 3,
    "out_size": 5982546,
    "ratio": 0.2769,
-   "compress_mbps": 125.54,
-   "decompress_mbps": 580.33
+   "compress_mbps": 125.39,
+   "decompress_mbps": 581.02
   },
   {
    "compressor": "zlib",
@@ -5714,8 +5714,8 @@
    "level": 4,
    "out_size": 5656400,
    "ratio": 0.2618,
-   "compress_mbps": 117.31,
-   "decompress_mbps": 578.51
+   "compress_mbps": 116.92,
+   "decompress_mbps": 576.69
   },
   {
    "compressor": "zlib",
@@ -5724,8 +5724,8 @@
    "level": 5,
    "out_size": 5511352,
    "ratio": 0.2551,
-   "compress_mbps": 82.61,
-   "decompress_mbps": 582.62
+   "compress_mbps": 82.58,
+   "decompress_mbps": 587.65
   },
   {
    "compressor": "zlib",
@@ -5734,8 +5734,8 @@
    "level": 6,
    "out_size": 5451399,
    "ratio": 0.2523,
-   "compress_mbps": 56.83,
-   "decompress_mbps": 594.35
+   "compress_mbps": 56.59,
+   "decompress_mbps": 593.88
   },
   {
    "compressor": "zlib",
@@ -5744,8 +5744,8 @@
    "level": 7,
    "out_size": 5417123,
    "ratio": 0.2507,
-   "compress_mbps": 46.8,
-   "decompress_mbps": 595.18
+   "compress_mbps": 46.71,
+   "decompress_mbps": 596.81
   },
   {
    "compressor": "zlib",
@@ -5754,8 +5754,8 @@
    "level": 8,
    "out_size": 5404364,
    "ratio": 0.2501,
-   "compress_mbps": 32.76,
-   "decompress_mbps": 597.8
+   "compress_mbps": 32.73,
+   "decompress_mbps": 602.78
   },
   {
    "compressor": "zlib",
@@ -5764,8 +5764,8 @@
    "level": 9,
    "out_size": 5402704,
    "ratio": 0.2501,
-   "compress_mbps": 29.7,
-   "decompress_mbps": 598.38
+   "compress_mbps": 29.69,
+   "decompress_mbps": 390.04
   },
   {
    "compressor": "zlib",
@@ -5774,8 +5774,8 @@
    "level": 1,
    "out_size": 5567768,
    "ratio": 0.7678,
-   "compress_mbps": 64.13,
-   "decompress_mbps": 318.14
+   "compress_mbps": 32.89,
+   "decompress_mbps": 211.48
   },
   {
    "compressor": "zlib",
@@ -5784,8 +5784,8 @@
    "level": 2,
    "out_size": 5504009,
    "ratio": 0.759,
-   "compress_mbps": 58.11,
-   "decompress_mbps": 327.28
+   "compress_mbps": 38.32,
+   "decompress_mbps": 168.63
   },
   {
    "compressor": "zlib",
@@ -5794,8 +5794,8 @@
    "level": 3,
    "out_size": 5439339,
    "ratio": 0.7501,
-   "compress_mbps": 46.08,
-   "decompress_mbps": 335.66
+   "compress_mbps": 29.43,
+   "decompress_mbps": 230.72
   },
   {
    "compressor": "zlib",
@@ -5804,8 +5804,8 @@
    "level": 4,
    "out_size": 5394604,
    "ratio": 0.7439,
-   "compress_mbps": 48.02,
-   "decompress_mbps": 347.14
+   "compress_mbps": 32.68,
+   "decompress_mbps": 256.53
   },
   {
    "compressor": "zlib",
@@ -5814,8 +5814,8 @@
    "level": 5,
    "out_size": 5370116,
    "ratio": 0.7405,
-   "compress_mbps": 33.04,
-   "decompress_mbps": 337.37
+   "compress_mbps": 28.44,
+   "decompress_mbps": 312.67
   },
   {
    "compressor": "zlib",
@@ -5824,8 +5824,8 @@
    "level": 6,
    "out_size": 5331793,
    "ratio": 0.7352,
-   "compress_mbps": 22.99,
-   "decompress_mbps": 345.73
+   "compress_mbps": 20.53,
+   "decompress_mbps": 329.4
   },
   {
    "compressor": "zlib",
@@ -5834,8 +5834,8 @@
    "level": 7,
    "out_size": 5327677,
    "ratio": 0.7347,
-   "compress_mbps": 21.08,
-   "decompress_mbps": 347.74
+   "compress_mbps": 21.16,
+   "decompress_mbps": 348.44
   },
   {
    "compressor": "zlib",
@@ -5844,8 +5844,8 @@
    "level": 8,
    "out_size": 5325914,
    "ratio": 0.7344,
-   "compress_mbps": 18.89,
-   "decompress_mbps": 346.56
+   "compress_mbps": 18.96,
+   "decompress_mbps": 349.29
   },
   {
    "compressor": "zlib",
@@ -5854,8 +5854,8 @@
    "level": 9,
    "out_size": 5325914,
    "ratio": 0.7344,
-   "compress_mbps": 18.88,
-   "decompress_mbps": 347.69
+   "compress_mbps": 18.95,
+   "decompress_mbps": 346.98
   },
   {
    "compressor": "zlib",
@@ -5864,8 +5864,8 @@
    "level": 1,
    "out_size": 14991236,
    "ratio": 0.3616,
-   "compress_mbps": 136.56,
-   "decompress_mbps": 379.42
+   "compress_mbps": 136.65,
+   "decompress_mbps": 380.3
   },
   {
    "compressor": "zlib",
@@ -5874,8 +5874,8 @@
    "level": 2,
    "out_size": 14249692,
    "ratio": 0.3437,
-   "compress_mbps": 119.84,
-   "decompress_mbps": 397.03
+   "compress_mbps": 120.34,
+   "decompress_mbps": 401.81
   },
   {
    "compressor": "zlib",
@@ -5884,8 +5884,8 @@
    "level": 3,
    "out_size": 13627761,
    "ratio": 0.3287,
-   "compress_mbps": 87.05,
-   "decompress_mbps": 412.83
+   "compress_mbps": 87.73,
+   "decompress_mbps": 414.55
   },
   {
    "compressor": "zlib",
@@ -5894,8 +5894,8 @@
    "level": 4,
    "out_size": 13001990,
    "ratio": 0.3136,
-   "compress_mbps": 84.9,
-   "decompress_mbps": 391.55
+   "compress_mbps": 85.4,
+   "decompress_mbps": 395.8
   },
   {
    "compressor": "zlib",
@@ -5904,8 +5904,8 @@
    "level": 5,
    "out_size": 12445991,
    "ratio": 0.3002,
-   "compress_mbps": 54.55,
-   "decompress_mbps": 391.05
+   "compress_mbps": 55.03,
+   "decompress_mbps": 392.94
   },
   {
    "compressor": "zlib",
@@ -5914,8 +5914,8 @@
    "level": 6,
    "out_size": 12213941,
    "ratio": 0.2946,
-   "compress_mbps": 36.52,
-   "decompress_mbps": 395.66
+   "compress_mbps": 36.53,
+   "decompress_mbps": 400.31
   },
   {
    "compressor": "zlib",
@@ -5924,8 +5924,8 @@
    "level": 7,
    "out_size": 12130416,
    "ratio": 0.2926,
-   "compress_mbps": 29.67,
-   "decompress_mbps": 396.94
+   "compress_mbps": 29.65,
+   "decompress_mbps": 401.43
   },
   {
    "compressor": "zlib",
@@ -5934,8 +5934,8 @@
    "level": 8,
    "out_size": 12073697,
    "ratio": 0.2912,
-   "compress_mbps": 21.46,
-   "decompress_mbps": 404.12
+   "compress_mbps": 21.5,
+   "decompress_mbps": 403.07
   },
   {
    "compressor": "zlib",
@@ -5944,8 +5944,8 @@
    "level": 9,
    "out_size": 12073469,
    "ratio": 0.2912,
-   "compress_mbps": 21.32,
-   "decompress_mbps": 406.77
+   "compress_mbps": 21.33,
+   "decompress_mbps": 403.44
   },
   {
    "compressor": "zlib",
@@ -5954,8 +5954,8 @@
    "level": 1,
    "out_size": 6033926,
    "ratio": 0.712,
-   "compress_mbps": 74.36,
-   "decompress_mbps": 292.66
+   "compress_mbps": 75.49,
+   "decompress_mbps": 294.33
   },
   {
    "compressor": "zlib",
@@ -5964,8 +5964,8 @@
    "level": 2,
    "out_size": 5997474,
    "ratio": 0.7077,
-   "compress_mbps": 68.1,
-   "decompress_mbps": 303.07
+   "compress_mbps": 68.78,
+   "decompress_mbps": 305.32
   },
   {
    "compressor": "zlib",
@@ -5974,8 +5974,8 @@
    "level": 3,
    "out_size": 5966621,
    "ratio": 0.7041,
-   "compress_mbps": 55.04,
-   "decompress_mbps": 309.58
+   "compress_mbps": 55.63,
+   "decompress_mbps": 312.38
   },
   {
    "compressor": "zlib",
@@ -5984,8 +5984,8 @@
    "level": 4,
    "out_size": 6091108,
    "ratio": 0.7188,
-   "compress_mbps": 46.0,
-   "decompress_mbps": 263.17
+   "compress_mbps": 46.09,
+   "decompress_mbps": 267.15
   },
   {
    "compressor": "zlib",
@@ -5994,8 +5994,8 @@
    "level": 5,
    "out_size": 6053566,
    "ratio": 0.7143,
-   "compress_mbps": 37.15,
-   "decompress_mbps": 272.69
+   "compress_mbps": 37.26,
+   "decompress_mbps": 274.93
   },
   {
    "compressor": "zlib",
@@ -6004,8 +6004,8 @@
    "level": 6,
    "out_size": 6045111,
    "ratio": 0.7134,
-   "compress_mbps": 34.92,
-   "decompress_mbps": 278.93
+   "compress_mbps": 34.97,
+   "decompress_mbps": 276.79
   },
   {
    "compressor": "zlib",
@@ -6014,8 +6014,8 @@
    "level": 7,
    "out_size": 6045034,
    "ratio": 0.7133,
-   "compress_mbps": 34.83,
-   "decompress_mbps": 276.89
+   "compress_mbps": 34.92,
+   "decompress_mbps": 278.07
   },
   {
    "compressor": "zlib",
@@ -6024,8 +6024,8 @@
    "level": 8,
    "out_size": 6045032,
    "ratio": 0.7133,
-   "compress_mbps": 34.92,
-   "decompress_mbps": 279.29
+   "compress_mbps": 34.97,
+   "decompress_mbps": 277.28
   },
   {
    "compressor": "zlib",
@@ -6034,8 +6034,8 @@
    "level": 9,
    "out_size": 6045032,
    "ratio": 0.7133,
-   "compress_mbps": 34.83,
-   "decompress_mbps": 278.14
+   "compress_mbps": 34.94,
+   "decompress_mbps": 277.39
   },
   {
    "compressor": "zlib",
@@ -6044,8 +6044,8 @@
    "level": 1,
    "out_size": 965242,
    "ratio": 0.1806,
-   "compress_mbps": 262.94,
-   "decompress_mbps": 691.56
+   "compress_mbps": 264.31,
+   "decompress_mbps": 697.56
   },
   {
    "compressor": "zlib",
@@ -6054,8 +6054,8 @@
    "level": 2,
    "out_size": 887265,
    "ratio": 0.166,
-   "compress_mbps": 246.29,
-   "decompress_mbps": 740.68
+   "compress_mbps": 246.22,
+   "decompress_mbps": 752.4
   },
   {
    "compressor": "zlib",
@@ -6064,8 +6064,8 @@
    "level": 3,
    "out_size": 822167,
    "ratio": 0.1538,
-   "compress_mbps": 191.44,
-   "decompress_mbps": 789.3
+   "compress_mbps": 191.48,
+   "decompress_mbps": 797.39
   },
   {
    "compressor": "zlib",
@@ -6074,8 +6074,8 @@
    "level": 4,
    "out_size": 807518,
    "ratio": 0.1511,
-   "compress_mbps": 167.77,
-   "decompress_mbps": 756.5
+   "compress_mbps": 169.01,
+   "decompress_mbps": 768.34
   },
   {
    "compressor": "zlib",
@@ -6084,8 +6084,8 @@
    "level": 5,
    "out_size": 730574,
    "ratio": 0.1367,
-   "compress_mbps": 121.41,
-   "decompress_mbps": 809.6
+   "compress_mbps": 121.75,
+   "decompress_mbps": 815.59
   },
   {
    "compressor": "zlib",
@@ -6094,8 +6094,8 @@
    "level": 6,
    "out_size": 687991,
    "ratio": 0.1287,
-   "compress_mbps": 79.32,
-   "decompress_mbps": 844.63
+   "compress_mbps": 79.31,
+   "decompress_mbps": 872.54
   },
   {
    "compressor": "zlib",
@@ -6104,8 +6104,8 @@
    "level": 7,
    "out_size": 673933,
    "ratio": 0.1261,
-   "compress_mbps": 65.03,
-   "decompress_mbps": 873.92
+   "compress_mbps": 64.99,
+   "decompress_mbps": 887.93
   },
   {
    "compressor": "zlib",
@@ -6114,8 +6114,8 @@
    "level": 8,
    "out_size": 659518,
    "ratio": 0.1234,
-   "compress_mbps": 43.05,
-   "decompress_mbps": 892.99
+   "compress_mbps": 43.0,
+   "decompress_mbps": 884.96
   },
   {
    "compressor": "zlib",
@@ -6124,8 +6124,8 @@
    "level": 9,
    "out_size": 658899,
    "ratio": 0.1233,
-   "compress_mbps": 39.78,
-   "decompress_mbps": 880.29
+   "compress_mbps": 39.85,
+   "decompress_mbps": 896.88
   },
   {
    "compressor": "miniz_oxide",
@@ -6134,8 +6134,8 @@
    "level": 1,
    "out_size": 5363862,
    "ratio": 0.5263,
-   "compress_mbps": 138.79,
-   "decompress_mbps": 402.28
+   "compress_mbps": 141.65,
+   "decompress_mbps": 389.91
   },
   {
    "compressor": "miniz_oxide",
@@ -6144,8 +6144,8 @@
    "level": 2,
    "out_size": 4438205,
    "ratio": 0.4354,
-   "compress_mbps": 127.63,
-   "decompress_mbps": 442.06
+   "compress_mbps": 128.9,
+   "decompress_mbps": 428.47
   },
   {
    "compressor": "miniz_oxide",
@@ -6154,8 +6154,8 @@
    "level": 3,
    "out_size": 4054333,
    "ratio": 0.3978,
-   "compress_mbps": 63.91,
-   "decompress_mbps": 489.94
+   "compress_mbps": 63.86,
+   "decompress_mbps": 475.64
   },
   {
    "compressor": "miniz_oxide",
@@ -6164,8 +6164,8 @@
    "level": 4,
    "out_size": 4038550,
    "ratio": 0.3962,
-   "compress_mbps": 57.47,
-   "decompress_mbps": 481.34
+   "compress_mbps": 57.76,
+   "decompress_mbps": 469.09
   },
   {
    "compressor": "miniz_oxide",
@@ -6174,8 +6174,8 @@
    "level": 5,
    "out_size": 3954920,
    "ratio": 0.388,
-   "compress_mbps": 40.18,
-   "decompress_mbps": 469.35
+   "compress_mbps": 40.27,
+   "decompress_mbps": 462.21
   },
   {
    "compressor": "miniz_oxide",
@@ -6184,8 +6184,8 @@
    "level": 6,
    "out_size": 3872874,
    "ratio": 0.38,
-   "compress_mbps": 22.54,
-   "decompress_mbps": 478.89
+   "compress_mbps": 22.58,
+   "decompress_mbps": 470.25
   },
   {
    "compressor": "miniz_oxide",
@@ -6194,8 +6194,8 @@
    "level": 7,
    "out_size": 3859937,
    "ratio": 0.3787,
-   "compress_mbps": 18.81,
-   "decompress_mbps": 480.39
+   "compress_mbps": 18.83,
+   "decompress_mbps": 472.38
   },
   {
    "compressor": "miniz_oxide",
@@ -6204,8 +6204,8 @@
    "level": 8,
    "out_size": 3855935,
    "ratio": 0.3783,
-   "compress_mbps": 17.05,
-   "decompress_mbps": 480.29
+   "compress_mbps": 17.07,
+   "decompress_mbps": 469.47
   },
   {
    "compressor": "miniz_oxide",
@@ -6214,8 +6214,8 @@
    "level": 9,
    "out_size": 3855791,
    "ratio": 0.3783,
-   "compress_mbps": 16.97,
-   "decompress_mbps": 481.0
+   "compress_mbps": 17.01,
+   "decompress_mbps": 470.52
   },
   {
    "compressor": "miniz_oxide",
@@ -6224,8 +6224,8 @@
    "level": 1,
    "out_size": 22334882,
    "ratio": 0.4361,
-   "compress_mbps": 230.25,
-   "decompress_mbps": 379.46
+   "compress_mbps": 233.89,
+   "decompress_mbps": 370.0
   },
   {
    "compressor": "miniz_oxide",
@@ -6234,8 +6234,8 @@
    "level": 2,
    "out_size": 20150366,
    "ratio": 0.3934,
-   "compress_mbps": 119.24,
-   "decompress_mbps": 382.29
+   "compress_mbps": 119.97,
+   "decompress_mbps": 375.66
   },
   {
    "compressor": "miniz_oxide",
@@ -6244,8 +6244,8 @@
    "level": 3,
    "out_size": 19495014,
    "ratio": 0.3806,
-   "compress_mbps": 69.01,
-   "decompress_mbps": 396.76
+   "compress_mbps": 70.13,
+   "decompress_mbps": 389.58
   },
   {
    "compressor": "miniz_oxide",
@@ -6254,8 +6254,8 @@
    "level": 4,
    "out_size": 19424978,
    "ratio": 0.3792,
-   "compress_mbps": 71.0,
-   "decompress_mbps": 410.3
+   "compress_mbps": 71.02,
+   "decompress_mbps": 402.97
   },
   {
    "compressor": "miniz_oxide",
@@ -6264,8 +6264,8 @@
    "level": 5,
    "out_size": 19298736,
    "ratio": 0.3768,
-   "compress_mbps": 53.98,
-   "decompress_mbps": 428.3
+   "compress_mbps": 54.1,
+   "decompress_mbps": 393.93
   },
   {
    "compressor": "miniz_oxide",
@@ -6274,8 +6274,8 @@
    "level": 6,
    "out_size": 19179167,
    "ratio": 0.3744,
-   "compress_mbps": 29.58,
-   "decompress_mbps": 410.38
+   "compress_mbps": 29.69,
+   "decompress_mbps": 422.35
   },
   {
    "compressor": "miniz_oxide",
@@ -6284,8 +6284,8 @@
    "level": 7,
    "out_size": 19151324,
    "ratio": 0.3739,
-   "compress_mbps": 21.9,
-   "decompress_mbps": 433.84
+   "compress_mbps": 21.89,
+   "decompress_mbps": 422.25
   },
   {
    "compressor": "miniz_oxide",
@@ -6294,8 +6294,8 @@
    "level": 8,
    "out_size": 19144373,
    "ratio": 0.3738,
-   "compress_mbps": 16.57,
-   "decompress_mbps": 433.62
+   "compress_mbps": 16.59,
+   "decompress_mbps": 407.62
   },
   {
    "compressor": "miniz_oxide",
@@ -6305,7 +6305,7 @@
    "out_size": 19141383,
    "ratio": 0.3737,
    "compress_mbps": 14.17,
-   "decompress_mbps": 432.76
+   "decompress_mbps": 420.85
   },
   {
    "compressor": "miniz_oxide",
@@ -6314,8 +6314,8 @@
    "level": 1,
    "out_size": 4249731,
    "ratio": 0.4262,
-   "compress_mbps": 305.95,
-   "decompress_mbps": 538.37
+   "compress_mbps": 313.35,
+   "decompress_mbps": 528.94
   },
   {
    "compressor": "miniz_oxide",
@@ -6324,8 +6324,8 @@
    "level": 2,
    "out_size": 3775479,
    "ratio": 0.3787,
-   "compress_mbps": 156.83,
-   "decompress_mbps": 562.45
+   "compress_mbps": 156.84,
+   "decompress_mbps": 517.84
   },
   {
    "compressor": "miniz_oxide",
@@ -6334,8 +6334,8 @@
    "level": 3,
    "out_size": 3656966,
    "ratio": 0.3668,
-   "compress_mbps": 80.0,
-   "decompress_mbps": 584.34
+   "compress_mbps": 79.84,
+   "decompress_mbps": 574.15
   },
   {
    "compressor": "miniz_oxide",
@@ -6344,8 +6344,8 @@
    "level": 4,
    "out_size": 3740378,
    "ratio": 0.3751,
-   "compress_mbps": 67.37,
-   "decompress_mbps": 545.09
+   "compress_mbps": 67.57,
+   "decompress_mbps": 534.79
   },
   {
    "compressor": "miniz_oxide",
@@ -6354,8 +6354,8 @@
    "level": 5,
    "out_size": 3713604,
    "ratio": 0.3725,
-   "compress_mbps": 48.51,
-   "decompress_mbps": 484.33
+   "compress_mbps": 48.45,
+   "decompress_mbps": 501.84
   },
   {
    "compressor": "miniz_oxide",
@@ -6364,8 +6364,8 @@
    "level": 6,
    "out_size": 3683556,
    "ratio": 0.3694,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 527.1
+   "compress_mbps": 24.87,
+   "decompress_mbps": 515.42
   },
   {
    "compressor": "miniz_oxide",
@@ -6374,8 +6374,8 @@
    "level": 7,
    "out_size": 3683797,
    "ratio": 0.3695,
-   "compress_mbps": 19.19,
-   "decompress_mbps": 541.63
+   "compress_mbps": 18.98,
+   "decompress_mbps": 521.98
   },
   {
    "compressor": "miniz_oxide",
@@ -6384,8 +6384,8 @@
    "level": 8,
    "out_size": 3684477,
    "ratio": 0.3695,
-   "compress_mbps": 14.48,
-   "decompress_mbps": 553.96
+   "compress_mbps": 14.34,
+   "decompress_mbps": 540.16
   },
   {
    "compressor": "miniz_oxide",
@@ -6394,8 +6394,8 @@
    "level": 9,
    "out_size": 3679414,
    "ratio": 0.369,
-   "compress_mbps": 12.46,
-   "decompress_mbps": 553.25
+   "compress_mbps": 12.34,
+   "decompress_mbps": 542.45
   },
   {
    "compressor": "miniz_oxide",
@@ -6404,8 +6404,8 @@
    "level": 1,
    "out_size": 5594622,
    "ratio": 0.1667,
-   "compress_mbps": 427.24,
-   "decompress_mbps": 862.52
+   "compress_mbps": 433.55,
+   "decompress_mbps": 834.3
   },
   {
    "compressor": "miniz_oxide",
@@ -6414,8 +6414,8 @@
    "level": 2,
    "out_size": 4179532,
    "ratio": 0.1246,
-   "compress_mbps": 328.94,
-   "decompress_mbps": 984.67
+   "compress_mbps": 327.38,
+   "decompress_mbps": 926.24
   },
   {
    "compressor": "miniz_oxide",
@@ -6424,8 +6424,8 @@
    "level": 3,
    "out_size": 3542329,
    "ratio": 0.1056,
-   "compress_mbps": 213.2,
-   "decompress_mbps": 881.48
+   "compress_mbps": 211.33,
+   "decompress_mbps": 842.8
   },
   {
    "compressor": "miniz_oxide",
@@ -6434,8 +6434,8 @@
    "level": 4,
    "out_size": 3323363,
    "ratio": 0.099,
-   "compress_mbps": 199.0,
-   "decompress_mbps": 931.51
+   "compress_mbps": 197.38,
+   "decompress_mbps": 872.41
   },
   {
    "compressor": "miniz_oxide",
@@ -6444,8 +6444,8 @@
    "level": 5,
    "out_size": 3230343,
    "ratio": 0.0963,
-   "compress_mbps": 162.98,
-   "decompress_mbps": 1000.38
+   "compress_mbps": 161.61,
+   "decompress_mbps": 952.97
   },
   {
    "compressor": "miniz_oxide",
@@ -6454,8 +6454,8 @@
    "level": 6,
    "out_size": 3123421,
    "ratio": 0.0931,
-   "compress_mbps": 96.32,
-   "decompress_mbps": 1059.98
+   "compress_mbps": 95.69,
+   "decompress_mbps": 997.1
   },
   {
    "compressor": "miniz_oxide",
@@ -6464,8 +6464,8 @@
    "level": 7,
    "out_size": 3093778,
    "ratio": 0.0922,
-   "compress_mbps": 70.78,
-   "decompress_mbps": 1016.77
+   "compress_mbps": 70.53,
+   "decompress_mbps": 972.37
   },
   {
    "compressor": "miniz_oxide",
@@ -6474,8 +6474,8 @@
    "level": 8,
    "out_size": 3067318,
    "ratio": 0.0914,
-   "compress_mbps": 50.19,
-   "decompress_mbps": 1054.41
+   "compress_mbps": 50.06,
+   "decompress_mbps": 1013.07
   },
   {
    "compressor": "miniz_oxide",
@@ -6484,8 +6484,8 @@
    "level": 9,
    "out_size": 3050695,
    "ratio": 0.0909,
-   "compress_mbps": 42.13,
-   "decompress_mbps": 1065.41
+   "compress_mbps": 41.98,
+   "decompress_mbps": 1022.82
   },
   {
    "compressor": "miniz_oxide",
@@ -6494,8 +6494,8 @@
    "level": 1,
    "out_size": 3543611,
    "ratio": 0.576,
-   "compress_mbps": 164.78,
-   "decompress_mbps": 280.52
+   "compress_mbps": 169.2,
+   "decompress_mbps": 269.98
   },
   {
    "compressor": "miniz_oxide",
@@ -6504,8 +6504,8 @@
    "level": 2,
    "out_size": 3226818,
    "ratio": 0.5245,
-   "compress_mbps": 86.26,
-   "decompress_mbps": 298.31
+   "compress_mbps": 86.03,
+   "decompress_mbps": 287.07
   },
   {
    "compressor": "miniz_oxide",
@@ -6514,8 +6514,8 @@
    "level": 3,
    "out_size": 3144140,
    "ratio": 0.5111,
-   "compress_mbps": 52.97,
-   "decompress_mbps": 310.3
+   "compress_mbps": 52.6,
+   "decompress_mbps": 297.45
   },
   {
    "compressor": "miniz_oxide",
@@ -6524,8 +6524,8 @@
    "level": 4,
    "out_size": 3129833,
    "ratio": 0.5087,
-   "compress_mbps": 51.8,
-   "decompress_mbps": 337.4
+   "compress_mbps": 51.39,
+   "decompress_mbps": 324.03
   },
   {
    "compressor": "miniz_oxide",
@@ -6534,8 +6534,8 @@
    "level": 5,
    "out_size": 3114809,
    "ratio": 0.5063,
-   "compress_mbps": 40.44,
-   "decompress_mbps": 350.24
+   "compress_mbps": 40.29,
+   "decompress_mbps": 338.27
   },
   {
    "compressor": "miniz_oxide",
@@ -6544,8 +6544,8 @@
    "level": 6,
    "out_size": 3095705,
    "ratio": 0.5032,
-   "compress_mbps": 25.18,
-   "decompress_mbps": 356.83
+   "compress_mbps": 25.04,
+   "decompress_mbps": 345.03
   },
   {
    "compressor": "miniz_oxide",
@@ -6554,8 +6554,8 @@
    "level": 7,
    "out_size": 3090055,
    "ratio": 0.5023,
-   "compress_mbps": 20.51,
-   "decompress_mbps": 358.26
+   "compress_mbps": 20.39,
+   "decompress_mbps": 345.41
   },
   {
    "compressor": "miniz_oxide",
@@ -6564,8 +6564,8 @@
    "level": 8,
    "out_size": 3087665,
    "ratio": 0.5019,
-   "compress_mbps": 17.44,
-   "decompress_mbps": 355.75
+   "compress_mbps": 17.41,
+   "decompress_mbps": 345.4
   },
   {
    "compressor": "miniz_oxide",
@@ -6574,8 +6574,8 @@
    "level": 9,
    "out_size": 3087158,
    "ratio": 0.5018,
-   "compress_mbps": 16.35,
-   "decompress_mbps": 359.29
+   "compress_mbps": 16.29,
+   "decompress_mbps": 345.8
   },
   {
    "compressor": "miniz_oxide",
@@ -6584,8 +6584,8 @@
    "level": 1,
    "out_size": 5419510,
    "ratio": 0.5373,
-   "compress_mbps": 240.77,
-   "decompress_mbps": 544.48
+   "compress_mbps": 243.36,
+   "decompress_mbps": 535.63
   },
   {
    "compressor": "miniz_oxide",
@@ -6594,8 +6594,8 @@
    "level": 2,
    "out_size": 3982547,
    "ratio": 0.3949,
-   "compress_mbps": 123.38,
-   "decompress_mbps": 560.61
+   "compress_mbps": 122.38,
+   "decompress_mbps": 550.66
   },
   {
    "compressor": "miniz_oxide",
@@ -6604,8 +6604,8 @@
    "level": 3,
    "out_size": 3806102,
    "ratio": 0.3774,
-   "compress_mbps": 82.03,
-   "decompress_mbps": 580.99
+   "compress_mbps": 80.86,
+   "decompress_mbps": 568.24
   },
   {
    "compressor": "miniz_oxide",
@@ -6614,8 +6614,8 @@
    "level": 4,
    "out_size": 3761477,
    "ratio": 0.373,
-   "compress_mbps": 78.68,
-   "decompress_mbps": 617.31
+   "compress_mbps": 78.11,
+   "decompress_mbps": 603.06
   },
   {
    "compressor": "miniz_oxide",
@@ -6624,8 +6624,8 @@
    "level": 5,
    "out_size": 3740298,
    "ratio": 0.3709,
-   "compress_mbps": 67.49,
-   "decompress_mbps": 621.76
+   "compress_mbps": 67.07,
+   "decompress_mbps": 611.24
   },
   {
    "compressor": "miniz_oxide",
@@ -6634,8 +6634,8 @@
    "level": 6,
    "out_size": 3686116,
    "ratio": 0.3655,
-   "compress_mbps": 49.45,
-   "decompress_mbps": 653.96
+   "compress_mbps": 49.52,
+   "decompress_mbps": 637.82
   },
   {
    "compressor": "miniz_oxide",
@@ -6644,8 +6644,8 @@
    "level": 7,
    "out_size": 3668442,
    "ratio": 0.3637,
-   "compress_mbps": 38.81,
-   "decompress_mbps": 670.52
+   "compress_mbps": 38.85,
+   "decompress_mbps": 662.0
   },
   {
    "compressor": "miniz_oxide",
@@ -6654,8 +6654,8 @@
    "level": 8,
    "out_size": 3665072,
    "ratio": 0.3634,
-   "compress_mbps": 33.14,
-   "decompress_mbps": 662.87
+   "compress_mbps": 33.15,
+   "decompress_mbps": 657.03
   },
   {
    "compressor": "miniz_oxide",
@@ -6664,8 +6664,8 @@
    "level": 9,
    "out_size": 3665057,
    "ratio": 0.3634,
-   "compress_mbps": 32.96,
-   "decompress_mbps": 660.26
+   "compress_mbps": 32.94,
+   "decompress_mbps": 653.51
   },
   {
    "compressor": "miniz_oxide",
@@ -6674,8 +6674,8 @@
    "level": 1,
    "out_size": 2842321,
    "ratio": 0.4289,
-   "compress_mbps": 189.93,
-   "decompress_mbps": 451.85
+   "compress_mbps": 193.08,
+   "decompress_mbps": 443.97
   },
   {
    "compressor": "miniz_oxide",
@@ -6684,8 +6684,8 @@
    "level": 2,
    "out_size": 2232180,
    "ratio": 0.3368,
-   "compress_mbps": 151.48,
-   "decompress_mbps": 524.72
+   "compress_mbps": 151.04,
+   "decompress_mbps": 514.91
   },
   {
    "compressor": "miniz_oxide",
@@ -6694,8 +6694,8 @@
    "level": 3,
    "out_size": 2003056,
    "ratio": 0.3022,
-   "compress_mbps": 81.98,
-   "decompress_mbps": 560.83
+   "compress_mbps": 81.92,
+   "decompress_mbps": 551.48
   },
   {
    "compressor": "miniz_oxide",
@@ -6704,8 +6704,8 @@
    "level": 4,
    "out_size": 1985375,
    "ratio": 0.2996,
-   "compress_mbps": 73.59,
-   "decompress_mbps": 568.31
+   "compress_mbps": 74.08,
+   "decompress_mbps": 566.46
   },
   {
    "compressor": "miniz_oxide",
@@ -6714,8 +6714,8 @@
    "level": 5,
    "out_size": 1933775,
    "ratio": 0.2918,
-   "compress_mbps": 51.74,
-   "decompress_mbps": 537.47
+   "compress_mbps": 51.93,
+   "decompress_mbps": 538.73
   },
   {
    "compressor": "miniz_oxide",
@@ -6724,8 +6724,8 @@
    "level": 6,
    "out_size": 1858103,
    "ratio": 0.2804,
-   "compress_mbps": 21.93,
-   "decompress_mbps": 545.54
+   "compress_mbps": 22.05,
+   "decompress_mbps": 541.6
   },
   {
    "compressor": "miniz_oxide",
@@ -6734,8 +6734,8 @@
    "level": 7,
    "out_size": 1840414,
    "ratio": 0.2777,
-   "compress_mbps": 15.07,
-   "decompress_mbps": 548.34
+   "compress_mbps": 15.15,
+   "decompress_mbps": 550.69
   },
   {
    "compressor": "miniz_oxide",
@@ -6744,8 +6744,8 @@
    "level": 8,
    "out_size": 1831679,
    "ratio": 0.2764,
-   "compress_mbps": 11.71,
-   "decompress_mbps": 549.72
+   "compress_mbps": 11.76,
+   "decompress_mbps": 543.82
   },
   {
    "compressor": "miniz_oxide",
@@ -6754,8 +6754,8 @@
    "level": 9,
    "out_size": 1827137,
    "ratio": 0.2757,
-   "compress_mbps": 10.12,
-   "decompress_mbps": 552.39
+   "compress_mbps": 10.16,
+   "decompress_mbps": 544.36
   },
   {
    "compressor": "miniz_oxide",
@@ -6764,8 +6764,8 @@
    "level": 1,
    "out_size": 7089759,
    "ratio": 0.3281,
-   "compress_mbps": 287.04,
-   "decompress_mbps": 569.29
+   "compress_mbps": 290.79,
+   "decompress_mbps": 557.71
   },
   {
    "compressor": "miniz_oxide",
@@ -6774,8 +6774,8 @@
    "level": 2,
    "out_size": 5966231,
    "ratio": 0.2761,
-   "compress_mbps": 172.98,
-   "decompress_mbps": 636.62
+   "compress_mbps": 174.66,
+   "decompress_mbps": 619.46
   },
   {
    "compressor": "miniz_oxide",
@@ -6784,8 +6784,8 @@
    "level": 3,
    "out_size": 5611838,
    "ratio": 0.2597,
-   "compress_mbps": 111.17,
-   "decompress_mbps": 664.17
+   "compress_mbps": 111.67,
+   "decompress_mbps": 648.0
   },
   {
    "compressor": "miniz_oxide",
@@ -6794,8 +6794,8 @@
    "level": 4,
    "out_size": 5535436,
    "ratio": 0.2562,
-   "compress_mbps": 104.98,
-   "decompress_mbps": 685.69
+   "compress_mbps": 105.54,
+   "decompress_mbps": 672.27
   },
   {
    "compressor": "miniz_oxide",
@@ -6804,8 +6804,8 @@
    "level": 5,
    "out_size": 5480971,
    "ratio": 0.2537,
-   "compress_mbps": 81.18,
-   "decompress_mbps": 694.96
+   "compress_mbps": 81.52,
+   "decompress_mbps": 680.77
   },
   {
    "compressor": "miniz_oxide",
@@ -6814,8 +6814,8 @@
    "level": 6,
    "out_size": 5437556,
    "ratio": 0.2517,
-   "compress_mbps": 49.46,
-   "decompress_mbps": 708.44
+   "compress_mbps": 49.47,
+   "decompress_mbps": 697.31
   },
   {
    "compressor": "miniz_oxide",
@@ -6824,8 +6824,8 @@
    "level": 7,
    "out_size": 5432108,
    "ratio": 0.2514,
-   "compress_mbps": 40.38,
-   "decompress_mbps": 711.1
+   "compress_mbps": 40.48,
+   "decompress_mbps": 694.27
   },
   {
    "compressor": "miniz_oxide",
@@ -6834,8 +6834,8 @@
    "level": 8,
    "out_size": 5428571,
    "ratio": 0.2512,
-   "compress_mbps": 33.59,
-   "decompress_mbps": 712.39
+   "compress_mbps": 33.62,
+   "decompress_mbps": 700.3
   },
   {
    "compressor": "miniz_oxide",
@@ -6844,8 +6844,8 @@
    "level": 9,
    "out_size": 5425526,
    "ratio": 0.2511,
-   "compress_mbps": 30.44,
-   "decompress_mbps": 715.29
+   "compress_mbps": 30.51,
+   "decompress_mbps": 703.33
   },
   {
    "compressor": "miniz_oxide",
@@ -6854,8 +6854,8 @@
    "level": 1,
    "out_size": 5900800,
    "ratio": 0.8137,
-   "compress_mbps": 187.77,
-   "decompress_mbps": 313.02
+   "compress_mbps": 188.47,
+   "decompress_mbps": 324.35
   },
   {
    "compressor": "miniz_oxide",
@@ -6864,8 +6864,8 @@
    "level": 2,
    "out_size": 5523611,
    "ratio": 0.7617,
-   "compress_mbps": 68.59,
-   "decompress_mbps": 330.66
+   "compress_mbps": 69.45,
+   "decompress_mbps": 340.66
   },
   {
    "compressor": "miniz_oxide",
@@ -6874,8 +6874,8 @@
    "level": 3,
    "out_size": 5393086,
    "ratio": 0.7437,
-   "compress_mbps": 40.06,
-   "decompress_mbps": 339.57
+   "compress_mbps": 40.33,
+   "decompress_mbps": 351.21
   },
   {
    "compressor": "miniz_oxide",
@@ -6884,8 +6884,8 @@
    "level": 4,
    "out_size": 5401582,
    "ratio": 0.7448,
-   "compress_mbps": 40.39,
-   "decompress_mbps": 353.51
+   "compress_mbps": 40.72,
+   "decompress_mbps": 367.5
   },
   {
    "compressor": "miniz_oxide",
@@ -6894,8 +6894,8 @@
    "level": 5,
    "out_size": 5371274,
    "ratio": 0.7407,
-   "compress_mbps": 31.1,
-   "decompress_mbps": 345.1
+   "compress_mbps": 31.31,
+   "decompress_mbps": 358.37
   },
   {
    "compressor": "miniz_oxide",
@@ -6904,8 +6904,8 @@
    "level": 6,
    "out_size": 5330096,
    "ratio": 0.735,
-   "compress_mbps": 20.73,
-   "decompress_mbps": 350.15
+   "compress_mbps": 20.8,
+   "decompress_mbps": 365.39
   },
   {
    "compressor": "miniz_oxide",
@@ -6914,8 +6914,8 @@
    "level": 7,
    "out_size": 5325437,
    "ratio": 0.7343,
-   "compress_mbps": 18.95,
-   "decompress_mbps": 349.58
+   "compress_mbps": 18.98,
+   "decompress_mbps": 366.05
   },
   {
    "compressor": "miniz_oxide",
@@ -6924,8 +6924,8 @@
    "level": 8,
    "out_size": 5323934,
    "ratio": 0.7341,
-   "compress_mbps": 18.0,
-   "decompress_mbps": 350.5
+   "compress_mbps": 18.05,
+   "decompress_mbps": 364.0
   },
   {
    "compressor": "miniz_oxide",
@@ -6934,8 +6934,8 @@
    "level": 9,
    "out_size": 5323621,
    "ratio": 0.7341,
-   "compress_mbps": 17.72,
-   "decompress_mbps": 350.16
+   "compress_mbps": 17.67,
+   "decompress_mbps": 364.02
   },
   {
    "compressor": "miniz_oxide",
@@ -6944,8 +6944,8 @@
    "level": 1,
    "out_size": 17587173,
    "ratio": 0.4242,
-   "compress_mbps": 181.57,
-   "decompress_mbps": 387.83
+   "compress_mbps": 185.73,
+   "decompress_mbps": 379.13
   },
   {
    "compressor": "miniz_oxide",
@@ -6954,8 +6954,8 @@
    "level": 2,
    "out_size": 14171707,
    "ratio": 0.3418,
-   "compress_mbps": 147.21,
-   "decompress_mbps": 422.36
+   "compress_mbps": 149.15,
+   "decompress_mbps": 409.08
   },
   {
    "compressor": "miniz_oxide",
@@ -6964,8 +6964,8 @@
    "level": 3,
    "out_size": 12774851,
    "ratio": 0.3081,
-   "compress_mbps": 85.63,
-   "decompress_mbps": 453.22
+   "compress_mbps": 85.71,
+   "decompress_mbps": 440.79
   },
   {
    "compressor": "miniz_oxide",
@@ -6974,8 +6974,8 @@
    "level": 4,
    "out_size": 12612554,
    "ratio": 0.3042,
-   "compress_mbps": 75.62,
-   "decompress_mbps": 444.68
+   "compress_mbps": 76.13,
+   "decompress_mbps": 444.75
   },
   {
    "compressor": "miniz_oxide",
@@ -6984,8 +6984,8 @@
    "level": 5,
    "out_size": 12392339,
    "ratio": 0.2989,
-   "compress_mbps": 57.71,
-   "decompress_mbps": 454.79
+   "compress_mbps": 58.1,
+   "decompress_mbps": 457.17
   },
   {
    "compressor": "miniz_oxide",
@@ -6994,8 +6994,8 @@
    "level": 6,
    "out_size": 12158314,
    "ratio": 0.2933,
-   "compress_mbps": 34.28,
-   "decompress_mbps": 468.62
+   "compress_mbps": 34.41,
+   "decompress_mbps": 463.08
   },
   {
    "compressor": "miniz_oxide",
@@ -7004,8 +7004,8 @@
    "level": 7,
    "out_size": 12107840,
    "ratio": 0.292,
-   "compress_mbps": 27.47,
-   "decompress_mbps": 468.3
+   "compress_mbps": 27.64,
+   "decompress_mbps": 466.33
   },
   {
    "compressor": "miniz_oxide",
@@ -7014,8 +7014,8 @@
    "level": 8,
    "out_size": 12081311,
    "ratio": 0.2914,
-   "compress_mbps": 22.78,
-   "decompress_mbps": 469.39
+   "compress_mbps": 22.88,
+   "decompress_mbps": 462.63
   },
   {
    "compressor": "miniz_oxide",
@@ -7024,8 +7024,8 @@
    "level": 9,
    "out_size": 12081011,
    "ratio": 0.2914,
-   "compress_mbps": 22.71,
-   "decompress_mbps": 477.7
+   "compress_mbps": 22.78,
+   "decompress_mbps": 460.01
   },
   {
    "compressor": "miniz_oxide",
@@ -7034,8 +7034,8 @@
    "level": 1,
    "out_size": 6527324,
    "ratio": 0.7703,
-   "compress_mbps": 235.88,
-   "decompress_mbps": 331.36
+   "compress_mbps": 238.95,
+   "decompress_mbps": 330.7
   },
   {
    "compressor": "miniz_oxide",
@@ -7044,8 +7044,8 @@
    "level": 2,
    "out_size": 6051483,
    "ratio": 0.7141,
-   "compress_mbps": 75.09,
-   "decompress_mbps": 332.98
+   "compress_mbps": 75.62,
+   "decompress_mbps": 332.39
   },
   {
    "compressor": "miniz_oxide",
@@ -7054,8 +7054,8 @@
    "level": 3,
    "out_size": 6010123,
    "ratio": 0.7092,
-   "compress_mbps": 51.89,
-   "decompress_mbps": 336.35
+   "compress_mbps": 52.06,
+   "decompress_mbps": 334.45
   },
   {
    "compressor": "miniz_oxide",
@@ -7064,8 +7064,8 @@
    "level": 4,
    "out_size": 6024815,
    "ratio": 0.711,
-   "compress_mbps": 44.26,
-   "decompress_mbps": 288.94
+   "compress_mbps": 44.63,
+   "decompress_mbps": 286.25
   },
   {
    "compressor": "miniz_oxide",
@@ -7074,8 +7074,8 @@
    "level": 5,
    "out_size": 6005181,
    "ratio": 0.7086,
-   "compress_mbps": 40.26,
-   "decompress_mbps": 295.67
+   "compress_mbps": 40.44,
+   "decompress_mbps": 293.0
   },
   {
    "compressor": "miniz_oxide",
@@ -7084,8 +7084,8 @@
    "level": 6,
    "out_size": 5997508,
    "ratio": 0.7077,
-   "compress_mbps": 37.69,
-   "decompress_mbps": 299.51
+   "compress_mbps": 37.97,
+   "decompress_mbps": 295.42
   },
   {
    "compressor": "miniz_oxide",
@@ -7094,8 +7094,8 @@
    "level": 7,
    "out_size": 5997403,
    "ratio": 0.7077,
-   "compress_mbps": 37.62,
-   "decompress_mbps": 298.2
+   "compress_mbps": 37.87,
+   "decompress_mbps": 295.69
   },
   {
    "compressor": "miniz_oxide",
@@ -7104,8 +7104,8 @@
    "level": 8,
    "out_size": 5997403,
    "ratio": 0.7077,
-   "compress_mbps": 37.72,
-   "decompress_mbps": 300.33
+   "compress_mbps": 37.82,
+   "decompress_mbps": 295.45
   },
   {
    "compressor": "miniz_oxide",
@@ -7114,8 +7114,8 @@
    "level": 9,
    "out_size": 5997403,
    "ratio": 0.7077,
-   "compress_mbps": 37.74,
-   "decompress_mbps": 299.39
+   "compress_mbps": 37.76,
+   "decompress_mbps": 292.96
   },
   {
    "compressor": "miniz_oxide",
@@ -7124,8 +7124,8 @@
    "level": 1,
    "out_size": 1147652,
    "ratio": 0.2147,
-   "compress_mbps": 382.79,
-   "decompress_mbps": 788.51
+   "compress_mbps": 388.67,
+   "decompress_mbps": 761.65
   },
   {
    "compressor": "miniz_oxide",
@@ -7134,8 +7134,8 @@
    "level": 2,
    "out_size": 919639,
    "ratio": 0.172,
-   "compress_mbps": 260.74,
-   "decompress_mbps": 978.63
+   "compress_mbps": 262.86,
+   "decompress_mbps": 956.95
   },
   {
    "compressor": "miniz_oxide",
@@ -7144,8 +7144,8 @@
    "level": 3,
    "out_size": 752341,
    "ratio": 0.1407,
-   "compress_mbps": 167.23,
-   "decompress_mbps": 1090.35
+   "compress_mbps": 167.46,
+   "decompress_mbps": 1057.51
   },
   {
    "compressor": "miniz_oxide",
@@ -7154,8 +7154,8 @@
    "level": 4,
    "out_size": 735537,
    "ratio": 0.1376,
-   "compress_mbps": 160.57,
-   "decompress_mbps": 1058.77
+   "compress_mbps": 161.37,
+   "decompress_mbps": 1037.21
   },
   {
    "compressor": "miniz_oxide",
@@ -7164,8 +7164,8 @@
    "level": 5,
    "out_size": 706789,
    "ratio": 0.1322,
-   "compress_mbps": 123.29,
-   "decompress_mbps": 1150.21
+   "compress_mbps": 123.5,
+   "decompress_mbps": 1129.34
   },
   {
    "compressor": "miniz_oxide",
@@ -7174,8 +7174,8 @@
    "level": 6,
    "out_size": 676279,
    "ratio": 0.1265,
-   "compress_mbps": 69.46,
-   "decompress_mbps": 1228.58
+   "compress_mbps": 69.53,
+   "decompress_mbps": 1219.4
   },
   {
    "compressor": "miniz_oxide",
@@ -7184,8 +7184,8 @@
    "level": 7,
    "out_size": 668772,
    "ratio": 0.1251,
-   "compress_mbps": 56.03,
-   "decompress_mbps": 1249.19
+   "compress_mbps": 55.97,
+   "decompress_mbps": 1208.21
   },
   {
    "compressor": "miniz_oxide",
@@ -7194,8 +7194,8 @@
    "level": 8,
    "out_size": 665340,
    "ratio": 0.1245,
-   "compress_mbps": 47.57,
-   "decompress_mbps": 1238.4
+   "compress_mbps": 47.61,
+   "decompress_mbps": 1208.14
   },
   {
    "compressor": "miniz_oxide",
@@ -7204,8 +7204,8 @@
    "level": 9,
    "out_size": 664273,
    "ratio": 0.1243,
-   "compress_mbps": 45.76,
-   "decompress_mbps": 1237.77
+   "compress_mbps": 45.85,
+   "decompress_mbps": 1218.11
   },
   {
    "compressor": "libdeflate",
@@ -7214,8 +7214,8 @@
    "level": 1,
    "out_size": 4217525,
    "ratio": 0.4138,
-   "compress_mbps": 242.99,
-   "decompress_mbps": 818.5
+   "compress_mbps": 243.85,
+   "decompress_mbps": 801.13
   },
   {
    "compressor": "libdeflate",
@@ -7224,8 +7224,8 @@
    "level": 2,
    "out_size": 4053259,
    "ratio": 0.3977,
-   "compress_mbps": 169.62,
-   "decompress_mbps": 871.55
+   "compress_mbps": 170.19,
+   "decompress_mbps": 864.66
   },
   {
    "compressor": "libdeflate",
@@ -7234,8 +7234,8 @@
    "level": 3,
    "out_size": 3989875,
    "ratio": 0.3915,
-   "compress_mbps": 139.67,
-   "decompress_mbps": 951.39
+   "compress_mbps": 140.0,
+   "decompress_mbps": 934.98
   },
   {
    "compressor": "libdeflate",
@@ -7244,8 +7244,8 @@
    "level": 4,
    "out_size": 3972869,
    "ratio": 0.3898,
-   "compress_mbps": 127.73,
-   "decompress_mbps": 829.14
+   "compress_mbps": 127.83,
+   "decompress_mbps": 825.71
   },
   {
    "compressor": "libdeflate",
@@ -7254,8 +7254,8 @@
    "level": 5,
    "out_size": 3894026,
    "ratio": 0.3821,
-   "compress_mbps": 99.4,
-   "decompress_mbps": 809.01
+   "compress_mbps": 99.29,
+   "decompress_mbps": 791.29
   },
   {
    "compressor": "libdeflate",
@@ -7264,8 +7264,8 @@
    "level": 6,
    "out_size": 3859436,
    "ratio": 0.3787,
-   "compress_mbps": 75.53,
-   "decompress_mbps": 835.8
+   "compress_mbps": 75.65,
+   "decompress_mbps": 819.18
   },
   {
    "compressor": "libdeflate",
@@ -7274,8 +7274,8 @@
    "level": 7,
    "out_size": 3837515,
    "ratio": 0.3765,
-   "compress_mbps": 55.75,
-   "decompress_mbps": 836.54
+   "compress_mbps": 55.71,
+   "decompress_mbps": 796.16
   },
   {
    "compressor": "libdeflate",
@@ -7284,8 +7284,8 @@
    "level": 8,
    "out_size": 3811467,
    "ratio": 0.374,
-   "compress_mbps": 35.98,
-   "decompress_mbps": 829.81
+   "compress_mbps": 36.03,
+   "decompress_mbps": 816.32
   },
   {
    "compressor": "libdeflate",
@@ -7294,8 +7294,8 @@
    "level": 9,
    "out_size": 3810354,
    "ratio": 0.3738,
-   "compress_mbps": 32.71,
-   "decompress_mbps": 830.58
+   "compress_mbps": 32.76,
+   "decompress_mbps": 816.68
   },
   {
    "compressor": "libdeflate",
@@ -7304,8 +7304,8 @@
    "level": 1,
    "out_size": 20192961,
    "ratio": 0.3942,
-   "compress_mbps": 240.89,
-   "decompress_mbps": 713.43
+   "compress_mbps": 242.16,
+   "decompress_mbps": 676.2
   },
   {
    "compressor": "libdeflate",
@@ -7314,8 +7314,8 @@
    "level": 2,
    "out_size": 19374226,
    "ratio": 0.3783,
-   "compress_mbps": 187.26,
-   "decompress_mbps": 726.95
+   "compress_mbps": 185.69,
+   "decompress_mbps": 710.78
   },
   {
    "compressor": "libdeflate",
@@ -7324,8 +7324,8 @@
    "level": 3,
    "out_size": 19234937,
    "ratio": 0.3755,
-   "compress_mbps": 174.61,
-   "decompress_mbps": 741.38
+   "compress_mbps": 173.04,
+   "decompress_mbps": 727.76
   },
   {
    "compressor": "libdeflate",
@@ -7334,8 +7334,8 @@
    "level": 4,
    "out_size": 19145385,
    "ratio": 0.3738,
-   "compress_mbps": 163.5,
-   "decompress_mbps": 743.76
+   "compress_mbps": 162.62,
+   "decompress_mbps": 728.74
   },
   {
    "compressor": "libdeflate",
@@ -7344,8 +7344,8 @@
    "level": 5,
    "out_size": 18878875,
    "ratio": 0.3686,
-   "compress_mbps": 144.02,
-   "decompress_mbps": 761.16
+   "compress_mbps": 142.62,
+   "decompress_mbps": 741.83
   },
   {
    "compressor": "libdeflate",
@@ -7354,8 +7354,8 @@
    "level": 6,
    "out_size": 18805391,
    "ratio": 0.3671,
-   "compress_mbps": 120.78,
-   "decompress_mbps": 768.98
+   "compress_mbps": 117.71,
+   "decompress_mbps": 750.56
   },
   {
    "compressor": "libdeflate",
@@ -7364,8 +7364,8 @@
    "level": 7,
    "out_size": 18749947,
    "ratio": 0.3661,
-   "compress_mbps": 87.76,
-   "decompress_mbps": 767.88
+   "compress_mbps": 87.16,
+   "decompress_mbps": 759.3
   },
   {
    "compressor": "libdeflate",
@@ -7374,8 +7374,8 @@
    "level": 8,
    "out_size": 18718540,
    "ratio": 0.3655,
-   "compress_mbps": 47.48,
-   "decompress_mbps": 762.04
+   "compress_mbps": 47.56,
+   "decompress_mbps": 766.6
   },
   {
    "compressor": "libdeflate",
@@ -7384,8 +7384,8 @@
    "level": 9,
    "out_size": 18713659,
    "ratio": 0.3654,
-   "compress_mbps": 33.6,
-   "decompress_mbps": 770.95
+   "compress_mbps": 33.49,
+   "decompress_mbps": 676.15
   },
   {
    "compressor": "libdeflate",
@@ -7394,8 +7394,8 @@
    "level": 1,
    "out_size": 3740775,
    "ratio": 0.3752,
-   "compress_mbps": 293.8,
-   "decompress_mbps": 764.71
+   "compress_mbps": 293.42,
+   "decompress_mbps": 755.42
   },
   {
    "compressor": "libdeflate",
@@ -7404,8 +7404,8 @@
    "level": 2,
    "out_size": 3707407,
    "ratio": 0.3718,
-   "compress_mbps": 216.83,
-   "decompress_mbps": 788.12
+   "compress_mbps": 217.45,
+   "decompress_mbps": 768.84
   },
   {
    "compressor": "libdeflate",
@@ -7414,8 +7414,8 @@
    "level": 3,
    "out_size": 3672389,
    "ratio": 0.3683,
-   "compress_mbps": 184.51,
-   "decompress_mbps": 816.82
+   "compress_mbps": 185.43,
+   "decompress_mbps": 809.7
   },
   {
    "compressor": "libdeflate",
@@ -7424,8 +7424,8 @@
    "level": 4,
    "out_size": 3660011,
    "ratio": 0.3671,
-   "compress_mbps": 170.65,
-   "decompress_mbps": 749.31
+   "compress_mbps": 171.62,
+   "decompress_mbps": 751.11
   },
   {
    "compressor": "libdeflate",
@@ -7434,8 +7434,8 @@
    "level": 5,
    "out_size": 3664245,
    "ratio": 0.3675,
-   "compress_mbps": 140.57,
-   "decompress_mbps": 708.21
+   "compress_mbps": 141.37,
+   "decompress_mbps": 712.85
   },
   {
    "compressor": "libdeflate",
@@ -7444,8 +7444,8 @@
    "level": 6,
    "out_size": 3648644,
    "ratio": 0.3659,
-   "compress_mbps": 106.69,
-   "decompress_mbps": 738.58
+   "compress_mbps": 106.84,
+   "decompress_mbps": 739.26
   },
   {
    "compressor": "libdeflate",
@@ -7454,8 +7454,8 @@
    "level": 7,
    "out_size": 3635323,
    "ratio": 0.3646,
-   "compress_mbps": 68.38,
-   "decompress_mbps": 746.64
+   "compress_mbps": 68.34,
+   "decompress_mbps": 735.43
   },
   {
    "compressor": "libdeflate",
@@ -7464,8 +7464,8 @@
    "level": 8,
    "out_size": 3624778,
    "ratio": 0.3635,
-   "compress_mbps": 43.1,
-   "decompress_mbps": 766.56
+   "compress_mbps": 43.04,
+   "decompress_mbps": 773.18
   },
   {
    "compressor": "libdeflate",
@@ -7474,8 +7474,8 @@
    "level": 9,
    "out_size": 3625176,
    "ratio": 0.3636,
-   "compress_mbps": 38.91,
-   "decompress_mbps": 754.84
+   "compress_mbps": 38.87,
+   "decompress_mbps": 757.44
   },
   {
    "compressor": "libdeflate",
@@ -7484,8 +7484,8 @@
    "level": 1,
    "out_size": 3837577,
    "ratio": 0.1144,
-   "compress_mbps": 609.63,
-   "decompress_mbps": 1525.29
+   "compress_mbps": 609.02,
+   "decompress_mbps": 1491.69
   },
   {
    "compressor": "libdeflate",
@@ -7494,8 +7494,8 @@
    "level": 2,
    "out_size": 3714632,
    "ratio": 0.1107,
-   "compress_mbps": 463.51,
-   "decompress_mbps": 1822.41
+   "compress_mbps": 462.85,
+   "decompress_mbps": 1747.31
   },
   {
    "compressor": "libdeflate",
@@ -7504,8 +7504,8 @@
    "level": 3,
    "out_size": 3599455,
    "ratio": 0.1073,
-   "compress_mbps": 428.22,
-   "decompress_mbps": 1889.16
+   "compress_mbps": 427.07,
+   "decompress_mbps": 1882.3
   },
   {
    "compressor": "libdeflate",
@@ -7514,8 +7514,8 @@
    "level": 4,
    "out_size": 3431843,
    "ratio": 0.1023,
-   "compress_mbps": 388.47,
-   "decompress_mbps": 1855.62
+   "compress_mbps": 388.74,
+   "decompress_mbps": 1763.39
   },
   {
    "compressor": "libdeflate",
@@ -7524,8 +7524,8 @@
    "level": 5,
    "out_size": 3268188,
    "ratio": 0.0974,
-   "compress_mbps": 347.32,
-   "decompress_mbps": 1750.89
+   "compress_mbps": 346.67,
+   "decompress_mbps": 1777.54
   },
   {
    "compressor": "libdeflate",
@@ -7534,8 +7534,8 @@
    "level": 6,
    "out_size": 3091741,
    "ratio": 0.0921,
-   "compress_mbps": 264.67,
-   "decompress_mbps": 1842.8
+   "compress_mbps": 264.16,
+   "decompress_mbps": 1787.13
   },
   {
    "compressor": "libdeflate",
@@ -7544,8 +7544,8 @@
    "level": 7,
    "out_size": 3032499,
    "ratio": 0.0904,
-   "compress_mbps": 186.26,
-   "decompress_mbps": 1809.44
+   "compress_mbps": 186.41,
+   "decompress_mbps": 1846.22
   },
   {
    "compressor": "libdeflate",
@@ -7554,8 +7554,8 @@
    "level": 8,
    "out_size": 2949097,
    "ratio": 0.0879,
-   "compress_mbps": 97.52,
-   "decompress_mbps": 1788.33
+   "compress_mbps": 97.63,
+   "decompress_mbps": 1789.45
   },
   {
    "compressor": "libdeflate",
@@ -7564,8 +7564,8 @@
    "level": 9,
    "out_size": 2925243,
    "ratio": 0.0872,
-   "compress_mbps": 69.09,
-   "decompress_mbps": 1844.29
+   "compress_mbps": 69.23,
+   "decompress_mbps": 1757.94
   },
   {
    "compressor": "libdeflate",
@@ -7574,8 +7574,8 @@
    "level": 1,
    "out_size": 3275124,
    "ratio": 0.5324,
-   "compress_mbps": 166.43,
-   "decompress_mbps": 463.32
+   "compress_mbps": 166.26,
+   "decompress_mbps": 462.6
   },
   {
    "compressor": "libdeflate",
@@ -7584,8 +7584,8 @@
    "level": 2,
    "out_size": 3150806,
    "ratio": 0.5121,
-   "compress_mbps": 127.91,
-   "decompress_mbps": 493.52
+   "compress_mbps": 128.39,
+   "decompress_mbps": 483.21
   },
   {
    "compressor": "libdeflate",
@@ -7594,8 +7594,8 @@
    "level": 3,
    "out_size": 3137061,
    "ratio": 0.5099,
-   "compress_mbps": 121.99,
-   "decompress_mbps": 505.69
+   "compress_mbps": 120.82,
+   "decompress_mbps": 502.43
   },
   {
    "compressor": "libdeflate",
@@ -7604,8 +7604,8 @@
    "level": 4,
    "out_size": 3129676,
    "ratio": 0.5087,
-   "compress_mbps": 118.35,
-   "decompress_mbps": 510.19
+   "compress_mbps": 116.89,
+   "decompress_mbps": 518.56
   },
   {
    "compressor": "libdeflate",
@@ -7614,8 +7614,8 @@
    "level": 5,
    "out_size": 3079277,
    "ratio": 0.5005,
-   "compress_mbps": 99.95,
-   "decompress_mbps": 527.83
+   "compress_mbps": 99.99,
+   "decompress_mbps": 536.74
   },
   {
    "compressor": "libdeflate",
@@ -7624,8 +7624,8 @@
    "level": 6,
    "out_size": 3072378,
    "ratio": 0.4994,
-   "compress_mbps": 88.97,
-   "decompress_mbps": 544.41
+   "compress_mbps": 88.82,
+   "decompress_mbps": 533.12
   },
   {
    "compressor": "libdeflate",
@@ -7634,8 +7634,8 @@
    "level": 7,
    "out_size": 3068123,
    "ratio": 0.4987,
-   "compress_mbps": 76.13,
-   "decompress_mbps": 535.41
+   "compress_mbps": 76.38,
+   "decompress_mbps": 542.11
   },
   {
    "compressor": "libdeflate",
@@ -7644,8 +7644,8 @@
    "level": 8,
    "out_size": 3067299,
    "ratio": 0.4986,
-   "compress_mbps": 55.45,
-   "decompress_mbps": 539.41
+   "compress_mbps": 55.33,
+   "decompress_mbps": 533.57
   },
   {
    "compressor": "libdeflate",
@@ -7654,8 +7654,8 @@
    "level": 9,
    "out_size": 3066968,
    "ratio": 0.4985,
-   "compress_mbps": 50.13,
-   "decompress_mbps": 528.48
+   "compress_mbps": 49.23,
+   "decompress_mbps": 507.58
   },
   {
    "compressor": "libdeflate",
@@ -7664,8 +7664,8 @@
    "level": 1,
    "out_size": 3868663,
    "ratio": 0.3836,
-   "compress_mbps": 287.22,
-   "decompress_mbps": 772.72
+   "compress_mbps": 285.16,
+   "decompress_mbps": 772.78
   },
   {
    "compressor": "libdeflate",
@@ -7674,8 +7674,8 @@
    "level": 2,
    "out_size": 3839158,
    "ratio": 0.3807,
-   "compress_mbps": 212.88,
-   "decompress_mbps": 912.26
+   "compress_mbps": 213.22,
+   "decompress_mbps": 914.82
   },
   {
    "compressor": "libdeflate",
@@ -7684,8 +7684,8 @@
    "level": 3,
    "out_size": 3818964,
    "ratio": 0.3787,
-   "compress_mbps": 197.38,
-   "decompress_mbps": 933.64
+   "compress_mbps": 197.74,
+   "decompress_mbps": 936.61
   },
   {
    "compressor": "libdeflate",
@@ -7694,8 +7694,8 @@
    "level": 4,
    "out_size": 3789325,
    "ratio": 0.3757,
-   "compress_mbps": 179.54,
-   "decompress_mbps": 957.12
+   "compress_mbps": 179.66,
+   "decompress_mbps": 954.8
   },
   {
    "compressor": "libdeflate",
@@ -7704,8 +7704,8 @@
    "level": 5,
    "out_size": 3666476,
    "ratio": 0.3635,
-   "compress_mbps": 156.54,
-   "decompress_mbps": 953.29
+   "compress_mbps": 157.89,
+   "decompress_mbps": 942.54
   },
   {
    "compressor": "libdeflate",
@@ -7714,8 +7714,8 @@
    "level": 6,
    "out_size": 3660266,
    "ratio": 0.3629,
-   "compress_mbps": 141.18,
-   "decompress_mbps": 1000.5
+   "compress_mbps": 142.43,
+   "decompress_mbps": 987.45
   },
   {
    "compressor": "libdeflate",
@@ -7724,8 +7724,8 @@
    "level": 7,
    "out_size": 3659491,
    "ratio": 0.3628,
-   "compress_mbps": 134.42,
-   "decompress_mbps": 1001.88
+   "compress_mbps": 135.11,
+   "decompress_mbps": 999.79
   },
   {
    "compressor": "libdeflate",
@@ -7734,8 +7734,8 @@
    "level": 8,
    "out_size": 3654863,
    "ratio": 0.3624,
-   "compress_mbps": 114.88,
-   "decompress_mbps": 1014.45
+   "compress_mbps": 114.32,
+   "decompress_mbps": 1009.23
   },
   {
    "compressor": "libdeflate",
@@ -7744,8 +7744,8 @@
    "level": 9,
    "out_size": 3654860,
    "ratio": 0.3624,
-   "compress_mbps": 115.03,
-   "decompress_mbps": 997.39
+   "compress_mbps": 114.27,
+   "decompress_mbps": 1001.2
   },
   {
    "compressor": "libdeflate",
@@ -7754,8 +7754,8 @@
    "level": 1,
    "out_size": 2197055,
    "ratio": 0.3315,
-   "compress_mbps": 301.19,
-   "decompress_mbps": 882.45
+   "compress_mbps": 300.85,
+   "decompress_mbps": 858.37
   },
   {
    "compressor": "libdeflate",
@@ -7764,8 +7764,8 @@
    "level": 2,
    "out_size": 2082309,
    "ratio": 0.3142,
-   "compress_mbps": 213.98,
-   "decompress_mbps": 1112.62
+   "compress_mbps": 214.77,
+   "decompress_mbps": 1130.12
   },
   {
    "compressor": "libdeflate",
@@ -7774,8 +7774,8 @@
    "level": 3,
    "out_size": 2021047,
    "ratio": 0.305,
-   "compress_mbps": 178.28,
-   "decompress_mbps": 1247.02
+   "compress_mbps": 178.67,
+   "decompress_mbps": 1236.6
   },
   {
    "compressor": "libdeflate",
@@ -7784,8 +7784,8 @@
    "level": 4,
    "out_size": 1990952,
    "ratio": 0.3004,
-   "compress_mbps": 158.5,
-   "decompress_mbps": 1172.21
+   "compress_mbps": 157.4,
+   "decompress_mbps": 1146.54
   },
   {
    "compressor": "libdeflate",
@@ -7794,8 +7794,8 @@
    "level": 5,
    "out_size": 1921113,
    "ratio": 0.2899,
-   "compress_mbps": 127.85,
-   "decompress_mbps": 1100.52
+   "compress_mbps": 127.99,
+   "decompress_mbps": 1093.81
   },
   {
    "compressor": "libdeflate",
@@ -7804,8 +7804,8 @@
    "level": 6,
    "out_size": 1876257,
    "ratio": 0.2831,
-   "compress_mbps": 87.16,
-   "decompress_mbps": 1098.71
+   "compress_mbps": 86.94,
+   "decompress_mbps": 1090.38
   },
   {
    "compressor": "libdeflate",
@@ -7814,8 +7814,8 @@
    "level": 7,
    "out_size": 1832695,
    "ratio": 0.2765,
-   "compress_mbps": 46.51,
-   "decompress_mbps": 1112.02
+   "compress_mbps": 46.02,
+   "decompress_mbps": 1103.5
   },
   {
    "compressor": "libdeflate",
@@ -7824,8 +7824,8 @@
    "level": 8,
    "out_size": 1809967,
    "ratio": 0.2731,
-   "compress_mbps": 24.22,
-   "decompress_mbps": 1069.25
+   "compress_mbps": 24.27,
+   "decompress_mbps": 1063.53
   },
   {
    "compressor": "libdeflate",
@@ -7834,8 +7834,8 @@
    "level": 9,
    "out_size": 1806374,
    "ratio": 0.2726,
-   "compress_mbps": 19.81,
-   "decompress_mbps": 1095.46
+   "compress_mbps": 19.83,
+   "decompress_mbps": 1054.62
   },
   {
    "compressor": "libdeflate",
@@ -7844,8 +7844,8 @@
    "level": 1,
    "out_size": 5866517,
    "ratio": 0.2715,
-   "compress_mbps": 340.25,
-   "decompress_mbps": 913.52
+   "compress_mbps": 338.52,
+   "decompress_mbps": 979.15
   },
   {
    "compressor": "libdeflate",
@@ -7854,8 +7854,8 @@
    "level": 2,
    "out_size": 5695942,
    "ratio": 0.2636,
-   "compress_mbps": 258.87,
-   "decompress_mbps": 1066.8
+   "compress_mbps": 258.0,
+   "decompress_mbps": 1031.45
   },
   {
    "compressor": "libdeflate",
@@ -7864,8 +7864,8 @@
    "level": 3,
    "out_size": 5605878,
    "ratio": 0.2595,
-   "compress_mbps": 235.77,
-   "decompress_mbps": 1112.43
+   "compress_mbps": 233.32,
+   "decompress_mbps": 1100.86
   },
   {
    "compressor": "libdeflate",
@@ -7874,8 +7874,8 @@
    "level": 4,
    "out_size": 5553432,
    "ratio": 0.257,
-   "compress_mbps": 218.44,
-   "decompress_mbps": 1099.73
+   "compress_mbps": 216.59,
+   "decompress_mbps": 1079.15
   },
   {
    "compressor": "libdeflate",
@@ -7884,8 +7884,8 @@
    "level": 5,
    "out_size": 5416713,
    "ratio": 0.2507,
-   "compress_mbps": 186.56,
-   "decompress_mbps": 1093.56
+   "compress_mbps": 186.71,
+   "decompress_mbps": 1066.93
   },
   {
    "compressor": "libdeflate",
@@ -7894,8 +7894,8 @@
    "level": 6,
    "out_size": 5337149,
    "ratio": 0.247,
-   "compress_mbps": 143.73,
-   "decompress_mbps": 1112.12
+   "compress_mbps": 142.78,
+   "decompress_mbps": 1079.29
   },
   {
    "compressor": "libdeflate",
@@ -7904,8 +7904,8 @@
    "level": 7,
    "out_size": 5310181,
    "ratio": 0.2458,
-   "compress_mbps": 100.22,
-   "decompress_mbps": 1086.54
+   "compress_mbps": 100.23,
+   "decompress_mbps": 1069.71
   },
   {
    "compressor": "libdeflate",
@@ -7914,8 +7914,8 @@
    "level": 8,
    "out_size": 5272761,
    "ratio": 0.244,
-   "compress_mbps": 62.28,
-   "decompress_mbps": 1105.35
+   "compress_mbps": 62.39,
+   "decompress_mbps": 1089.17
   },
   {
    "compressor": "libdeflate",
@@ -7924,8 +7924,8 @@
    "level": 9,
    "out_size": 5270405,
    "ratio": 0.2439,
-   "compress_mbps": 50.01,
-   "decompress_mbps": 1102.39
+   "compress_mbps": 50.04,
+   "decompress_mbps": 1101.61
   },
   {
    "compressor": "libdeflate",
@@ -7934,8 +7934,8 @@
    "level": 1,
    "out_size": 5575128,
    "ratio": 0.7688,
-   "compress_mbps": 162.61,
-   "decompress_mbps": 486.6
+   "compress_mbps": 162.23,
+   "decompress_mbps": 485.07
   },
   {
    "compressor": "libdeflate",
@@ -7944,8 +7944,8 @@
    "level": 2,
    "out_size": 5417142,
    "ratio": 0.747,
-   "compress_mbps": 117.06,
-   "decompress_mbps": 514.89
+   "compress_mbps": 116.65,
+   "decompress_mbps": 518.27
   },
   {
    "compressor": "libdeflate",
@@ -7954,8 +7954,8 @@
    "level": 3,
    "out_size": 5397999,
    "ratio": 0.7444,
-   "compress_mbps": 105.54,
-   "decompress_mbps": 528.01
+   "compress_mbps": 105.25,
+   "decompress_mbps": 528.2
   },
   {
    "compressor": "libdeflate",
@@ -7964,8 +7964,8 @@
    "level": 4,
    "out_size": 5391125,
    "ratio": 0.7434,
-   "compress_mbps": 99.63,
-   "decompress_mbps": 538.68
+   "compress_mbps": 99.31,
+   "decompress_mbps": 542.53
   },
   {
    "compressor": "libdeflate",
@@ -7974,8 +7974,8 @@
    "level": 5,
    "out_size": 5352212,
    "ratio": 0.738,
-   "compress_mbps": 86.74,
-   "decompress_mbps": 512.9
+   "compress_mbps": 87.58,
+   "decompress_mbps": 513.46
   },
   {
    "compressor": "libdeflate",
@@ -7984,8 +7984,8 @@
    "level": 6,
    "out_size": 5335405,
    "ratio": 0.7357,
-   "compress_mbps": 73.38,
-   "decompress_mbps": 532.08
+   "compress_mbps": 73.79,
+   "decompress_mbps": 526.1
   },
   {
    "compressor": "libdeflate",
@@ -7994,8 +7994,8 @@
    "level": 7,
    "out_size": 5325697,
    "ratio": 0.7344,
-   "compress_mbps": 63.24,
-   "decompress_mbps": 529.71
+   "compress_mbps": 63.45,
+   "decompress_mbps": 513.46
   },
   {
    "compressor": "libdeflate",
@@ -8004,8 +8004,8 @@
    "level": 8,
    "out_size": 5324004,
    "ratio": 0.7341,
-   "compress_mbps": 52.63,
-   "decompress_mbps": 530.0
+   "compress_mbps": 52.34,
+   "decompress_mbps": 522.62
   },
   {
    "compressor": "libdeflate",
@@ -8014,8 +8014,8 @@
    "level": 9,
    "out_size": 5323197,
    "ratio": 0.734,
-   "compress_mbps": 50.8,
-   "decompress_mbps": 535.0
+   "compress_mbps": 50.85,
+   "decompress_mbps": 511.04
   },
   {
    "compressor": "libdeflate",
@@ -8024,8 +8024,8 @@
    "level": 1,
    "out_size": 13550569,
    "ratio": 0.3268,
-   "compress_mbps": 267.32,
-   "decompress_mbps": 828.33
+   "compress_mbps": 266.06,
+   "decompress_mbps": 891.09
   },
   {
    "compressor": "libdeflate",
@@ -8034,8 +8034,8 @@
    "level": 2,
    "out_size": 13130705,
    "ratio": 0.3167,
-   "compress_mbps": 201.17,
-   "decompress_mbps": 977.83
+   "compress_mbps": 199.84,
+   "decompress_mbps": 973.65
   },
   {
    "compressor": "libdeflate",
@@ -8044,8 +8044,8 @@
    "level": 3,
    "out_size": 12839361,
    "ratio": 0.3097,
-   "compress_mbps": 178.79,
-   "decompress_mbps": 1037.82
+   "compress_mbps": 176.74,
+   "decompress_mbps": 1015.15
   },
   {
    "compressor": "libdeflate",
@@ -8054,8 +8054,8 @@
    "level": 4,
    "out_size": 12601933,
    "ratio": 0.304,
-   "compress_mbps": 163.54,
-   "decompress_mbps": 923.46
+   "compress_mbps": 161.98,
+   "decompress_mbps": 899.79
   },
   {
    "compressor": "libdeflate",
@@ -8064,8 +8064,8 @@
    "level": 5,
    "out_size": 12310776,
    "ratio": 0.2969,
-   "compress_mbps": 132.79,
-   "decompress_mbps": 882.71
+   "compress_mbps": 131.58,
+   "decompress_mbps": 879.58
   },
   {
    "compressor": "libdeflate",
@@ -8074,8 +8074,8 @@
    "level": 6,
    "out_size": 12140474,
    "ratio": 0.2928,
-   "compress_mbps": 104.66,
-   "decompress_mbps": 894.6
+   "compress_mbps": 104.62,
+   "decompress_mbps": 887.92
   },
   {
    "compressor": "libdeflate",
@@ -8084,8 +8084,8 @@
    "level": 7,
    "out_size": 12025296,
    "ratio": 0.2901,
-   "compress_mbps": 72.39,
-   "decompress_mbps": 907.96
+   "compress_mbps": 75.01,
+   "decompress_mbps": 892.91
   },
   {
    "compressor": "libdeflate",
@@ -8094,8 +8094,8 @@
    "level": 8,
    "out_size": 11893824,
    "ratio": 0.2869,
-   "compress_mbps": 45.96,
-   "decompress_mbps": 891.22
+   "compress_mbps": 45.87,
+   "decompress_mbps": 886.31
   },
   {
    "compressor": "libdeflate",
@@ -8104,8 +8104,8 @@
    "level": 9,
    "out_size": 11882496,
    "ratio": 0.2866,
-   "compress_mbps": 39.48,
-   "decompress_mbps": 899.94
+   "compress_mbps": 39.46,
+   "decompress_mbps": 930.2
   },
   {
    "compressor": "libdeflate",
@@ -8114,8 +8114,8 @@
    "level": 1,
    "out_size": 6293390,
    "ratio": 0.7426,
-   "compress_mbps": 146.95,
-   "decompress_mbps": 521.91
+   "compress_mbps": 145.39,
+   "decompress_mbps": 523.59
   },
   {
    "compressor": "libdeflate",
@@ -8124,8 +8124,8 @@
    "level": 2,
    "out_size": 6058412,
    "ratio": 0.7149,
-   "compress_mbps": 119.59,
-   "decompress_mbps": 529.24
+   "compress_mbps": 120.35,
+   "decompress_mbps": 529.46
   },
   {
    "compressor": "libdeflate",
@@ -8134,8 +8134,8 @@
    "level": 3,
    "out_size": 6058381,
    "ratio": 0.7149,
-   "compress_mbps": 120.02,
-   "decompress_mbps": 541.76
+   "compress_mbps": 120.3,
+   "decompress_mbps": 539.19
   },
   {
    "compressor": "libdeflate",
@@ -8144,8 +8144,8 @@
    "level": 4,
    "out_size": 6058363,
    "ratio": 0.7149,
-   "compress_mbps": 119.96,
-   "decompress_mbps": 431.91
+   "compress_mbps": 120.03,
+   "decompress_mbps": 437.57
   },
   {
    "compressor": "libdeflate",
@@ -8154,8 +8154,8 @@
    "level": 5,
    "out_size": 5998400,
    "ratio": 0.7078,
-   "compress_mbps": 106.11,
-   "decompress_mbps": 455.98
+   "compress_mbps": 108.52,
+   "decompress_mbps": 459.54
   },
   {
    "compressor": "libdeflate",
@@ -8164,8 +8164,8 @@
    "level": 6,
    "out_size": 5998438,
    "ratio": 0.7078,
-   "compress_mbps": 106.4,
-   "decompress_mbps": 459.47
+   "compress_mbps": 108.55,
+   "decompress_mbps": 463.75
   },
   {
    "compressor": "libdeflate",
@@ -8174,8 +8174,8 @@
    "level": 7,
    "out_size": 5998439,
    "ratio": 0.7078,
-   "compress_mbps": 106.38,
-   "decompress_mbps": 462.95
+   "compress_mbps": 108.18,
+   "decompress_mbps": 462.69
   },
   {
    "compressor": "libdeflate",
@@ -8184,8 +8184,8 @@
    "level": 8,
    "out_size": 5986859,
    "ratio": 0.7065,
-   "compress_mbps": 89.81,
-   "decompress_mbps": 460.6
+   "compress_mbps": 90.15,
+   "decompress_mbps": 462.82
   },
   {
    "compressor": "libdeflate",
@@ -8194,8 +8194,8 @@
    "level": 9,
    "out_size": 5986859,
    "ratio": 0.7065,
-   "compress_mbps": 89.94,
-   "decompress_mbps": 455.68
+   "compress_mbps": 90.18,
+   "decompress_mbps": 454.72
   },
   {
    "compressor": "libdeflate",
@@ -8204,8 +8204,8 @@
    "level": 1,
    "out_size": 887708,
    "ratio": 0.1661,
-   "compress_mbps": 488.17,
-   "decompress_mbps": 1435.22
+   "compress_mbps": 492.83,
+   "decompress_mbps": 1270.45
   },
   {
    "compressor": "libdeflate",
@@ -8214,8 +8214,8 @@
    "level": 2,
    "out_size": 843475,
    "ratio": 0.1578,
-   "compress_mbps": 360.78,
-   "decompress_mbps": 1807.54
+   "compress_mbps": 363.79,
+   "decompress_mbps": 1801.54
   },
   {
    "compressor": "libdeflate",
@@ -8224,8 +8224,8 @@
    "level": 3,
    "out_size": 793388,
    "ratio": 0.1484,
-   "compress_mbps": 335.82,
-   "decompress_mbps": 1924.87
+   "compress_mbps": 337.16,
+   "decompress_mbps": 1867.27
   },
   {
    "compressor": "libdeflate",
@@ -8234,8 +8234,8 @@
    "level": 4,
    "out_size": 747602,
    "ratio": 0.1399,
-   "compress_mbps": 302.16,
-   "decompress_mbps": 1812.67
+   "compress_mbps": 304.24,
+   "decompress_mbps": 1819.5
   },
   {
    "compressor": "libdeflate",
@@ -8244,8 +8244,8 @@
    "level": 5,
    "out_size": 718615,
    "ratio": 0.1344,
-   "compress_mbps": 261.18,
-   "decompress_mbps": 1822.06
+   "compress_mbps": 263.07,
+   "decompress_mbps": 1830.67
   },
   {
    "compressor": "libdeflate",
@@ -8254,8 +8254,8 @@
    "level": 6,
    "out_size": 684405,
    "ratio": 0.128,
-   "compress_mbps": 205.14,
-   "decompress_mbps": 1905.29
+   "compress_mbps": 206.4,
+   "decompress_mbps": 1920.08
   },
   {
    "compressor": "libdeflate",
@@ -8264,8 +8264,8 @@
    "level": 7,
    "out_size": 664859,
    "ratio": 0.1244,
-   "compress_mbps": 142.19,
-   "decompress_mbps": 1863.45
+   "compress_mbps": 142.72,
+   "decompress_mbps": 1906.99
   },
   {
    "compressor": "libdeflate",
@@ -8274,8 +8274,8 @@
    "level": 8,
    "out_size": 650835,
    "ratio": 0.1218,
-   "compress_mbps": 84.32,
-   "decompress_mbps": 1894.64
+   "compress_mbps": 81.56,
+   "decompress_mbps": 1892.16
   },
   {
    "compressor": "libdeflate",
@@ -8284,8 +8284,8 @@
    "level": 9,
    "out_size": 649494,
    "ratio": 0.1215,
-   "compress_mbps": 68.05,
-   "decompress_mbps": 1897.25
+   "compress_mbps": 68.13,
+   "decompress_mbps": 1902.14
   },
   {
    "compressor": "go",


### PR DESCRIPTION
This PR hashes 4 bytes instead of 3 into the LZ77 chain buckets. The chain walk (`chainWalkPacked`) is 65% of L6 compress time and its cost is the chain length — the number of positions sharing a bucket. Hashing 4 bytes (a multiplicative high-bit mix of bytes `pos..pos+3`, then `% hashSize` for the bound) sends positions that share only a 3-byte prefix to different buckets, so chains are much shorter: fewer `chainWalkPacked` iterations, and the surviving 4-gram candidates are higher quality so the early-exit fires sooner.

It is a frontier push, not a move along the speed/ratio curve: on text and repetitive data it is both faster AND better ratio, because the shorter chains walk faster while the 4-gram candidates yield longer matches within the same depth budget. The 4th byte uses a guarded read (0 past the end of the buffer), so the per-position guard and the whole matcher structure are unchanged.

All three `hash3` copies change identically, so `hash3_eq` and every proof that uses the hash as an opaque `< hashSize` index still hold: 0 sorries, no proof changes, full test suite green (roundtrip conformance).

Measured on 2 MB Silesia slices versus the prefilter+gate baseline:
- text: L4 +38%, L6 +58% speed; ratio 38.47% -> 38.06% (better)
- repetitive: L4 +8%, L6 +21% speed; ratio 10.77% -> 10.29% (better)
- binary: L4 +43%, L6 +59% speed; ratio 73.71% -> 75.17% (worse ~2%)

The ratio cost lands only on barely-compressible binary, where the skipped length-3 matches still help and native is not ratio-competitive regardless. Text and repetitive — the bulk of the corpus — improve on both axes. Text L6 13.5 -> 21.3 MB/s closes most of the gap to fflate (28.8) while keeping a ratio lead.

🤖 Prepared with Claude Code