### PR TITLE
bench: dashboard refresh — native rows after the decode de-box (#2657)

### DIFF
--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p2570e6faf8)">
+   <g clip-path="url(#pc7a0c6234e)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJFElEQVR4nO3Yz4rkZxmG4aqemiEMzRCF/HEQESHiwr2LHIObHIhH4FnkCAQhq2xFdOnOM1A0SIhjiM2MGTo9le6e+mWXfeD+eE1xXUfwFAVv3fXtT19+tO34fjleTy9Y5/hyesES293t9IRl9k/enp6wxsM3phesc3ExvWCNu+P0gnX25/mdbS+eTU9Y5jy/MQCAQQILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACB2+NfuanrDEnen4/SEZX705s+mJyxzub07PWGJ/VfPpycs85dXf5+esMSPH709PWGZ+9Pt9IQlrl+f792/Pd1PT1jiV09+Mj1hGS9YAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENu//PrjbXrECq/ur6cnLPPW6fH0hHXub6cXrHF9Nb1gnXd+Pr1gievtZnrCMud6H9/aLqcnLPNs93x6whJPr/43PWEZL1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQO1y+uJresMTl4dH0hHWOn08vWGa7/nJ6whqn0/SCZfaPv5iesMQ535DLw5PpCWs8emN6wTJPX91OT1hiu/nP9IRlvGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQO29Xn0xv4rk6n6QXwre3fn0xPWOPC/8/vHbeR/yMuCABATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQOv/nvp9MblnhxfD09YZm/Pns5PWGZP3zw/vSEJd59/NPpCcv88ne/n56wxK/f++H0hGX++eI4PYHv6I9/+sf0hCVuPvzt9IRlvGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbH9/+vM2PWKF16f76QnLXOzPt4sfHG+mJ6zx4DC9YJ2vnk8vWOL0g6fTE5bZttP0hCUenPGbwd12nr9pD+/P83Ptdl6wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIHa4ONfGujhML1jm4otPpicss10/n56wxu3d9IJl9r94f3rCEmd6GXe73W532k8vWOTrm+kFyzy8O05PWGL77G/TE5Y55xsCADBCYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxL4Bk0+KCAE/SI4AAAAASUVORK5CYII=" id="image874051d7eb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3YzYrk5RmH4eqemkGGZkgCfg0iIZCQRfYSPAY3HohH4FnkCAKCK7ciunTnIeRDQsCJaDOjQztTdvfU35174X55YnFdR/ArCp666z07fv/htuPX5XA1vWCdw9PpBUtsN9fTE5Y5e/DK9IQ17r40vWCd8/PpBWvcHKYXrHN2mt/Z9uTR9IRlTvMbAwAYJLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL7/+wupzcscXM8TE9Y5vXf/GF6wjIX22vTE5Y4++Hx9IRlPn/+j+kJS7xx75XpCcvcHq+nJyxx9eJ07/718XZ6whJvPXhzesIyXrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdvb0x4+26RErPL+9mp6wzMvH+9MT1rm9nl6wxtXl9IJ1Xv3T9IIlrrZn0xOWOdX7+PJ2MT1hmUe7x9MTlnh4+d30hGW8YAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBsf/HkcnrDEhf7e9MT1jl8Pb1gme3q++kJaxyP0wuWObv/zfSEJU75hlzsH0xPWOPeS9MLlnn4/Hp6whLbs/9NT1jGCxYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGy/XX49vYFf6nicXgA/2776cnrCGuf+f/7quI38H3FBAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILZ/79v/Tm9Y4snhxfSEZb549HR6wjIfv/v29IQlXrv/++kJy/zl7x9MT1jinT/+bnrCMv9+cpiewC/0yaf/mp6wxLO/vT89YRkvWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABA7uz1+tk2PWOHF8XZ6wjLnZ6fbxXcOz6YnrHFnP71gnR8eTy9Y4vjbh9MTltm24/SEJe6c8JvBzXaav2l3b0/zc+12XrAAAHICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtj8/1cY6308vWOb8my+nJyyzXT2enrDG9c30gmW2P/91esISJ3sbd7vdi91xesIaN4fpBcvc/fFqesIS21f/nJ6wzOleEACAIQILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACD2E8gzjAPNN8KXAAAAAElFTkSuQmCC" id="image44dfef7242" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mb8f09ca219" d="M 0 0 
+       <path id="m61a1b48d29" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb8f09ca219" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mb8f09ca219" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mb8f09ca219" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb8f09ca219" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb8f09ca219" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb8f09ca219" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mb8f09ca219" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb8f09ca219" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mb8f09ca219" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb8f09ca219" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mb8f09ca219" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m61a1b48d29" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mb25a139f17" d="M 0 0 
+       <path id="mfcadbe4423" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb25a139f17" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcadbe4423" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mb25a139f17" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcadbe4423" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb25a139f17" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcadbe4423" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mb25a139f17" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcadbe4423" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mb25a139f17" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcadbe4423" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mb25a139f17" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcadbe4423" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb25a139f17" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcadbe4423" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mb25a139f17" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfcadbe4423" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1423,8 +1423,78 @@ z
     </g>
    </g>
    <g id="text_24">
-    <!-- -93 -->
+    <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- +4 -->
+    <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -0 -->
+    <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +7 -->
+    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -17 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -34 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1456,64 +1526,6 @@ Q 2613 4750 3031 4423
 Q 3450 4097 3450 3541 
 Q 3450 3153 3228 2886 
 Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- +3 -->
-    <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -2 -->
-    <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- +6 -->
-    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -19 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -34 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1563,18 +1575,6 @@ z
    <g id="text_35">
     <!-- -17 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -2180,18 +2180,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image8ac35385f0" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image1e20cae3e8" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m8adc1b05af" d="M 0 0 
+       <path id="m406477a218" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8adc1b05af" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m406477a218" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2214,7 +2214,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m8adc1b05af" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m406477a218" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m8adc1b05af" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m406477a218" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2242,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m8adc1b05af" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m406477a218" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2255,7 +2255,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m8adc1b05af" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m406477a218" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2268,7 +2268,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m8adc1b05af" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m406477a218" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2281,7 +2281,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m8adc1b05af" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m406477a218" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2942,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-18T02:39:37Z  ·  Linux chungus x86_64  ·  commit 3a38cf0a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(20.068516 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-18T10:42:34Z  ·  Linux chungus x86_64  ·  commit 90fb3272  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.606953 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3012,14 +3012,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3058,109 +3058,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3350.585938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3414.208984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.275391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.009766 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.388672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3911.865234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.728516 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4011.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.089844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.613281 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.417969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.201172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.724609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.003906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.382812 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.697266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4577.876953 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.287109 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.320312 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.027344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4970.890625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5025.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.429688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.638672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.0625 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.441406 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5577.917969 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.296875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5704.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.361328 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.148438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5922.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.724609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.136719 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.660156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6204.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6476.84375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.123047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.599609 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.699219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.259766 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.160156 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6882.947266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.060547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.339844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.300781 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.083984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.183594 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7256.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7381.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.179688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.261719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.640625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.732422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.515625 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2570e6faf8">
+  <clipPath id="pc7a0c6234e">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="me77e4cbe21" d="M 0 0 
+       <path id="me7a1485bf8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me77e4cbe21" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7a1485bf8" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me77e4cbe21" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7a1485bf8" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me77e4cbe21" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7a1485bf8" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me77e4cbe21" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7a1485bf8" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me77e4cbe21" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7a1485bf8" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me77e4cbe21" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7a1485bf8" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me77e4cbe21" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7a1485bf8" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m4a5d941c4c" d="M 0 0 
+       <path id="mcf08da9fcc" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4a5d941c4c" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf08da9fcc" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m4a5d941c4c" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf08da9fcc" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m4a5d941c4c" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcf08da9fcc" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mb156a7fb56" d="M 0 0 
+       <path id="mcb1a6d0ecc" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mb156a7fb56" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mcb1a6d0ecc" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 176.195934) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 175.83363) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 331.226844) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 331.378346) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7d99adc229" d="M -2.5 2.5 
+     <path id="m10ae1ece2f" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bd67a0f40)">
-     <use xlink:href="#m7d99adc229" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d99adc229" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d99adc229" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d99adc229" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d99adc229" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d99adc229" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d99adc229" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d99adc229" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7d99adc229" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb607471df4)">
+     <use xlink:href="#m10ae1ece2f" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10ae1ece2f" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10ae1ece2f" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10ae1ece2f" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10ae1ece2f" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10ae1ece2f" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10ae1ece2f" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10ae1ece2f" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m10ae1ece2f" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1a802262a5" d="M 0 -2.5 
+     <path id="mff686843b9" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bd67a0f40)">
-     <use xlink:href="#m1a802262a5" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a802262a5" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a802262a5" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a802262a5" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a802262a5" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a802262a5" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a802262a5" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a802262a5" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a802262a5" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb607471df4)">
+     <use xlink:href="#mff686843b9" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff686843b9" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff686843b9" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff686843b9" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff686843b9" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff686843b9" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff686843b9" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff686843b9" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mff686843b9" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,39 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m947c7da12a" d="M -0 3.535534 
+     <path id="m81a76d77e9" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bd67a0f40)">
-     <use xlink:href="#m947c7da12a" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m947c7da12a" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m947c7da12a" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m947c7da12a" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m947c7da12a" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m947c7da12a" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m947c7da12a" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m947c7da12a" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m947c7da12a" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb607471df4)">
+     <use xlink:href="#m81a76d77e9" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81a76d77e9" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81a76d77e9" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81a76d77e9" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81a76d77e9" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81a76d77e9" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81a76d77e9" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81a76d77e9" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m81a76d77e9" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1d670fe279" d="M -0 2.5 
+     <path id="m3b1ba4bde3" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bd67a0f40)">
-     <use xlink:href="#m1d670fe279" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb607471df4)">
+     <use xlink:href="#m3b1ba4bde3" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1854,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1a838be6d8" d="M -0.833333 2.5 
+     <path id="m12d6af9dd2" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1871,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bd67a0f40)">
-     <use xlink:href="#m1a838be6d8" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a838be6d8" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a838be6d8" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a838be6d8" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a838be6d8" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a838be6d8" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a838be6d8" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a838be6d8" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a838be6d8" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb607471df4)">
+     <use xlink:href="#m12d6af9dd2" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d6af9dd2" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d6af9dd2" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d6af9dd2" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d6af9dd2" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d6af9dd2" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d6af9dd2" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d6af9dd2" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m12d6af9dd2" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1893,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m8725d1a912" d="M -1.25 2.5 
+     <path id="m3d5222f503" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1910,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bd67a0f40)">
-     <use xlink:href="#m8725d1a912" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8725d1a912" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8725d1a912" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8725d1a912" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8725d1a912" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8725d1a912" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8725d1a912" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8725d1a912" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8725d1a912" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb607471df4)">
+     <use xlink:href="#m3d5222f503" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d5222f503" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d5222f503" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d5222f503" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d5222f503" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d5222f503" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d5222f503" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d5222f503" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d5222f503" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1932,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m01ca6d8594" d="M 0 -2.5 
+     <path id="mff3736a009" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1947,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p3bd67a0f40)">
-     <use xlink:href="#m01ca6d8594" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01ca6d8594" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01ca6d8594" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01ca6d8594" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01ca6d8594" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01ca6d8594" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01ca6d8594" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01ca6d8594" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01ca6d8594" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pb607471df4)">
+     <use xlink:href="#mff3736a009" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3736a009" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3736a009" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3736a009" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3736a009" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3736a009" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3736a009" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3736a009" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mff3736a009" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1969,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m61adb41649" d="M 0 -2.5 
+     <path id="mc5a7612362" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bd67a0f40)">
-     <use xlink:href="#m61adb41649" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61adb41649" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61adb41649" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61adb41649" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61adb41649" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61adb41649" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61adb41649" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61adb41649" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m61adb41649" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb607471df4)">
+     <use xlink:href="#mc5a7612362" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5a7612362" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5a7612362" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5a7612362" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5a7612362" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5a7612362" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5a7612362" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5a7612362" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc5a7612362" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m215b443f56" d="M 0 3.5 
+      <path id="m8d447cb2b0" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m215b443f56" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m8d447cb2b0" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7d99adc229" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m10ae1ece2f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1a802262a5" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mff686843b9" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m947c7da12a" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m81a76d77e9" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1d670fe279" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3b1ba4bde3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1a838be6d8" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m12d6af9dd2" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m8725d1a912" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3d5222f503" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m01ca6d8594" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mff3736a009" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m61adb41649" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc5a7612362" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 181.195934 
-L 214.084819 183.652786 
-L 206.266533 185.974032 
-L 187.75787 192.735599 
-L 186.58897 193.559229 
-L 184.505355 195.655006 
-L 152.30308 249.297503 
-L 150.950891 251.291662 
-L 98.348822 336.226844 
-" clip-path="url(#p3bd67a0f40)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p3bd67a0f40)">
-     <use xlink:href="#m215b443f56" x="226.647908" y="181.195934" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m215b443f56" x="214.084819" y="183.652786" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m215b443f56" x="206.266533" y="185.974032" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m215b443f56" x="187.75787" y="192.735599" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m215b443f56" x="186.58897" y="193.559229" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m215b443f56" x="184.505355" y="195.655006" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m215b443f56" x="152.30308" y="249.297503" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m215b443f56" x="150.950891" y="251.291662" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m215b443f56" x="98.348822" y="336.226844" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 180.83363 
+L 214.084819 183.375509 
+L 206.266533 185.718667 
+L 187.75787 192.370738 
+L 186.58897 193.392641 
+L 184.505355 195.496555 
+L 152.30308 249.103947 
+L 150.950891 251.006559 
+L 98.348822 336.378346 
+" clip-path="url(#pb607471df4)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#pb607471df4)">
+     <use xlink:href="#m8d447cb2b0" x="226.647908" y="180.83363" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d447cb2b0" x="214.084819" y="183.375509" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d447cb2b0" x="206.266533" y="185.718667" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d447cb2b0" x="187.75787" y="192.370738" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d447cb2b0" x="186.58897" y="193.392641" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d447cb2b0" x="184.505355" y="195.496555" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d447cb2b0" x="152.30308" y="249.103947" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d447cb2b0" x="150.950891" y="251.006559" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8d447cb2b0" x="98.348822" y="336.378346" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-18T02:39:37Z  ·  Linux chungus x86_64  ·  commit 3a38cf0a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.068516 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-18T10:42:34Z  ·  Linux chungus x86_64  ·  commit 90fb3272  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.606953 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2916,46 +2916,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -3015,6 +2975,46 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3055,14 +3055,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3101,109 +3101,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3350.585938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3414.208984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.275391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.009766 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.388672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3911.865234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.728516 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4011.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.089844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.613281 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.417969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.201172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.724609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.003906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.382812 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.697266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4577.876953 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.287109 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.320312 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.027344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4970.890625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5025.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.429688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.638672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.0625 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.441406 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5577.917969 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.296875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5704.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.361328 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.148438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5922.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.724609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.136719 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.660156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6204.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6476.84375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.123047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.599609 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.699219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.259766 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.160156 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6882.947266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.060547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.339844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.300781 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.083984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.183594 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7256.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7381.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.179688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.261719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.640625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.732422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.515625 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3bd67a0f40">
+  <clipPath id="pb607471df4">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p0fe46e054c)">
+   <g clip-path="url(#pc2f960e7fe)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="imagef11ee257b7" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image22c0264c09" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m4a1cb52c8e" d="M 0 0 
+       <path id="m5611bf8dc9" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m4a1cb52c8e" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5611bf8dc9" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m6592139786" d="M 0 0 
+       <path id="mc23f449600" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6592139786" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc23f449600" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m6592139786" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc23f449600" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6592139786" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc23f449600" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m6592139786" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc23f449600" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m6592139786" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc23f449600" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m6592139786" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc23f449600" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6592139786" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc23f449600" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m6592139786" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc23f449600" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image57b4bb4407" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagedddb6495e2" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m1404bfb4d6" d="M 0 0 
+       <path id="md127eed562" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1404bfb4d6" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md127eed562" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m1404bfb4d6" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md127eed562" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1404bfb4d6" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md127eed562" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m1404bfb4d6" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md127eed562" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1404bfb4d6" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md127eed562" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m1404bfb4d6" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md127eed562" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1404bfb4d6" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md127eed562" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m1404bfb4d6" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md127eed562" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1404bfb4d6" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md127eed562" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-18T02:39:37Z  ·  Linux chungus x86_64  ·  commit 3a38cf0a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(20.068516 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-18T10:42:34Z  ·  Linux chungus x86_64  ·  commit 90fb3272  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.606953 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,14 +2953,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3350.585938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3414.208984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.275391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.009766 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.388672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3911.865234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.728516 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4011.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.089844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.613281 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.417969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.201172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.724609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.003906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.382812 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.697266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4577.876953 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.287109 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.320312 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.027344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4970.890625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5025.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.429688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.638672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.0625 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.441406 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5577.917969 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.296875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5704.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.361328 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.148438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5922.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.724609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.136719 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.660156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6204.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6476.84375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.123047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.599609 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.699219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.259766 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.160156 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6882.947266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.060547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.339844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.300781 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.083984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.183594 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7256.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7381.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.179688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.261719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.640625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.732422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.515625 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0fe46e054c">
+  <clipPath id="pc2f960e7fe">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.262969pt" height="386.202469pt" viewBox="0 0 568.262969 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.186094pt" height="386.202469pt" viewBox="0 0 569.186094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.262969 386.202469 
-L 568.262969 0 
+L 569.186094 386.202469 
+L 569.186094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.256484 104.1264 
-L 290.881484 104.1264 
-L 290.881484 74.7432 
-L 186.256484 74.7432 
+    <path d="M 186.718047 104.1264 
+L 291.343047 104.1264 
+L 291.343047 74.7432 
+L 186.718047 74.7432 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.881484 104.1264 
-L 395.506484 104.1264 
-L 395.506484 74.7432 
-L 290.881484 74.7432 
+    <path d="M 291.343047 104.1264 
+L 395.968047 104.1264 
+L 395.968047 74.7432 
+L 291.343047 74.7432 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.506484 104.1264 
-L 500.131484 104.1264 
-L 500.131484 74.7432 
-L 395.506484 74.7432 
+    <path d="M 395.968047 104.1264 
+L 500.593047 104.1264 
+L 500.593047 74.7432 
+L 395.968047 74.7432 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.256484 133.5096 
-L 290.881484 133.5096 
-L 290.881484 104.1264 
-L 186.256484 104.1264 
+    <path d="M 186.718047 133.5096 
+L 291.343047 133.5096 
+L 291.343047 104.1264 
+L 186.718047 104.1264 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.881484 133.5096 
-L 395.506484 133.5096 
-L 395.506484 104.1264 
-L 290.881484 104.1264 
+    <path d="M 291.343047 133.5096 
+L 395.968047 133.5096 
+L 395.968047 104.1264 
+L 291.343047 104.1264 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.506484 133.5096 
-L 500.131484 133.5096 
-L 500.131484 104.1264 
-L 395.506484 104.1264 
+    <path d="M 395.968047 133.5096 
+L 500.593047 133.5096 
+L 500.593047 104.1264 
+L 395.968047 104.1264 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.256484 162.8928 
-L 290.881484 162.8928 
-L 290.881484 133.5096 
-L 186.256484 133.5096 
+    <path d="M 186.718047 162.8928 
+L 291.343047 162.8928 
+L 291.343047 133.5096 
+L 186.718047 133.5096 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.881484 162.8928 
-L 395.506484 162.8928 
-L 395.506484 133.5096 
-L 290.881484 133.5096 
+    <path d="M 291.343047 162.8928 
+L 395.968047 162.8928 
+L 395.968047 133.5096 
+L 291.343047 133.5096 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.506484 162.8928 
-L 500.131484 162.8928 
-L 500.131484 133.5096 
-L 395.506484 133.5096 
+    <path d="M 395.968047 162.8928 
+L 500.593047 162.8928 
+L 500.593047 133.5096 
+L 395.968047 133.5096 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.256484 192.276 
-L 290.881484 192.276 
-L 290.881484 162.8928 
-L 186.256484 162.8928 
+    <path d="M 186.718047 192.276 
+L 291.343047 192.276 
+L 291.343047 162.8928 
+L 186.718047 162.8928 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.881484 192.276 
-L 395.506484 192.276 
-L 395.506484 162.8928 
-L 290.881484 162.8928 
+    <path d="M 291.343047 192.276 
+L 395.968047 192.276 
+L 395.968047 162.8928 
+L 291.343047 162.8928 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.506484 192.276 
-L 500.131484 192.276 
-L 500.131484 162.8928 
-L 395.506484 162.8928 
+    <path d="M 395.968047 192.276 
+L 500.593047 192.276 
+L 500.593047 162.8928 
+L 395.968047 162.8928 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.256484 221.6592 
-L 290.881484 221.6592 
-L 290.881484 192.276 
-L 186.256484 192.276 
+    <path d="M 186.718047 221.6592 
+L 291.343047 221.6592 
+L 291.343047 192.276 
+L 186.718047 192.276 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.881484 221.6592 
-L 395.506484 221.6592 
-L 395.506484 192.276 
-L 290.881484 192.276 
+    <path d="M 291.343047 221.6592 
+L 395.968047 221.6592 
+L 395.968047 192.276 
+L 291.343047 192.276 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.506484 221.6592 
-L 500.131484 221.6592 
-L 500.131484 192.276 
-L 395.506484 192.276 
+    <path d="M 395.968047 221.6592 
+L 500.593047 221.6592 
+L 500.593047 192.276 
+L 395.968047 192.276 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.256484 251.0424 
-L 290.881484 251.0424 
-L 290.881484 221.6592 
-L 186.256484 221.6592 
+    <path d="M 186.718047 251.0424 
+L 291.343047 251.0424 
+L 291.343047 221.6592 
+L 186.718047 221.6592 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.881484 251.0424 
-L 395.506484 251.0424 
-L 395.506484 221.6592 
-L 290.881484 221.6592 
+    <path d="M 291.343047 251.0424 
+L 395.968047 251.0424 
+L 395.968047 221.6592 
+L 291.343047 221.6592 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.506484 251.0424 
-L 500.131484 251.0424 
-L 500.131484 221.6592 
-L 395.506484 221.6592 
+    <path d="M 395.968047 251.0424 
+L 500.593047 251.0424 
+L 500.593047 221.6592 
+L 395.968047 221.6592 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #eb5a3a; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.256484 280.4256 
-L 290.881484 280.4256 
-L 290.881484 251.0424 
-L 186.256484 251.0424 
+    <path d="M 186.718047 280.4256 
+L 291.343047 280.4256 
+L 291.343047 251.0424 
+L 186.718047 251.0424 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.881484 280.4256 
-L 395.506484 280.4256 
-L 395.506484 251.0424 
-L 290.881484 251.0424 
+    <path d="M 291.343047 280.4256 
+L 395.968047 280.4256 
+L 395.968047 251.0424 
+L 291.343047 251.0424 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.506484 280.4256 
-L 500.131484 280.4256 
-L 500.131484 251.0424 
-L 395.506484 251.0424 
+    <path d="M 395.968047 280.4256 
+L 500.593047 280.4256 
+L 500.593047 251.0424 
+L 395.968047 251.0424 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.256484 309.8088 
-L 290.881484 309.8088 
-L 290.881484 280.4256 
-L 186.256484 280.4256 
+    <path d="M 186.718047 309.8088 
+L 291.343047 309.8088 
+L 291.343047 280.4256 
+L 186.718047 280.4256 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.881484 309.8088 
-L 395.506484 309.8088 
-L 395.506484 280.4256 
-L 290.881484 280.4256 
+    <path d="M 291.343047 309.8088 
+L 395.968047 309.8088 
+L 395.968047 280.4256 
+L 291.343047 280.4256 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.506484 309.8088 
-L 500.131484 309.8088 
-L 500.131484 280.4256 
-L 395.506484 280.4256 
+    <path d="M 395.968047 309.8088 
+L 500.593047 309.8088 
+L 500.593047 280.4256 
+L 395.968047 280.4256 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.256484 339.192 
-L 290.881484 339.192 
-L 290.881484 309.8088 
-L 186.256484 309.8088 
+    <path d="M 186.718047 339.192 
+L 291.343047 339.192 
+L 291.343047 309.8088 
+L 186.718047 309.8088 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.881484 339.192 
-L 395.506484 339.192 
-L 395.506484 309.8088 
-L 290.881484 309.8088 
+    <path d="M 291.343047 339.192 
+L 395.968047 339.192 
+L 395.968047 309.8088 
+L 291.343047 309.8088 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.506484 339.192 
-L 500.131484 339.192 
-L 500.131484 309.8088 
-L 395.506484 309.8088 
+    <path d="M 395.968047 339.192 
+L 500.593047 339.192 
+L 500.593047 309.8088 
+L 395.968047 309.8088 
 z
-" clip-path="url(#p3e6418dfed)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pab340a9c1c)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.24375 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.705313 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.527969 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.989531 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.100078 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.561641 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.451797 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.913359 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.181484 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.643047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.117734 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(335.558984 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.020547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.183984 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.819609 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.281172 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.117734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.103984 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.183984 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.082734 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.544297 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.117734 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.103984 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.183984 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.388984 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.850547 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.117734 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.103984 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.183984 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(118.545234 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.006797 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.117734 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.103984 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.183984 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.890859 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.352422 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(225.917109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.378672 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1700,7 +1700,7 @@ z
    </g>
    <g id="text_27">
     <!-- 25 -->
-    <g transform="translate(337.627734 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.089297 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1755,8 +1755,8 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- 119 -->
-    <g transform="translate(439.469609 238.5583) scale(0.08 -0.08)">
+    <!-- 113 -->
+    <g transform="translate(439.931172 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1772,45 +1772,15 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
-z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(95.005859 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.467422 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1939,7 +1909,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(227.117734 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1949,14 +1919,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(338.103984 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(440.183984 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1964,7 +1934,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(97.512734 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.974297 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2020,7 +1990,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(227.117734 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2030,21 +2000,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(338.103984 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(442.728984 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.190547 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.227109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.688672 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2055,7 +2025,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.117734 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2065,13 +2035,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(340.648984 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.110547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.818984 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.280547 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2087,7 +2057,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(133.640234 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.101797 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2300,7 +2270,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-18T02:39:37Z  ·  Linux chungus x86_64  ·  commit 3a38cf0a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-18T10:42:34Z  ·  Linux chungus x86_64  ·  commit 90fb3272  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2441,14 +2411,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2487,110 +2457,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3350.585938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3414.208984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.275391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.009766 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.388672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3911.865234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.728516 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4011.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.089844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.613281 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.417969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.201172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.724609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.003906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.382812 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.697266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4577.876953 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.287109 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.320312 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.027344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4970.890625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5025.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.429688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.638672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.0625 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.441406 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5577.917969 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.296875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5704.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.361328 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.148438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5922.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.724609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.136719 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.660156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6204.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6476.84375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.123047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.599609 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.699219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.259766 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.160156 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6882.947266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.060547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.339844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.300781 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.083984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.183594 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7256.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7381.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.179688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.261719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.640625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.732422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.515625 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3e6418dfed">
-   <rect x="81.631484" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pab340a9c1c">
+   <rect x="82.093047" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pca0ea09ffd)">
+   <g clip-path="url(#p65c059e785)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ6ElEQVR4nO3Xu46VVQCGYfbMZkAOEQUhakJs1EoTopWNd2DhZVja2lta29p7A1YaKxNjtMNOghYKkYgcMjN7Zo9XYEXWu4Y/z3MFX/If1rtW27+/OjmzZJv92Qt4Ftuj2QvGWu3MXjDW0eHsBWNduDJ7wVgHj2cvGGt3b/YCnsXS38+9C7MXDLXw0w8AgNNGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkFr/tLkze8NQ653d2ROG2p6czJ4w1PXL12dPGOrOv7/PnjDWwq+4b52/MnvCUJtze7MnDPXzvduzJwz17rU3Z08Y6mBvO3vCUKvV09kThlr48QAAwGkjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS65uX35i9Yagr567PnjDU/f0/Zk8Y6rWny74jXbr6zuwJQ+2u1rMnDLU9s509YahXzlybPWGoo2uHsycMdePCzdkThtpsl/38Lh4u+/+y7NMdAIBTR4ACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJBar1bLbtBHmwezJwz1wu6l2ROGOr768uwJQ/358JfZE4Z6fLg/e8JQ7730/uwJQx3uzl4w1pPNo9kTeAb/HNybPWGsc9dnLxhq2fUJAMCpI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEitjr//9GT2iKG229kL4P/tuAM+1/xfnm9L//6W/n56fs+1hT89AABOGwEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqfePHX2dvGGpnvezGvnf7/uwJQ335ya3ZE4b6/Ie/Zk8Y6sObL86eMNTX3/02e8JQn3389uwJQ33x7d3ZE4b66NarsycMdffhwewJQ33w+sXZE4Zadp0BAHDqCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1Gpz/M3J7BEj7R4dzZ4w1s569oKxjvZnLxhr78LsBWOtFn7HPdnOXjDWxvf3XDte9vm3WS37+zu78H5Z+OkAAMBpI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEittyfb2RuG2l3vzZ4w1mrhd4iHD2YvGOp47/zsCUPtHh3NnjDWwv+fZw6fzl4w1JOdZb+fF4+XfT6cXfr5d/B49oKhFv70AAA4bQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/wDD736c3IrNpwAAAABJRU5ErkJggg==" id="image503c0b09a4" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ6klEQVR4nO3YPW5cVQCGYY89cUJ+RCAhESBFNEAFUgQVDTugYBmUtPSU1LT0bIAKRIWEEHShIwoUkIiIkB/FHnvMCqii8x7n6nlW8Fnn3jnv9Wr791cnO0u2eTp7Ac9iezR7wVir3dkLxjo6nL1grPOXZy8Y6+DR7AVj7e3PXsCzWPrzuX9+9oKhFn77AQBw2ghQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS6582t2dvGGq9uzd7wlDbk5PZE4a6duna7AlD3f7399kTxlr4J+5b5y7PnjDU5uz+7AlD/Xz31uwJQ7179c3ZE4Y62N/OnjDUavVk9oShFn49AABw2ghQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT6xqU3Zm8Y6vLZa7MnDHXv6R+zJwz12pNlfyNdvPLO7AlD7a3WsycMtd3Zzp4w1Cs7V2dPGOro6uHsCUNdP39j9oShNttln9+Fw2X/viz7dgcA4NQRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApNar1bIb9OHm/uwJQ72wd3H2hKGOr7w8e8JQfz74ZfaEoR4dPp09Yaj3Xnp/9oShDvdmLxjr8ebh7Ak8g38O7s6eMNbZa7MXDLXs+gQA4NQRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApFbH3396MnvEUNvt7AXw/3Z9Az7X/L4835b+/i39+XR+z7WFnx4AAKeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILW+/uOvszcMtbtedmPfvXVv9oShvvzk5uwJQ33+w1+zJwz14Y0XZ08Y6uvvfps9YajPPn579oShvvj2zuwJQ31089XZE4a68+Bg9oShPnj9wuwJQy27zgAAOHUEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqtTn+5mT2iJH2jo5mTxhrdz17wVhHT2cvGGv//OwFY60W/o17sp29YKyN9++5drzs+2+zWvb7d2bh/bLw2wEAgNNGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkFpvT7azNwy1d+bc7AlDbXeWfX67D+7PnjDU8f6yn8+9zeHsCTyLwyezFwz1ePdo9oShLhwv+39MZ1bL/vt2Dh7NXjDUwk8PAIDTRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJD6D5d8fposqcCEAAAAAElFTkSuQmCC" id="image1a72e39f4d" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me59779580c" d="M 0 0 
+       <path id="mc02abc87e8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me59779580c" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me59779580c" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me59779580c" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me59779580c" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me59779580c" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me59779580c" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me59779580c" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me59779580c" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me59779580c" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me59779580c" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me59779580c" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me59779580c" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc02abc87e8" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mf52fd82ca5" d="M 0 0 
+       <path id="ma87294f766" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf52fd82ca5" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma87294f766" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf52fd82ca5" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma87294f766" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mf52fd82ca5" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma87294f766" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mf52fd82ca5" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma87294f766" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mf52fd82ca5" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma87294f766" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf52fd82ca5" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma87294f766" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mf52fd82ca5" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma87294f766" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf52fd82ca5" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma87294f766" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +8 -->
+    <!-- +9 -->
     <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,81 +1156,44 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
 z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -4 -->
+    <!-- -2 -->
     <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +2 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1257,8 +1220,36 @@ Q 1991 1309 1228 531
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +4 -->
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1353,47 +1344,8 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- -9 -->
-    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
     <!-- -11 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1413,6 +1365,37 @@ z
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -10 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1467,19 +1450,60 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- -12 -->
+    <!-- -13 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- -27 -->
+    <!-- -28 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1591,29 +1615,6 @@ z
    <g id="text_47">
     <!-- +305 -->
     <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -2192,18 +2193,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image5e2d7fcf2b" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image4e1e5893e2" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mf735f4f187" d="M 0 0 
+       <path id="mf3d91beaf4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf735f4f187" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf3d91beaf4" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2226,7 +2227,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mf735f4f187" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf3d91beaf4" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2240,7 +2241,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mf735f4f187" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf3d91beaf4" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2254,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf735f4f187" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf3d91beaf4" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2267,7 +2268,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mf735f4f187" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf3d91beaf4" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2280,7 +2281,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf735f4f187" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf3d91beaf4" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2293,7 +2294,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mf735f4f187" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf3d91beaf4" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2909,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-18T02:39:37Z  ·  Linux chungus x86_64  ·  commit 3a38cf0a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.068516 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-18T10:42:34Z  ·  Linux chungus x86_64  ·  commit 90fb3272  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.606953 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3001,14 +3002,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3047,109 +3048,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3350.585938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3414.208984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.275391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.009766 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.388672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3911.865234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.728516 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4011.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.089844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.613281 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.417969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.201172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.724609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.003906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.382812 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.697266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4577.876953 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.287109 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.320312 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.027344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4970.890625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5025.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.429688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.638672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.0625 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.441406 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5577.917969 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.296875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5704.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.361328 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.148438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5922.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.724609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.136719 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.660156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6204.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6476.84375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.123047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.599609 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.699219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.259766 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.160156 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6882.947266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.060547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.339844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.300781 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.083984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.183594 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7256.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7381.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.179688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.261719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.640625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.732422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.515625 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pca0ea09ffd">
+  <clipPath id="p65c059e785">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mc94a6e33c8" d="M 0 0 
+       <path id="m257f297485" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc94a6e33c8" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m257f297485" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc94a6e33c8" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m257f297485" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc94a6e33c8" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m257f297485" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc94a6e33c8" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m257f297485" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc94a6e33c8" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m257f297485" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc94a6e33c8" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m257f297485" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc94a6e33c8" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m257f297485" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="maf36e50ffc" d="M 0 0 
+       <path id="m6fcf506829" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#maf36e50ffc" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6fcf506829" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#maf36e50ffc" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6fcf506829" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#maf36e50ffc" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6fcf506829" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mf5de4b401f" d="M 0 0 
+       <path id="ma1356a3e99" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mf5de4b401f" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#ma1356a3e99" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 149.799244) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 149.254171) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 351.995385) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 352.176692) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1eb34ce28b" d="M -2.5 2.5 
+     <path id="m2bbc0b68f1" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdac5428ad0)">
-     <use xlink:href="#m1eb34ce28b" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eb34ce28b" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eb34ce28b" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eb34ce28b" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eb34ce28b" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eb34ce28b" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eb34ce28b" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eb34ce28b" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1eb34ce28b" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0e7347369d)">
+     <use xlink:href="#m2bbc0b68f1" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2bbc0b68f1" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2bbc0b68f1" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2bbc0b68f1" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2bbc0b68f1" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2bbc0b68f1" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2bbc0b68f1" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2bbc0b68f1" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2bbc0b68f1" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1a159b567e" d="M 0 -2.5 
+     <path id="m840bd12558" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdac5428ad0)">
-     <use xlink:href="#m1a159b567e" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a159b567e" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a159b567e" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a159b567e" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a159b567e" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a159b567e" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a159b567e" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a159b567e" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a159b567e" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0e7347369d)">
+     <use xlink:href="#m840bd12558" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m840bd12558" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m840bd12558" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m840bd12558" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m840bd12558" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m840bd12558" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m840bd12558" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m840bd12558" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m840bd12558" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,39 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma0eb6d6cdf" d="M -0 3.535534 
+     <path id="me003b5d54d" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdac5428ad0)">
-     <use xlink:href="#ma0eb6d6cdf" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma0eb6d6cdf" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma0eb6d6cdf" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma0eb6d6cdf" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma0eb6d6cdf" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma0eb6d6cdf" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma0eb6d6cdf" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma0eb6d6cdf" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma0eb6d6cdf" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0e7347369d)">
+     <use xlink:href="#me003b5d54d" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me003b5d54d" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me003b5d54d" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me003b5d54d" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me003b5d54d" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me003b5d54d" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me003b5d54d" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me003b5d54d" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me003b5d54d" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mcf43cb9393" d="M -0 2.5 
+     <path id="me5a6250c8b" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdac5428ad0)">
-     <use xlink:href="#mcf43cb9393" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0e7347369d)">
+     <use xlink:href="#me5a6250c8b" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1808,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m66a1cd97dc" d="M -0.833333 2.5 
+     <path id="m8f8828f4d4" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1825,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdac5428ad0)">
-     <use xlink:href="#m66a1cd97dc" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m66a1cd97dc" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m66a1cd97dc" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m66a1cd97dc" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m66a1cd97dc" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m66a1cd97dc" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m66a1cd97dc" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m66a1cd97dc" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m66a1cd97dc" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0e7347369d)">
+     <use xlink:href="#m8f8828f4d4" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f8828f4d4" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f8828f4d4" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f8828f4d4" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f8828f4d4" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f8828f4d4" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f8828f4d4" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f8828f4d4" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f8828f4d4" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1847,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb4566e0ebf" d="M -1.25 2.5 
+     <path id="m54e1c3d075" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1864,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdac5428ad0)">
-     <use xlink:href="#mb4566e0ebf" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4566e0ebf" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4566e0ebf" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4566e0ebf" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4566e0ebf" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4566e0ebf" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4566e0ebf" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4566e0ebf" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb4566e0ebf" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0e7347369d)">
+     <use xlink:href="#m54e1c3d075" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54e1c3d075" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54e1c3d075" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54e1c3d075" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54e1c3d075" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54e1c3d075" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54e1c3d075" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54e1c3d075" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m54e1c3d075" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1886,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0a232f93b8" d="M 0 -2.5 
+     <path id="m8af2bcc172" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1901,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pdac5428ad0)">
-     <use xlink:href="#m0a232f93b8" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a232f93b8" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a232f93b8" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a232f93b8" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a232f93b8" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a232f93b8" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a232f93b8" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a232f93b8" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0a232f93b8" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p0e7347369d)">
+     <use xlink:href="#m8af2bcc172" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8af2bcc172" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8af2bcc172" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8af2bcc172" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8af2bcc172" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8af2bcc172" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8af2bcc172" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8af2bcc172" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8af2bcc172" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1923,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m79f9d6d281" d="M 0 -2.5 
+     <path id="m5f643a1a6b" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pdac5428ad0)">
-     <use xlink:href="#m79f9d6d281" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79f9d6d281" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79f9d6d281" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79f9d6d281" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79f9d6d281" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79f9d6d281" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79f9d6d281" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79f9d6d281" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m79f9d6d281" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0e7347369d)">
+     <use xlink:href="#m5f643a1a6b" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5f643a1a6b" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5f643a1a6b" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5f643a1a6b" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5f643a1a6b" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5f643a1a6b" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5f643a1a6b" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5f643a1a6b" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5f643a1a6b" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="mf61b1068ee" d="M 0 3.5 
+      <path id="mae603fd162" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mf61b1068ee" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mae603fd162" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1eb34ce28b" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2bbc0b68f1" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1a159b567e" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m840bd12558" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma0eb6d6cdf" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me003b5d54d" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mcf43cb9393" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me5a6250c8b" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m66a1cd97dc" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8f8828f4d4" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb4566e0ebf" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m54e1c3d075" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0a232f93b8" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m8af2bcc172" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m79f9d6d281" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5f643a1a6b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 154.799244 
-L 236.23654 159.150479 
-L 222.073314 163.032452 
-L 202.315941 172.372961 
-L 199.905291 174.12289 
-L 195.893147 177.949703 
-L 157.982343 243.485067 
-L 157.246106 245.686756 
-L 95.319203 356.995385 
-" clip-path="url(#pdac5428ad0)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pdac5428ad0)">
-     <use xlink:href="#mf61b1068ee" x="257.531237" y="154.799244" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf61b1068ee" x="236.23654" y="159.150479" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf61b1068ee" x="222.073314" y="163.032452" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf61b1068ee" x="202.315941" y="172.372961" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf61b1068ee" x="199.905291" y="174.12289" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf61b1068ee" x="195.893147" y="177.949703" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf61b1068ee" x="157.982343" y="243.485067" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf61b1068ee" x="157.246106" y="245.686756" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mf61b1068ee" x="95.319203" y="356.995385" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 154.254171 
+L 236.23654 158.427477 
+L 222.073314 162.162962 
+L 202.315941 172.494046 
+L 199.905291 173.995659 
+L 195.893147 177.840428 
+L 157.982343 243.559675 
+L 157.246106 245.453438 
+L 95.319203 357.176692 
+" clip-path="url(#p0e7347369d)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p0e7347369d)">
+     <use xlink:href="#mae603fd162" x="257.531237" y="154.254171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae603fd162" x="236.23654" y="158.427477" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae603fd162" x="222.073314" y="162.162962" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae603fd162" x="202.315941" y="172.494046" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae603fd162" x="199.905291" y="173.995659" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae603fd162" x="195.893147" y="177.840428" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae603fd162" x="157.982343" y="243.559675" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae603fd162" x="157.246106" y="245.453438" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mae603fd162" x="95.319203" y="357.176692" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-18T02:39:37Z  ·  Linux chungus x86_64  ·  commit 3a38cf0a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.068516 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-18T10:42:34Z  ·  Linux chungus x86_64  ·  commit 90fb3272  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.606953 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2828,46 +2828,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2927,6 +2887,46 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -2967,14 +2967,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3013,109 +3013,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3350.585938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3414.208984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.275391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.009766 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.388672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3911.865234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.728516 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4011.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.089844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.613281 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.417969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.201172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.724609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.003906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.382812 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.697266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4577.876953 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.287109 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.320312 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.027344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4970.890625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5025.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.429688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.638672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.0625 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.441406 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5577.917969 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.296875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5704.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.361328 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.148438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5922.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.724609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.136719 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.660156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6204.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6476.84375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.123047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.599609 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.699219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.259766 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.160156 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6882.947266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.060547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.339844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.300781 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.083984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.183594 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7256.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7381.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.179688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.261719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.640625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.732422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.515625 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pdac5428ad0">
+  <clipPath id="p0e7347369d">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p340b84483c)">
+   <g clip-path="url(#pfbee412ebc)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image1d1bcbc4b3" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image13dda8f0f6" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m32c714e90e" d="M 0 0 
+       <path id="m8a3c25bded" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m32c714e90e" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m32c714e90e" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m32c714e90e" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m32c714e90e" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m32c714e90e" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m32c714e90e" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m32c714e90e" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m32c714e90e" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m32c714e90e" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m32c714e90e" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m32c714e90e" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m32c714e90e" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8a3c25bded" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m4352cecd8c" d="M 0 0 
+       <path id="m7134907cae" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4352cecd8c" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7134907cae" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m4352cecd8c" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7134907cae" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m4352cecd8c" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7134907cae" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m4352cecd8c" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7134907cae" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m4352cecd8c" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7134907cae" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m4352cecd8c" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7134907cae" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m4352cecd8c" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7134907cae" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m4352cecd8c" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7134907cae" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageb4a713f674" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagea706714f88" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="md326a9dce6" d="M 0 0 
+       <path id="ma8752b42c2" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md326a9dce6" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8752b42c2" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md326a9dce6" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8752b42c2" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#md326a9dce6" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8752b42c2" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md326a9dce6" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8752b42c2" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#md326a9dce6" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma8752b42c2" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-18T02:39:37Z  ·  Linux chungus x86_64  ·  commit 3a38cf0a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.068516 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-18T10:42:34Z  ·  Linux chungus x86_64  ·  commit 90fb3272  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.606953 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2872,14 +2872,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3350.585938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3414.208984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.275391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.009766 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.388672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3911.865234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.728516 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4011.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.089844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.613281 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.417969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.201172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.724609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.003906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.382812 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.697266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4577.876953 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.287109 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.320312 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.027344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4970.890625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5025.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.429688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.638672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.0625 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.441406 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5577.917969 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.296875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5704.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.361328 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.148438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5922.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.724609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.136719 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.660156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6204.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6476.84375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.123047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.599609 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.699219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.259766 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.160156 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6882.947266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.060547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.339844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.300781 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.083984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.183594 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7256.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7381.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.179688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.261719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.640625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.732422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.515625 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p340b84483c">
+  <clipPath id="pfbee412ebc">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.262969pt" height="386.202469pt" viewBox="0 0 568.262969 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.186094pt" height="386.202469pt" viewBox="0 0 569.186094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.262969 386.202469 
-L 568.262969 0 
+L 569.186094 386.202469 
+L 569.186094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.256484 104.1264 
-L 290.881484 104.1264 
-L 290.881484 74.7432 
-L 186.256484 74.7432 
+    <path d="M 186.718047 104.1264 
+L 291.343047 104.1264 
+L 291.343047 74.7432 
+L 186.718047 74.7432 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.881484 104.1264 
-L 395.506484 104.1264 
-L 395.506484 74.7432 
-L 290.881484 74.7432 
+    <path d="M 291.343047 104.1264 
+L 395.968047 104.1264 
+L 395.968047 74.7432 
+L 291.343047 74.7432 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.506484 104.1264 
-L 500.131484 104.1264 
-L 500.131484 74.7432 
-L 395.506484 74.7432 
+    <path d="M 395.968047 104.1264 
+L 500.593047 104.1264 
+L 500.593047 74.7432 
+L 395.968047 74.7432 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.256484 133.5096 
-L 290.881484 133.5096 
-L 290.881484 104.1264 
-L 186.256484 104.1264 
+    <path d="M 186.718047 133.5096 
+L 291.343047 133.5096 
+L 291.343047 104.1264 
+L 186.718047 104.1264 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.881484 133.5096 
-L 395.506484 133.5096 
-L 395.506484 104.1264 
-L 290.881484 104.1264 
+    <path d="M 291.343047 133.5096 
+L 395.968047 133.5096 
+L 395.968047 104.1264 
+L 291.343047 104.1264 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.506484 133.5096 
-L 500.131484 133.5096 
-L 500.131484 104.1264 
-L 395.506484 104.1264 
+    <path d="M 395.968047 133.5096 
+L 500.593047 133.5096 
+L 500.593047 104.1264 
+L 395.968047 104.1264 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.256484 162.8928 
-L 290.881484 162.8928 
-L 290.881484 133.5096 
-L 186.256484 133.5096 
+    <path d="M 186.718047 162.8928 
+L 291.343047 162.8928 
+L 291.343047 133.5096 
+L 186.718047 133.5096 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.881484 162.8928 
-L 395.506484 162.8928 
-L 395.506484 133.5096 
-L 290.881484 133.5096 
+    <path d="M 291.343047 162.8928 
+L 395.968047 162.8928 
+L 395.968047 133.5096 
+L 291.343047 133.5096 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.506484 162.8928 
-L 500.131484 162.8928 
-L 500.131484 133.5096 
-L 395.506484 133.5096 
+    <path d="M 395.968047 162.8928 
+L 500.593047 162.8928 
+L 500.593047 133.5096 
+L 395.968047 133.5096 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.256484 192.276 
-L 290.881484 192.276 
-L 290.881484 162.8928 
-L 186.256484 162.8928 
+    <path d="M 186.718047 192.276 
+L 291.343047 192.276 
+L 291.343047 162.8928 
+L 186.718047 162.8928 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.881484 192.276 
-L 395.506484 192.276 
-L 395.506484 162.8928 
-L 290.881484 162.8928 
+    <path d="M 291.343047 192.276 
+L 395.968047 192.276 
+L 395.968047 162.8928 
+L 291.343047 162.8928 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.506484 192.276 
-L 500.131484 192.276 
-L 500.131484 162.8928 
-L 395.506484 162.8928 
+    <path d="M 395.968047 192.276 
+L 500.593047 192.276 
+L 500.593047 162.8928 
+L 395.968047 162.8928 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.256484 221.6592 
-L 290.881484 221.6592 
-L 290.881484 192.276 
-L 186.256484 192.276 
+    <path d="M 186.718047 221.6592 
+L 291.343047 221.6592 
+L 291.343047 192.276 
+L 186.718047 192.276 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.881484 221.6592 
-L 395.506484 221.6592 
-L 395.506484 192.276 
-L 290.881484 192.276 
+    <path d="M 291.343047 221.6592 
+L 395.968047 221.6592 
+L 395.968047 192.276 
+L 291.343047 192.276 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.506484 221.6592 
-L 500.131484 221.6592 
-L 500.131484 192.276 
-L 395.506484 192.276 
+    <path d="M 395.968047 221.6592 
+L 500.593047 221.6592 
+L 500.593047 192.276 
+L 395.968047 192.276 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.256484 251.0424 
-L 290.881484 251.0424 
-L 290.881484 221.6592 
-L 186.256484 221.6592 
+    <path d="M 186.718047 251.0424 
+L 291.343047 251.0424 
+L 291.343047 221.6592 
+L 186.718047 221.6592 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.881484 251.0424 
-L 395.506484 251.0424 
-L 395.506484 221.6592 
-L 290.881484 221.6592 
+    <path d="M 291.343047 251.0424 
+L 395.968047 251.0424 
+L 395.968047 221.6592 
+L 291.343047 221.6592 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.506484 251.0424 
-L 500.131484 251.0424 
-L 500.131484 221.6592 
-L 395.506484 221.6592 
+    <path d="M 395.968047 251.0424 
+L 500.593047 251.0424 
+L 500.593047 221.6592 
+L 395.968047 221.6592 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.256484 280.4256 
-L 290.881484 280.4256 
-L 290.881484 251.0424 
-L 186.256484 251.0424 
+    <path d="M 186.718047 280.4256 
+L 291.343047 280.4256 
+L 291.343047 251.0424 
+L 186.718047 251.0424 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.881484 280.4256 
-L 395.506484 280.4256 
-L 395.506484 251.0424 
-L 290.881484 251.0424 
+    <path d="M 291.343047 280.4256 
+L 395.968047 280.4256 
+L 395.968047 251.0424 
+L 291.343047 251.0424 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.506484 280.4256 
-L 500.131484 280.4256 
-L 500.131484 251.0424 
-L 395.506484 251.0424 
+    <path d="M 395.968047 280.4256 
+L 500.593047 280.4256 
+L 500.593047 251.0424 
+L 395.968047 251.0424 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #f57245; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #f57547; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.256484 309.8088 
-L 290.881484 309.8088 
-L 290.881484 280.4256 
-L 186.256484 280.4256 
+    <path d="M 186.718047 309.8088 
+L 291.343047 309.8088 
+L 291.343047 280.4256 
+L 186.718047 280.4256 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.881484 309.8088 
-L 395.506484 309.8088 
-L 395.506484 280.4256 
-L 290.881484 280.4256 
+    <path d="M 291.343047 309.8088 
+L 395.968047 309.8088 
+L 395.968047 280.4256 
+L 291.343047 280.4256 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.506484 309.8088 
-L 500.131484 309.8088 
-L 500.131484 280.4256 
-L 395.506484 280.4256 
+    <path d="M 395.968047 309.8088 
+L 500.593047 309.8088 
+L 500.593047 280.4256 
+L 395.968047 280.4256 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.256484 339.192 
-L 290.881484 339.192 
-L 290.881484 309.8088 
-L 186.256484 309.8088 
+    <path d="M 186.718047 339.192 
+L 291.343047 339.192 
+L 291.343047 309.8088 
+L 186.718047 309.8088 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.881484 339.192 
-L 395.506484 339.192 
-L 395.506484 309.8088 
-L 290.881484 309.8088 
+    <path d="M 291.343047 339.192 
+L 395.968047 339.192 
+L 395.968047 309.8088 
+L 291.343047 309.8088 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.506484 339.192 
-L 500.131484 339.192 
-L 500.131484 309.8088 
-L 395.506484 309.8088 
+    <path d="M 395.968047 339.192 
+L 500.593047 339.192 
+L 500.593047 309.8088 
+L 395.968047 309.8088 
 z
-" clip-path="url(#p9a0cde3e63)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p03255d7792)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.24375 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.705313 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.527969 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.989531 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.100078 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.561641 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.451797 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.913359 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.181484 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.643047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.117734 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(335.558984 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.020547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.183984 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.819609 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.281172 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.117734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.103984 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.183984 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.512734 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.974297 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.117734 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.103984 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.183984 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(118.545234 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.006797 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.117734 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.103984 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.183984 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.082734 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.544297 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.117734 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.103984 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.183984 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(110.388984 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(110.850547 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(227.117734 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(338.103984 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(440.183984 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.645547 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.890859 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.352422 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(225.917109 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.378672 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1854,7 +1854,7 @@ z
    </g>
    <g id="text_31">
     <!-- 34 -->
-    <g transform="translate(337.627734 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.089297 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1881,8 +1881,8 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 137 -->
-    <g transform="translate(439.469609 267.9415) scale(0.08 -0.08)">
+    <!-- 139 -->
+    <g transform="translate(439.931172 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1898,25 +1898,45 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.005859 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.467422 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1981,7 +2001,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.117734 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1991,21 +2011,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.103984 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.565547 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(442.728984 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.190547 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.227109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.688672 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2016,7 +2036,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.117734 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.579297 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2026,13 +2046,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(340.648984 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.110547 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.818984 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.280547 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2048,7 +2068,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(150.733203 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.194766 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2192,7 +2212,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-18T02:39:37Z  ·  Linux chungus x86_64  ·  commit 3a38cf0a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-18T10:42:34Z  ·  Linux chungus x86_64  ·  commit 90fb3272  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2333,14 +2353,14 @@ z
     <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2379,110 +2399,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3315.380859 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3350.585938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3414.208984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.488281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.275391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.0625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3570.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.636719 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.423828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.207031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.009766 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.388672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3911.865234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.728516 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4011.910156 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.089844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.613281 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.726562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.417969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.201172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.724609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.003906 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.382812 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.005859 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.697266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4577.876953 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.5 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.287109 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4736.910156 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.533203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.320312 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4895.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.027344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4970.890625 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5025.871094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.494141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.28125 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.068359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5184.855469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.429688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.638672 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.017578 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5389.880859 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.0625 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.441406 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5577.917969 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.296875 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5704.773438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.152344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.361328 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.148438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5922.9375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.724609 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.136719 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.660156 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.136719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6204.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.199219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.365234 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6476.84375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.123047 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.599609 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.699219 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.259766 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.46875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.160156 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6882.947266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.060547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.339844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.513672 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.300781 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.083984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.183594 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7256.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.447266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7381.970703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.179688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.703125 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.066406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.261719 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.640625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.732422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.515625 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9a0cde3e63">
-   <rect x="81.631484" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p03255d7792">
+   <rect x="82.093047" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-18T02:39:37Z",
+  "date": "2026-06-18T10:42:34Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "3a38cf0a",
+  "git_commit": "90fb3272",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 40.14,
-   "decompress_mbps": 105.26
+   "compress_mbps": 40.88,
+   "decompress_mbps": 106.77
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 37.25,
-   "decompress_mbps": 115.98
+   "compress_mbps": 37.64,
+   "decompress_mbps": 117.37
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.22,
-   "decompress_mbps": 127.22
+   "compress_mbps": 34.86,
+   "decompress_mbps": 132.43
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 28.03,
-   "decompress_mbps": 131.31
+   "compress_mbps": 28.22,
+   "decompress_mbps": 134.02
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 27.25,
-   "decompress_mbps": 134.38
+   "compress_mbps": 26.88,
+   "decompress_mbps": 137.05
   },
   {
    "compressor": "native",
@@ -65,7 +65,7 @@
    "out_size": 54535,
    "ratio": 0.3586,
    "compress_mbps": 25.19,
-   "decompress_mbps": 140.4
+   "decompress_mbps": 143.14
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 9.28,
-   "decompress_mbps": 139.61
+   "compress_mbps": 9.45,
+   "decompress_mbps": 142.13
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.11,
-   "decompress_mbps": 140.13
+   "compress_mbps": 9.39,
+   "decompress_mbps": 143.09
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.28,
-   "decompress_mbps": 140.05
+   "compress_mbps": 1.27,
+   "decompress_mbps": 145.18
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 37.14,
-   "decompress_mbps": 101.92
+   "compress_mbps": 37.79,
+   "decompress_mbps": 103.53
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 34.5,
-   "decompress_mbps": 106.71
+   "compress_mbps": 34.99,
+   "decompress_mbps": 108.9
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 32.28,
-   "decompress_mbps": 113.81
+   "compress_mbps": 32.56,
+   "decompress_mbps": 116.37
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.66,
-   "decompress_mbps": 119.22
+   "compress_mbps": 25.71,
+   "decompress_mbps": 123.16
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 24.86,
-   "decompress_mbps": 124.94
+   "compress_mbps": 25.03,
+   "decompress_mbps": 127.76
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.89,
-   "decompress_mbps": 126.28
+   "compress_mbps": 23.94,
+   "decompress_mbps": 128.81
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.87,
-   "decompress_mbps": 127.5
+   "compress_mbps": 9.01,
+   "decompress_mbps": 131.31
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.86,
-   "decompress_mbps": 127.55
+   "compress_mbps": 9.0,
+   "decompress_mbps": 131.79
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 1.4,
-   "decompress_mbps": 127.2
+   "compress_mbps": 1.39,
+   "decompress_mbps": 130.63
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 34.1,
-   "decompress_mbps": 112.4
+   "compress_mbps": 34.15,
+   "decompress_mbps": 108.66
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 32.88,
-   "decompress_mbps": 118.43
+   "compress_mbps": 32.99,
+   "decompress_mbps": 113.57
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 32.15,
-   "decompress_mbps": 121.3
+   "compress_mbps": 32.33,
+   "decompress_mbps": 115.87
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.4,
-   "decompress_mbps": 122.1
+   "compress_mbps": 30.5,
+   "decompress_mbps": 116.35
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 29.83,
-   "decompress_mbps": 126.93
+   "compress_mbps": 29.73,
+   "decompress_mbps": 119.0
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 29.25,
-   "decompress_mbps": 126.64
+   "compress_mbps": 29.02,
+   "decompress_mbps": 119.19
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.72,
-   "decompress_mbps": 124.68
+   "compress_mbps": 9.71,
+   "decompress_mbps": 120.41
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.71,
-   "decompress_mbps": 128.01
+   "compress_mbps": 9.69,
+   "decompress_mbps": 120.38
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 1.63,
-   "decompress_mbps": 128.59
+   "compress_mbps": 1.62,
+   "decompress_mbps": 121.39
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.87,
-   "decompress_mbps": 93.25
+   "compress_mbps": 23.65,
+   "decompress_mbps": 82.07
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 23.31,
-   "decompress_mbps": 95.98
+   "compress_mbps": 23.29,
+   "decompress_mbps": 83.68
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.9,
-   "decompress_mbps": 97.32
+   "compress_mbps": 23.01,
+   "decompress_mbps": 86.54
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.81,
-   "decompress_mbps": 101.36
+   "compress_mbps": 21.98,
+   "decompress_mbps": 88.32
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.7,
-   "decompress_mbps": 102.34
+   "compress_mbps": 21.69,
+   "decompress_mbps": 89.3
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 21.5,
-   "decompress_mbps": 103.5
+   "compress_mbps": 21.51,
+   "decompress_mbps": 90.08
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.16,
-   "decompress_mbps": 103.65
+   "compress_mbps": 7.12,
+   "decompress_mbps": 89.58
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.12,
-   "decompress_mbps": 103.46
+   "compress_mbps": 7.14,
+   "decompress_mbps": 89.36
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 1.54,
-   "decompress_mbps": 103.53
+   "compress_mbps": 1.53,
+   "decompress_mbps": 89.6
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 12.0,
-   "decompress_mbps": 50.23
+   "compress_mbps": 11.8,
+   "decompress_mbps": 40.07
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.9,
-   "decompress_mbps": 50.76
+   "compress_mbps": 11.7,
+   "decompress_mbps": 40.16
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.81,
-   "decompress_mbps": 50.52
+   "compress_mbps": 11.61,
+   "decompress_mbps": 40.33
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.45,
-   "decompress_mbps": 51.53
+   "compress_mbps": 11.44,
+   "decompress_mbps": 40.81
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.6,
-   "decompress_mbps": 51.97
+   "compress_mbps": 11.45,
+   "decompress_mbps": 41.24
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.6,
-   "decompress_mbps": 52.02
+   "compress_mbps": 11.41,
+   "decompress_mbps": 40.78
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.92,
-   "decompress_mbps": 52.22
+   "compress_mbps": 3.87,
+   "decompress_mbps": 41.59
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.92,
-   "decompress_mbps": 51.97
+   "compress_mbps": 3.87,
+   "decompress_mbps": 41.59
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 1.25,
-   "decompress_mbps": 52.09
+   "compress_mbps": 1.24,
+   "decompress_mbps": 41.58
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 65.87,
-   "decompress_mbps": 173.93
+   "compress_mbps": 66.32,
+   "decompress_mbps": 171.44
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 61.27,
-   "decompress_mbps": 210.33
+   "compress_mbps": 60.69,
+   "decompress_mbps": 203.44
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 60.78,
-   "decompress_mbps": 222.79
+   "compress_mbps": 58.92,
+   "decompress_mbps": 215.03
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 54.53,
-   "decompress_mbps": 232.92
+   "compress_mbps": 55.28,
+   "decompress_mbps": 224.68
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 54.4,
-   "decompress_mbps": 170.51
+   "compress_mbps": 54.65,
+   "decompress_mbps": 164.7
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 51.53,
-   "decompress_mbps": 167.49
+   "compress_mbps": 51.91,
+   "decompress_mbps": 165.72
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 9.62,
-   "decompress_mbps": 152.91
+   "compress_mbps": 9.64,
+   "decompress_mbps": 149.86
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.65,
-   "decompress_mbps": 145.43
+   "compress_mbps": 7.56,
+   "decompress_mbps": 143.17
   },
   {
    "compressor": "native",
@@ -545,7 +545,7 @@
    "out_size": 178311,
    "ratio": 0.1732,
    "compress_mbps": 0.97,
-   "decompress_mbps": 149.75
+   "decompress_mbps": 149.26
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 43.15,
-   "decompress_mbps": 111.49
+   "compress_mbps": 44.32,
+   "decompress_mbps": 116.09
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 39.45,
-   "decompress_mbps": 118.74
+   "compress_mbps": 40.38,
+   "decompress_mbps": 121.78
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 36.75,
-   "decompress_mbps": 131.64
+   "compress_mbps": 37.09,
+   "decompress_mbps": 135.3
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 28.84,
-   "decompress_mbps": 135.22
+   "compress_mbps": 28.96,
+   "decompress_mbps": 140.02
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 27.79,
-   "decompress_mbps": 141.22
+   "compress_mbps": 28.74,
+   "decompress_mbps": 146.53
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 26.05,
-   "decompress_mbps": 143.89
+   "compress_mbps": 26.44,
+   "decompress_mbps": 147.96
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 9.83,
-   "decompress_mbps": 144.1
+   "compress_mbps": 10.03,
+   "decompress_mbps": 147.79
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.79,
-   "decompress_mbps": 143.89
+   "compress_mbps": 10.01,
+   "decompress_mbps": 147.52
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 138661,
    "ratio": 0.3249,
-   "compress_mbps": 1.3,
-   "decompress_mbps": 141.04
+   "compress_mbps": 1.31,
+   "decompress_mbps": 147.41
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 36.57,
-   "decompress_mbps": 96.18
+   "compress_mbps": 37.18,
+   "decompress_mbps": 100.29
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 34.63,
-   "decompress_mbps": 102.95
+   "compress_mbps": 35.11,
+   "decompress_mbps": 110.28
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 31.94,
-   "decompress_mbps": 110.34
+   "compress_mbps": 32.71,
+   "decompress_mbps": 116.09
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 22.95,
-   "decompress_mbps": 115.75
+   "compress_mbps": 23.31,
+   "decompress_mbps": 119.63
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 22.13,
-   "decompress_mbps": 121.3
+   "compress_mbps": 22.46,
+   "decompress_mbps": 125.02
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 20.6,
-   "decompress_mbps": 124.48
+   "compress_mbps": 20.94,
+   "decompress_mbps": 128.53
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 8.4,
-   "decompress_mbps": 124.12
+   "compress_mbps": 8.47,
+   "decompress_mbps": 128.87
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.34,
-   "decompress_mbps": 124.88
+   "compress_mbps": 8.48,
+   "decompress_mbps": 128.88
   },
   {
    "compressor": "native",
@@ -725,7 +725,7 @@
    "out_size": 186472,
    "ratio": 0.387,
    "compress_mbps": 1.25,
-   "decompress_mbps": 125.63
+   "decompress_mbps": 128.48
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 118.58,
-   "decompress_mbps": 311.59
+   "compress_mbps": 120.08,
+   "decompress_mbps": 317.08
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 105.11,
-   "decompress_mbps": 321.94
+   "compress_mbps": 106.45,
+   "decompress_mbps": 332.06
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 90.5,
-   "decompress_mbps": 336.0
+   "compress_mbps": 91.82,
+   "decompress_mbps": 346.05
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 72.27,
-   "decompress_mbps": 311.36
+   "compress_mbps": 73.73,
+   "decompress_mbps": 315.24
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 69.67,
-   "decompress_mbps": 333.3
+   "compress_mbps": 70.73,
+   "decompress_mbps": 338.61
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 63.08,
-   "decompress_mbps": 353.19
+   "compress_mbps": 64.19,
+   "decompress_mbps": 357.89
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53495,
    "ratio": 0.1042,
-   "compress_mbps": 19.26,
-   "decompress_mbps": 365.88
+   "compress_mbps": 19.08,
+   "decompress_mbps": 378.65
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.91,
-   "decompress_mbps": 388.27
+   "compress_mbps": 16.9,
+   "decompress_mbps": 393.38
   },
   {
    "compressor": "native",
@@ -815,7 +815,7 @@
    "out_size": 51490,
    "ratio": 0.1003,
    "compress_mbps": 0.97,
-   "decompress_mbps": 394.18
+   "decompress_mbps": 404.11
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.75,
-   "decompress_mbps": 81.65
+   "compress_mbps": 26.62,
+   "decompress_mbps": 80.99
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 26.14,
-   "decompress_mbps": 86.13
+   "compress_mbps": 26.25,
+   "decompress_mbps": 86.85
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.42,
-   "decompress_mbps": 89.68
+   "compress_mbps": 25.7,
+   "decompress_mbps": 89.99
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.36,
-   "decompress_mbps": 87.71
+   "compress_mbps": 23.47,
+   "decompress_mbps": 87.59
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 23.16,
-   "decompress_mbps": 93.54
+   "compress_mbps": 22.85,
+   "decompress_mbps": 93.69
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 22.08,
-   "decompress_mbps": 94.34
+   "compress_mbps": 21.95,
+   "decompress_mbps": 94.37
   },
   {
    "compressor": "native",
@@ -885,7 +885,7 @@
    "out_size": 13035,
    "ratio": 0.3409,
    "compress_mbps": 5.88,
-   "decompress_mbps": 94.1
+   "decompress_mbps": 92.94
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.53,
-   "decompress_mbps": 98.66
+   "compress_mbps": 5.51,
+   "decompress_mbps": 99.63
   },
   {
    "compressor": "native",
@@ -905,7 +905,7 @@
    "out_size": 12278,
    "ratio": 0.3211,
    "compress_mbps": 1.21,
-   "decompress_mbps": 97.7
+   "decompress_mbps": 96.95
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.99,
-   "decompress_mbps": 51.46
+   "compress_mbps": 13.19,
+   "decompress_mbps": 43.22
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 13.08,
-   "decompress_mbps": 52.61
+   "compress_mbps": 13.21,
+   "decompress_mbps": 43.98
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 13.05,
-   "decompress_mbps": 52.7
+   "compress_mbps": 13.2,
+   "decompress_mbps": 44.1
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.87,
-   "decompress_mbps": 53.5
+   "compress_mbps": 12.97,
+   "decompress_mbps": 44.6
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.88,
-   "decompress_mbps": 53.83
+   "compress_mbps": 12.98,
+   "decompress_mbps": 44.93
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.86,
-   "decompress_mbps": 53.73
+   "compress_mbps": 12.97,
+   "decompress_mbps": 44.66
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.21,
-   "decompress_mbps": 54.02
+   "compress_mbps": 4.25,
+   "decompress_mbps": 44.7
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.19,
-   "decompress_mbps": 54.02
+   "compress_mbps": 4.23,
+   "decompress_mbps": 44.8
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 1.41,
-   "decompress_mbps": 54.03
+   "compress_mbps": 1.4,
+   "decompress_mbps": 44.79
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 37.37,
-   "decompress_mbps": 100.09
+   "compress_mbps": 38.61,
+   "decompress_mbps": 105.38
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 34.9,
-   "decompress_mbps": 104.83
+   "compress_mbps": 34.76,
+   "decompress_mbps": 110.56
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 33.14,
-   "decompress_mbps": 111.77
+   "compress_mbps": 33.79,
+   "decompress_mbps": 116.18
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.64,
-   "decompress_mbps": 114.55
+   "compress_mbps": 25.76,
+   "decompress_mbps": 118.02
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 24.83,
-   "decompress_mbps": 117.02
+   "compress_mbps": 25.07,
+   "decompress_mbps": 122.06
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 23.01,
-   "decompress_mbps": 120.26
+   "compress_mbps": 23.12,
+   "decompress_mbps": 124.19
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 8.99,
-   "decompress_mbps": 122.89
+   "compress_mbps": 8.96,
+   "decompress_mbps": 130.67
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.96,
-   "decompress_mbps": 127.69
+   "compress_mbps": 9.04,
+   "decompress_mbps": 129.71
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3712344,
    "ratio": 0.3642,
-   "compress_mbps": 1.27,
-   "decompress_mbps": 130.09
+   "compress_mbps": 1.26,
+   "decompress_mbps": 134.58
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 50.36,
-   "decompress_mbps": 93.5
+   "compress_mbps": 50.44,
+   "decompress_mbps": 93.27
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 47.31,
-   "decompress_mbps": 97.92
+   "compress_mbps": 47.88,
+   "decompress_mbps": 98.38
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 45.44,
-   "decompress_mbps": 101.54
+   "compress_mbps": 45.74,
+   "decompress_mbps": 102.45
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 38.24,
-   "decompress_mbps": 104.44
+   "compress_mbps": 38.42,
+   "decompress_mbps": 105.89
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 36.31,
-   "decompress_mbps": 110.45
+   "compress_mbps": 36.69,
+   "decompress_mbps": 111.65
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 32.14,
-   "decompress_mbps": 110.93
+   "compress_mbps": 32.83,
+   "decompress_mbps": 112.73
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 19177172,
    "ratio": 0.3744,
-   "compress_mbps": 7.73,
-   "decompress_mbps": 111.64
+   "compress_mbps": 7.55,
+   "decompress_mbps": 113.44
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.99,
-   "decompress_mbps": 111.66
+   "compress_mbps": 7.0,
+   "decompress_mbps": 113.47
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.19,
-   "decompress_mbps": 113.77
+   "compress_mbps": 1.18,
+   "decompress_mbps": 111.64
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 51.62,
-   "decompress_mbps": 89.73
+   "compress_mbps": 52.21,
+   "decompress_mbps": 93.44
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 47.12,
-   "decompress_mbps": 93.51
+   "compress_mbps": 48.06,
+   "decompress_mbps": 96.43
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 41.93,
-   "decompress_mbps": 91.0
+   "compress_mbps": 42.63,
+   "decompress_mbps": 95.97
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.13,
-   "decompress_mbps": 90.49
+   "compress_mbps": 31.41,
+   "decompress_mbps": 91.64
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 29.29,
-   "decompress_mbps": 95.09
+   "compress_mbps": 29.94,
+   "decompress_mbps": 96.7
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 26.98,
-   "decompress_mbps": 97.0
+   "compress_mbps": 27.44,
+   "decompress_mbps": 97.91
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3609769,
    "ratio": 0.362,
-   "compress_mbps": 8.4,
-   "decompress_mbps": 98.58
+   "compress_mbps": 8.41,
+   "decompress_mbps": 96.21
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.05,
-   "decompress_mbps": 94.63
+   "compress_mbps": 8.11,
+   "decompress_mbps": 99.67
   },
   {
    "compressor": "native",
@@ -4235,7 +4235,7 @@
    "out_size": 3520112,
    "ratio": 0.3531,
    "compress_mbps": 1.0,
-   "decompress_mbps": 99.0
+   "decompress_mbps": 98.97
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 119.15,
-   "decompress_mbps": 319.99
+   "compress_mbps": 120.65,
+   "decompress_mbps": 345.51
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 101.41,
-   "decompress_mbps": 368.12
+   "compress_mbps": 105.11,
+   "decompress_mbps": 383.83
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 88.2,
-   "decompress_mbps": 401.2
+   "compress_mbps": 88.49,
+   "decompress_mbps": 423.04
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 79.4,
-   "decompress_mbps": 413.17
+   "compress_mbps": 79.04,
+   "decompress_mbps": 431.65
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 76.99,
-   "decompress_mbps": 461.76
+   "compress_mbps": 76.44,
+   "decompress_mbps": 480.06
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 71.36,
-   "decompress_mbps": 485.9
+   "compress_mbps": 71.82,
+   "decompress_mbps": 512.07
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3123611,
    "ratio": 0.0931,
-   "compress_mbps": 26.01,
-   "decompress_mbps": 497.25
+   "compress_mbps": 25.73,
+   "decompress_mbps": 515.86
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.78,
-   "decompress_mbps": 501.79
+   "compress_mbps": 22.81,
+   "decompress_mbps": 525.34
   },
   {
    "compressor": "native",
@@ -4325,7 +4325,7 @@
    "out_size": 2868751,
    "ratio": 0.0855,
    "compress_mbps": 0.78,
-   "decompress_mbps": 477.01
+   "decompress_mbps": 489.17
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 36.87,
-   "decompress_mbps": 61.32
+   "compress_mbps": 37.53,
+   "decompress_mbps": 63.46
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 35.5,
-   "decompress_mbps": 63.42
+   "compress_mbps": 36.32,
+   "decompress_mbps": 65.65
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 34.5,
-   "decompress_mbps": 67.75
+   "compress_mbps": 34.94,
+   "decompress_mbps": 70.42
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 29.58,
-   "decompress_mbps": 66.41
+   "compress_mbps": 29.43,
+   "decompress_mbps": 72.04
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 29.11,
-   "decompress_mbps": 70.68
+   "compress_mbps": 28.86,
+   "decompress_mbps": 74.4
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 27.87,
-   "decompress_mbps": 72.98
+   "compress_mbps": 27.95,
+   "decompress_mbps": 74.83
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3165678,
    "ratio": 0.5146,
-   "compress_mbps": 6.84,
-   "decompress_mbps": 73.47
+   "compress_mbps": 6.87,
+   "decompress_mbps": 73.88
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.73,
-   "decompress_mbps": 74.08
+   "compress_mbps": 6.76,
+   "decompress_mbps": 76.2
   },
   {
    "compressor": "native",
@@ -4415,7 +4415,7 @@
    "out_size": 3017696,
    "ratio": 0.4905,
    "compress_mbps": 1.45,
-   "decompress_mbps": 72.65
+   "decompress_mbps": 76.68
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 52.53,
-   "decompress_mbps": 87.78
+   "compress_mbps": 53.87,
+   "decompress_mbps": 88.09
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 49.46,
-   "decompress_mbps": 90.22
+   "compress_mbps": 50.47,
+   "decompress_mbps": 90.73
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 48.18,
-   "decompress_mbps": 94.44
+   "compress_mbps": 49.08,
+   "decompress_mbps": 93.39
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 44.82,
-   "decompress_mbps": 95.89
+   "compress_mbps": 44.92,
+   "decompress_mbps": 96.27
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 44.8,
-   "decompress_mbps": 94.57
+   "compress_mbps": 45.02,
+   "decompress_mbps": 92.83
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 44.89,
-   "decompress_mbps": 93.98
+   "compress_mbps": 44.0,
+   "decompress_mbps": 90.85
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 11.8,
-   "decompress_mbps": 96.59
+   "compress_mbps": 12.1,
+   "decompress_mbps": 95.13
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.02,
-   "decompress_mbps": 95.15
+   "compress_mbps": 12.09,
+   "decompress_mbps": 95.16
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 1.78,
-   "decompress_mbps": 95.53
+   "compress_mbps": 1.77,
+   "decompress_mbps": 90.9
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 46.64,
-   "decompress_mbps": 118.56
+   "compress_mbps": 47.36,
+   "decompress_mbps": 127.26
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 40.79,
-   "decompress_mbps": 130.01
+   "compress_mbps": 42.23,
+   "decompress_mbps": 135.87
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 35.29,
-   "decompress_mbps": 143.53
+   "compress_mbps": 36.73,
+   "decompress_mbps": 147.84
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 26.58,
-   "decompress_mbps": 147.21
+   "compress_mbps": 26.87,
+   "decompress_mbps": 150.28
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.58,
-   "decompress_mbps": 158.39
+   "compress_mbps": 24.62,
+   "decompress_mbps": 159.16
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.4,
-   "decompress_mbps": 162.75
+   "compress_mbps": 20.46,
+   "decompress_mbps": 166.61
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1843401,
    "ratio": 0.2782,
-   "compress_mbps": 8.42,
-   "decompress_mbps": 177.49
+   "compress_mbps": 8.49,
+   "decompress_mbps": 182.89
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.71,
-   "decompress_mbps": 172.87
+   "compress_mbps": 7.8,
+   "decompress_mbps": 183.51
   },
   {
    "compressor": "native",
@@ -4595,7 +4595,7 @@
    "out_size": 1724560,
    "ratio": 0.2602,
    "compress_mbps": 0.92,
-   "decompress_mbps": 167.52
+   "decompress_mbps": 177.92
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 65.28,
-   "decompress_mbps": 173.32
+   "compress_mbps": 66.43,
+   "decompress_mbps": 175.54
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 59.41,
-   "decompress_mbps": 181.54
+   "compress_mbps": 60.29,
+   "decompress_mbps": 184.15
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 54.62,
-   "decompress_mbps": 186.99
+   "compress_mbps": 55.49,
+   "decompress_mbps": 193.42
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 46.26,
-   "decompress_mbps": 194.83
+   "compress_mbps": 46.89,
+   "decompress_mbps": 200.68
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 45.19,
-   "decompress_mbps": 204.01
+   "compress_mbps": 44.76,
+   "decompress_mbps": 205.55
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 42.18,
-   "decompress_mbps": 209.34
+   "compress_mbps": 42.6,
+   "decompress_mbps": 209.05
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5409010,
    "ratio": 0.2503,
-   "compress_mbps": 13.24,
-   "decompress_mbps": 200.15
+   "compress_mbps": 13.2,
+   "decompress_mbps": 208.72
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.74,
-   "decompress_mbps": 203.82
+   "compress_mbps": 12.86,
+   "decompress_mbps": 209.14
   },
   {
    "compressor": "native",
@@ -4685,7 +4685,7 @@
    "out_size": 5169629,
    "ratio": 0.2393,
    "compress_mbps": 1.31,
-   "decompress_mbps": 210.39
+   "decompress_mbps": 217.48
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 32.65,
-   "decompress_mbps": 81.6
+   "compress_mbps": 32.12,
+   "decompress_mbps": 81.61
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 30.72,
-   "decompress_mbps": 84.06
+   "compress_mbps": 30.99,
+   "decompress_mbps": 82.74
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 29.47,
-   "decompress_mbps": 87.23
+   "compress_mbps": 29.97,
+   "decompress_mbps": 86.67
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 25.14,
-   "decompress_mbps": 89.45
+   "compress_mbps": 25.07,
+   "decompress_mbps": 88.57
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 24.65,
-   "decompress_mbps": 90.6
+   "compress_mbps": 24.59,
+   "decompress_mbps": 89.97
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 24.1,
-   "decompress_mbps": 90.77
+   "compress_mbps": 24.06,
+   "decompress_mbps": 91.81
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5429379,
    "ratio": 0.7487,
-   "compress_mbps": 6.22,
-   "decompress_mbps": 91.37
+   "compress_mbps": 6.23,
+   "decompress_mbps": 90.16
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.15,
-   "decompress_mbps": 92.55
+   "compress_mbps": 6.26,
+   "decompress_mbps": 89.34
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 1.57,
-   "decompress_mbps": 94.54
+   "compress_mbps": 1.56,
+   "decompress_mbps": 91.52
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 49.05,
-   "decompress_mbps": 126.98
+   "compress_mbps": 50.3,
+   "decompress_mbps": 131.84
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 45.65,
-   "decompress_mbps": 134.77
+   "compress_mbps": 46.15,
+   "decompress_mbps": 140.92
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 42.14,
-   "decompress_mbps": 144.11
+   "compress_mbps": 43.39,
+   "decompress_mbps": 149.65
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 35.45,
-   "decompress_mbps": 152.35
+   "compress_mbps": 35.94,
+   "decompress_mbps": 156.31
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 34.02,
-   "decompress_mbps": 155.32
+   "compress_mbps": 34.38,
+   "decompress_mbps": 162.37
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 31.0,
-   "decompress_mbps": 159.85
+   "compress_mbps": 31.2,
+   "decompress_mbps": 165.21
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 11.55,
-   "decompress_mbps": 160.13
+   "compress_mbps": 11.63,
+   "decompress_mbps": 169.16
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.35,
-   "decompress_mbps": 161.56
+   "compress_mbps": 11.34,
+   "decompress_mbps": 166.55
   },
   {
    "compressor": "native",
@@ -4865,7 +4865,7 @@
    "out_size": 11638957,
    "ratio": 0.2807,
    "compress_mbps": 1.22,
-   "decompress_mbps": 161.06
+   "decompress_mbps": 168.22
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 32.57,
-   "decompress_mbps": 49.58
+   "compress_mbps": 32.14,
+   "decompress_mbps": 52.83
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 32.33,
-   "decompress_mbps": 53.82
+   "compress_mbps": 32.12,
+   "decompress_mbps": 57.29
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 32.45,
-   "decompress_mbps": 58.37
+   "compress_mbps": 32.54,
+   "decompress_mbps": 61.56
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 30.61,
-   "decompress_mbps": 56.57
+   "compress_mbps": 30.51,
+   "decompress_mbps": 59.27
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.69,
-   "decompress_mbps": 58.44
+   "compress_mbps": 30.51,
+   "decompress_mbps": 60.25
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.75,
-   "decompress_mbps": 59.2
+   "compress_mbps": 30.34,
+   "decompress_mbps": 61.53
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.69,
-   "decompress_mbps": 58.71
+   "compress_mbps": 4.64,
+   "decompress_mbps": 59.33
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.72,
-   "decompress_mbps": 58.71
+   "compress_mbps": 4.68,
+   "decompress_mbps": 61.01
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 1.7,
-   "decompress_mbps": 58.07
+   "compress_mbps": 1.68,
+   "decompress_mbps": 60.76
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 97.26,
-   "decompress_mbps": 237.9
+   "compress_mbps": 96.44,
+   "decompress_mbps": 263.67
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 86.69,
-   "decompress_mbps": 277.68
+   "compress_mbps": 85.93,
+   "decompress_mbps": 258.33
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 77.59,
-   "decompress_mbps": 310.67
+   "compress_mbps": 78.46,
+   "decompress_mbps": 296.32
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 65.25,
-   "decompress_mbps": 319.25
+   "compress_mbps": 60.85,
+   "decompress_mbps": 282.21
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 62.94,
-   "decompress_mbps": 350.35
+   "compress_mbps": 63.12,
+   "decompress_mbps": 314.35
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 57.99,
-   "decompress_mbps": 342.52
+   "compress_mbps": 57.29,
+   "decompress_mbps": 342.46
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 675427,
    "ratio": 0.1264,
-   "compress_mbps": 21.68,
-   "decompress_mbps": 358.31
+   "compress_mbps": 21.41,
+   "decompress_mbps": 362.9
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.37,
-   "decompress_mbps": 372.31
+   "compress_mbps": 20.23,
+   "decompress_mbps": 367.61
   },
   {
    "compressor": "native",
@@ -5045,7 +5045,7 @@
    "out_size": 637424,
    "ratio": 0.1192,
    "compress_mbps": 0.98,
-   "decompress_mbps": 393.59
+   "decompress_mbps": 401.14
   },
   {
    "compressor": "zlib",


### PR DESCRIPTION
This PR re-records the native rows of the benchmark dashboard so master's committed baseline reflects the post-#2657 decode path. PR #2657 (de-box the Huffman fast-decode table) changed native decode performance but did not refresh the dashboard, leaving `bench/results/latest.json` stamped at the pre-de-box commit `3a38cf0a` — stale for any subsequent perf PR that baselines against it (the perf-pr-graphs freshness guard flags exactly this). It re-runs `bench/run.sh --native-only` (native median-of-5 over Canterbury + Silesia, all 9 levels), splicing the fresh native rows over the existing dashboard via `merge_native.py`; the reference-language rows (zlib, miniz_oxide, libdeflate, Go, JS, Zig, OCaml) are reused unchanged, since their ratio is deterministic and their MB/s drifts <~3% run-to-run. Native ratios are unchanged (the de-box is output-neutral); only the throughput numbers and the regenerated `bench/graphs/*.svg` move.

🤖 Prepared with Claude Code