### PR TITLE
chore: add perf-pr-graphs skill (before/after bench graphs before merge)

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -65,33 +65,72 @@ project `.claude/CLAUDE.md`); elsewhere run them directly.
    when you only care about decode). For a **compress** PR, keep all 9 levels —
    L9 is usually the point.
 
-4. **Measure BEFORE** (master's native path), without disturbing the branch:
+4. **Measure BEFORE** (the branch's native path *without this PR's commits*),
+   without disturbing the branch. **Baseline against the branch's merge-base with
+   master — NOT `origin/master` directly.** If the branch is behind master,
+   swapping in `origin/master`'s files pulls in *unrelated* perf commits that
+   touched the same files, so "before" ends up faster (or slower) for reasons that
+   have nothing to do with this PR, and the graph shows a phantom regression. The
+   merge-base is the exact point the branch diverged, so swapping its files
+   isolates only this PR's changes.
+
+   First check how stale the branch is, then swap in the merge-base versions of
+   only the files this PR changed:
    ```
    git fetch origin -q
-   # swap in master's versions of ONLY the files this PR changed, e.g.:
-   git checkout origin/master -- Zip/Native/Inflate.lean Zip/Spec/InflateBufCorrect.lean
+   base=$(git merge-base origin/master HEAD)
+   behind=$(git rev-list --count HEAD..origin/master)
+   [ "$behind" -gt 0 ] && echo "NOTE: branch is $behind commits behind master; \
+baselining against merge-base ${base:0:8} (NOT origin/master) so unrelated \
+commits don't leak into 'before'."
+   # files this PR changed, relative to the divergence point:
+   git diff --name-only "$base"...HEAD
+   # swap ONLY those to their merge-base version, e.g.:
+   git checkout "$base" -- Zip/Native/Inflate.lean Zip/Spec/InflateBufCorrect.lean
    lake build bench-report
    lake env .lake/build/bin/bench-report --native-only /tmp/perf_before.json   # same level list as step 3
    git checkout HEAD -- Zip/Native/Inflate.lean Zip/Spec/InflateBufCorrect.lean # restore branch
    ```
-   Use `git diff --name-only origin/master...HEAD` to see which files to swap.
-   Always restore with `git checkout HEAD -- <files>` and confirm `git status`
-   is clean afterwards.
+   Always restore with `git checkout HEAD -- <files>` and confirm `git status` is
+   clean afterwards. (For a single-commit PR, `$base` and `HEAD~1` coincide.)
 
-5. **Plot** (other-language curves are reused from `latest.json`, never
-   re-measured):
+5. **Sanity-check before plotting.** Two independent checks — they catch
+   different failures, so read both:
+   - **Output-neutrality (`max |Δratio|`, printed by the plotter).** A PR that
+     does not change *output* (a dispatch/escape, a re-timed loop, a proof-side
+     refactor) **must** show `max |Δratio| = 0.000000`. A nonzero value means the
+     change is not output-neutral after all (or, rarely, the two runs saw
+     different corpora). A PR that *intends* to change the parse (better ratio)
+     shows a nonzero Δratio — that is the point; confirm it moves the right way.
+   - **Baseline correctness (the staleness guard from step 4).** Note that
+     `max |Δratio|` does **not** catch a stale-branch baseline: if "before" leaked
+     in an unrelated perf commit that touched the same files, both still produce
+     identical output, so Δratio stays `0.000000` while the *speed* curve is
+     silently wrong (this is the classic phantom regression — "before" looks
+     faster than "after" for reasons unrelated to the PR). The only defence is
+     step 4's `behind` check: if the branch was behind master and you baselined
+     against `origin/master` instead of the merge-base, redo step 4.
+
+6. **Plot** (other-language curves are reused from `latest.json`, never
+   re-measured). The graphs are a report artifact — write them to the gitignored
+   `/tmp` so they can never be accidentally committed to the perf PR:
    ```
    python3 .claude/skills/perf-pr-graphs/plot_before_after.py \
-     /tmp/perf_before.json /tmp/perf_after.json <compress_mbps|decompress_mbps>
+     /tmp/perf_before.json /tmp/perf_after.json <compress_mbps|decompress_mbps> \
+     bench/results/latest.json /tmp
    ```
-   This writes `bench/graphs/perf_before_after_<metric>_<corpus>.{svg,png}`
-   (UNCOMMITTED — they show as untracked; do not `git add` them to the perf PR)
-   and prints a per-level before/after geomean table.
+   This writes `/tmp/perf_before_after_<metric>_<corpus>.{svg,png}` and prints the
+   per-level before/after geomean table plus `max |Δratio|`.
 
-6. **Show Kim and wait.** Read the PNGs back so they render, present the
+7. **Show Kim and wait.** Read the PNGs back so they render, present the
    before/after geomean tables and the per-corpus speedup, and **stop for Kim's
    go-ahead before merging.** State the metric, the machine, and any caveat
    (e.g. machine mismatch, levels skipped, ratio shift on a compress change).
+   Quote the numeric speedup — the y-axis is log, so trust the table, not the eye
+   (see Notes). **Canterbury is measured median-of-5 and is the row set to read
+   for a speed verdict; Silesia is single-pass (`reps=1`), so its per-file MB/s
+   carries ±30%+ run-to-run noise even on byte-identical code — use it for ratio
+   and coverage, not for a fine speed delta.**
 
 ## Notes
 
@@ -103,5 +142,6 @@ project `.claude/CLAUDE.md`); elsewhere run them directly.
   the ratio (curve moves right) may not be a net win. zopfli's frozen ratio
   ceiling is in `bench/results/zopfli-ceiling.json` if you want the best-ratio
   reference.
-- Keep the temporary jsons in `/tmp`; clean up swapped-in source files before
-  finishing (`git status` must be clean on the PR branch).
+- Keep the temporary jsons and graphs in `/tmp`; restore any swapped-in source
+  files before finishing (`git status` must be clean on the PR branch — a leftover
+  merge-base checkout or a stray graph under `bench/graphs/` is a real footgun).

--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -65,34 +65,40 @@ project `.claude/CLAUDE.md`); elsewhere run them directly.
    when you only care about decode). For a **compress** PR, keep all 9 levels —
    L9 is usually the point.
 
-4. **Measure BEFORE** (the branch's native path *without this PR's commits*),
-   without disturbing the branch. **Baseline against the branch's merge-base with
-   master — NOT `origin/master` directly.** If the branch is behind master,
-   swapping in `origin/master`'s files pulls in *unrelated* perf commits that
-   touched the same files, so "before" ends up faster (or slower) for reasons that
-   have nothing to do with this PR, and the graph shows a phantom regression. The
-   merge-base is the exact point the branch diverged, so swapping its files
-   isolates only this PR's changes.
+4. **Measure BEFORE** (the branch's native path *without this PR's commits*).
+   **Build it in a throwaway worktree checked out at the branch's merge-base with
+   master — NOT at `origin/master`, and NOT by swapping files in place.**
 
-   First check how stale the branch is, then swap in the merge-base versions of
-   only the files this PR changed:
+   Why the merge-base: if the branch is behind master, `origin/master` contains
+   *unrelated* perf commits; any that touched a file this PR also touches would
+   leak into "before", making it faster (or slower) for reasons that have nothing
+   to do with the PR — a phantom regression on the speed curve. The merge-base is
+   the exact point the branch diverged, so it is master-minus-the-PR with no
+   extra commits.
+
+   Why a worktree and not `git checkout <base> -- <files>`: the in-place swap
+   forces you to guess "which files did the PR change" (miss a support module,
+   build file, generated table, or a rename/delete and "before" is a hybrid that
+   compiles HEAD code against base code), and it leaves the main worktree's build
+   artifacts in a stale state afterwards. A clean worktree at `$base` is the whole
+   tree at the divergence point — no guessing, no contamination:
    ```
    git fetch origin -q
    base=$(git merge-base origin/master HEAD)
    behind=$(git rev-list --count HEAD..origin/master)
    [ "$behind" -gt 0 ] && echo "NOTE: branch is $behind commits behind master; \
-baselining against merge-base ${base:0:8} (NOT origin/master) so unrelated \
-commits don't leak into 'before'."
-   # files this PR changed, relative to the divergence point:
-   git diff --name-only "$base"...HEAD
-   # swap ONLY those to their merge-base version, e.g.:
-   git checkout "$base" -- Zip/Native/Inflate.lean Zip/Spec/InflateBufCorrect.lean
-   lake build bench-report
-   lake env .lake/build/bin/bench-report --native-only /tmp/perf_before.json   # same level list as step 3
-   git checkout HEAD -- Zip/Native/Inflate.lean Zip/Spec/InflateBufCorrect.lean # restore branch
+baselining BEFORE at merge-base ${base:0:8} (not origin/master) so unrelated \
+commits don't leak in."
+   tmp="/tmp/perf-before-${base:0:8}"
+   git worktree add --detach "$tmp" "$base"
+   ( cd "$tmp" && lake build bench-report \
+       && lake env .lake/build/bin/bench-report --native-only /tmp/perf_before.json )  # same level list as step 3
+   git worktree remove --force "$tmp"
    ```
-   Always restore with `git checkout HEAD -- <files>` and confirm `git status` is
-   clean afterwards. (For a single-commit PR, `$base` and `HEAD~1` coincide.)
+   `bench-report` stamps the JSON `meta.git_commit` from the worktree's HEAD, so
+   `/tmp/perf_before.json`'s commit should equal `$base` — the plotter prints it
+   (step 6) for you to confirm. On NixOS the inner `cd` changes the nix-shell
+   working dir; run the whole `( … )` inside one `nix-shell --run "…"`.
 
 5. **Sanity-check before plotting.** Two independent checks — they catch
    different failures, so read both:
@@ -102,14 +108,16 @@ commits don't leak into 'before'."
      change is not output-neutral after all (or, rarely, the two runs saw
      different corpora). A PR that *intends* to change the parse (better ratio)
      shows a nonzero Δratio — that is the point; confirm it moves the right way.
-   - **Baseline correctness (the staleness guard from step 4).** Note that
-     `max |Δratio|` does **not** catch a stale-branch baseline: if "before" leaked
-     in an unrelated perf commit that touched the same files, both still produce
-     identical output, so Δratio stays `0.000000` while the *speed* curve is
-     silently wrong (this is the classic phantom regression — "before" looks
-     faster than "after" for reasons unrelated to the PR). The only defence is
-     step 4's `behind` check: if the branch was behind master and you baselined
-     against `origin/master` instead of the merge-base, redo step 4.
+   - **Baseline correctness.** `max |Δratio|` does **not** catch a stale-branch
+     baseline: if "before" leaked in an unrelated perf commit that touched the
+     same files, both still produce identical output, so Δratio stays `0.000000`
+     while the *speed* curve is silently wrong (the classic phantom regression —
+     "before" looks faster than "after" for reasons unrelated to the PR). The
+     defences are the merge-base worktree (step 4, which makes a hybrid tree
+     impossible) plus the commit/coverage line the plotter prints: confirm
+     BEFORE's `meta.git_commit` equals `$base` and that before/after cover the
+     same `(pattern, level)` rows. If BEFORE's commit is `origin/master` rather
+     than the merge-base, redo step 4.
 
 6. **Plot** (other-language curves are reused from `latest.json`, never
    re-measured). The graphs are a report artifact — write them to the gitignored
@@ -120,7 +128,9 @@ commits don't leak into 'before'."
      bench/results/latest.json /tmp
    ```
    This writes `/tmp/perf_before_after_<metric>_<corpus>.{svg,png}` and prints the
-   per-level before/after geomean table plus `max |Δratio|`.
+   before/after `meta` (machine + git_commit of each run), a row-coverage line
+   (any `(pattern, level)` present in one run but not the other), the per-level
+   before/after geomean table, and `max |Δratio|`.
 
 7. **Show Kim and wait.** Read the PNGs back so they render, present the
    before/after geomean tables and the per-corpus speedup, and **stop for Kim's

--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: perf-pr-graphs
+description: Produce before/after native speed-vs-ratio comparison graphs (against the other-language curves) and show them to Kim BEFORE merging. Use REQUIRED for any lean-zip performance PR (perf:/runtime/throughput change to compress or decode) once it is green and before it merges — Kim must see the graphs first. Most interesting for compression changes.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Pre-merge performance comparison graphs
+
+## When this is mandatory
+
+Any PR that changes runtime performance of the native path — anything titled
+`perf:`, or any change to `Zip/Native/Deflate*`, `Zip/Native/Inflate*`,
+`Zip/Native/LZ77*`, `Zip/Native/DeflateParse*`, the bit reader/writer, or the
+Huffman codec. **Do not merge such a PR until you have generated these graphs
+and Kim has seen them.** This is a required gate, not an optional nicety.
+
+The graphs show **native before vs after** on the real corpora (Canterbury +
+Silesia), overlaid on the existing other-language curves (zlib, miniz_oxide,
+libdeflate, Go, JS, Zig, OCaml) for context. They are a **report artifact —
+NOT committed** (the routine dashboard in `bench/graphs/*.svg` is regenerated
+separately by `bench/run.sh`).
+
+## Which metric
+
+- **Compression PR → `compress_mbps`.** This is the interesting case: a
+  compression change can move *both* the ratio and the speed, so the
+  speed-vs-ratio Pareto frontier is the thing to read — does native shift up
+  (faster at the same ratio) or right (worse ratio)?
+- **Decompression PR → `decompress_mbps`.** Decode speed does not trade off
+  against ratio, so this is just a throughput-vs-ratio scatter — still worth
+  showing, but less rich than the compress view.
+- A PR touching both: produce both sets.
+
+## Workflow
+
+Run from the repo root. On NixOS wrap commands in `nix-shell --run "…"` (see the
+project `.claude/CLAUDE.md`); elsewhere run them directly.
+
+1. **Confirm the machine matches the dashboard.** The overlay is only honest if
+   you measure on the same machine the committed other-language numbers used:
+   ```
+   uname -mns
+   python3 -c "import json;print(json.load(open('bench/results/latest.json'))['meta']['machine'])"
+   ```
+   If they differ, say so loudly in the report — the before/after delta is still
+   valid (same machine), but native-vs-other-language positioning is not.
+
+2. **Materialize the corpora.** Canterbury is committed; Silesia (~203 MB,
+   gitignored) is fetched on demand:
+   ```
+   [ -d bench/corpora/silesia ] && [ -n "$(ls -A bench/corpora/silesia 2>/dev/null)" ] \
+     || bash bench/fetch_corpora.sh silesia
+   ```
+
+3. **Measure AFTER** (the PR branch, already built):
+   ```
+   lake build bench-report
+   lake env .lake/build/bin/bench-report --native-only /tmp/perf_after.json
+   ```
+   `--native-only` records native `ratio`, `compress_mbps` and
+   `decompress_mbps` and reuses nothing else. For a **decode-only** PR, append a
+   level list that skips the slow L9 optimal-parse compress, e.g.
+   `… --native-only /tmp/perf_after.json 1,2,3,4,5,6,7,8` (decode is measured at
+   every listed level; native L9 *compress* on 203 MB is minutes of pure waste
+   when you only care about decode). For a **compress** PR, keep all 9 levels —
+   L9 is usually the point.
+
+4. **Measure BEFORE** (master's native path), without disturbing the branch:
+   ```
+   git fetch origin -q
+   # swap in master's versions of ONLY the files this PR changed, e.g.:
+   git checkout origin/master -- Zip/Native/Inflate.lean Zip/Spec/InflateBufCorrect.lean
+   lake build bench-report
+   lake env .lake/build/bin/bench-report --native-only /tmp/perf_before.json   # same level list as step 3
+   git checkout HEAD -- Zip/Native/Inflate.lean Zip/Spec/InflateBufCorrect.lean # restore branch
+   ```
+   Use `git diff --name-only origin/master...HEAD` to see which files to swap.
+   Always restore with `git checkout HEAD -- <files>` and confirm `git status`
+   is clean afterwards.
+
+5. **Plot** (other-language curves are reused from `latest.json`, never
+   re-measured):
+   ```
+   python3 .claude/skills/perf-pr-graphs/plot_before_after.py \
+     /tmp/perf_before.json /tmp/perf_after.json <compress_mbps|decompress_mbps>
+   ```
+   This writes `bench/graphs/perf_before_after_<metric>_<corpus>.{svg,png}`
+   (UNCOMMITTED — they show as untracked; do not `git add` them to the perf PR)
+   and prints a per-level before/after geomean table.
+
+6. **Show Kim and wait.** Read the PNGs back so they render, present the
+   before/after geomean tables and the per-corpus speedup, and **stop for Kim's
+   go-ahead before merging.** State the metric, the machine, and any caveat
+   (e.g. machine mismatch, levels skipped, ratio shift on a compress change).
+
+## Notes
+
+- `bench-report --native-only [levels]` lives in `ZipBenchReport.lean`; the plot
+  styling mirrors `bench/plot.py` (same colours/markers) for visual continuity.
+- The y-axis is log, so a +30% gain reads as a modest visual gap — quote the
+  numeric speedup from the printed table, don't rely on the eye alone.
+- For a compress PR, also call out any **ratio** change: a speed win that worsens
+  the ratio (curve moves right) may not be a net win. zopfli's frozen ratio
+  ceiling is in `bench/results/zopfli-ceiling.json` if you want the best-ratio
+  reference.
+- Keep the temporary jsons in `/tmp`; clean up swapped-in source files before
+  finishing (`git status` must be clean on the PR branch).

--- a/.claude/skills/perf-pr-graphs/plot_before_after.py
+++ b/.claude/skills/perf-pr-graphs/plot_before_after.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Before/after native speed-vs-ratio graphs for a lean-zip performance PR.
+
+Plots the chosen throughput metric (log y) against compression ratio (x) for
+native BEFORE vs native AFTER, overlaid on the existing other-language curves
+(reused from bench/results/latest.json — never re-measured). One chart per
+corpus. Also prints a per-level before/after geomean table to stdout.
+
+Usage:
+  plot_before_after.py <before.json> <after.json> <metric> [latest.json] [outdir]
+
+  metric : compress_mbps   (compression PRs — the interesting case: the
+                            optimization can move BOTH ratio and speed, so the
+                            speed-vs-ratio Pareto frontier is what to read)
+           decompress_mbps (decode PRs — no ratio/speed tradeoff; this is just
+                            a throughput-vs-ratio scatter for context)
+
+  latest.json defaults to bench/results/latest.json
+  outdir      defaults to bench/graphs
+
+The before/after jsons are the native rows from `bench-report --native-only`
+run on master (before) and the PR branch (after); see SKILL.md.
+"""
+import json, math, sys
+from pathlib import Path
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+before_path, after_path, metric = sys.argv[1], sys.argv[2], sys.argv[3]
+latest_path = sys.argv[4] if len(sys.argv) > 4 else "bench/results/latest.json"
+outdir = Path(sys.argv[5] if len(sys.argv) > 5 else "bench/graphs")
+assert metric in ("compress_mbps", "decompress_mbps"), f"bad metric {metric}"
+outdir.mkdir(parents=True, exist_ok=True)
+
+BEFORE = json.load(open(before_path))["results"]
+AFTER  = json.load(open(after_path))["results"]
+LATEST_DOC = json.load(open(latest_path))
+LATEST = LATEST_DOC["results"]
+LMETA  = LATEST_DOC.get("meta", {})
+
+# Other-language / reference curves reused from latest.json (not re-measured).
+# (compressor key, label, colour, marker)
+REFS = [
+    ("zlib",        "zlib (C)",            "#1f77b4", "s"),
+    ("miniz_oxide", "miniz_oxide (Rust)",  "#2ca02c", "^"),
+    ("libdeflate",  "libdeflate (C+SIMD)", "#9467bd", "D"),
+    ("go",          "Go compress/flate",   "#8c564b", "P"),
+    ("js",          "JS fflate",           "#e377c2", "X"),
+    ("zig",         "Zig std.flate",       "#bcbd22", "*"),
+    ("ocaml",       "OCaml decompress",    "#17becf", "h"),
+]
+
+def geomean(xs):
+    xs = [x for x in xs if x and x > 0]
+    return math.exp(sum(math.log(x) for x in xs) / len(xs)) if xs else None
+
+def corpora(rows):
+    return sorted({r["pattern"].split("/")[0] for r in rows})
+
+def files(rows, corpus):
+    return sorted({r["pattern"] for r in rows if r["pattern"].startswith(corpus + "/")})
+
+def find(rows, comp, pat, lvl):
+    for r in rows:
+        if r["compressor"] == comp and r["pattern"] == pat and r["level"] == lvl:
+            return r
+    return None
+
+def levels(rows, comp, corpus):
+    return sorted({r["level"] for r in rows
+                   if r["compressor"] == comp and r["pattern"].startswith(corpus + "/")})
+
+def curve(rows, comp, corpus):
+    """[(geomean ratio, geomean metric)] per level — points of the speed-vs-ratio curve."""
+    pts = []
+    for lvl in levels(rows, comp, corpus):
+        fs = files(rows, corpus)
+        rs = [find(rows, comp, p, lvl)["ratio"] for p in fs
+              if find(rows, comp, p, lvl) and find(rows, comp, p, lvl).get("ratio") is not None]
+        ss = [find(rows, comp, p, lvl)[metric] for p in fs
+              if find(rows, comp, p, lvl) and find(rows, comp, p, lvl).get(metric) is not None]
+        gr, gs = geomean(rs), geomean(ss)
+        if gr and gs:
+            pts.append((gr, gs))
+    return sorted(pts)
+
+label_speed = "compression speed" if metric == "compress_mbps" else "decode throughput"
+
+for corpus in corpora(AFTER):
+    fig, ax = plt.subplots(figsize=(10, 6.5))
+    # other-language context (reused), drawn as hollow rings underneath
+    for comp, lab, col, mk in REFS:
+        pts = curve(LATEST, comp, corpus)
+        if not pts:
+            continue
+        ax.plot([p[0] for p in pts], [p[1] for p in pts], marker=mk, color=col,
+                lw=1.3, ms=5, alpha=0.9, zorder=4,
+                markerfacecolor="none", markeredgecolor=col, label=lab)
+    # native before (grey dashed) and after (solid red), on top
+    pb = curve(BEFORE, "native", corpus)
+    if pb:
+        ax.plot([p[0] for p in pb], [p[1] for p in pb], marker="o", color="#7f7f7f",
+                lw=2.2, ms=7, ls="--", zorder=11,
+                markerfacecolor="none", markeredgecolor="#7f7f7f",
+                label="lean-zip native — before")
+    pa = curve(AFTER, "native", corpus)
+    if pa:
+        ax.plot([p[0] for p in pa], [p[1] for p in pa], marker="o", color="#d62728",
+                lw=2.6, ms=8, zorder=12, label="lean-zip native — AFTER")
+    ax.set_yscale("log")
+    ax.set_xlabel("compression ratio  (compressed / original — ← smaller = more compressed)")
+    ax.set_ylabel(f"{label_speed}  (MB/s, log)")
+    ax.set_title(f"DEFLATE {label_speed} vs ratio — {corpus}\n"
+                 f"native before/after; other languages reused "
+                 f"({LMETA.get('machine','?')}; geomean over {len(files(AFTER, corpus))} files)")
+    ax.grid(True, which="both", ls=":", alpha=0.4)
+    ax.legend(fontsize=8, ncol=2, loc="best")
+    fig.tight_layout()
+    stem = outdir / f"perf_before_after_{metric}_{corpus}"
+    fig.savefig(str(stem) + ".svg")
+    fig.savefig(str(stem) + ".png", dpi=130)
+    print(f"wrote {stem}.png / .svg")
+
+    print(f"\n=== {corpus}: native {metric} geomean by level ===")
+    print(f"{'lvl':>3} {'ratio':>7} {'before':>9} {'after':>9} {'speedup':>8}")
+    for lvl in levels(AFTER, "native", corpus):
+        fs = files(AFTER, corpus)
+        b = geomean([find(BEFORE, "native", p, lvl)[metric] for p in fs
+                     if find(BEFORE, "native", p, lvl) and find(BEFORE, "native", p, lvl).get(metric)])
+        a = geomean([find(AFTER, "native", p, lvl)[metric] for p in fs
+                     if find(AFTER, "native", p, lvl) and find(AFTER, "native", p, lvl).get(metric)])
+        r = geomean([find(AFTER, "native", p, lvl)["ratio"] for p in fs
+                     if find(AFTER, "native", p, lvl)])
+        if a and b and r:
+            print(f"{lvl:>3} {r:>7.3f} {b:>9.1f} {a:>9.1f} {a/b:>7.2f}x")

--- a/.claude/skills/perf-pr-graphs/plot_before_after.py
+++ b/.claude/skills/perf-pr-graphs/plot_before_after.py
@@ -16,10 +16,11 @@ Usage:
                             a throughput-vs-ratio scatter for context)
 
   latest.json defaults to bench/results/latest.json
-  outdir      defaults to bench/graphs
+  outdir      defaults to /tmp (report artifact — keep it out of the tree)
 
-The before/after jsons are the native rows from `bench-report --native-only`
-run on master (before) and the PR branch (after); see SKILL.md.
+The before/after jsons are the native rows from `bench-report --native-only`.
+BEFORE is measured at the branch's merge-base with master (a throwaway worktree),
+AFTER on the PR branch; see SKILL.md step 4 for why merge-base and not master.
 """
 import json, math, sys
 from pathlib import Path
@@ -29,15 +30,27 @@ import matplotlib.pyplot as plt
 
 before_path, after_path, metric = sys.argv[1], sys.argv[2], sys.argv[3]
 latest_path = sys.argv[4] if len(sys.argv) > 4 else "bench/results/latest.json"
-outdir = Path(sys.argv[5] if len(sys.argv) > 5 else "bench/graphs")
+outdir = Path(sys.argv[5] if len(sys.argv) > 5 else "/tmp")
 assert metric in ("compress_mbps", "decompress_mbps"), f"bad metric {metric}"
 outdir.mkdir(parents=True, exist_ok=True)
 
-BEFORE = json.load(open(before_path))["results"]
-AFTER  = json.load(open(after_path))["results"]
+BEFORE_DOC = json.load(open(before_path))
+AFTER_DOC  = json.load(open(after_path))
+BEFORE = BEFORE_DOC["results"]
+AFTER  = AFTER_DOC["results"]
 LATEST_DOC = json.load(open(latest_path))
 LATEST = LATEST_DOC["results"]
 LMETA  = LATEST_DOC.get("meta", {})
+
+def _meta1(doc):
+    m = doc.get("meta", {})
+    return f"machine={m.get('machine','?')} commit={m.get('git_commit','?')}"
+
+# Provenance: what is actually being compared. The user must confirm BEFORE's
+# commit is the branch merge-base (not origin/master) — see SKILL.md step 4.
+print(f"BEFORE: {_meta1(BEFORE_DOC)}")
+print(f"AFTER : {_meta1(AFTER_DOC)}")
+print(f"refs  : {_meta1(LATEST_DOC)}  (reused, not re-measured)")
 
 # Other-language / reference curves reused from latest.json (not re-measured).
 # (compressor key, label, colour, marker)
@@ -135,19 +148,40 @@ for corpus in corpora(AFTER):
         if a and b and r:
             print(f"{lvl:>3} {r:>7.3f} {b:>9.1f} {a:>9.1f} {a/b:>7.2f}x")
 
-# Baseline sanity: the largest before/after ratio difference over every measured
-# (pattern, level). An output-neutral PR (dispatch/escape, re-timed loop) MUST
-# read 0.000000 here — a nonzero value means the BEFORE baseline is wrong (a
-# stale-branch leak; recheck SKILL.md step 4) or the change is not output-neutral.
-bkey = {(r["compressor"], r["pattern"], r["level"]): r for r in BEFORE}
+# Row coverage: before/after must cover the same native (pattern, level) keys,
+# else the comparison is over a partial intersection and every aggregate
+# (including max |Δratio|) is computed on incomplete data. Report mismatches.
+bkeys = {(r["pattern"], r["level"]) for r in BEFORE if r["compressor"] == "native"}
+akeys = {(r["pattern"], r["level"]) for r in AFTER  if r["compressor"] == "native"}
+only_b, only_a = sorted(bkeys - akeys), sorted(akeys - bkeys)
+if only_b or only_a:
+    print(f"\nWARNING: before/after native rows do not match "
+          f"({len(only_b)} only in before, {len(only_a)} only in after); "
+          f"aggregates use the {len(bkeys & akeys)}-row intersection only.")
+    for tag, ks in (("before-only", only_b), ("after-only", only_a)):
+        if ks:
+            print(f"  {tag}: " + ", ".join(f"{p} L{l}" for p, l in ks[:6])
+                  + (" …" if len(ks) > 6 else ""))
+
+# Output-neutrality: largest before/after ratio difference over the shared
+# native rows. An output-neutral PR (dispatch/escape, re-timed loop, proof-side
+# refactor) MUST read 0.000000; a nonzero value means output changed (intended
+# for a parse change, a bug otherwise) or the two runs saw different corpora.
+# NOTE: this does NOT validate baseline freshness — a stale-branch BEFORE has
+# identical output, so Δratio stays 0 while the speed curve is silently wrong
+# (confirm BEFORE's commit == merge-base above).
+bratio = {(r["pattern"], r["level"]): r["ratio"]
+          for r in BEFORE if r["compressor"] == "native" and r.get("ratio") is not None}
 worst, worst_at = 0.0, None
 for r in AFTER:
-    b = bkey.get((r["compressor"], r["pattern"], r["level"]))
-    if b and r.get("ratio") is not None and b.get("ratio") is not None:
-        d = abs(r["ratio"] - b["ratio"])
+    if r["compressor"] != "native" or r.get("ratio") is None:
+        continue
+    b = bratio.get((r["pattern"], r["level"]))
+    if b is not None:
+        d = abs(r["ratio"] - b)
         if d > worst:
             worst, worst_at = d, (r["pattern"], r["level"])
 print(f"\nmax |Δratio| (before vs after) = {worst:.6f}"
       + (f"  at {worst_at[0]} L{worst_at[1]}" if worst_at and worst > 0 else "")
       + ("   [output-neutral: OK]" if worst == 0
-         else "   [ratio changed — intended for a parse change; a stale-baseline leak otherwise]"))
+         else "   [ratio changed — intended for a parse change; check it moved the right way]"))

--- a/.claude/skills/perf-pr-graphs/plot_before_after.py
+++ b/.claude/skills/perf-pr-graphs/plot_before_after.py
@@ -134,3 +134,20 @@ for corpus in corpora(AFTER):
                      if find(AFTER, "native", p, lvl)])
         if a and b and r:
             print(f"{lvl:>3} {r:>7.3f} {b:>9.1f} {a:>9.1f} {a/b:>7.2f}x")
+
+# Baseline sanity: the largest before/after ratio difference over every measured
+# (pattern, level). An output-neutral PR (dispatch/escape, re-timed loop) MUST
+# read 0.000000 here — a nonzero value means the BEFORE baseline is wrong (a
+# stale-branch leak; recheck SKILL.md step 4) or the change is not output-neutral.
+bkey = {(r["compressor"], r["pattern"], r["level"]): r for r in BEFORE}
+worst, worst_at = 0.0, None
+for r in AFTER:
+    b = bkey.get((r["compressor"], r["pattern"], r["level"]))
+    if b and r.get("ratio") is not None and b.get("ratio") is not None:
+        d = abs(r["ratio"] - b["ratio"])
+        if d > worst:
+            worst, worst_at = d, (r["pattern"], r["level"])
+print(f"\nmax |Δratio| (before vs after) = {worst:.6f}"
+      + (f"  at {worst_at[0]} L{worst_at[1]}" if worst_at and worst > 0 else "")
+      + ("   [output-neutral: OK]" if worst == 0
+         else "   [ratio changed — intended for a parse change; a stale-baseline leak otherwise]"))


### PR DESCRIPTION
This PR adds a project skill, perf-pr-graphs, that requires generating before/after native speed-vs-ratio comparison graphs and showing them to Kim before any performance PR is merged. The graphs plot the native path before vs after on the Canterbury and Silesia corpora, overlaid on the existing other-language curves (zlib, miniz_oxide, libdeflate, Go, JS, Zig, OCaml) reused from bench/results/latest.json without re-measuring them. They are a report artifact and stay uncommitted, distinct from the routine bench/graphs dashboard regenerated by bench/run.sh.

The skill covers both metrics: compress_mbps (the interesting case, where an optimization can shift both ratio and speed, so the speed-vs-ratio frontier is what to read) and decompress_mbps (a throughput-vs-ratio scatter, less rich since decode does not trade off against ratio). It ships a plot_before_after.py helper that mirrors bench/plot.py styling and prints a per-level before/after geomean table, plus a workflow that measures AFTER on the branch and BEFORE by swapping in master's changed files, both via bench-report --native-only, and that stops for Kim's go-ahead before merging.

🤖 Prepared with Claude Code