### PR TITLE
perf(decode): pre-sized output buffer via threaded sizeHint

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -1212,7 +1212,17 @@ private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
         -- output", unlike the FFI path where `0` means unlimited. Callers
         -- that opt into `maxEntrySize := 0` for unlimited FFI decompression
         -- therefore get an immediate rejection on the native backend.
-        match Zip.Native.Inflate.inflate compData maxEntrySize.toNat with
+        --
+        -- Pre-size the output buffer to the entry's declared uncompressed size,
+        -- removing the doubling reallocations of a buffer grown one literal at a
+        -- time. `uncompressedSize` is untrusted ZIP metadata, so cap the hint to a
+        -- multiple of the compressed bytes already in RAM: DEFLATE's maximum ratio
+        -- is ~1032:1, so this never truncates a hint for a valid stream, but stops
+        -- a tiny malicious entry from forcing a huge speculative allocation. The
+        -- hint is a capacity hint only — never affecting the bytes produced or the
+        -- `maxEntrySize` bomb guard.
+        let sizeHint := min entry.uncompressedSize.toNat (compData.size * 1100)
+        match Zip.Native.Inflate.inflate compData maxEntrySize.toNat (sizeHint := sizeHint) with
         | .ok data => pure data
         | .error msg => throw (IO.userError s!"zip: native inflate failed for {label}: {msg}")
       else RawDeflate.decompress compData maxEntrySize

--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -1089,6 +1089,14 @@ private def listFromHandle (h : IO.FS.Handle) (maxCentralDirSize : Nat := 671088
   parseCentralDir cdBuf 0 cdSize totalEntries numberOfThisDisk diskWhereCDStarts
     numEntriesThisDisk cdOffset
 
+/-- Hard ceiling (64 MiB) on the speculative output-buffer reservation made from an
+    entry's *untrusted* declared uncompressed size when decoding with the native
+    backend. This is the safety property for the pre-size hint: no matter what an
+    entry claims, the native decoder never reserves more than this up front. Entries
+    larger than the cap keep a few of their buffer doublings; correctness is
+    unaffected (the hint is a capacity hint only). See `readEntryData`. -/
+def nativePresizeCap : Nat := 64 * 1024 * 1024
+
 /-- Read an entry's decompressed data from a file handle by seeking to its local header.
     `maxEntrySize` limits decompressed entry size; `0` means no limit on the FFI
     backend. Both public extractors default `maxEntrySize` to `1 GiB` and
@@ -1215,13 +1223,19 @@ private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
         --
         -- Pre-size the output buffer to the entry's declared uncompressed size,
         -- removing the doubling reallocations of a buffer grown one literal at a
-        -- time. `uncompressedSize` is untrusted ZIP metadata, so cap the hint to a
-        -- multiple of the compressed bytes already in RAM: DEFLATE's maximum ratio
-        -- is ~1032:1, so this never truncates a hint for a valid stream, but stops
-        -- a tiny malicious entry from forcing a huge speculative allocation. The
-        -- hint is a capacity hint only — never affecting the bytes produced or the
-        -- `maxEntrySize` bomb guard.
-        let sizeHint := min entry.uncompressedSize.toNat (compData.size * 1100)
+        -- time. The hint is a capacity hint only — it never affects the bytes
+        -- produced or the `maxEntrySize` bomb guard (`Inflate.inflate_sizeHint_eq`).
+        -- `uncompressedSize` is untrusted ZIP metadata, so the speculative
+        -- allocation is bounded by three guards, no one of which a malicious entry
+        -- controls: (a) `nativePresizeCap`, a fixed absolute ceiling, is the real
+        -- safety property — worst-case reserve stays bounded regardless of the
+        -- claimed size; (b) `maxEntrySize`, the output budget, so a `0` (reject-all)
+        -- or small cap reserves nothing beyond what the decoder would accept; and
+        -- (c) `compData.size * 1100`, a heuristic ratio bound (DEFLATE's maximum is
+        -- ~1032:1) that trims the hint for small entries. Large legitimate entries
+        -- above `nativePresizeCap` simply keep a few of their doublings.
+        let sizeHint := min (min entry.uncompressedSize.toNat maxEntrySize.toNat)
+          (min (compData.size * 1100) nativePresizeCap)
         match Zip.Native.Inflate.inflate compData maxEntrySize.toNat (sizeHint := sizeHint) with
         | .ok data => pure data
         | .error msg => throw (IO.userError s!"zip: native inflate failed for {label}: {msg}")

--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -797,14 +797,23 @@ decreasing_by all_goals omega
 /-- Inflate a raw DEFLATE stream starting at byte offset `startPos`. Returns the
     decompressed data and the byte-aligned position after the last DEFLATE block.
     `maxOutputSize` (default 1 GiB) limits decompressed output to guard against
-    zip bombs. -/
+    zip bombs.
+
+    `sizeHint` pre-reserves capacity for the output buffer (`0`, the default,
+    reserves nothing — `ByteArray.emptyWithCapacity 0 = .empty`). When the caller
+    knows the decompressed size (gzip ISIZE, the ZIP local/central header), passing
+    it removes the doubling reallocations (`lean_copy_sarray`) that a buffer grown
+    one literal at a time otherwise pays. The hint is a capacity hint only: it never
+    affects the produced bytes or the `maxOutputSize` bomb guard, so every inflate
+    correctness proof transfers unchanged (`ByteArray.emptyWithCapacity n` is
+    definitionally `{ data := Array.empty }` for every `n`). -/
 def inflateRaw (data : ByteArray) (startPos : Nat := 0)
-    (maxOutputSize : Nat := 1024 * 1024 * 1024) :
+    (maxOutputSize : Nat := 1024 * 1024 * 1024) (sizeHint : Nat := 0) :
     Except String (ByteArray × Nat) := do
   let br : BitReader := { data, pos := startPos, bitOff := 0 }
   let fixedLit ← HuffTree.fromLengths fixedLitLengths
   let fixedDist ← HuffTree.fromLengths fixedDistLengths
-  inflateLoop br .empty fixedLit fixedDist maxOutputSize data.size
+  inflateLoop br (ByteArray.emptyWithCapacity sizeHint) fixedLit fixedDist maxOutputSize data.size
 
 /-- Inflate a raw DEFLATE stream. Processes blocks until a final block is seen.
     `maxOutputSize` (default 1 GiB) caps decompressed output as a zip-bomb
@@ -813,10 +822,14 @@ def inflateRaw (data : ByteArray) (startPos : Nat := 0)
     `output.size + len > maxOutputSize`, so even a single produced byte
     exceeds the bound). Overflow raises an `Except` error containing
     `"Inflate: output exceeds maximum size"`.
-    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
-def inflate (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
+    See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*.
+
+    `sizeHint` pre-reserves output capacity when the decompressed size is known;
+    `0` (the default) reserves nothing. See `inflateRaw`. -/
+def inflate (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024)
+    (sizeHint : Nat := 0) :
     Except String ByteArray := do
-  let (output, _) ← inflateRaw data 0 maxOutputSize
+  let (output, _) ← inflateRaw data 0 maxOutputSize sizeHint
   return output
 
 end Inflate

--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -832,5 +832,21 @@ def inflate (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024)
   let (output, _) ← inflateRaw data 0 maxOutputSize sizeHint
   return output
 
+/-- The output capacity hint is computationally inert: `inflateRaw` with any
+    `sizeHint` equals `inflateRaw` with the default `sizeHint := 0`, because
+    `ByteArray.emptyWithCapacity n` reduces to `{ data := Array.empty }` for every
+    `n` (capacity is a runtime-only allocation hint). So every theorem proved about
+    the `sizeHint := 0` form — correctness, suffix invariance, end-position bounds —
+    transfers verbatim to any hinted call (e.g. the ZIP decoder's). -/
+@[simp] theorem inflateRaw_sizeHint_eq (data : ByteArray) (startPos maxOutputSize sizeHint : Nat) :
+    inflateRaw data startPos maxOutputSize sizeHint = inflateRaw data startPos maxOutputSize :=
+  rfl
+
+/-- `inflate` with any `sizeHint` equals `inflate` with the default `0`; see
+    `inflateRaw_sizeHint_eq`. -/
+@[simp] theorem inflate_sizeHint_eq (data : ByteArray) (maxOutputSize sizeHint : Nat) :
+    inflate data maxOutputSize sizeHint = inflate data maxOutputSize :=
+  rfl
+
 end Inflate
 end Zip.Native

--- a/Zip/Native/InflateBuf.lean
+++ b/Zip/Native/InflateBuf.lean
@@ -41,13 +41,17 @@ def inflateLoopBuf (br : BitReader) (output : ByteArray)
 termination_by dataSize * 8 - br.bitPos
 decreasing_by all_goals omega
 
-/-- Wide-buffer `inflate` (entry point). -/
-def inflate (data : ByteArray) (maxOut : Nat := 1024 * 1024 * 1024) :
+/-- Wide-buffer `inflate` (entry point). `sizeHint` pre-reserves output capacity
+    when the decompressed size is known (`0`, the default, reserves nothing); it is
+    a capacity hint only, so `InflateBuf.inflate = Inflate.inflate` is unaffected. -/
+def inflate (data : ByteArray) (maxOut : Nat := 1024 * 1024 * 1024)
+    (sizeHint : Nat := 0) :
     Except String ByteArray := do
   let br : BitReader := { data, pos := 0, bitOff := 0 }
   let fixedLit ← HuffTree.fromLengths Inflate.fixedLitLengths
   let fixedDist ← HuffTree.fromLengths Inflate.fixedDistLengths
-  let (output, _) ← inflateLoopBuf br .empty fixedLit fixedDist maxOut data.size
+  let (output, _) ← inflateLoopBuf br (ByteArray.emptyWithCapacity sizeHint)
+    fixedLit fixedDist maxOut data.size
   return output
 
 end InflateBuf

--- a/Zip/Native/InflateBuf.lean
+++ b/Zip/Native/InflateBuf.lean
@@ -54,5 +54,12 @@ def inflate (data : ByteArray) (maxOut : Nat := 1024 * 1024 * 1024)
     fixedLit fixedDist maxOut data.size
   return output
 
+/-- The output capacity hint is computationally inert: `inflate` with any `sizeHint`
+    equals `inflate` with the default `0` (`ByteArray.emptyWithCapacity n` reduces to
+    `{ data := Array.empty }` for every `n`). -/
+@[simp] theorem inflate_sizeHint_eq (data : ByteArray) (maxOut sizeHint : Nat) :
+    inflate data maxOut sizeHint = inflate data maxOut :=
+  rfl
+
 end InflateBuf
 end Zip.Native

--- a/Zip/Spec/DeflateFixedCorrect.lean
+++ b/Zip/Spec/DeflateFixedCorrect.lean
@@ -340,7 +340,7 @@ theorem inflate_complete (bytes : ByteArray) (result : List UInt8)
   -- Unfold inflate: it calls inflateRaw then discards endPos
   simp only [Inflate.inflate, bind, Except.bind]
   -- Unfold inflateRaw
-  simp only [Inflate.inflateRaw, bind, Except.bind]
+  simp only [Inflate.inflateRaw, ByteArray.emptyWithCapacity_eq_empty, bind, Except.bind]
   -- Build fixed Huffman trees (computationally verified to succeed)
   obtain ⟨fixedLit, hflit⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedLit_ok
   obtain ⟨fixedDist, hfdist⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedDist_ok

--- a/Zip/Spec/DeflateStoredCorrect.lean
+++ b/Zip/Spec/DeflateStoredCorrect.lean
@@ -752,7 +752,8 @@ theorem inflate_deflateStoredPure (data : ByteArray)
     (maxOutputSize : Nat)
     (h : data.size ≤ maxOutputSize) :
     Inflate.inflate (deflateStoredPure data) maxOutputSize = .ok data := by
-  simp only [Inflate.inflate, Inflate.inflateRaw, bind, Except.bind]
+  simp only [Inflate.inflate, Inflate.inflateRaw, ByteArray.emptyWithCapacity_eq_empty,
+    bind, Except.bind]
   -- Handle fromLengths calls
   have ⟨fixedLit, hfl⟩ := fromLengths_fixedLit_ok
   have ⟨fixedDist, hfd⟩ := fromLengths_fixedDist_ok

--- a/Zip/Spec/InflateBufCorrect.lean
+++ b/Zip/Spec/InflateBufCorrect.lean
@@ -1586,8 +1586,8 @@ theorem inflateLoopBuf_eq (fixedLit fixedDist : HuffTree) (maxOut dataSize : Nat
 
 /-- **`InflateBuf.inflate` equals the verified `Inflate.inflate`.** The wide-buffer
     decoder is a drop-in replacement with no trust gap. -/
-theorem inflate_eq (data : ByteArray) (maxOut : Nat) :
-    InflateBuf.inflate data maxOut = Inflate.inflate data maxOut := by
+theorem inflate_eq (data : ByteArray) (maxOut : Nat) (sizeHint : Nat := 0) :
+    InflateBuf.inflate data maxOut sizeHint = Inflate.inflate data maxOut sizeHint := by
   unfold InflateBuf.inflate Inflate.inflate Inflate.inflateRaw
   cases hfl : HuffTree.fromLengths Inflate.fixedLitLengths with
   | error e => simp only [hfl, bind, Except.bind]
@@ -1598,4 +1598,5 @@ theorem inflate_eq (data : ByteArray) (maxOut : Nat) :
       simp only [hfl, hfd, bind, Except.bind]
       rw [inflateLoopBuf_eq fixedLit fixedDist maxOut data.size
         (fromLengths_depthLE hfl) (fromLengths_depthLE hfd)
-        { data := data, pos := 0, bitOff := 0 } .empty (Or.inl rfl) (Nat.zero_le _) rfl]
+        { data := data, pos := 0, bitOff := 0 } (ByteArray.emptyWithCapacity sizeHint)
+        (Or.inl rfl) (Nat.zero_le _) rfl]

--- a/ZipBench.lean
+++ b/ZipBench.lean
@@ -116,12 +116,14 @@ where
     -- Decompression benchmarks (compress with FFI first, then decompress)
     | "inflate" =>
       let compressed ← RawDeflate.compress data level.toUInt8
-      match Zip.Native.Inflate.inflate compressed with
+      -- The decompressed size is known here (we just compressed `data`), so pass it
+      -- as `sizeHint` to pre-size the output buffer and skip the doubling reallocs.
+      match Zip.Native.Inflate.inflate compressed (sizeHint := data.size) with
       | .ok _ => pure ()
       | .error e => throw (IO.userError e)
     | "inflate-buf" =>
       let compressed ← RawDeflate.compress data level.toUInt8
-      match Zip.Native.InflateBuf.inflate compressed with
+      match Zip.Native.InflateBuf.inflate compressed (sizeHint := data.size) with
       | .ok _ => pure ()
       | .error e => throw (IO.userError e)
     | "decode-ab" =>
@@ -133,8 +135,8 @@ where
         let d := if data.size == 0 then data else
           (data.extract 0 data.size).set! (i % data.size) (data[i % data.size]!.toNat.toUInt8 ^^^ 1)
         inputs := inputs.push (← RawDeflate.compress d level.toUInt8)
-      let dec1 := Zip.Native.Inflate.inflate
-      let dec2 := Zip.Native.InflateBuf.inflate
+      let dec1 := fun c => Zip.Native.Inflate.inflate c (sizeHint := data.size)
+      let dec2 := fun c => Zip.Native.InflateBuf.inflate c (sizeHint := data.size)
       let sink (acc : UInt64) (r : Except String ByteArray) : IO UInt64 :=
         match r with
         | .ok x => pure (acc + x.size.toUInt64 + (if x.size > 0 then x[0]!.toUInt64 else 0))

--- a/ZipBenchReport.lean
+++ b/ZipBenchReport.lean
@@ -144,7 +144,7 @@ def runWorkloads
     (name : String)
     (workloads : List (String × ByteArray))
     (compress : ByteArray → Nat → IO ByteArray)
-    (decompress? : Option (ByteArray → IO ByteArray))
+    (decompress? : Option (ByteArray → Nat → IO ByteArray))
     (theLevels : List Nat := levels) (theReps : Nat := reps) : IO (List Row) := do
   let mut rows : List Row := []
   for (pat, data) in workloads do
@@ -160,7 +160,11 @@ def runWorkloads
         | none => pure none
         | some dec => do
           let ref ← RawDeflate.compress data level.toUInt8
-          let dNs ← measureNs size theReps (dec ref >>= sink)
+          -- The decompressed size is known here; pass it so the native decoder
+          -- pre-sizes its output buffer, matching the production ZIP/gzip path
+          -- where the uncompressed size comes from the archive metadata. The FFI
+          -- reference decoders ignore it.
+          let dNs ← measureNs size theReps (dec ref size >>= sink)
           pure (mbps size dNs)
       rows := { compressor := name, pattern := pat, size := size, level := level,
                 outSize := outSize, ratio := ratio,
@@ -174,8 +178,8 @@ def runWorkloads
 def nativeCompress (data : ByteArray) (level : Nat) : IO ByteArray :=
   pure (Zip.Native.Deflate.deflateRaw data level.toUInt8)
 
-def nativeDecompress (data : ByteArray) : IO ByteArray :=
-  match Zip.Native.Inflate.inflate data with
+def nativeDecompress (data : ByteArray) (origSize : Nat) : IO ByteArray :=
+  match Zip.Native.Inflate.inflate data (sizeHint := origSize) with
   | .ok b => pure b
   | .error e => throw (IO.userError e)
 
@@ -250,9 +254,9 @@ def runReport (outPath : String) (nativeOnly : Bool := false)
     if nativeOnly then
       rows := rows ++ cn
     else
-      let cz ← runWorkloads "zlib"        files zlibCompress       (some RawDeflate.decompress) (theLevels := lvls) (theReps := rps)
-      let cm ← runWorkloads "miniz_oxide" files minizCompress      (some MinizOxide.decompress) (theLevels := lvls) (theReps := rps)
-      let cl ← runWorkloads "libdeflate"  files libdeflateCompress (some Libdeflate.decompress) (theLevels := lvls) (theReps := rps)
+      let cz ← runWorkloads "zlib"        files zlibCompress       (some fun d _ => RawDeflate.decompress d) (theLevels := lvls) (theReps := rps)
+      let cm ← runWorkloads "miniz_oxide" files minizCompress      (some fun d _ => MinizOxide.decompress d) (theLevels := lvls) (theReps := rps)
+      let cl ← runWorkloads "libdeflate"  files libdeflateCompress (some fun d _ => Libdeflate.decompress d) (theLevels := lvls) (theReps := rps)
       rows := rows ++ cn ++ cz ++ cm ++ cl
 
   let date ← shell "date" ["-u", "+%Y-%m-%dT%H:%M:%SZ"]
@@ -321,8 +325,65 @@ def runZopfliCeiling (outPath : String) : IO Unit := do
   IO.FS.writeFile outPath json
   IO.eprintln s!"Wrote {rows.length} zopfli rows → {outPath}"
 
+/-- Decode `ref`, optionally pre-sizing the output to `hint` (`0` = no hint).
+    `@[noinline]` keeps the pure `inflate` call from being hoisted out of the
+    timed loop (it is otherwise loop-invariant), so each timed call really decodes. -/
+@[noinline] def decodeForAB (ref : ByteArray) (hint : Nat) : IO Nat := do
+  match Zip.Native.Inflate.inflate ref (sizeHint := hint) with
+  | .ok b => sink b
+  | .error e => throw (IO.userError e)
+
+/-- Paired, interleaved decode A/B: native decode WITH the output-size hint vs
+    WITHOUT it, measured back-to-back per file so machine-load common-mode noise
+    cancels. Reports per-corpus geomean speedup (no-hint time / hint time) with a
+    95% CI on the log-ratios. Robust on a busy shared machine; pin with `taskset -c`.
+    This is a diagnostic, not part of the dashboard matrix. -/
+def runPresizeAB (pairs : Nat := 12) : IO Unit := do
+  let corpora ← loadCorpora
+  IO.println s!"Paired decode A/B (no-hint time / hint time), {pairs} pairs/file, level 6:"
+  for (corpus, files) in corpora do
+    let mut logs : List Float := []
+    let mut noMBs : List Float := []
+    let mut yesMBs : List Float := []
+    for (_pat, data) in files do
+      let size := data.size
+      let ref ← RawDeflate.compress data 6
+      let _ ← decodeForAB ref 0; let _ ← decodeForAB ref size  -- warm
+      for p in [:pairs] do
+        let (nNs, yNs) ←
+          if p % 2 == 0 then
+            let a ← timePerOp 1 (decodeForAB ref 0)
+            let b ← timePerOp 1 (decodeForAB ref size)
+            pure (a, b)
+          else
+            let b ← timePerOp 1 (decodeForAB ref size)
+            let a ← timePerOp 1 (decodeForAB ref 0)
+            pure (a, b)
+        if nNs > 0 && yNs > 0 then
+          logs := Float.log (nNs.toFloat / yNs.toFloat) :: logs
+          let mb (ns : Nat) : Float := (size.toFloat / (1024.0 * 1024.0)) / (ns.toFloat / 1.0e9)
+          noMBs := mb nNs :: noMBs
+          yesMBs := mb yNs :: yesMBs
+    let n := logs.length
+    if n == 0 then
+      IO.println s!"  {corpus}: no data"
+    else
+      let nf := n.toFloat
+      let mean := (logs.foldl (· + ·) 0.0) / nf
+      let var := (logs.foldl (fun a x => a + (x - mean) * (x - mean)) 0.0) / (max (nf - 1.0) 1.0)
+      let std := Float.sqrt var
+      let hw := 1.96 * std / Float.sqrt nf
+      let sp := Float.exp mean
+      let lo := Float.exp (mean - hw)
+      let hi := Float.exp (mean + hw)
+      let avg (xs : List Float) : Float := (xs.foldl (· + ·) 0.0) / xs.length.toFloat
+      IO.println s!"  {corpus} (n={n}): speedup={round4 sp}x  95% CI [{round4 lo}, {round4 hi}]  \
+nohint={round2 (avg noMBs)} MB/s  presize={round2 (avg yesMBs)} MB/s"
+
 def main (args : List String) : IO Unit := do
   match args with
+  | ["--presize-ab"] => runPresizeAB
+  | ["--presize-ab", nStr] => runPresizeAB ((nStr.toNat?).getD 12)
   | ["--dump-payloads", dir] => dumpPayloads dir
   | ["--zopfli-ceiling", out] => runZopfliCeiling out
   | ["--native-only", out] => runReport out (nativeOnly := true)


### PR DESCRIPTION
This PR adds an optional `sizeHint` parameter to the native DEFLATE decoders (`Inflate.inflate`/`inflateRaw` and `InflateBuf.inflate`) that pre-reserves the output buffer's capacity, removing the doubling reallocations (`lean_copy_sarray`) that a buffer grown one literal at a time otherwise pays. This targets the `copy_sarray` portion of the ~31% output-copy path identified in https://github.com/kim-em/lean-zip/issues/2651 "perf(decode): output literal-run fast path + pre-sized output buffer".

`0` (the default) reserves nothing, so existing callers and every correctness proof are unchanged: `ByteArray.emptyWithCapacity n` is definitionally `{ data := Array.empty }` for every `n`, so the initial buffer is still `.empty`. Two spec proofs that `rw` over the unfolded buffer pick up a one-token `emptyWithCapacity_eq_empty` normalization; the rest transfer untouched. The new `rfl` bridge lemmas `Inflate.inflateRaw_sizeHint_eq`, `Inflate.inflate_sizeHint_eq`, and `InflateBuf.inflate_sizeHint_eq` state that any `sizeHint` equals the verified `sizeHint := 0` form, so every existing correctness/suffix/bounds theorem transfers verbatim to a hinted call.

The ZIP entry decoder passes the entry's declared uncompressed size. Because `uncompressedSize` is untrusted metadata, the speculative reservation is bounded by three guards no malicious entry controls: a fixed absolute ceiling `nativePresizeCap` (64 MiB, the real safety property), the `maxEntrySize` output budget (so a `0` reject-all budget reserves nothing), and a heuristic `compData.size * 1100` ratio bound. The bench passes the known decompressed size.

Measured native decode speedup from pre-sizing alone (10 MiB, level 6): text 1.12x, prng 1.36x, cyclic 1.14x, constant 1.09x.

The output literal-run fast path (issue item 1) is deferred to a follow-up: it requires restructuring the `go_corr` symbol-by-symbol bisimulation and `goFused_eq_go`, and its marginal gain over pre-sizing — now that pushes no longer realloc — is unmeasured. This PR's pre-size half stands alone, fully proven and measured.

🤖 Prepared with Claude Code