### PR TITLE
perf(decode): de-box the Huffman fast-decode table into parallel scalar arrays

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -154,11 +154,29 @@ where
       else if bits % 2 == 0 then go z (bits / 2) (depth + 1)
       else go o (bits / 2) (depth + 1)
 
+/-- A de-boxed fast-decode table: the `(symbol, codeLen)` of each slot split into
+    two parallel scalar arrays. Storing `Array (UInt16 × UInt8)` boxes every slot
+    as a heap pair, so each per-symbol read pointer-chases through `lean_ctor_get`
+    twice; the split keeps each field in a scalar array (`lean_array_fget` +
+    `unbox`, no chase), which is the de-box of #2650.
+
+    Two scalar arrays rather than one packed `UInt32` word: extracting the high
+    field of a packed word needs a shift, and the well-founded recursions `go` /
+    `goFused` would force that shift to weak head normal form during equation
+    compilation and loop on `Nat.div`. A plain array read stays stuck under
+    `whnf`, so the split keeps both the de-box and the proofs. -/
+structure DecodeTable where
+  syms : Array UInt16
+  lens : Array UInt8
+
 /-- Build the `2^fastBits`-entry decode table for `tree`: slot `i` holds the
-    `(symbol, codeLen)` reached by walking `tree` on the bits of `i`. Built once
-    per Huffman tree; cheap relative to the symbols decoded with it. -/
-def buildTable (tree : HuffTree) : Array (UInt16 × UInt8) :=
-  Array.ofFn (n := 2 ^ fastBits) (fun i : Fin (2 ^ fastBits) => tableEntry tree i.val)
+    `(symbol, codeLen)` reached by walking `tree` on the bits of `i`, with the two
+    fields split into the parallel scalar arrays of `DecodeTable` so each
+    per-symbol read is a de-boxed scalar load instead of a heap-pair pointer-chase.
+    Built once per Huffman tree; cheap relative to the symbols decoded with it. -/
+def buildTable (tree : HuffTree) : DecodeTable where
+  syms := Array.ofFn (n := 2 ^ fastBits) (fun i : Fin (2 ^ fastBits) => (tableEntry tree i.val).1)
+  lens := Array.ofFn (n := 2 ^ fastBits) (fun i : Fin (2 ^ fastBits) => (tableEntry tree i.val).2)
 
 /-- Bits remaining in the reader from its current `(pos, bitOff)`. -/
 def bitsAvail (br : BitReader) : Nat :=
@@ -177,7 +195,7 @@ def peekFast (br : BitReader) : UInt32 :=
     Falls back to the canonical `decode` tree walk for long codes (sentinel
     `codeLen = 0`) and when fewer than `codeLen` bits remain. Proven equal to
     `decode` when `table = buildTable tree` (`Zip.Spec.InflateTable`). -/
-def decodeWithTable (tree : HuffTree) (table : Array (UInt16 × UInt8))
+def decodeWithTable (tree : HuffTree) (table : DecodeTable)
     (br : BitReader) : Except String (UInt16 × BitReader) :=
   -- `bitOff ≥ 8` is unreachable for a well-formed reader (every `readBit`
   -- leaves `bitOff < 8`); the guard makes the equality with `decode`
@@ -185,13 +203,12 @@ def decodeWithTable (tree : HuffTree) (table : Array (UInt16 × UInt8))
   if br.bitOff ≥ 8 then tree.decode br
   else
     let idx := (peekFast br).toNat
-    let entry := table[idx]!
-    let len := entry.2.toNat
+    let len := table.lens[idx]!.toNat
     if len == 0 || len > bitsAvail br then
       tree.decode br
     else
       let total := br.bitOff + len
-      .ok (entry.1, { br with pos := br.pos + total / 8, bitOff := total % 8 })
+      .ok (table.syms[idx]!, { br with pos := br.pos + total / 8, bitOff := total % 8 })
 
 end HuffTree
 
@@ -481,7 +498,7 @@ protected def decodeHuffmanFastBR (br : BitReader) (output : ByteArray)
     : Except String (ByteArray × BitReader) :=
   go litTree.buildTable distTree.buildTable br.data.size br output
 where
-  go (litTable distTable : Array (UInt16 × UInt8))
+  go (litTable distTable : HuffTree.DecodeTable)
       (dataSize : Nat) (br : BitReader) (output : ByteArray)
       : Except String (ByteArray × BitReader) := do
     let (sym, br₁) ← litTree.decodeWithTable litTable br
@@ -580,13 +597,12 @@ def walkTree (t : HuffTree) (bitBuf : UInt64) (cnt depth : Nat) :
 /-- Decode one Huffman symbol from the (refilled) buffer via the 9-bit table,
     falling back to the tree walk for long codes / near EOF. Returns the symbol,
     remaining buffer state, and bits consumed. -/
-@[inline] def decodeSym (tree : HuffTree) (table : Array (UInt16 × UInt8))
+@[inline] def decodeSym (tree : HuffTree) (table : HuffTree.DecodeTable)
     (bitBuf : UInt64) (cnt : Nat) : Except String (UInt16 × UInt64 × Nat × Nat) :=
   let idx := (bitBuf &&& 0x1FF).toNat
-  let entry := table[idx]!
-  let len := entry.2.toNat
+  let len := table.lens[idx]!.toNat
   if len == 0 || len > cnt then walkTree tree bitBuf cnt 0
-  else .ok (entry.1, bitBuf >>> len.toUInt64, cnt - len, len)
+  else .ok (table.syms[idx]!, bitBuf >>> len.toUInt64, cnt - len, len)
 
 /-- Read `n` bits LSB-first from the buffer without refilling. Errors (like
     `readBitsFast`) when the buffer holds fewer than `n` bits — for a refilled
@@ -601,7 +617,7 @@ set_option maxRecDepth 4096 in
 /-- Wide-buffer Huffman symbol loop (mirrors `Inflate.decodeHuffmanFastBR.go`).
     `bitpos` is the stream bit position (`= pos*8 - cnt` under the buffer
     invariant); it carries the well-founded measure and the progress guards. -/
-def go (litTable distTable : Array (UInt16 × UInt8))
+def go (litTable distTable : HuffTree.DecodeTable)
     (data : ByteArray) (litTree distTree : HuffTree) (maxOut dataSize : Nat)
     (pos : Nat) (bitBuf : UInt64) (cnt bitpos : Nat) (output : ByteArray) :
     Except String (ByteArray × Nat × UInt64 × Nat × Nat) := do
@@ -663,7 +679,7 @@ set_option maxRecDepth 4096 in
     decreases lexicographically: refill steps shrink `data.size - pos` (first
     component fixed since `bitpos` is unchanged), decode steps shrink
     `dataSize*8 - bitpos` via the progress guards. See #2637. -/
-def goFused (litTable distTable : Array (UInt16 × UInt8))
+def goFused (litTable distTable : HuffTree.DecodeTable)
     (data : ByteArray) (litTree distTree : HuffTree) (maxOut dataSize : Nat)
     (pos : Nat) (bitBuf : UInt64) (cnt bitpos : Nat) (output : ByteArray) :
     Except String (ByteArray × Nat × UInt64 × Nat × Nat) := do

--- a/Zip/Spec/InflateBufCorrect.lean
+++ b/Zip/Spec/InflateBufCorrect.lean
@@ -672,11 +672,11 @@ open HuffTree in
 /-- **`decodeSym` corresponds to `HuffTree.decodeWithTable`.** Same symbol/error,
     and on success the resulting buffer corresponds to the advanced reader. The
     table code length is bounded by `fastBits` (true for `buildTable`). -/
-theorem decodeSym_corr (tree : HuffTree) (table : Array (UInt16 × UInt8))
+theorem decodeSym_corr (tree : HuffTree) (table : HuffTree.DecodeTable)
     {data : ByteArray} {br : BitReader} {pos : Nat} {bitBuf : UInt64} {cnt : Nat}
     (h : BufCorr data br.bitPos pos bitBuf cnt) (hwf : br.bitOff < 8) (hdata : br.data = data)
     (hr : 21 < cnt ∨ pos = data.size)
-    (hlen : (table[(bitBuf &&& 0x1FF).toNat]!).2.toNat ≤ 9) (hdep : treeDepthLE tree 15) :
+    (hlen : (table.lens[(bitBuf &&& 0x1FF).toNat]!).toNat ≤ 9) (hdep : treeDepthLE tree 15) :
     match HuffTree.decodeWithTable tree table br, decodeSym tree table bitBuf cnt with
     | .error e1, .error e2 => e1 = e2
     | .ok (s1, br'), .ok (s2, bb, c, used) =>
@@ -698,16 +698,18 @@ theorem decodeSym_corr (tree : HuffTree) (table : Array (UInt16 × UInt8))
   unfold HuffTree.decodeWithTable decodeSym
   rw [if_neg (show ¬ br.bitOff ≥ 8 from by omega), hidx]
   simp only []
-  generalize hentry : table[(peekFast br).toNat]! = entry at hlen ⊢
+  -- generalize the two parallel reads (the de-boxed table splits sym/len)
+  generalize hlenv : table.lens[(peekFast br).toNat]! = lenB at hlen ⊢
+  generalize hsymv : table.syms[(peekFast br).toNat]! = symV
   -- the two guards have the same truth value (cnt vs bitsAvail, with len ≤ 9)
-  have hgd : (entry.2.toNat == 0 || decide (entry.2.toNat > HuffTree.bitsAvail br))
-           = (entry.2.toNat == 0 || decide (entry.2.toNat > cnt)) := by
+  have hgd : (lenB.toNat == 0 || decide (lenB.toNat > HuffTree.bitsAvail br))
+           = (lenB.toNat == 0 || decide (lenB.toNat > cnt)) := by
     rcases hr with hc | hpe
-    · have h1 : ¬ entry.2.toNat > HuffTree.bitsAvail br := by have := hav.1; omega
-      have h2 : ¬ entry.2.toNat > cnt := by omega
+    · have h1 : ¬ lenB.toNat > HuffTree.bitsAvail br := by have := hav.1; omega
+      have h2 : ¬ lenB.toNat > cnt := by omega
       simp [h1, h2]
     · rw [hav.2 hpe]
-  by_cases hg : (entry.2.toNat == 0 || decide (entry.2.toNat > cnt)) = true
+  by_cases hg : (lenB.toNat == 0 || decide (lenB.toNat > cnt)) = true
   · -- fallback: walkTree ↔ decode
     rw [if_pos (hgd.trans hg), if_pos hg, HuffTree.decode]
     have hwc := walkTree_corr (depth := 0) tree h hwf hdata (by
@@ -724,18 +726,15 @@ theorem decodeSym_corr (tree : HuffTree) (table : Array (UInt16 × UInt8))
     rw [if_neg (by rw [hgd]; exact hg), if_neg hg]
     simp only [Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq, not_or, Nat.not_lt] at hg
     obtain ⟨hne, hle⟩ := hg
-    have hcc := consume_corr h hle (show entry.2.toNat < 64 from by omega)
-    have hbpe : ({ br with pos := br.pos + (br.bitOff + entry.2.toNat) / 8, bitOff := (br.bitOff + entry.2.toNat) % 8 } : BitReader).bitPos = br.bitPos + entry.2.toNat := by simp only [BitReader.bitPos]; omega
+    have hcc := consume_corr h hle (show lenB.toNat < 64 from by omega)
+    have hbpe : ({ br with pos := br.pos + (br.bitOff + lenB.toNat) / 8, bitOff := (br.bitOff + lenB.toNat) % 8 } : BitReader).bitPos = br.bitPos + lenB.toNat := by simp only [BitReader.bitPos]; omega
     exact ⟨rfl, hbpe.symm ▸ hcc, hdata, Nat.mod_lt _ (by decide), Nat.sub_le cnt _, by omega⟩
 
 /-- Every `buildTable` entry's code length is at most `fastBits = 9`
     (the table walk stops at `fastBits`, or returns the `0` sentinel). -/
 theorem buildTable_codeLen_le (tree : HuffTree) (idx : Nat) (hidx : idx < 2 ^ HuffTree.fastBits) :
-    (tree.buildTable[idx]!).2.toNat ≤ 9 := by
-  have htab : tree.buildTable[idx]! = HuffTree.tableEntry tree idx := by
-    simp only [HuffTree.buildTable]
-    rw [getElem!_pos _ _ (by rw [Array.size_ofFn]; exact hidx), Array.getElem_ofFn]
-  rw [htab, HuffTree.tableEntry]
+    (tree.buildTable.lens[idx]!).toNat ≤ 9 := by
+  rw [HuffTree.buildTable_lens_getElem tree idx hidx, HuffTree.tableEntry]
   rcases hg : HuffTree.tableEntry.go tree idx 0 with ⟨sym, lenB⟩
   show lenB.toNat ≤ 9
   by_cases hp : 0 < lenB.toNat
@@ -1057,7 +1056,7 @@ theorem fromLengths_depthLE {lengths : Array UInt8} {maxBits : Nat} {tree : Huff
     uses only the refilled `(pos,bitBuf,cnt)`, advancing the cursor by one byte
     (exactly when the refill loop would) does not change `go`'s result. The
     workhorse for `goFused_eq_go`. -/
-theorem go_refill_step (litTable distTable : Array (UInt16 × UInt8)) (data : ByteArray)
+theorem go_refill_step (litTable distTable : HuffTree.DecodeTable) (data : ByteArray)
     (litTree distTree : HuffTree) (maxOut dataSize : Nat)
     (pos : Nat) (bitBuf : UInt64) (cnt bitpos : Nat) (output : ByteArray)
     (hrc : cnt ≤ 56 ∧ pos < data.size) :
@@ -1078,7 +1077,7 @@ set_option maxRecDepth 8000 in
     `go_refill_step`, and each decode branch is byte-identical to `go`'s body once
     the leading `refill` (a no-op here, `¬(cnt ≤ 56 ∧ pos < size)`) is discharged.
     See #2637. -/
-theorem goFused_eq_go (litTable distTable : Array (UInt16 × UInt8)) (data : ByteArray)
+theorem goFused_eq_go (litTable distTable : HuffTree.DecodeTable) (data : ByteArray)
     (litTree distTree : HuffTree) (maxOut dataSize : Nat) :
     ∀ (pos : Nat) (bitBuf : UInt64) (cnt bitpos : Nat) (output : ByteArray),
     goFused litTable distTable data litTree distTree maxOut dataSize pos bitBuf cnt bitpos output

--- a/Zip/Spec/InflateTable.lean
+++ b/Zip/Spec/InflateTable.lean
@@ -328,6 +328,23 @@ theorem advReader_eq (br br' : BitReader) (k : Nat)
   · dsimp only []; omega
   · exact hwf'
 
+/-- The symbol array of `buildTable` at a valid index is the first component of
+    `tableEntry` — the de-boxed table splits the `(sym, len)` pair into two
+    parallel scalar arrays, so each field projects back through `Array.getElem_ofFn`. -/
+theorem buildTable_syms_getElem (tree : HuffTree) (idx : Nat)
+    (hidx : idx < 2 ^ fastBits) :
+    (tree.buildTable).syms[idx]! = (tableEntry tree idx).1 := by
+  simp only [HuffTree.buildTable]
+  rw [getElem!_pos _ _ (by rw [Array.size_ofFn]; exact hidx), Array.getElem_ofFn]
+
+/-- The length array of `buildTable` at a valid index is the second component of
+    `tableEntry`. -/
+theorem buildTable_lens_getElem (tree : HuffTree) (idx : Nat)
+    (hidx : idx < 2 ^ fastBits) :
+    (tree.buildTable).lens[idx]! = (tableEntry tree idx).2 := by
+  simp only [HuffTree.buildTable]
+  rw [getElem!_pos _ _ (by rw [Array.size_ofFn]; exact hidx), Array.getElem_ofFn]
+
 set_option maxRecDepth 4096 in
 /-- **Symbol lemma.** The table-driven single-symbol decode built from `tree`
     agrees with the canonical tree walk, as a full `Except` result (same symbol
@@ -341,12 +358,13 @@ theorem decodeWithTable_eq (tree : HuffTree) (br : BitReader) :
     rw [UInt32.toNat_and]
     simp only [fastBits]
     exact Nat.and_lt_two_pow _ (by decide)
-  have htab : (tree.buildTable)[(peekFast br).toNat]! = tableEntry tree (peekFast br).toNat := by
-    unfold HuffTree.buildTable
-    rw [getElem!_pos _ _ (by rw [Array.size_ofFn]; exact hidx), Array.getElem_ofFn]
+  have hlens : (tree.buildTable).lens[(peekFast br).toNat]!
+      = (tableEntry tree (peekFast br).toNat).2 := buildTable_lens_getElem tree _ hidx
+  have hsyms : (tree.buildTable).syms[(peekFast br).toNat]!
+      = (tableEntry tree (peekFast br).toNat).1 := buildTable_syms_getElem tree _ hidx
   unfold HuffTree.decodeWithTable
   simp only []
-  rw [htab]
+  rw [hlens, hsyms]
   -- destructure the table entry into opaque `sym`, `lenB`
   generalize hentry : tableEntry tree (peekFast br).toNat = entry
   obtain ⟨sym, lenB⟩ := entry

--- a/ZipTest/InflateTable.lean
+++ b/ZipTest/InflateTable.lean
@@ -75,7 +75,7 @@ private def sameResult (a b : Except String (UInt16 × BitReader)) : Bool :=
 
 /-- Run the table decoder and the tree-walk decoder over `tree` from every bit
     offset of `data`, returning a mismatch description on the first divergence. -/
-private def checkStream (label : String) (tree : HuffTree) (table : Array (UInt16 × UInt8))
+private def checkStream (label : String) (tree : HuffTree) (table : HuffTree.DecodeTable)
     (data : ByteArray) : Option String := Id.run do
   for startPos in [:data.size] do
     for bitOff in [:8] do


### PR DESCRIPTION
This PR de-boxes the 9-bit Huffman fast-decode table that drives `Inflate.inflate`, closing https://github.com/kim-em/lean-zip/issues/2650 — "perf(decode): de-box the Huffman symbol table (Array (UInt16 × UInt8) -> packed word)". The table was `Array (UInt16 × UInt8)`, which stores each slot as a boxed heap pair, so every per-symbol read in the `goFused` hot loop compiled to `lean_array_get` followed by two `lean_ctor_get` calls pointer-chasing into a per-element pair — once per literal, twice per match. This replaces it with a `DecodeTable` structure holding two parallel scalar arrays (`syms : Array UInt16`, `lens : Array UInt8`), so each read is `lean_array_fget` + `unbox` with no chase. The generated C confirms the per-element `ctor_get` pointer-chase is gone; the only remaining `ctor_get(table, 0/1)` are loop-invariant struct-field reads on the same hot table object.

The issue suggested packing each entry into a single `UInt32` word read with masks. That approach does not survive elaboration here: extracting the high field of a packed word needs a shift, and the well-founded recursions `go`/`goFused` force that shift expression to weak head normal form during equation compilation, looping on `Nat.div` (deterministic timeout at whnf, even at 1M heartbeats; `@[irreducible]` on the accessors does not help, because the WF equation compiler's whnf unfolds through it). Plain array reads stay stuck under whnf, so the two-array split is what keeps both the de-box and the proofs. The rationale is documented on `DecodeTable`.

The correctness proofs transfer as a localized representation change with the load-bearing statements unchanged (`decodeWithTable_eq`, `goFused_eq_go`, and hence `decodeHuffmanFast = decodeHuffman`): `buildTable_syms_getElem` / `buildTable_lens_getElem` replace the single `htab` projection lemma, and `decodeSym_corr` generalizes the two parallel reads instead of one pair. There is no new `sorry`, no `native_decide`, no trust gap. The full library builds and the test suite passes, including the InflateTable differential test (table decode vs canonical tree walk) over 72 stream batches across 9 trees.

🤖 Prepared with Claude Code