### PR TITLE
fix: restore L9 optimal-parse ratio — 3-byte hash for the candidate cache

### DIFF
--- a/Zip/Native/DeflateParse.lean
+++ b/Zip/Native/DeflateParse.lean
@@ -156,6 +156,18 @@ decreasing_by all_goals omega
   else
     chainWalkAll data prev pos maxLen hpm cand fuel bestLen k slotBase lens dists
 
+/-- 3-byte chain hash for the L9 candidate cache. The optimal parser maximises
+    *ratio*, so it must see every candidate — including length-3 matches. The
+    L1-L8 matchers switched to a 4-byte hash for speed (#2620), which drops
+    positions that share only a 3-byte prefix; on binary that measurably hurt the
+    L9 parse (x-ray +7.4%, ooffice +3.5% ratio). So the cache keeps the original
+    3-byte hash. Heuristic — opaque to correctness (the cache never enters a proof). -/
+@[inline] def hash3opt (data : ByteArray) (pos hashSize : Nat) (h : pos + 2 < data.size) : Nat :=
+  let a := (data[pos]'(by omega)).toUInt32
+  let b := (data[pos + 1]'(by omega)).toUInt32
+  let c := (data[pos + 2]'(by omega)).toUInt32
+  ((a ^^^ (b <<< 5) ^^^ (c <<< 10)).toNat % hashSize)
+
 /-- Build the candidate cache for region `[base, base + r)`: at **every**
     position (the DP can land anywhere, so none may be skipped) insert the
     position into the hash chains and record its candidate frontier.
@@ -173,7 +185,7 @@ def buildCache (data : ByteArray) (hashTable prev : Array Nat) (depth slots base
   if hj : j < r then
     let pos := base + j
     if hlt : pos + 2 < data.size then
-      let h := lz77Greedy.hash3 data pos 65536 hlt
+      let h := hash3opt data pos 65536 hlt
       let head := headProbeGuarded hashTable h
       let hashTable := guardedSet hashTable h pos
       let prev := guardedSet prev pos head


### PR DESCRIPTION
This PR restores the L9 (max-ratio, close-to-zopfli) optimal-parse compression ratio that the 4-byte chain hash (#2620) quietly regressed. The 4-byte hash is a real compress *speed* win for L1-L8, but it cannot find length-3 matches: positions sharing only a 3-byte prefix now hash to different buckets. The L9 optimal parser builds its candidate cache (`buildCache`) from the shared `lz77Greedy.hash3`, so it inherited that loss, and on binary inputs the dropped length-3 candidates measurably hurt the parse — native L9 ratio regressed by a mean +2.0% across Silesia (x-ray +7.4%, ooffice +3.5%, mozilla +2.7%, sao +1.9%; text roughly neutral). L9 is the tier where ratio matters far more than speed, so that is the wrong trade there.

Give the L9 candidate cache its own 3-byte hash (`hash3opt`, the exact pre-#2620 XOR-shift), restoring the full candidate set and the pre-#2620 L9 ratio, while L1-L8 keep the 4-byte hash for speed. Same-slice A/B: x-ray 69.04 -> 65.32% (-5.4%), ooffice 56.24 -> 54.57%, sao 73.60 -> 72.56%, dickens (text) +0.2%. L9 is about 17% slower, the right trade for a ratio-priority tier.

The candidate cache is heuristic and opaque to correctness (match validity is re-established at emission by `countMatch`/`chainWalk_spec`), so this is proof-free. 0 sorries, all tests green.

🤖 Prepared with Claude Code