### PR TITLE
doc: perf-pr-graphs — baseline from committed latest.json; make generate/look/post compulsory

### DIFF
--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -6,13 +6,32 @@ allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 
 # Pre-merge performance comparison graphs
 
+## TL;DR — this is compulsory, in this exact order
+
+For **every** native-performance PR (see the trigger list below), you **must**,
+once the PR is green and before it merges:
+
+1. **Generate** the before/after comparison graphs (steps 1–6). This is not
+   optional and not "if Kim asks" — it is automatic for every qualifying PR.
+   Never skip it, never ask whether to do it, never merge without it.
+2. **Look** at the rendered graphs yourself (step 7) — `Read` the PNGs as images,
+   do not reason only from the numeric table.
+3. **Post** the graphs as a PR comment with the geomean table and caveats
+   (step 8). The `/tmp` PNGs are not durable; the PR comment is the artifact.
+4. **Give Kim the link** to that PR comment in your reply, and stop for her
+   go-ahead before merging.
+
+If you generated graphs but did not look at them, did not post them, or did not
+hand Kim a link, you are **not done** — finish steps 2–4.
+
 ## When this is mandatory
 
 Any PR that changes runtime performance of the native path — anything titled
 `perf:`, or any change to `Zip/Native/Deflate*`, `Zip/Native/Inflate*`,
 `Zip/Native/LZ77*`, `Zip/Native/DeflateParse*`, the bit reader/writer, or the
-Huffman codec. **Do not merge such a PR until you have generated these graphs
-and Kim has seen them.** This is a required gate, not an optional nicety.
+Huffman codec. **Do not merge such a PR until you have generated these graphs,
+posted them to the PR, and Kim has seen them.** This is a required gate, not an
+optional nicety.
 
 The graphs show **native before vs after** on the real corpora (Canterbury +
 Silesia), overlaid on the existing other-language curves (zlib, miniz_oxide,
@@ -65,38 +84,54 @@ project `.claude/CLAUDE.md`); elsewhere run them directly.
    when you only care about decode). For a **compress** PR, keep all 9 levels —
    L9 is usually the point.
 
-4. **Measure BEFORE** (the branch's native path *without this PR's commits*).
-   **Build it in a throwaway worktree checked out at the branch's merge-base with
-   master — NOT at `origin/master`, and NOT by swapping files in place.**
+4. **BEFORE is `bench/results/latest.json` — do NOT rebuild it.** Master already
+   carries up-to-date native numbers: `bench/results/latest.json` is the
+   committed dashboard snapshot (native `ratio` / `compress_mbps` /
+   `decompress_mbps`, median-of-5 on Canterbury, same machine), and it is the
+   canonical BEFORE. There is **no merge-base worktree build** — that whole step
+   was wasted work, because the data it would reproduce is already recorded in
+   the tree. Pass `bench/results/latest.json` straight to the plotter as BEFORE
+   (step 6).
 
-   Why the merge-base, not `origin/master`: if the branch is behind master,
-   `origin/master` carries *unrelated* perf commits; any touching a file this PR
-   also touches leak into "before" — a phantom regression on the speed curve. The
-   merge-base is the exact divergence point: master-minus-the-PR with no extra
-   commits.
+   **The invariant that makes this valid: `latest.json` must always reflect the
+   current native path on master.** It is kept current by the "bench: dashboard
+   refresh" commits — every native-perf PR is followed by a dashboard refresh
+   that re-records `latest.json`. If a native-perf change ever merges *without*
+   that refresh, master's recorded BEFORE goes stale and every subsequent perf PR
+   baselines against the wrong code. So keep the dashboard fresh, and run the
+   freshness guard below before trusting it.
 
-   Why a worktree, not `git checkout <base> -- <files>`: the in-place swap forces
-   you to guess which files the PR changed (miss a support module, build file,
-   generated table, or rename/delete and "before" is a hybrid of HEAD code against
-   base code), and leaves the main worktree's build artifacts stale. A clean
-   worktree at `$base` is the whole tree at the divergence point:
+   **Freshness guard (run it, every time).** Confirm no native-path commit landed
+   between the snapshot's recorded commit and this branch's merge-base — if one
+   did, `latest.json` predates code your BEFORE must include, and it is stale:
    ```
    git fetch origin -q
    base=$(git merge-base origin/master HEAD)
-   behind=$(git rev-list --count HEAD..origin/master)
-   [ "$behind" -gt 0 ] && echo "NOTE: branch is $behind commits behind master; \
-baselining BEFORE at merge-base ${base:0:8} (not origin/master) so unrelated \
-commits don't leak in."
-   tmp="/tmp/perf-before-${base:0:8}"
-   git worktree add --detach "$tmp" "$base"
-   ( cd "$tmp" && lake build bench-report \
-       && lake env .lake/build/bin/bench-report --native-only /tmp/perf_before.json )  # same level list as step 3
-   git worktree remove --force "$tmp"
+   rec=$(python3 -c "import json;print(json.load(open('bench/results/latest.json'))['meta']['git_commit'])")
+   # native CODE paths only — a `bench/` change (a dashboard refresh, the very
+   # commit that re-recorded latest.json) does NOT invalidate the native baseline.
+   stale=$(git log --oneline ${rec}..${base} -- Zip/Native ZipCommon 2>/dev/null)
+   [ -n "$stale" ] && echo "STALE latest.json (recorded at ${rec}); native commits since:" && echo "$stale"
    ```
-   `bench-report` stamps the JSON `meta.git_commit` from the worktree's HEAD, so
-   `/tmp/perf_before.json`'s commit should equal `$base` — the plotter prints it
-   (step 6) for you to confirm. On NixOS the inner `cd` changes the nix-shell
-   working dir; run the whole `( … )` inside one `nix-shell --run "…"`.
+   - **Empty → use `latest.json` as BEFORE.** Its native rows already reflect the
+     merge-base; nothing to rebuild.
+   - **Non-empty → `latest.json` is stale; the dashboard was not refreshed after
+     a native merge.** Fix the invariant rather than working around it:
+     regenerate it (`bash bench/run.sh`, commit the refreshed
+     `bench/results/latest.json`, ideally as its own `bench: dashboard refresh`
+     PR) so master is current again, then use it. Only if you genuinely cannot
+     refresh now, fall back to a one-off merge-base build as a documented
+     workaround (`git worktree add --detach /tmp/before $base && ( cd /tmp/before
+     && lake build bench-report && lake env .lake/build/bin/bench-report
+     --native-only /tmp/perf_before.json )`, then `git worktree remove --force
+     /tmp/before`) and pass `/tmp/perf_before.json` as BEFORE.
+
+   **Cross-session caveat.** BEFORE (recorded earlier) and AFTER (measured now)
+   are different sessions, so a small single-digit-% speed delta can be
+   cross-session / machine-load noise rather than the PR. Before reading a fine
+   speed verdict, make the AFTER run on a quiet machine (no competing `lake`
+   builds — check `uptime` / `ps` first), and weight Canterbury's median-of-5
+   over Silesia's single pass.
 
 5. **Sanity-check before plotting.** Two independent checks — they catch
    different failures, so read both:
@@ -106,23 +141,23 @@ commits don't leak in."
      change is not output-neutral after all (or, rarely, the two runs saw
      different corpora). A PR that *intends* to change the parse (better ratio)
      shows a nonzero Δratio — that is the point; confirm it moves the right way.
-   - **Baseline correctness.** `max |Δratio|` does **not** catch a stale-branch
-     baseline: if "before" leaked in an unrelated perf commit that touched the
-     same files, both still produce identical output, so Δratio stays `0.000000`
-     while the *speed* curve is silently wrong (the classic phantom regression —
-     "before" looks faster than "after" for reasons unrelated to the PR). The
-     defences are the merge-base worktree (step 4, which makes a hybrid tree
-     impossible) plus the commit/coverage line the plotter prints: confirm
-     BEFORE's `meta.git_commit` equals `$base` and that before/after cover the
-     same `(pattern, level)` rows. If BEFORE's commit is `origin/master` rather
-     than the merge-base, redo step 4.
+   - **Baseline currency.** The freshness guard in step 4 is what keeps the
+     baseline honest now that BEFORE is `latest.json`: if it flagged stale, a
+     native commit landed after the snapshot and the *speed* curve would be
+     silently wrong even though Δratio stays `0.000000` (the classic phantom
+     regression — "before" reflects different code than the merge-base). Confirm
+     the guard came back empty, and confirm the plotter's printed BEFORE
+     `meta.git_commit` is the snapshot you expect and that before/after cover the
+     same `(pattern, level)` rows.
 
 6. **Plot** (other-language curves are reused from `latest.json`, never
    re-measured). The graphs are a report artifact — write them to the gitignored
    `/tmp` so they can never be accidentally committed to the perf PR:
+   `<before.json>` is `bench/results/latest.json` (step 4) — pass it twice, once
+   as BEFORE and once as the reused other-language source:
    ```
    python3 .claude/skills/perf-pr-graphs/plot_before_after.py \
-     /tmp/perf_before.json /tmp/perf_after.json <compress_mbps|decompress_mbps> \
+     bench/results/latest.json /tmp/perf_after.json <compress_mbps|decompress_mbps> \
      bench/results/latest.json /tmp
    ```
    This writes `/tmp/perf_before_after_<metric>_<corpus>.{svg,png}` and prints the
@@ -130,22 +165,42 @@ commits don't leak in."
    (any `(pattern, level)` present in one run but not the other), the per-level
    before/after geomean table, and `max |Δratio|`.
 
-7. **Show Kim and wait.** Read the PNGs back so they render, present the
-   before/after geomean tables and the per-corpus speedup, and **stop for Kim's
-   go-ahead before merging.** State the metric, the machine, and any caveat
-   (e.g. machine mismatch, levels skipped, ratio shift on a compress change).
-   Quote the numeric speedup — the y-axis is log, so trust the table, not the eye
-   (see Notes). **Canterbury is measured median-of-5 and is the row set to read
-   for a speed verdict; Silesia is single-pass (`reps=1`), so its per-file MB/s
-   carries ±30%+ run-to-run noise even on byte-identical code — use it for ratio
-   and coverage, not for a fine speed delta.**
+7. **Actually LOOK at the graphs, then show Kim and wait.** This means
+   `Read`-ing the PNG files so they render as images in your context and visually
+   inspecting them — **not** reading the SVG as text and **not** reasoning only
+   from the numeric geomean table. The table gives you the per-level delta; the
+   picture gives you what the table cannot — where the native before/after curves
+   sit *relative to the other-language curves* (is lean-zip in the fast cluster or
+   the slow one? which engines, if any, does this PR move us past?), whether
+   before/after visibly separate or sit on top of each other, and whether any
+   point is an obvious outlier. A reviewer who only quotes the table has not done
+   step 7.
+   ```
+   # render BOTH corpora as images and look at them — required, not optional
+   Read /tmp/perf_before_after_<metric>_canterbury.png
+   Read /tmp/perf_before_after_<metric>_silesia.png
+   ```
+   Present the before/after geomean tables, the per-corpus speedup, **and your
+   visual read of where native lands among the other languages**, then **stop for
+   Kim's go-ahead before merging.** State the metric, the machine, and any caveat
+   (machine mismatch, levels skipped, ratio shift on a compress change, a noisy
+   AFTER run). Quote the numeric speedup — the y-axis is log, so trust the table
+   for the *magnitude* and the picture for the *positioning*. **Canterbury is
+   measured median-of-5 and is the row set to read for a speed verdict; Silesia is
+   single-pass (`reps=1`), so its per-file MB/s carries ±30%+ run-to-run noise
+   even on byte-identical code — use it for ratio and coverage, not for a fine
+   speed delta.**
 
-8. **Also post the graphs as a PR comment.** The PNGs otherwise live only in
-   `/tmp` — so a session Kim was not watching (or that she reads later) leaves
-   her nothing to look at. Make the artifact durable and async-visible by
-   embedding the before/after PNGs in a `gh pr comment`, alongside the geomean
-   table and the metric/machine/caveat line from step 7. This is in addition to
-   the interactive show-and-wait, not a replacement for it.
+8. **Always post the graphs as a PR comment — then give Kim the link.** This step
+   is compulsory, not "also if convenient": every qualifying PR gets a PR comment
+   with the graphs, and your reply to Kim must contain the URL of that comment
+   (`gh pr comment` prints it on success — capture it) so she can click straight
+   to it. The PNGs otherwise live only in `/tmp` — so a session Kim was not
+   watching (or that she reads later) leaves her nothing to look at. Make the
+   artifact durable and async-visible by embedding the before/after PNGs in a
+   `gh pr comment`, alongside the geomean table and the metric/machine/caveat line
+   from step 7. This is in addition to the interactive show-and-wait, not a
+   replacement for it.
 
    `gh` cannot attach images to a comment directly, and the PNGs must **not** be
    committed to the perf PR (step 6 keeps them out of the diff) or to `master`.
@@ -182,6 +237,6 @@ commits don't leak in."
   the ratio (curve moves right) may not be a net win. zopfli's frozen ratio
   ceiling is in `bench/results/zopfli-ceiling.json` if you want the best-ratio
   reference.
-- Keep the temporary jsons and graphs in `/tmp`; restore any swapped-in source
-  files before finishing (`git status` must be clean on the PR branch — a leftover
-  merge-base checkout or a stray graph under `bench/graphs/` is a real footgun).
+- Keep the temporary jsons and graphs in `/tmp`; `git status` must be clean on
+  the PR branch before finishing — a stray graph under `bench/graphs/`, or (if you
+  used the step-4 stale fallback) a leftover `git worktree`, is a real footgun.

--- a/.claude/skills/perf-pr-graphs/SKILL.md
+++ b/.claude/skills/perf-pr-graphs/SKILL.md
@@ -185,11 +185,23 @@ project `.claude/CLAUDE.md`); elsewhere run them directly.
    Kim's go-ahead before merging.** State the metric, the machine, and any caveat
    (machine mismatch, levels skipped, ratio shift on a compress change, a noisy
    AFTER run). Quote the numeric speedup — the y-axis is log, so trust the table
-   for the *magnitude* and the picture for the *positioning*. **Canterbury is
-   measured median-of-5 and is the row set to read for a speed verdict; Silesia is
-   single-pass (`reps=1`), so its per-file MB/s carries ±30%+ run-to-run noise
-   even on byte-identical code — use it for ratio and coverage, not for a fine
-   speed delta.**
+   for the *magnitude* and the picture for the *positioning*.
+
+   **Silesia is the corpus that matters most — weight it above Canterbury for the
+   merge decision.** Silesia is large real-world data (10–50 MB files); Canterbury
+   is small synthetic files (≤1 MB). They **can and do disagree**, because the
+   decode-table access pattern is cache-bound: a change can help on Silesia's
+   large hot-loop files while hurting tiny Canterbury files that fit in cache
+   regardless (issue #2650's de-box measured **−4.5% Canterbury but +5.8%
+   Silesia** — a real split, not noise). **A Silesia win outweighs a Canterbury
+   loss.** Do NOT read Canterbury alone and call it the verdict.
+
+   The catch: Canterbury is median-of-5 (low per-run noise) but unrepresentative;
+   Silesia is single-pass (`reps=1`), so a *single* Silesia run carries ±30%+
+   run-to-run noise and a lone graph cannot resolve a single-digit-% delta on it.
+   When the Silesia delta is small or borderline — exactly when the merge decision
+   hinges on it — do the controlled interleaved measurement below instead of
+   trusting one pass or a cross-session graph.
 
 8. **Always post the graphs as a PR comment — then give Kim the link.** This step
    is compulsory, not "also if convenient": every qualifying PR gets a PR comment
@@ -226,6 +238,38 @@ project `.claude/CLAUDE.md`); elsewhere run them directly.
    Pin the raw URL to the pushed commit SHA (`${gsha}`), not a branch name, so the
    image keeps rendering even if the branch is later updated or deleted. Confirm
    the PR branch's own `git status` is still clean afterward (step 6 footgun).
+
+## Resolving a small or borderline delta (controlled interleaved measurement)
+
+The routine graph (steps 1–8) compares a fresh AFTER against the recorded
+`latest.json` BEFORE — a *cross-session* comparison whose noise floor is a few
+percent, which is fine for visible wins but **cannot** settle a single-digit-%
+delta (and single-pass Silesia adds ±30% on top). When the merge decision hinges
+on a small delta — especially on Silesia — measure both sides **back-to-back in
+one session** so common-mode noise (background load, turbo, thermal) cancels:
+
+- Build a BEFORE binary at the branch merge-base (`git worktree add --detach
+  /tmp/before $(git merge-base origin/master HEAD)` then `lake build bench-report`
+  in it). The AFTER binary is the PR branch's.
+- Run the two binaries **alternately, N times** (≥5 pairs), each pinned to one
+  core (`taskset -c <core>`). Consecutive AFTER/BEFORE runs then see near-identical
+  machine state, so their *ratio* is robust even on a busy machine — the paired
+  ratio + its 95% CI is the verdict, not any single run.
+- **Run BOTH binaries from the MAIN worktree's directory.** Silesia is gitignored
+  and fetched only into the main worktree, so the merge-base worktree has *only*
+  committed Canterbury — running the BEFORE binary from there silently measures
+  Canterbury while AFTER measures Silesia, and the two never overlap. (The
+  `meta.git_commit` stamp follows the CWD, not the binary, so distinguish the two
+  by output filename, not by the stamp.)
+- To get **Silesia** rows, set Canterbury aside (`mv bench/corpora/canterbury …`)
+  so the matrix is fast enough to repeat; restore it after (a `trap` on EXIT).
+  L9's optimal-parse *compress* on 203 MB is minutes/run — measure L9 with fewer
+  pairs, or skip it if 1–8 already settles the sign (decode delta was uniform
+  across levels in #2650).
+- Aggregate paired: for each `(file, level, pair)` take `after/before`, then the
+  geomean and a 95% CI on the log-ratios. CI excluding 1.0 → real; spanning 1.0 →
+  genuinely within noise. This is what turned #2650's "−3% but maybe noise" into a
+  firm "−4.5% Canterbury / +5.8% Silesia".
 
 ## Notes
 

--- a/.claude/skills/perf-pr-graphs/plot_before_after.py
+++ b/.claude/skills/perf-pr-graphs/plot_before_after.py
@@ -18,9 +18,10 @@ Usage:
   latest.json defaults to bench/results/latest.json
   outdir      defaults to /tmp (report artifact — keep it out of the tree)
 
-The before/after jsons are the native rows from `bench-report --native-only`.
-BEFORE is measured at the branch's merge-base with master (a throwaway worktree),
-AFTER on the PR branch; see SKILL.md step 4 for why merge-base and not master.
+AFTER is the native rows from `bench-report --native-only` on the PR branch.
+BEFORE is the committed dashboard `bench/results/latest.json` (its native rows);
+master keeps it current, so no merge-base rebuild — see SKILL.md step 4, and run
+its freshness guard so the snapshot is not stale relative to the merge-base.
 """
 import json, math, sys
 from pathlib import Path
@@ -47,7 +48,7 @@ def _meta1(doc):
     return f"machine={m.get('machine','?')} commit={m.get('git_commit','?')}"
 
 # Provenance: what is actually being compared. The user must confirm BEFORE's
-# commit is the branch merge-base (not origin/master) — see SKILL.md step 4.
+# commit is bench/results/latest.json's; confirm it is not stale — see SKILL.md step 4.
 print(f"BEFORE: {_meta1(BEFORE_DOC)}")
 print(f"AFTER : {_meta1(AFTER_DOC)}")
 print(f"refs  : {_meta1(LATEST_DOC)}  (reused, not re-measured)")
@@ -167,9 +168,9 @@ if only_b or only_a:
 # native rows. An output-neutral PR (dispatch/escape, re-timed loop, proof-side
 # refactor) MUST read 0.000000; a nonzero value means output changed (intended
 # for a parse change, a bug otherwise) or the two runs saw different corpora.
-# NOTE: this does NOT validate baseline freshness — a stale-branch BEFORE has
+# NOTE: this does NOT validate baseline freshness — a stale latest.json BEFORE has
 # identical output, so Δratio stays 0 while the speed curve is silently wrong
-# (confirm BEFORE's commit == merge-base above).
+# (run SKILL.md step 4's freshness guard: no native commit after BEFORE's commit).
 bratio = {(r["pattern"], r["level"]): r["ratio"]
           for r in BEFORE if r["compressor"] == "native" and r.get("ratio") is not None}
 worst, worst_at = 0.0, None


### PR DESCRIPTION
This PR reworks the `perf-pr-graphs` skill so its before/after baseline reads from the committed dashboard `bench/results/latest.json` rather than rebuilding the native path in a merge-base worktree. Master already records up-to-date native median-of-5 numbers, so the rebuild was wasted work: step 4 now passes `latest.json` straight to the plotter as BEFORE, guarded by a freshness check (no `Zip/Native`/`ZipCommon` commit between the snapshot's recorded commit and the branch merge-base — `bench/` changes like a dashboard refresh do not count), with a one-off merge-base build kept only as a documented stale fallback. It records the invariant that native-perf merges must keep the dashboard fresh, and adds a cross-session-noise caveat (a small single-digit-% delta can be machine load, not the PR, since BEFORE was recorded in an earlier session).

It also makes the procedure unmistakably compulsory: a TL;DR spelling out generate → look → post → link in order; step 7 now insists on actually `Read`-ing the rendered PNGs (not reasoning from the numeric table alone) and reporting where native sits among the other-language curves; and step 8 requires posting the graphs as a PR comment and handing Kim the comment URL.

🤖 Prepared with Claude Code