### PR TITLE
perf(decode): packed single-word decode-table entry

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -154,29 +154,90 @@ where
       else if bits % 2 == 0 then go z (bits / 2) (depth + 1)
       else go o (bits / 2) (depth + 1)
 
-/-- A de-boxed fast-decode table: the `(symbol, codeLen)` of each slot split into
-    two parallel scalar arrays. Storing `Array (UInt16 × UInt8)` boxes every slot
-    as a heap pair, so each per-symbol read pointer-chases through `lean_ctor_get`
-    twice; the split keeps each field in a scalar array (`lean_array_fget` +
-    `unbox`, no chase), which is the de-box of #2650.
+/-- Pack a slot's `(symbol, codeLen)` into one `UInt32` word: the codeword length
+    in the low byte (bits 0–7), the 16-bit symbol in bits 8–23. libdeflate-style
+    single-word entry (libdeflate also uses a `u32`). The source reads the slot
+    through `lenAt`/`symAt`, which name the same `packed[idx]!` element; the
+    compiler CSEs the shared read, so a per-symbol decode lowers to **one**
+    `lean_array_get` plus register shifts (verified in the generated C for the
+    fastloop literal path), rather than two reads into the parallel `syms`/`lens`
+    arrays of #2650 (which also touched two cache lines). Even without the CSE it
+    is two reads of one tagged-scalar array, never the old two-array / two-cache-
+    line shape.
 
-    Two scalar arrays rather than one packed `UInt32` word: extracting the high
-    field of a packed word needs a shift, and the well-founded recursions `go` /
-    `goFused` would force that shift to weak head normal form during equation
-    compilation and loop on `Nat.div`. A plain array read stays stuck under
-    `whnf`, so the split keeps both the de-box and the proofs. -/
+    **`UInt32`, not `UInt64`.** On a 64-bit target `lean_box_uint32` is a tagged
+    scalar stored inline in the array (no allocation), exactly like the old
+    `Array UInt8`/`Array UInt16`; `lean_box_uint64` instead heap-allocates a boxed
+    word per entry, so an `Array UInt64` would pointer-chase through `lean_ctor_get`
+    on every read — re-introducing the very boxing #2650 removed. A `UInt32` holds
+    len (8 bits) + symbol (16 bits) with room to spare.
+
+    **The length is the low byte deliberately.** Only the length flows into the
+    well-founded recursions' termination measure (`cnt - len`), and extracting it
+    must avoid a shift: a `>>>` on the stuck array read `packed[idx]!` forces
+    `Nat.shiftRight`/`Nat.div` during the equation compiler's `whnf`, which loops
+    on the opaque value — the #2650 hazard. The low byte extracts with `toUInt8`
+    (a width truncation, no `Nat.div`), so `unpackLen` stays inert under `whnf`.
+    The symbol uses a shift, but it never enters the measure, so its `whnf` is
+    never forced during termination checking. -/
+@[inline] def packEntry (sym : UInt16) (len : UInt8) : UInt32 :=
+  len.toUInt32 ||| (sym.toUInt32 <<< 8)
+
+/-- The symbol field (bits 8–23) of a packed entry. -/
+@[inline] def unpackSym (e : UInt32) : UInt16 := (e >>> 8).toUInt16
+
+/-- The codeword-length field (low byte) of a packed entry. Shift-free so it stays
+    inert under the `whnf` the well-founded recursions force (see `packEntry`). -/
+@[inline] def unpackLen (e : UInt32) : UInt8 := e.toUInt8
+
+/-- A de-boxed fast-decode table: each slot's `(symbol, codeLen)` packed into one
+    `UInt32` word (`packEntry`), stored in a single scalar `Array UInt32`. Storing
+    `Array (UInt16 × UInt8)` boxes every slot as a heap pair, so each per-symbol
+    read pointer-chases through `lean_ctor_get` twice; #2650 split the fields into
+    two parallel scalar arrays to de-box; this folds them back into one packed
+    word so a per-symbol read is a single `lean_array_fget` plus shifts (`symAt` /
+    `lenAt`) touching one tagged-scalar array / one cache line instead of two.
+
+    The only packed field on the well-founded recursions' termination measure is
+    the length, and `lenAt` extracts it shift-free (`toUInt8` of the low byte), so
+    it stays inert under the `whnf` those recursions force during equation
+    compilation — the `Nat.div` loop #2650 warned of (a `>>>` on the stuck
+    `packed[idx]!` reducing to `Nat.shiftRight`/`Nat.div`) does not fire. `symAt`
+    does shift, but the symbol never enters a measure, so its `whnf` is never
+    forced (see `packEntry`). The packed table is kept behind an equivalence to
+    the split projections
+    (`buildTable_lenAt` / `buildTable_symAt` recover `(tableEntry …).2` /
+    `(tableEntry …).1`), so every decode proof transfers. -/
 structure DecodeTable where
-  syms : Array UInt16
-  lens : Array UInt8
+  packed : Array UInt32
 
-/-- Build the `2^fastBits`-entry decode table for `tree`: slot `i` holds the
-    `(symbol, codeLen)` reached by walking `tree` on the bits of `i`, with the two
-    fields split into the parallel scalar arrays of `DecodeTable` so each
-    per-symbol read is a de-boxed scalar load instead of a heap-pair pointer-chase.
+/-- The codeword length of slot `idx`: the low byte of the packed entry. One
+    scalar-array read plus a width truncation (no shift — see `packEntry` for why
+    the length is the low byte, so this stays inert under the well-founded
+    recursions' `whnf`). -/
+@[inline] def DecodeTable.lenAt (t : DecodeTable) (idx : Nat) : UInt8 :=
+  unpackLen t.packed[idx]!
+
+/-- The symbol of slot `idx`: bits 8–23 of the packed entry. One scalar-array read
+    plus a shift; the symbol never enters a termination measure, so the shift is
+    never `whnf`-forced. -/
+@[inline] def DecodeTable.symAt (t : DecodeTable) (idx : Nat) : UInt16 :=
+  unpackSym t.packed[idx]!
+
+theorem DecodeTable.lenAt_def (t : DecodeTable) (idx : Nat) :
+    t.lenAt idx = unpackLen t.packed[idx]! := rfl
+
+theorem DecodeTable.symAt_def (t : DecodeTable) (idx : Nat) :
+    t.symAt idx = unpackSym t.packed[idx]! := rfl
+
+/-- Build the `2^fastBits`-entry decode table for `tree`: slot `i` holds
+    `packEntry sym codeLen` for the `(sym, codeLen)` reached by walking `tree` on
+    the bits of `i`, stored in a single packed scalar array so each per-symbol read
+    is one de-boxed `UInt32` load instead of two reads / a heap-pair pointer-chase.
     Built once per Huffman tree; cheap relative to the symbols decoded with it. -/
 def buildTable (tree : HuffTree) : DecodeTable where
-  syms := Array.ofFn (n := 2 ^ fastBits) (fun i : Fin (2 ^ fastBits) => (tableEntry tree i.val).1)
-  lens := Array.ofFn (n := 2 ^ fastBits) (fun i : Fin (2 ^ fastBits) => (tableEntry tree i.val).2)
+  packed := Array.ofFn (n := 2 ^ fastBits) (fun i : Fin (2 ^ fastBits) =>
+    packEntry (tableEntry tree i.val).1 (tableEntry tree i.val).2)
 
 /-- Bits remaining in the reader from its current `(pos, bitOff)`. -/
 def bitsAvail (br : BitReader) : Nat :=
@@ -203,12 +264,12 @@ def decodeWithTable (tree : HuffTree) (table : DecodeTable)
   if br.bitOff ≥ 8 then tree.decode br
   else
     let idx := (peekFast br).toNat
-    let len := table.lens[idx]!.toNat
+    let len := (table.lenAt idx).toNat
     if len == 0 || len > bitsAvail br then
       tree.decode br
     else
       let total := br.bitOff + len
-      .ok (table.syms[idx]!, { br with pos := br.pos + total / 8, bitOff := total % 8 })
+      .ok (table.symAt idx, { br with pos := br.pos + total / 8, bitOff := total % 8 })
 
 end HuffTree
 
@@ -603,12 +664,12 @@ theorem refillGuard_usize (data : ByteArray) (pos cnt : USize) (hsz : data.size 
 /-- The inline-literal guard read in `USize` matches the `Nat` guard (the length
     field round-trips since it is a `UInt8`). -/
 theorem litGuard_usize (table : HuffTree.DecodeTable) (bitBuf : UInt64) (cnt : USize) :
-    (table.lens[(bitBuf &&& 0x1FF).toNat]!.toNat ≠ 0
-        ∧ (table.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUSize ≤ cnt
-        ∧ table.syms[(bitBuf &&& 0x1FF).toNat]! < 256)
-      ↔ (table.lens[(bitBuf &&& 0x1FF).toNat]!.toNat ≠ 0
-        ∧ table.lens[(bitBuf &&& 0x1FF).toNat]!.toNat ≤ cnt.toNat
-        ∧ table.syms[(bitBuf &&& 0x1FF).toNat]! < 256) := by
+    ((table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
+        ∧ ((table.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize ≤ cnt
+        ∧ table.symAt (bitBuf &&& 0x1FF).toNat < 256)
+      ↔ ((table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
+        ∧ (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt.toNat
+        ∧ table.symAt (bitBuf &&& 0x1FF).toNat < 256) := by
   rw [USize.le_iff_toNat_le, toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)]
 
 /-- Load whole bytes into the high end of `bitBuf` until it holds > 56 bits or
@@ -645,9 +706,9 @@ def walkTree (t : HuffTree) (bitBuf : UInt64) (cnt depth : Nat) :
 @[inline] def decodeSym (tree : HuffTree) (table : HuffTree.DecodeTable)
     (bitBuf : UInt64) (cnt : Nat) : Except String (UInt16 × UInt64 × Nat × Nat) :=
   let idx := (bitBuf &&& 0x1FF).toNat
-  let len := table.lens[idx]!.toNat
+  let len := (table.lenAt idx).toNat
   if len == 0 || len > cnt then walkTree tree bitBuf cnt 0
-  else .ok (table.syms[idx]!, bitBuf >>> len.toUInt64, cnt - len, len)
+  else .ok (table.symAt idx, bitBuf >>> len.toUInt64, cnt - len, len)
 
 /-- Read `n` bits LSB-first from the buffer without refilling. Errors (like
     `readBitsFast`) when the buffer holds fewer than `n` bits — for a refilled
@@ -804,15 +865,15 @@ def goFusedP (litTable distTable : HuffTree.DecodeTable)
     goFusedP litTable distTable data litTree distTree maxOut
       (pos + 1) (bitBuf ||| (data[pos]!.toUInt64 <<< cnt.toUInt64)) (cnt + 8) output
   else
-  if hlit : litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat ≠ 0
-      ∧ litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat ≤ cnt
-      ∧ litTable.syms[(bitBuf &&& 0x1FF).toNat]! < 256 then
+  if hlit : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
+      ∧ (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt
+      ∧ litTable.symAt (bitBuf &&& 0x1FF).toNat < 256 then
     if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
     else
       goFusedP litTable distTable data litTree distTree maxOut pos
-        (bitBuf >>> (litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUInt64)
-        (cnt - litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat)
-        (output.push litTable.syms[(bitBuf &&& 0x1FF).toNat]!.toUInt8)
+        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUInt64)
+        (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat)
+        (output.push (litTable.symAt (bitBuf &&& 0x1FF).toNat).toUInt8)
   else
   let cnt0 := cnt
   match decodeSym litTree litTable bitBuf cnt with
@@ -884,16 +945,16 @@ def goFusedPU (litTable distTable : HuffTree.DecodeTable)
           rwa [toUSize_toNat_of_lt hsz] at h)).toUInt64 <<< cnt.toUInt64))
       (cnt + 8) hsz output
   else
-  if hlit : litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat ≠ 0
-      ∧ (litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUSize ≤ cnt
-      ∧ litTable.syms[(bitBuf &&& 0x1FF).toNat]! < 256 then
+  if hlit : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0
+      ∧ ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize ≤ cnt
+      ∧ litTable.symAt (bitBuf &&& 0x1FF).toNat < 256 then
     if output.size ≥ maxOut then throw "Inflate: output exceeds maximum size"
     else
       goFusedPU litTable distTable data litTree distTree maxOut pos
-        (bitBuf >>> (litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUInt64)
-        (cnt - (litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUSize)
+        (bitBuf >>> ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUInt64)
+        (cnt - ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize)
         hsz
-        (output.push litTable.syms[(bitBuf &&& 0x1FF).toNat]!.toUInt8)
+        (output.push (litTable.symAt (bitBuf &&& 0x1FF).toNat).toUInt8)
   else
   let cnt0 := cnt.toNat
   match decodeSym litTree litTable bitBuf cnt.toNat with
@@ -955,13 +1016,13 @@ def goFusedPU (litTable distTable : HuffTree.DecodeTable)
       rw [hpa, hca]; omega
     · -- inline literal: cnt drops by len ≥ 1
       obtain ⟨hne, hle, _⟩ := hlit
-      have hlen : (litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUSize.toNat
-          = litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat :=
+      have hlen : ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize.toNat
+          = (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat :=
         toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - (litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUSize).toNat
-          = cnt.toNat - litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat := by
+      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize).toNat
+          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat := by
         rw [USize.toNat_sub_of_le _ _ hle, hlen]
-      have hlecnt : litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat ≤ cnt.toNat :=
+      have hlecnt : (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt.toNat :=
         hlen ▸ USize.le_iff_toNat_le.mp hle
       rw [hsub]; omega
     · -- slow literal: cnt' < cnt0 = cnt.toNat from the no-progress guard

--- a/Zip/Spec/InflateBufCorrect.lean
+++ b/Zip/Spec/InflateBufCorrect.lean
@@ -730,7 +730,7 @@ theorem decodeSym_corr (tree : HuffTree) (table : HuffTree.DecodeTable)
     {data : ByteArray} {br : BitReader} {pos : Nat} {bitBuf : UInt64} {cnt : Nat}
     (h : BufCorr data br.bitPos pos bitBuf cnt) (hwf : br.bitOff < 8) (hdata : br.data = data)
     (hr : 21 < cnt ∨ pos = data.size)
-    (hlen : (table.lens[(bitBuf &&& 0x1FF).toNat]!).toNat ≤ 9) (hdep : treeDepthLE tree 15) :
+    (hlen : (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ 9) (hdep : treeDepthLE tree 15) :
     match HuffTree.decodeWithTable tree table br, decodeSym tree table bitBuf cnt with
     | .error e1, .error e2 => e1 = e2
     | .ok (s1, br'), .ok (s2, bb, c, used) =>
@@ -752,9 +752,9 @@ theorem decodeSym_corr (tree : HuffTree) (table : HuffTree.DecodeTable)
   unfold HuffTree.decodeWithTable decodeSym
   rw [if_neg (show ¬ br.bitOff ≥ 8 from by omega), hidx]
   simp only []
-  -- generalize the two parallel reads (the de-boxed table splits sym/len)
-  generalize hlenv : table.lens[(peekFast br).toNat]! = lenB at hlen ⊢
-  generalize hsymv : table.syms[(peekFast br).toNat]! = symV
+  -- generalize the packed table's len/sym projections of this slot
+  generalize hlenv : table.lenAt (peekFast br).toNat = lenB at hlen ⊢
+  generalize hsymv : table.symAt (peekFast br).toNat = symV
   -- the two guards have the same truth value (cnt vs bitsAvail, with len ≤ 9)
   have hgd : (lenB.toNat == 0 || decide (lenB.toNat > HuffTree.bitsAvail br))
            = (lenB.toNat == 0 || decide (lenB.toNat > cnt)) := by
@@ -787,8 +787,8 @@ theorem decodeSym_corr (tree : HuffTree) (table : HuffTree.DecodeTable)
 /-- Every `buildTable` entry's code length is at most `fastBits = 9`
     (the table walk stops at `fastBits`, or returns the `0` sentinel). -/
 theorem buildTable_codeLen_le (tree : HuffTree) (idx : Nat) (hidx : idx < 2 ^ HuffTree.fastBits) :
-    (tree.buildTable.lens[idx]!).toNat ≤ 9 := by
-  rw [HuffTree.buildTable_lens_getElem tree idx hidx, HuffTree.tableEntry]
+    (tree.buildTable.lenAt idx).toNat ≤ 9 := by
+  rw [HuffTree.buildTable_lenAt tree idx hidx, HuffTree.tableEntry]
   rcases hg : HuffTree.tableEntry.go tree idx 0 with ⟨sym, lenB⟩
   show lenB.toNat ≤ 9
   by_cases hp : 0 < lenB.toNat
@@ -1126,13 +1126,13 @@ theorem go_refill_step (litTable distTable : HuffTree.DecodeTable) (data : ByteA
     inline table read does it — near-definitional, the else branch of `decodeSym`. -/
 theorem decodeSym_inline (tree : HuffTree) (table : HuffTree.DecodeTable)
     (bitBuf : UInt64) (cnt : Nat)
-    (h0 : table.lens[(bitBuf &&& 0x1FF).toNat]!.toNat ≠ 0)
-    (hle : table.lens[(bitBuf &&& 0x1FF).toNat]!.toNat ≤ cnt) :
+    (h0 : (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≠ 0)
+    (hle : (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat ≤ cnt) :
     decodeSym tree table bitBuf cnt =
-      .ok (table.syms[(bitBuf &&& 0x1FF).toNat]!,
-        bitBuf >>> (table.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUInt64,
-        cnt - table.lens[(bitBuf &&& 0x1FF).toNat]!.toNat,
-        table.lens[(bitBuf &&& 0x1FF).toNat]!.toNat) := by
+      .ok (table.symAt (bitBuf &&& 0x1FF).toNat,
+        bitBuf >>> ((table.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUInt64,
+        cnt - (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat,
+        (table.lenAt (bitBuf &&& 0x1FF).toNat).toNat) := by
   unfold decodeSym
   simp only []
   rw [if_neg (by simp only [Bool.or_eq_true, beq_iff_eq, decide_eq_true_eq]; omega)]
@@ -1226,11 +1226,11 @@ theorem goFusedP_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArra
           goFused, dif_neg hrc, decodeSym_inline litTree litTable bitBuf cnt hl0 hl1]
       simp only []
       rw [if_pos hl2, if_neg hmax,
-          dif_neg (show ¬ bp + (cnt - (cnt - litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat)) ≤ bp by omega),
-          dif_neg (show ¬ data.size * 8 < bp + (cnt - (cnt - litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat)) by
+          dif_neg (show ¬ bp + (cnt - (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat)) ≤ bp by omega),
+          dif_neg (show ¬ data.size * 8 < bp + (cnt - (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat)) by
             have : pos * 8 ≤ data.size * 8 := by omega
             omega)]
-      exact ih (bp + (cnt - (cnt - litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat))) (by omega) (by omega)
+      exact ih (bp + (cnt - (cnt - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat))) (by omega) (by omega)
   | case4 pos bitBuf cnt output hrc hlit e hde =>
       intro bp hpos hbp
       rw [goFusedP, dif_neg hrc, dif_neg hlit, goFused, dif_neg hrc]
@@ -1467,11 +1467,11 @@ theorem goFusedPU_eq (litTable distTable : HuffTree.DecodeTable) (data : ByteArr
   | case3 pos bitBuf cnt output hrc hlit hmax ih =>
       intro hpos
       obtain ⟨hl0, hl1, hl2⟩ := hlit
-      have hlen : (litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUSize.toNat
-          = litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat :=
+      have hlen : ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize.toNat
+          = (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat :=
         InflateBuf.toUSize_toNat_of_lt (UInt8.toNat_lt_usizeSize _)
-      have hsub : (cnt - (litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat).toUSize).toNat
-          = cnt.toNat - litTable.lens[(bitBuf &&& 0x1FF).toNat]!.toNat := by
+      have hsub : (cnt - ((litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat).toUSize).toNat
+          = cnt.toNat - (litTable.lenAt (bitBuf &&& 0x1FF).toNat).toNat := by
         rw [USize.toNat_sub_of_le _ _ hl1, hlen]
       rw [InflateBuf.goFusedPU, dif_neg hrc, dif_pos ⟨hl0, hl1, hl2⟩, if_neg hmax,
           InflateBuf.goFusedP, dif_neg (fun h => hrc ((InflateBuf.refillGuard_usize data pos cnt hsz).mpr h)),

--- a/Zip/Spec/InflateTable.lean
+++ b/Zip/Spec/InflateTable.lean
@@ -328,22 +328,39 @@ theorem advReader_eq (br br' : BitReader) (k : Nat)
   · dsimp only []; omega
   · exact hwf'
 
-/-- The symbol array of `buildTable` at a valid index is the first component of
-    `tableEntry` — the de-boxed table splits the `(sym, len)` pair into two
-    parallel scalar arrays, so each field projects back through `Array.getElem_ofFn`. -/
-theorem buildTable_syms_getElem (tree : HuffTree) (idx : Nat)
+/-- `unpackSym` recovers the symbol packed by `packEntry` (the high field, bits
+    8–23, after shifting off the length byte). -/
+@[simp] theorem unpackSym_packEntry (sym : UInt16) (len : UInt8) :
+    unpackSym (packEntry sym len) = sym := by
+  simp only [unpackSym, packEntry]; bv_decide
+
+/-- `unpackLen` recovers the codeword length packed by `packEntry`. -/
+@[simp] theorem unpackLen_packEntry (sym : UInt16) (len : UInt8) :
+    unpackLen (packEntry sym len) = len := by
+  simp only [unpackLen, packEntry]; bv_decide
+
+/-- The packed entry of `buildTable` at a valid index is `packEntry` of the
+    `(sym, len)` reached by `tableEntry` — the single packed array projects back
+    through `Array.getElem_ofFn`. -/
+theorem buildTable_packed_getElem (tree : HuffTree) (idx : Nat)
     (hidx : idx < 2 ^ fastBits) :
-    (tree.buildTable).syms[idx]! = (tableEntry tree idx).1 := by
+    (tree.buildTable).packed[idx]! = packEntry (tableEntry tree idx).1 (tableEntry tree idx).2 := by
   simp only [HuffTree.buildTable]
   rw [getElem!_pos _ _ (by rw [Array.size_ofFn]; exact hidx), Array.getElem_ofFn]
 
-/-- The length array of `buildTable` at a valid index is the second component of
-    `tableEntry`. -/
-theorem buildTable_lens_getElem (tree : HuffTree) (idx : Nat)
+/-- The symbol of `buildTable` slot `idx` is the first component of `tableEntry` —
+    the packed table is kept behind this equivalence to the split projections. -/
+theorem buildTable_symAt (tree : HuffTree) (idx : Nat)
     (hidx : idx < 2 ^ fastBits) :
-    (tree.buildTable).lens[idx]! = (tableEntry tree idx).2 := by
-  simp only [HuffTree.buildTable]
-  rw [getElem!_pos _ _ (by rw [Array.size_ofFn]; exact hidx), Array.getElem_ofFn]
+    (tree.buildTable).symAt idx = (tableEntry tree idx).1 := by
+  rw [DecodeTable.symAt_def, buildTable_packed_getElem tree idx hidx, unpackSym_packEntry]
+
+/-- The codeword length of `buildTable` slot `idx` is the second component of
+    `tableEntry`. -/
+theorem buildTable_lenAt (tree : HuffTree) (idx : Nat)
+    (hidx : idx < 2 ^ fastBits) :
+    (tree.buildTable).lenAt idx = (tableEntry tree idx).2 := by
+  rw [DecodeTable.lenAt_def, buildTable_packed_getElem tree idx hidx, unpackLen_packEntry]
 
 set_option maxRecDepth 4096 in
 /-- **Symbol lemma.** The table-driven single-symbol decode built from `tree`
@@ -358,10 +375,10 @@ theorem decodeWithTable_eq (tree : HuffTree) (br : BitReader) :
     rw [UInt32.toNat_and]
     simp only [fastBits]
     exact Nat.and_lt_two_pow _ (by decide)
-  have hlens : (tree.buildTable).lens[(peekFast br).toNat]!
-      = (tableEntry tree (peekFast br).toNat).2 := buildTable_lens_getElem tree _ hidx
-  have hsyms : (tree.buildTable).syms[(peekFast br).toNat]!
-      = (tableEntry tree (peekFast br).toNat).1 := buildTable_syms_getElem tree _ hidx
+  have hlens : (tree.buildTable).lenAt (peekFast br).toNat
+      = (tableEntry tree (peekFast br).toNat).2 := buildTable_lenAt tree _ hidx
+  have hsyms : (tree.buildTable).symAt (peekFast br).toNat
+      = (tableEntry tree (peekFast br).toNat).1 := buildTable_symAt tree _ hidx
   unfold HuffTree.decodeWithTable
   simp only []
   rw [hlens, hsyms]

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p93035117d3)">
+   <g clip-path="url(#pe16209b2d1)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJE0lEQVR4nO3YQYrkZx2H8eqemiEMzRCFxDiIhEDEhXsRz+DGg+QEuYUnEARXbiXo0p1HSKKIkDFqM23Gzkylu6b+7twHnpdfUnw+J/gWBb966r04ffHbbce3y+F2esE6hxfTC5bY7u+mJyxz8eTt6QlrPHxjesE6l5fTC9a4P0wvWOfiPL+z7ebZ9IRlzvMbAwAYJLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL7v+2upzcscX86TE9Y5vtvvjc9YZmr7Z3pCUtcfPl8esIyf3r18fSEJX7w6O3pCcscT3fTE5a4fX2+d//udJyesMRPn/xwesIyXrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdvHiq99t0yNWeHW8nZ6wzFunx9MT1jneTS9Y4/Z6esE63/vR9IIlbreX0xOWOdf7+NZ2NT1hmWe759MTlnh6/Z/pCct4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY/urmenrDElf7R9MT1jl8Pr1gme32i+kJa5xO0wuWuXj8r+kJS5zzDbnaP5mesMajN6YXLPP01d30hCW2l/+YnrCMFywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNh+u/58egNf1+k0vQD+b/vsr9MT1rj0//Nbx23kG8QFAQCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNj+g3//fXrDEjeH19MTlvnzsxfTE5b5/S9/Pj1hiXcevzs9YZmf/Po30xOW+MX7352esMxfbg7TE/iaPvrDp9MTlnj5qw+nJyzjBQsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiF8fTH7fpESu8Ph2nJyxzeXG+Xfzg8HJ6whoP9tML1vny+fSCJU7feTo9YZltO01PWOLBGb8Z3G/n+Zv28Hien2u384IFAJATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsf3luTbW5X56wTKX//x0esIy239vpiescTxOL1hm+/HPpicscba3cbfbvd6dpiescX+YXrDMw69upycssX32yfSEZc73ggAADBFYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/wHDF4wD+BRBZAAAAABJRU5ErkJggg==" id="imageff9fe5cc60" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEUlEQVR4nO3YT4pl5R3H4brVtxtpiiYK/mtCkEBCBpmHkDVk4kJcgbtwBYLgyKmIGWaWJcREQsBWTNmdbsrqsvr2Pc4yFz4vv3h5nhV8Dwfe8znv7vj04+2Mn5ebq+kF69w8m16wxPbidnrCMrsHb0xPWOPuK9ML1jk/n16wxoub6QXr7E7znW1PHk1PWOY03xgAwCCBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2//r7HJ6wxIvjjfTE5Z5+xe/np6wzMX21vSEJXbfP56esMxfn/99esISv7z3xvSEZQ7H2+kJS1y9PN1z//Z4mJ6wxB8e/Gp6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2e/bDJ9v0iBWeH66mJyzz+vH+9IR1DrfTC9a4upxesM6bv51esMTVdj09YZlTPR9f3y6mJyzz6Ozx9IQlHl7+d3rCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa/eHI5vWGJi/296Qnr3HwzvWCZ7erp9IQ1jsfpBcvs7n87PWGJUz5DLvYPpiesce+V6QXLPHx+Oz1hie366+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI7bfLb6Y38FMdj9ML4H+2r76cnrDGuf/Pnx1nI/9HnCAAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ27/3n39Pb1jiyc3L6QnL/O3Rs+kJy3z67p+mJyzx1v13pics8/sPP5qesMSff/Pa9IRl/vnkZnoCP9Fnn/9jesIS1x+8Pz1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENsdjn/Zpkes8PJ4mJ6wzPnudLv4zs319IQ17uynF6zz/ePpBUscX304PWGZbTtOT1jizgnfGbzYTvObdvdwms91duYGCwAgJ7AAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL78216wiLn++kFy5x/++X0hGW2Z99NT1jjcJhesMz2uz9OT1ji/IT/P4+76QWL/HA9vWCZu7en+WzbV19MT1jmdE8QAIAhAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIPYjq2KMAzI9Ph4AAAAASUVORK5CYII=" id="imaged071bd05d6" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mea2f45ded1" d="M 0 0 
+       <path id="m79cfb91616" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mea2f45ded1" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mea2f45ded1" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mea2f45ded1" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mea2f45ded1" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mea2f45ded1" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mea2f45ded1" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mea2f45ded1" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mea2f45ded1" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mea2f45ded1" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mea2f45ded1" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mea2f45ded1" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m79cfb91616" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="md2fb4f1061" d="M 0 0 
+       <path id="m30e8105fa0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md2fb4f1061" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m30e8105fa0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#md2fb4f1061" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m30e8105fa0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md2fb4f1061" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m30e8105fa0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md2fb4f1061" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m30e8105fa0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md2fb4f1061" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m30e8105fa0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md2fb4f1061" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m30e8105fa0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md2fb4f1061" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m30e8105fa0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md2fb4f1061" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m30e8105fa0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1344,7 +1344,7 @@ z
     </g>
    </g>
    <g id="text_21">
-    <!-- +3 -->
+    <!-- +4 -->
     <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1362,22 +1362,33 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -59 -->
+    <!-- -58 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -87 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1418,86 +1429,95 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -86 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- +4 -->
+    <!-- +3 -->
     <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -1 -->
+    <!-- -2 -->
     <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +7 -->
+    <!-- +6 -->
     <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -18 -->
+    <!-- -19 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -34 -->
+    <!-- -35 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1541,6 +1561,18 @@ z
    <g id="text_35">
     <!-- -17 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -1549,38 +1581,6 @@ z
    <g id="text_36">
     <!-- -46 -->
     <g transform="translate(306.247477 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -2178,18 +2178,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imageca9d08f9f3" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image5105204d9b" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m0d1dc1445b" d="M 0 0 
+       <path id="m5c84dbce03" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0d1dc1445b" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c84dbce03" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m0d1dc1445b" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c84dbce03" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2226,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m0d1dc1445b" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c84dbce03" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2240,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m0d1dc1445b" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c84dbce03" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2253,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0d1dc1445b" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c84dbce03" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2266,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m0d1dc1445b" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c84dbce03" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2279,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0d1dc1445b" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c84dbce03" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2940,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-19T10:21:38Z  ·  Linux chungus x86_64  ·  commit f47f4e53  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(20.670078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3007,16 +3007,16 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3056,109 +3056,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3205.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3331.054688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3394.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3458.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3490.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3521.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3553.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3585.449219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3617.236328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3645.019531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3706.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3767.822266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3831.201172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3894.677734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3933.541016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3994.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4053.902344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4115.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4156.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4190.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4218.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4279.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4340.816406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4404.195312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4467.818359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4501.509766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4560.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4624.3125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4656.099609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4719.722656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4783.345703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4815.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4878.755859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4914.839844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4953.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5008.683594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5072.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5104.09375 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5135.880859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5167.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5199.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5231.242188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5270.451172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5333.830078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5372.693359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5433.875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5497.253906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5560.730469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5624.109375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5687.585938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5750.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5790.173828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5821.960938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5905.75 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5937.537109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6034.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6096.472656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6159.949219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6187.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6249.011719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6312.390625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6344.177734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6459.65625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6520.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6584.412109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6699.890625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6761.072266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6800.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6833.972656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6865.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6906.873047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6968.152344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7007.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7035.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7096.326172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7128.113281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7155.896484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7239.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7303.259766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7364.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7403.992188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7465.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7504.878906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7602.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7630.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7693.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7721.236328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7812.544922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7840.328125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p93035117d3">
+  <clipPath id="pe16209b2d1">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m5b7b8b3f1b" d="M 0 0 
+       <path id="m017ae46f6a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5b7b8b3f1b" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m017ae46f6a" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5b7b8b3f1b" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m017ae46f6a" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5b7b8b3f1b" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m017ae46f6a" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5b7b8b3f1b" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m017ae46f6a" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5b7b8b3f1b" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m017ae46f6a" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5b7b8b3f1b" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m017ae46f6a" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5b7b8b3f1b" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m017ae46f6a" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="md4eab58bd0" d="M 0 0 
+       <path id="me7c02f062d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md4eab58bd0" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7c02f062d" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md4eab58bd0" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7c02f062d" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md4eab58bd0" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me7c02f062d" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m44b3310078" d="M 0 0 
+       <path id="m8b8a645fd4" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m44b3310078" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m8b8a645fd4" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 176.810437) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 177.010476) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 331.881572) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 331.711397) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7562c5d9a9" d="M -2.5 2.5 
+     <path id="ma438fab564" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb6f7b7fe23)">
-     <use xlink:href="#m7562c5d9a9" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7562c5d9a9" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7562c5d9a9" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7562c5d9a9" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7562c5d9a9" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7562c5d9a9" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7562c5d9a9" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7562c5d9a9" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7562c5d9a9" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1485ea9e7f)">
+     <use xlink:href="#ma438fab564" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma438fab564" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma438fab564" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma438fab564" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma438fab564" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma438fab564" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma438fab564" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma438fab564" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma438fab564" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mef010bef62" d="M 0 -2.5 
+     <path id="m1189e8c40f" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb6f7b7fe23)">
-     <use xlink:href="#mef010bef62" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef010bef62" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef010bef62" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef010bef62" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef010bef62" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef010bef62" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef010bef62" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef010bef62" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mef010bef62" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1485ea9e7f)">
+     <use xlink:href="#m1189e8c40f" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1189e8c40f" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1189e8c40f" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1189e8c40f" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1189e8c40f" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1189e8c40f" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1189e8c40f" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1189e8c40f" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1189e8c40f" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,39 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m193179b09c" d="M -0 3.535534 
+     <path id="mf60f1c6ca7" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb6f7b7fe23)">
-     <use xlink:href="#m193179b09c" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m193179b09c" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m193179b09c" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m193179b09c" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m193179b09c" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m193179b09c" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m193179b09c" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m193179b09c" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m193179b09c" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1485ea9e7f)">
+     <use xlink:href="#mf60f1c6ca7" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf60f1c6ca7" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf60f1c6ca7" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf60f1c6ca7" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf60f1c6ca7" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf60f1c6ca7" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf60f1c6ca7" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf60f1c6ca7" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf60f1c6ca7" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7a7504ba43" d="M -0 2.5 
+     <path id="m5d6f889b6c" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb6f7b7fe23)">
-     <use xlink:href="#m7a7504ba43" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1485ea9e7f)">
+     <use xlink:href="#m5d6f889b6c" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1854,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf3f44d83c1" d="M -0.833333 2.5 
+     <path id="meac0638faf" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1871,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb6f7b7fe23)">
-     <use xlink:href="#mf3f44d83c1" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3f44d83c1" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3f44d83c1" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3f44d83c1" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3f44d83c1" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3f44d83c1" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3f44d83c1" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3f44d83c1" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf3f44d83c1" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1485ea9e7f)">
+     <use xlink:href="#meac0638faf" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meac0638faf" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meac0638faf" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meac0638faf" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meac0638faf" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meac0638faf" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meac0638faf" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meac0638faf" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meac0638faf" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1893,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mcad6deaab9" d="M -1.25 2.5 
+     <path id="m7380496e1d" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1910,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb6f7b7fe23)">
-     <use xlink:href="#mcad6deaab9" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcad6deaab9" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcad6deaab9" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcad6deaab9" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcad6deaab9" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcad6deaab9" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcad6deaab9" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcad6deaab9" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcad6deaab9" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1485ea9e7f)">
+     <use xlink:href="#m7380496e1d" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7380496e1d" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7380496e1d" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7380496e1d" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7380496e1d" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7380496e1d" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7380496e1d" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7380496e1d" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7380496e1d" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1932,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m0651498665" d="M 0 -2.5 
+     <path id="m6286642f26" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1947,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pb6f7b7fe23)">
-     <use xlink:href="#m0651498665" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0651498665" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0651498665" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0651498665" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0651498665" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0651498665" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0651498665" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0651498665" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m0651498665" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p1485ea9e7f)">
+     <use xlink:href="#m6286642f26" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6286642f26" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6286642f26" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6286642f26" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6286642f26" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6286642f26" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6286642f26" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6286642f26" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m6286642f26" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1969,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6fba88b719" d="M 0 -2.5 
+     <path id="mbf5e0f79bd" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pb6f7b7fe23)">
-     <use xlink:href="#m6fba88b719" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6fba88b719" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6fba88b719" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6fba88b719" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6fba88b719" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6fba88b719" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6fba88b719" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6fba88b719" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6fba88b719" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1485ea9e7f)">
+     <use xlink:href="#mbf5e0f79bd" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf5e0f79bd" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf5e0f79bd" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf5e0f79bd" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf5e0f79bd" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf5e0f79bd" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf5e0f79bd" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf5e0f79bd" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbf5e0f79bd" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="mc5fcbdcb11" d="M 0 3.5 
+      <path id="m486e54e1b3" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mc5fcbdcb11" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m486e54e1b3" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7562c5d9a9" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma438fab564" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mef010bef62" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1189e8c40f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m193179b09c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf60f1c6ca7" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7a7504ba43" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5d6f889b6c" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf3f44d83c1" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#meac0638faf" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mcad6deaab9" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7380496e1d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0651498665" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m6286642f26" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6fba88b719" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbf5e0f79bd" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 181.810437 
-L 214.084819 184.393958 
-L 206.266533 186.611596 
-L 187.75787 193.133028 
-L 186.58897 194.010434 
-L 184.505355 196.143453 
-L 152.30308 249.467129 
-L 150.950891 251.57091 
-L 98.348822 336.881572 
-" clip-path="url(#pb6f7b7fe23)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#pb6f7b7fe23)">
-     <use xlink:href="#mc5fcbdcb11" x="226.647908" y="181.810437" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc5fcbdcb11" x="214.084819" y="184.393958" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc5fcbdcb11" x="206.266533" y="186.611596" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc5fcbdcb11" x="187.75787" y="193.133028" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc5fcbdcb11" x="186.58897" y="194.010434" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc5fcbdcb11" x="184.505355" y="196.143453" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc5fcbdcb11" x="152.30308" y="249.467129" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc5fcbdcb11" x="150.950891" y="251.57091" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc5fcbdcb11" x="98.348822" y="336.881572" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 182.010476 
+L 214.084819 184.35903 
+L 206.266533 187.050863 
+L 187.75787 193.186538 
+L 186.58897 193.984995 
+L 184.505355 196.319133 
+L 152.30308 249.650734 
+L 150.950891 251.698077 
+L 98.348822 336.711397 
+" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p1485ea9e7f)">
+     <use xlink:href="#m486e54e1b3" x="226.647908" y="182.010476" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m486e54e1b3" x="214.084819" y="184.35903" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m486e54e1b3" x="206.266533" y="187.050863" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m486e54e1b3" x="187.75787" y="193.186538" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m486e54e1b3" x="186.58897" y="193.984995" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m486e54e1b3" x="184.505355" y="196.319133" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m486e54e1b3" x="152.30308" y="249.650734" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m486e54e1b3" x="150.950891" y="251.698077" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m486e54e1b3" x="98.348822" y="336.711397" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,39 +2891,9 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-19T10:21:38Z  ·  Linux chungus x86_64  ·  commit f47f4e53  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.670078 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
     <defs>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2946,6 +2916,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -3005,6 +3000,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -3013,31 +3038,6 @@ L 1172 0
 L 2766 4134 
 L 525 4134 
 L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
@@ -3077,16 +3077,16 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3126,109 +3126,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3205.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3331.054688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3394.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3458.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3490.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3521.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3553.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3585.449219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3617.236328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3645.019531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3706.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3767.822266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3831.201172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3894.677734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3933.541016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3994.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4053.902344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4115.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4156.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4190.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4218.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4279.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4340.816406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4404.195312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4467.818359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4501.509766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4560.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4624.3125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4656.099609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4719.722656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4783.345703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4815.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4878.755859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4914.839844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4953.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5008.683594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5072.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5104.09375 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5135.880859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5167.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5199.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5231.242188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5270.451172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5333.830078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5372.693359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5433.875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5497.253906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5560.730469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5624.109375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5687.585938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5750.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5790.173828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5821.960938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5905.75 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5937.537109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6034.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6096.472656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6159.949219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6187.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6249.011719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6312.390625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6344.177734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6459.65625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6520.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6584.412109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6699.890625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6761.072266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6800.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6833.972656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6865.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6906.873047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6968.152344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7007.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7035.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7096.326172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7128.113281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7155.896484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7239.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7303.259766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7364.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7403.992188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7465.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7504.878906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7602.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7630.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7693.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7721.236328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7812.544922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7840.328125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb6f7b7fe23">
+  <clipPath id="p1485ea9e7f">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pe4be625871)">
+   <g clip-path="url(#p2f36b9bb58)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image910b4f1f76" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image24da510372" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m375a9c08a7" d="M 0 0 
+       <path id="m47ec8d25a7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m375a9c08a7" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m375a9c08a7" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m375a9c08a7" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m375a9c08a7" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m375a9c08a7" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m375a9c08a7" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m375a9c08a7" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m375a9c08a7" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m375a9c08a7" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m375a9c08a7" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m375a9c08a7" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m47ec8d25a7" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m55a10129b0" d="M 0 0 
+       <path id="m09f057a626" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m55a10129b0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09f057a626" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m55a10129b0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09f057a626" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m55a10129b0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09f057a626" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m55a10129b0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09f057a626" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m55a10129b0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09f057a626" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m55a10129b0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09f057a626" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m55a10129b0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09f057a626" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m55a10129b0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09f057a626" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image674e32fdf2" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8a35ff46db" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m5e66d9c5f9" d="M 0 0 
+       <path id="m8b2eefb923" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5e66d9c5f9" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b2eefb923" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m5e66d9c5f9" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b2eefb923" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m5e66d9c5f9" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b2eefb923" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m5e66d9c5f9" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b2eefb923" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5e66d9c5f9" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b2eefb923" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m5e66d9c5f9" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b2eefb923" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5e66d9c5f9" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b2eefb923" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m5e66d9c5f9" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b2eefb923" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m5e66d9c5f9" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b2eefb923" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-19T10:21:38Z  ·  Linux chungus x86_64  ·  commit f47f4e53  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(20.670078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,16 +2950,16 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3205.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3331.054688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3394.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3458.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3490.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3521.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3553.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3585.449219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3617.236328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3645.019531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3706.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3767.822266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3831.201172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3894.677734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3933.541016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3994.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4053.902344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4115.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4156.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4190.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4218.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4279.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4340.816406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4404.195312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4467.818359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4501.509766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4560.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4624.3125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4656.099609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4719.722656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4783.345703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4815.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4878.755859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4914.839844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4953.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5008.683594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5072.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5104.09375 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5135.880859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5167.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5199.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5231.242188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5270.451172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5333.830078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5372.693359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5433.875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5497.253906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5560.730469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5624.109375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5687.585938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5750.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5790.173828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5821.960938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5905.75 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5937.537109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6034.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6096.472656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6159.949219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6187.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6249.011719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6312.390625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6344.177734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6459.65625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6520.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6584.412109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6699.890625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6761.072266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6800.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6833.972656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6865.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6906.873047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6968.152344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7007.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7035.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7096.326172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7128.113281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7155.896484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7239.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7303.259766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7364.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7403.992188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7465.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7504.878906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7602.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7630.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7693.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7721.236328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7812.544922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7840.328125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe4be625871">
+  <clipPath id="p2f36b9bb58">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="567.059844pt" height="386.202469pt" viewBox="0 0 567.059844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 567.059844 386.202469 
-L 567.059844 0 
+L 569.022031 386.202469 
+L 569.022031 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 185.654922 104.1264 
-L 290.279922 104.1264 
-L 290.279922 74.7432 
-L 185.654922 74.7432 
+    <path d="M 186.636016 104.1264 
+L 291.261016 104.1264 
+L 291.261016 74.7432 
+L 186.636016 74.7432 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.279922 104.1264 
-L 394.904922 104.1264 
-L 394.904922 74.7432 
-L 290.279922 74.7432 
+    <path d="M 291.261016 104.1264 
+L 395.886016 104.1264 
+L 395.886016 74.7432 
+L 291.261016 74.7432 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 394.904922 104.1264 
-L 499.529922 104.1264 
-L 499.529922 74.7432 
-L 394.904922 74.7432 
+    <path d="M 395.886016 104.1264 
+L 500.511016 104.1264 
+L 500.511016 74.7432 
+L 395.886016 74.7432 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 185.654922 133.5096 
-L 290.279922 133.5096 
-L 290.279922 104.1264 
-L 185.654922 104.1264 
+    <path d="M 186.636016 133.5096 
+L 291.261016 133.5096 
+L 291.261016 104.1264 
+L 186.636016 104.1264 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.279922 133.5096 
-L 394.904922 133.5096 
-L 394.904922 104.1264 
-L 290.279922 104.1264 
+    <path d="M 291.261016 133.5096 
+L 395.886016 133.5096 
+L 395.886016 104.1264 
+L 291.261016 104.1264 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 394.904922 133.5096 
-L 499.529922 133.5096 
-L 499.529922 104.1264 
-L 394.904922 104.1264 
+    <path d="M 395.886016 133.5096 
+L 500.511016 133.5096 
+L 500.511016 104.1264 
+L 395.886016 104.1264 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 185.654922 162.8928 
-L 290.279922 162.8928 
-L 290.279922 133.5096 
-L 185.654922 133.5096 
+    <path d="M 186.636016 162.8928 
+L 291.261016 162.8928 
+L 291.261016 133.5096 
+L 186.636016 133.5096 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.279922 162.8928 
-L 394.904922 162.8928 
-L 394.904922 133.5096 
-L 290.279922 133.5096 
+    <path d="M 291.261016 162.8928 
+L 395.886016 162.8928 
+L 395.886016 133.5096 
+L 291.261016 133.5096 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 394.904922 162.8928 
-L 499.529922 162.8928 
-L 499.529922 133.5096 
-L 394.904922 133.5096 
+    <path d="M 395.886016 162.8928 
+L 500.511016 162.8928 
+L 500.511016 133.5096 
+L 395.886016 133.5096 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 185.654922 192.276 
-L 290.279922 192.276 
-L 290.279922 162.8928 
-L 185.654922 162.8928 
+    <path d="M 186.636016 192.276 
+L 291.261016 192.276 
+L 291.261016 162.8928 
+L 186.636016 162.8928 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.279922 192.276 
-L 394.904922 192.276 
-L 394.904922 162.8928 
-L 290.279922 162.8928 
+    <path d="M 291.261016 192.276 
+L 395.886016 192.276 
+L 395.886016 162.8928 
+L 291.261016 162.8928 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 394.904922 192.276 
-L 499.529922 192.276 
-L 499.529922 162.8928 
-L 394.904922 162.8928 
+    <path d="M 395.886016 192.276 
+L 500.511016 192.276 
+L 500.511016 162.8928 
+L 395.886016 162.8928 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 185.654922 221.6592 
-L 290.279922 221.6592 
-L 290.279922 192.276 
-L 185.654922 192.276 
+    <path d="M 186.636016 221.6592 
+L 291.261016 221.6592 
+L 291.261016 192.276 
+L 186.636016 192.276 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.279922 221.6592 
-L 394.904922 221.6592 
-L 394.904922 192.276 
-L 290.279922 192.276 
+    <path d="M 291.261016 221.6592 
+L 395.886016 221.6592 
+L 395.886016 192.276 
+L 291.261016 192.276 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 394.904922 221.6592 
-L 499.529922 221.6592 
-L 499.529922 192.276 
-L 394.904922 192.276 
+    <path d="M 395.886016 221.6592 
+L 500.511016 221.6592 
+L 500.511016 192.276 
+L 395.886016 192.276 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 185.654922 251.0424 
-L 290.279922 251.0424 
-L 290.279922 221.6592 
-L 185.654922 221.6592 
+    <path d="M 186.636016 251.0424 
+L 291.261016 251.0424 
+L 291.261016 221.6592 
+L 186.636016 221.6592 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.279922 251.0424 
-L 394.904922 251.0424 
-L 394.904922 221.6592 
-L 290.279922 221.6592 
+    <path d="M 291.261016 251.0424 
+L 395.886016 251.0424 
+L 395.886016 221.6592 
+L 291.261016 221.6592 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 394.904922 251.0424 
-L 499.529922 251.0424 
-L 499.529922 221.6592 
-L 394.904922 221.6592 
+    <path d="M 395.886016 251.0424 
+L 500.511016 251.0424 
+L 500.511016 221.6592 
+L 395.886016 221.6592 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 185.654922 280.4256 
-L 290.279922 280.4256 
-L 290.279922 251.0424 
-L 185.654922 251.0424 
+    <path d="M 186.636016 280.4256 
+L 291.261016 280.4256 
+L 291.261016 251.0424 
+L 186.636016 251.0424 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.279922 280.4256 
-L 394.904922 280.4256 
-L 394.904922 251.0424 
-L 290.279922 251.0424 
+    <path d="M 291.261016 280.4256 
+L 395.886016 280.4256 
+L 395.886016 251.0424 
+L 291.261016 251.0424 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 394.904922 280.4256 
-L 499.529922 280.4256 
-L 499.529922 251.0424 
-L 394.904922 251.0424 
+    <path d="M 395.886016 280.4256 
+L 500.511016 280.4256 
+L 500.511016 251.0424 
+L 395.886016 251.0424 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 185.654922 309.8088 
-L 290.279922 309.8088 
-L 290.279922 280.4256 
-L 185.654922 280.4256 
+    <path d="M 186.636016 309.8088 
+L 291.261016 309.8088 
+L 291.261016 280.4256 
+L 186.636016 280.4256 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.279922 309.8088 
-L 394.904922 309.8088 
-L 394.904922 280.4256 
-L 290.279922 280.4256 
+    <path d="M 291.261016 309.8088 
+L 395.886016 309.8088 
+L 395.886016 280.4256 
+L 291.261016 280.4256 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 394.904922 309.8088 
-L 499.529922 309.8088 
-L 499.529922 280.4256 
-L 394.904922 280.4256 
+    <path d="M 395.886016 309.8088 
+L 500.511016 309.8088 
+L 500.511016 280.4256 
+L 395.886016 280.4256 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 185.654922 339.192 
-L 290.279922 339.192 
-L 290.279922 309.8088 
-L 185.654922 309.8088 
+    <path d="M 186.636016 339.192 
+L 291.261016 339.192 
+L 291.261016 309.8088 
+L 186.636016 309.8088 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.279922 339.192 
-L 394.904922 339.192 
-L 394.904922 309.8088 
-L 290.279922 309.8088 
+    <path d="M 291.261016 339.192 
+L 395.886016 339.192 
+L 395.886016 309.8088 
+L 291.261016 309.8088 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 394.904922 339.192 
-L 499.529922 339.192 
-L 499.529922 309.8088 
-L 394.904922 309.8088 
+    <path d="M 395.886016 339.192 
+L 500.511016 339.192 
+L 500.511016 309.8088 
+L 395.886016 309.8088 
 z
-" clip-path="url(#pe22ae946b2)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p71790097ce)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(118.642188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(225.926406 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(304.498516 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(402.850234 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(114.579922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(226.516172 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(334.957422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(439.582422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.218047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(226.516172 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(337.502422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(439.582422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(126.481172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.462266 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(226.516172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(337.502422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(439.582422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(109.787422 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.768516 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(226.516172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(337.502422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(439.582422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(117.943672 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(118.924766 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(226.516172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(337.502422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(439.582422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.289297 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.270391 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(225.315547 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.296641 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1699,8 +1699,8 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 25 -->
-    <g transform="translate(337.026172 238.5583) scale(0.08 -0.08)">
+    <!-- 24 -->
+    <g transform="translate(338.007266 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1724,39 +1724,14 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 117 -->
-    <g transform="translate(438.868047 238.5583) scale(0.08 -0.08)">
+    <!-- 137 -->
+    <g transform="translate(439.849141 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1784,13 +1759,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
      <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(94.404297 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.385391 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1919,7 +1894,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(226.516172 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1929,14 +1904,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(337.502422 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(439.582422 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1944,7 +1919,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(96.911172 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.892266 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2000,7 +1975,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(226.516172 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2010,21 +1985,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(337.502422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(442.127422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(122.625547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2035,7 +2010,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(226.516172 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2045,13 +2020,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(340.047422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.217422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2067,7 +2042,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(133.038672 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.019766 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2280,7 +2255,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-19T10:21:38Z  ·  Linux chungus x86_64  ·  commit f47f4e53  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2418,16 +2393,16 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2467,110 +2442,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3205.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3331.054688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3394.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3458.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3490.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3521.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3553.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3585.449219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3617.236328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3645.019531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3706.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3767.822266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3831.201172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3894.677734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3933.541016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3994.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4053.902344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4115.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4156.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4190.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4218.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4279.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4340.816406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4404.195312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4467.818359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4501.509766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4560.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4624.3125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4656.099609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4719.722656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4783.345703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4815.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4878.755859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4914.839844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4953.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5008.683594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5072.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5104.09375 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5135.880859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5167.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5199.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5231.242188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5270.451172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5333.830078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5372.693359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5433.875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5497.253906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5560.730469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5624.109375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5687.585938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5750.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5790.173828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5821.960938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5905.75 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5937.537109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6034.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6096.472656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6159.949219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6187.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6249.011719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6312.390625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6344.177734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6459.65625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6520.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6584.412109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6699.890625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6761.072266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6800.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6833.972656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6865.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6906.873047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6968.152344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7007.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7035.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7096.326172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7128.113281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7155.896484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7239.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7303.259766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7364.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7403.992188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7465.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7504.878906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7602.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7630.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7693.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7721.236328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7812.544922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7840.328125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe22ae946b2">
-   <rect x="81.029922" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p71790097ce">
+   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p0b748aaf72)">
+   <g clip-path="url(#p32e61e563f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8ElEQVR4nO3Yv46ldR3H8T0zh1nYhbjKugRNNjZohQmRisY7oOAyKGntKa1t7b0BKo2ViTHaYQdBClgicWXZ7MyZOeMVWG1+7+/sk9frCj4nz5/f+zm7479/f31ryw7PphfwPI6X0wvW2p1ML1jr8mJ6wVp37k0vWOv8yfSCtU7PphfwPLZ+f57dmV6w1MZPPwAAbhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav+3w+fTG5ban5xOT1jqeH09PWGpB689mJ6w1Of//df0hLU2/on785fvTU9Y6nD7bHrCUn9/9On0hKV+ef+t6QlLnZ8dpycstds9nZ6w1MaPBwAAbhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaP3ztZ9Mblrp3+8H0hKW+efbl9ISlfvJ0299Ir77+9vSEpU53++kJSx1vHacnLPXjW/enJyx1ef9iesJSb9x5OD1hqcNx29fv7sW23y/bPt0BALhxBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9brftBv3u8O30hKVeOX11esJSV6//aHrCUl89/sf0hKWeXDybnrDUr3747vSEpS5Opxes9f3hu+kJPIf/nD+anrDW7QfTC5badn0CAHDjCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFK7qz9/dD09YqnjcXoB/H8nvgFfaN4vL7atP39bvz9dvxfaxq8eAAA3jQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1f+Ov/5zesNTJftuN/ejTb6YnLPW7D9+ZnrDUx3/5enrCUr9++IPpCUv94U+fTU9Y6jcf/GJ6wlK//eMX0xOWev+dN6cnLPXF4/PpCUu999O70xOW2nadAQBw4whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTucPXJ9fSIlU4vL6cnrHWyn16w1uWz6QVrnd2ZXrDWbuPfuNfH6QVrHTx/L7SrbZ9/h922n7+XNt4vGz8dAAC4aQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/fH6OL1hqdP92fSEpY676QVrnTz+dnrCUldnL09PWOr0cDE9gedx8XR6wVLfn1xOT1jq7tW2/2N6abft33fr/Mn0gqU2fvUAALhpBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn/AYWSfZp0uJWIAAAAAElFTkSuQmCC" id="image543d240a31" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8ElEQVR4nO3Yv46ldR3H8T0zh1nYhbjKugRNNjZohQmRisY7oOAyKGntKa1t7b0BKo2ViTHaYQdBClgicWXZ7MyZOeMVWG1+7+/sk9frCj4nz5/f+zm7479/f31ryw7PphfwPI6X0wvW2p1ML1jr8mJ6wVp37k0vWOv8yfSCtU7PphfwPLZ+f57dmV6w1MZPPwAAbhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav+3w+fTG5ban5xOT1jqeH09PWGpB689mJ6w1Of//df0hLU2/on785fvTU9Y6nD7bHrCUn9/9On0hKV+ef+t6QlLnZ8dpycstds9nZ6w1MaPBwAAbhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaP3ztZ9Mblrp3+8H0hKW+efbl9ISlfvJ0299Ir77+9vSEpU53++kJSx1vHacnLPXjW/enJyx1ef9iesJSb9x5OD1hqcNx29fv7sW23y/bPt0BALhxBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9brftBv3u8O30hKVeOX11esJSV6//aHrCUl89/sf0hKWeXDybnrDUr3747vSEpS5Opxes9f3hu+kJPIf/nD+anrDW7QfTC5badn0CAHDjCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFK7qz9/dD09YqnjcXoB/H8nvgFfaN4vL7atP39bvz9dvxfaxq8eAAA3jQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1f+Ov/5zesNTJftuN/ejTb6YnLPW7D9+ZnrDUx3/5enrCUr9++IPpCUv94U+fTU9Y6jcf/GJ6wlK//eMX0xOWev+dN6cnLPXF4/PpCUu999O70xOW2nadAQBw4whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTucPXJ9fSIlU4vL6cnrHWyn16w1uWz6QVrnd2ZXrDWbuPfuNfH6QVrHTx/L7SrbZ9/h922n7+XNt4vGz8dAAC4aQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/fH6OL1hqdP92fSEpY676QVrnTz+dnrCUldnL09PWOr0cDE9gedx8XR6wVLfn1xOT1jq7tW2/2N6abft33fr/Mn0gqU2fvUAALhpBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn/AYWSfZp0uJWIAAAAAElFTkSuQmCC" id="image913226b9bf" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m613cfe31ab" d="M 0 0 
+       <path id="mec6c2f9281" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m613cfe31ab" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m613cfe31ab" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m613cfe31ab" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m613cfe31ab" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m613cfe31ab" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m613cfe31ab" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m613cfe31ab" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m613cfe31ab" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m613cfe31ab" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m613cfe31ab" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m613cfe31ab" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m613cfe31ab" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mec6c2f9281" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="me2f686eae5" d="M 0 0 
+       <path id="mc0e916c336" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me2f686eae5" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0e916c336" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me2f686eae5" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0e916c336" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me2f686eae5" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0e916c336" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me2f686eae5" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0e916c336" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me2f686eae5" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0e916c336" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me2f686eae5" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0e916c336" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me2f686eae5" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0e916c336" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me2f686eae5" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc0e916c336" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1269,10 +1269,42 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- +7 -->
+    <!-- +6 -->
     <g transform="translate(272.133333 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
@@ -1321,15 +1353,15 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- -10 -->
+    <!-- -11 -->
     <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -25 -->
+    <!-- -26 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
@@ -1356,6 +1388,24 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- +17 -->
+    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -15 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
 L 3169 4134 
@@ -1383,77 +1433,50 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +17 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -15 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- -13 -->
+    <!-- -14 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- -28 -->
+    <!-- -27 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- +6 -->
     <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
@@ -1810,27 +1833,6 @@ z
    <g id="text_73">
     <!-- +64 -->
     <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
@@ -2191,18 +2193,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image7e67ea6bcf" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image72534f1d25" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m276561f03c" d="M 0 0 
+       <path id="ma2a229a83e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m276561f03c" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2a229a83e" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2225,7 +2227,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m276561f03c" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2a229a83e" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2239,7 +2241,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m276561f03c" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2a229a83e" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2253,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m276561f03c" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2a229a83e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2266,7 +2268,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m276561f03c" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2a229a83e" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2279,7 +2281,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m276561f03c" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2a229a83e" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2292,7 +2294,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m276561f03c" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma2a229a83e" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2908,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-19T10:21:38Z  ·  Linux chungus x86_64  ·  commit f47f4e53  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.670078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2997,16 +2999,16 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3046,109 +3048,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3205.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3331.054688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3394.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3458.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3490.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3521.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3553.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3585.449219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3617.236328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3645.019531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3706.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3767.822266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3831.201172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3894.677734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3933.541016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3994.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4053.902344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4115.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4156.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4190.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4218.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4279.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4340.816406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4404.195312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4467.818359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4501.509766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4560.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4624.3125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4656.099609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4719.722656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4783.345703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4815.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4878.755859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4914.839844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4953.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5008.683594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5072.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5104.09375 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5135.880859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5167.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5199.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5231.242188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5270.451172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5333.830078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5372.693359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5433.875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5497.253906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5560.730469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5624.109375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5687.585938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5750.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5790.173828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5821.960938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5905.75 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5937.537109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6034.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6096.472656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6159.949219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6187.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6249.011719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6312.390625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6344.177734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6459.65625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6520.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6584.412109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6699.890625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6761.072266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6800.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6833.972656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6865.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6906.873047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6968.152344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7007.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7035.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7096.326172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7128.113281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7155.896484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7239.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7303.259766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7364.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7403.992188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7465.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7504.878906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7602.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7630.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7693.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7721.236328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7812.544922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7840.328125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0b748aaf72">
+  <clipPath id="p32e61e563f">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m1617d1a735" d="M 0 0 
+       <path id="mf932cfc11c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1617d1a735" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf932cfc11c" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1617d1a735" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf932cfc11c" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m1617d1a735" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf932cfc11c" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1617d1a735" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf932cfc11c" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1617d1a735" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf932cfc11c" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m1617d1a735" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf932cfc11c" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1617d1a735" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf932cfc11c" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mb3de350a22" d="M 0 0 
+       <path id="mee54c87ccf" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb3de350a22" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee54c87ccf" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb3de350a22" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee54c87ccf" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb3de350a22" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mee54c87ccf" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m8402e3f46c" d="M 0 0 
+       <path id="mddeb160c53" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m8402e3f46c" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mddeb160c53" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 149.575115) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 150.637342) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 352.82291) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 352.56427) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mc88ff2ce7f" d="M -2.5 2.5 
+     <path id="m50c0fa6663" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p63ecd16380)">
-     <use xlink:href="#mc88ff2ce7f" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc88ff2ce7f" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc88ff2ce7f" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc88ff2ce7f" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc88ff2ce7f" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc88ff2ce7f" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc88ff2ce7f" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc88ff2ce7f" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc88ff2ce7f" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p82ad7000b3)">
+     <use xlink:href="#m50c0fa6663" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50c0fa6663" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50c0fa6663" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50c0fa6663" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50c0fa6663" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50c0fa6663" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50c0fa6663" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50c0fa6663" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m50c0fa6663" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m94eb987ee8" d="M 0 -2.5 
+     <path id="m9242dac054" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p63ecd16380)">
-     <use xlink:href="#m94eb987ee8" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94eb987ee8" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94eb987ee8" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94eb987ee8" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94eb987ee8" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94eb987ee8" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94eb987ee8" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94eb987ee8" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m94eb987ee8" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p82ad7000b3)">
+     <use xlink:href="#m9242dac054" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9242dac054" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9242dac054" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9242dac054" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9242dac054" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9242dac054" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9242dac054" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9242dac054" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9242dac054" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,39 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2cde161c4e" d="M -0 3.535534 
+     <path id="m2af8fc868a" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p63ecd16380)">
-     <use xlink:href="#m2cde161c4e" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2cde161c4e" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2cde161c4e" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2cde161c4e" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2cde161c4e" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2cde161c4e" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2cde161c4e" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2cde161c4e" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2cde161c4e" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p82ad7000b3)">
+     <use xlink:href="#m2af8fc868a" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2af8fc868a" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2af8fc868a" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2af8fc868a" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2af8fc868a" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2af8fc868a" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2af8fc868a" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2af8fc868a" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2af8fc868a" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m68191644d4" d="M -0 2.5 
+     <path id="m7e6694d5b1" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p63ecd16380)">
-     <use xlink:href="#m68191644d4" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p82ad7000b3)">
+     <use xlink:href="#m7e6694d5b1" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1808,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mddc5a7cc21" d="M -0.833333 2.5 
+     <path id="mcbe58fd8a6" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1825,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p63ecd16380)">
-     <use xlink:href="#mddc5a7cc21" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddc5a7cc21" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddc5a7cc21" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddc5a7cc21" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddc5a7cc21" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddc5a7cc21" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddc5a7cc21" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddc5a7cc21" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mddc5a7cc21" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p82ad7000b3)">
+     <use xlink:href="#mcbe58fd8a6" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbe58fd8a6" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbe58fd8a6" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbe58fd8a6" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbe58fd8a6" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbe58fd8a6" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbe58fd8a6" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbe58fd8a6" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcbe58fd8a6" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1847,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="md6855c4cbb" d="M -1.25 2.5 
+     <path id="m5b66e67a84" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1864,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p63ecd16380)">
-     <use xlink:href="#md6855c4cbb" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6855c4cbb" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6855c4cbb" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6855c4cbb" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6855c4cbb" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6855c4cbb" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6855c4cbb" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6855c4cbb" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md6855c4cbb" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p82ad7000b3)">
+     <use xlink:href="#m5b66e67a84" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b66e67a84" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b66e67a84" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b66e67a84" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b66e67a84" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b66e67a84" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b66e67a84" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b66e67a84" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b66e67a84" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1886,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="me35fe39fe4" d="M 0 -2.5 
+     <path id="macb9df86c3" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1901,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p63ecd16380)">
-     <use xlink:href="#me35fe39fe4" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me35fe39fe4" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me35fe39fe4" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me35fe39fe4" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me35fe39fe4" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me35fe39fe4" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me35fe39fe4" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me35fe39fe4" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me35fe39fe4" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p82ad7000b3)">
+     <use xlink:href="#macb9df86c3" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macb9df86c3" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macb9df86c3" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macb9df86c3" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macb9df86c3" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macb9df86c3" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macb9df86c3" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macb9df86c3" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#macb9df86c3" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1923,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mb0fef62399" d="M 0 -2.5 
+     <path id="mdac33ce478" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p63ecd16380)">
-     <use xlink:href="#mb0fef62399" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb0fef62399" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb0fef62399" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb0fef62399" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb0fef62399" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb0fef62399" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb0fef62399" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb0fef62399" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb0fef62399" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p82ad7000b3)">
+     <use xlink:href="#mdac33ce478" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac33ce478" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac33ce478" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac33ce478" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac33ce478" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac33ce478" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac33ce478" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac33ce478" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac33ce478" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m81c023269c" d="M 0 3.5 
+      <path id="m1859526068" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m81c023269c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m1859526068" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mc88ff2ce7f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m50c0fa6663" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m94eb987ee8" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9242dac054" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2cde161c4e" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2af8fc868a" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m68191644d4" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7e6694d5b1" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mddc5a7cc21" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcbe58fd8a6" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#md6855c4cbb" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5b66e67a84" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#me35fe39fe4" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#macb9df86c3" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mb0fef62399" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdac33ce478" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 154.575115 
-L 236.23654 158.989218 
-L 222.073314 162.442206 
-L 202.315941 172.68106 
-L 199.905291 174.017169 
-L 195.893147 177.946223 
-L 157.982343 243.861255 
-L 157.246106 245.850903 
-L 95.319203 357.82291 
-" clip-path="url(#p63ecd16380)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p63ecd16380)">
-     <use xlink:href="#m81c023269c" x="257.531237" y="154.575115" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m81c023269c" x="236.23654" y="158.989218" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m81c023269c" x="222.073314" y="162.442206" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m81c023269c" x="202.315941" y="172.68106" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m81c023269c" x="199.905291" y="174.017169" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m81c023269c" x="195.893147" y="177.946223" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m81c023269c" x="157.982343" y="243.861255" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m81c023269c" x="157.246106" y="245.850903" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m81c023269c" x="95.319203" y="357.82291" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 155.637342 
+L 236.23654 159.215188 
+L 222.073314 163.095774 
+L 202.315941 172.716799 
+L 199.905291 174.333319 
+L 195.893147 178.106216 
+L 157.982343 243.551047 
+L 157.246106 245.651483 
+L 95.319203 357.56427 
+" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p82ad7000b3)">
+     <use xlink:href="#m1859526068" x="257.531237" y="155.637342" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1859526068" x="236.23654" y="159.215188" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1859526068" x="222.073314" y="163.095774" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1859526068" x="202.315941" y="172.716799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1859526068" x="199.905291" y="174.333319" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1859526068" x="195.893147" y="178.106216" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1859526068" x="157.982343" y="243.551047" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1859526068" x="157.246106" y="245.651483" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1859526068" x="95.319203" y="357.56427" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,39 +2803,9 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-19T10:21:38Z  ·  Linux chungus x86_64  ·  commit f47f4e53  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.670078 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
     <defs>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2858,6 +2828,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2917,6 +2912,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -2925,31 +2950,6 @@ L 1172 0
 L 2766 4134 
 L 525 4134 
 L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
@@ -2989,16 +2989,16 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3038,109 +3038,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3205.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3331.054688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3394.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3458.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3490.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3521.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3553.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3585.449219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3617.236328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3645.019531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3706.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3767.822266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3831.201172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3894.677734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3933.541016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3994.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4053.902344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4115.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4156.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4190.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4218.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4279.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4340.816406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4404.195312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4467.818359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4501.509766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4560.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4624.3125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4656.099609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4719.722656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4783.345703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4815.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4878.755859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4914.839844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4953.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5008.683594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5072.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5104.09375 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5135.880859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5167.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5199.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5231.242188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5270.451172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5333.830078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5372.693359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5433.875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5497.253906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5560.730469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5624.109375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5687.585938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5750.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5790.173828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5821.960938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5905.75 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5937.537109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6034.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6096.472656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6159.949219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6187.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6249.011719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6312.390625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6344.177734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6459.65625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6520.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6584.412109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6699.890625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6761.072266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6800.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6833.972656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6865.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6906.873047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6968.152344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7007.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7035.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7096.326172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7128.113281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7155.896484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7239.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7303.259766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7364.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7403.992188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7465.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7504.878906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7602.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7630.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7693.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7721.236328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7812.544922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7840.328125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p63ecd16380">
+  <clipPath id="p82ad7000b3">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p6af1c763ac)">
+   <g clip-path="url(#pdf9118cc88)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image60b3573c5b" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image193907e3da" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc82da5f1be" d="M 0 0 
+       <path id="m437818802e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc82da5f1be" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc82da5f1be" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc82da5f1be" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc82da5f1be" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc82da5f1be" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc82da5f1be" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc82da5f1be" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc82da5f1be" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc82da5f1be" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc82da5f1be" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc82da5f1be" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc82da5f1be" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m437818802e" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mdbac9e284a" d="M 0 0 
+       <path id="m00a7a1f506" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdbac9e284a" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00a7a1f506" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdbac9e284a" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00a7a1f506" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mdbac9e284a" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00a7a1f506" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdbac9e284a" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00a7a1f506" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mdbac9e284a" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00a7a1f506" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdbac9e284a" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00a7a1f506" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mdbac9e284a" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00a7a1f506" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdbac9e284a" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m00a7a1f506" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageec7e93b859" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagece0c6a463b" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m05e4d7f129" d="M 0 0 
+       <path id="m634ef6ffb6" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m05e4d7f129" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m634ef6ffb6" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m05e4d7f129" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m634ef6ffb6" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m05e4d7f129" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m634ef6ffb6" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m05e4d7f129" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m634ef6ffb6" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m05e4d7f129" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m634ef6ffb6" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-19T10:21:38Z  ·  Linux chungus x86_64  ·  commit f47f4e53  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.670078 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2869,16 +2869,16 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3205.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3331.054688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3394.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3458.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3490.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3521.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3553.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3585.449219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3617.236328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3645.019531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3706.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3767.822266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3831.201172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3894.677734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3933.541016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3994.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4053.902344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4115.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4156.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4190.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4218.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4279.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4340.816406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4404.195312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4467.818359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4501.509766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4560.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4624.3125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4656.099609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4719.722656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4783.345703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4815.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4878.755859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4914.839844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4953.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5008.683594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5072.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5104.09375 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5135.880859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5167.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5199.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5231.242188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5270.451172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5333.830078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5372.693359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5433.875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5497.253906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5560.730469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5624.109375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5687.585938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5750.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5790.173828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5821.960938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5905.75 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5937.537109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6034.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6096.472656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6159.949219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6187.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6249.011719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6312.390625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6344.177734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6459.65625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6520.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6584.412109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6699.890625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6761.072266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6800.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6833.972656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6865.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6906.873047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6968.152344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7007.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7035.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7096.326172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7128.113281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7155.896484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7239.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7303.259766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7364.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7403.992188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7465.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7504.878906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7602.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7630.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7693.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7721.236328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7812.544922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7840.328125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p6af1c763ac">
+  <clipPath id="pdf9118cc88">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="567.059844pt" height="386.202469pt" viewBox="0 0 567.059844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 567.059844 386.202469 
-L 567.059844 0 
+L 569.022031 386.202469 
+L 569.022031 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 185.654922 104.1264 
-L 290.279922 104.1264 
-L 290.279922 74.7432 
-L 185.654922 74.7432 
+    <path d="M 186.636016 104.1264 
+L 291.261016 104.1264 
+L 291.261016 74.7432 
+L 186.636016 74.7432 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.279922 104.1264 
-L 394.904922 104.1264 
-L 394.904922 74.7432 
-L 290.279922 74.7432 
+    <path d="M 291.261016 104.1264 
+L 395.886016 104.1264 
+L 395.886016 74.7432 
+L 291.261016 74.7432 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 394.904922 104.1264 
-L 499.529922 104.1264 
-L 499.529922 74.7432 
-L 394.904922 74.7432 
+    <path d="M 395.886016 104.1264 
+L 500.511016 104.1264 
+L 500.511016 74.7432 
+L 395.886016 74.7432 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 185.654922 133.5096 
-L 290.279922 133.5096 
-L 290.279922 104.1264 
-L 185.654922 104.1264 
+    <path d="M 186.636016 133.5096 
+L 291.261016 133.5096 
+L 291.261016 104.1264 
+L 186.636016 104.1264 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.279922 133.5096 
-L 394.904922 133.5096 
-L 394.904922 104.1264 
-L 290.279922 104.1264 
+    <path d="M 291.261016 133.5096 
+L 395.886016 133.5096 
+L 395.886016 104.1264 
+L 291.261016 104.1264 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 394.904922 133.5096 
-L 499.529922 133.5096 
-L 499.529922 104.1264 
-L 394.904922 104.1264 
+    <path d="M 395.886016 133.5096 
+L 500.511016 133.5096 
+L 500.511016 104.1264 
+L 395.886016 104.1264 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 185.654922 162.8928 
-L 290.279922 162.8928 
-L 290.279922 133.5096 
-L 185.654922 133.5096 
+    <path d="M 186.636016 162.8928 
+L 291.261016 162.8928 
+L 291.261016 133.5096 
+L 186.636016 133.5096 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.279922 162.8928 
-L 394.904922 162.8928 
-L 394.904922 133.5096 
-L 290.279922 133.5096 
+    <path d="M 291.261016 162.8928 
+L 395.886016 162.8928 
+L 395.886016 133.5096 
+L 291.261016 133.5096 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 394.904922 162.8928 
-L 499.529922 162.8928 
-L 499.529922 133.5096 
-L 394.904922 133.5096 
+    <path d="M 395.886016 162.8928 
+L 500.511016 162.8928 
+L 500.511016 133.5096 
+L 395.886016 133.5096 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 185.654922 192.276 
-L 290.279922 192.276 
-L 290.279922 162.8928 
-L 185.654922 162.8928 
+    <path d="M 186.636016 192.276 
+L 291.261016 192.276 
+L 291.261016 162.8928 
+L 186.636016 162.8928 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.279922 192.276 
-L 394.904922 192.276 
-L 394.904922 162.8928 
-L 290.279922 162.8928 
+    <path d="M 291.261016 192.276 
+L 395.886016 192.276 
+L 395.886016 162.8928 
+L 291.261016 162.8928 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 394.904922 192.276 
-L 499.529922 192.276 
-L 499.529922 162.8928 
-L 394.904922 162.8928 
+    <path d="M 395.886016 192.276 
+L 500.511016 192.276 
+L 500.511016 162.8928 
+L 395.886016 162.8928 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 185.654922 221.6592 
-L 290.279922 221.6592 
-L 290.279922 192.276 
-L 185.654922 192.276 
+    <path d="M 186.636016 221.6592 
+L 291.261016 221.6592 
+L 291.261016 192.276 
+L 186.636016 192.276 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.279922 221.6592 
-L 394.904922 221.6592 
-L 394.904922 192.276 
-L 290.279922 192.276 
+    <path d="M 291.261016 221.6592 
+L 395.886016 221.6592 
+L 395.886016 192.276 
+L 291.261016 192.276 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 394.904922 221.6592 
-L 499.529922 221.6592 
-L 499.529922 192.276 
-L 394.904922 192.276 
+    <path d="M 395.886016 221.6592 
+L 500.511016 221.6592 
+L 500.511016 192.276 
+L 395.886016 192.276 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 185.654922 251.0424 
-L 290.279922 251.0424 
-L 290.279922 221.6592 
-L 185.654922 221.6592 
+    <path d="M 186.636016 251.0424 
+L 291.261016 251.0424 
+L 291.261016 221.6592 
+L 186.636016 221.6592 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.279922 251.0424 
-L 394.904922 251.0424 
-L 394.904922 221.6592 
-L 290.279922 221.6592 
+    <path d="M 291.261016 251.0424 
+L 395.886016 251.0424 
+L 395.886016 221.6592 
+L 291.261016 221.6592 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 394.904922 251.0424 
-L 499.529922 251.0424 
-L 499.529922 221.6592 
-L 394.904922 221.6592 
+    <path d="M 395.886016 251.0424 
+L 500.511016 251.0424 
+L 500.511016 221.6592 
+L 395.886016 221.6592 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 185.654922 280.4256 
-L 290.279922 280.4256 
-L 290.279922 251.0424 
-L 185.654922 251.0424 
+    <path d="M 186.636016 280.4256 
+L 291.261016 280.4256 
+L 291.261016 251.0424 
+L 186.636016 251.0424 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.279922 280.4256 
-L 394.904922 280.4256 
-L 394.904922 251.0424 
-L 290.279922 251.0424 
+    <path d="M 291.261016 280.4256 
+L 395.886016 280.4256 
+L 395.886016 251.0424 
+L 291.261016 251.0424 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 394.904922 280.4256 
-L 499.529922 280.4256 
-L 499.529922 251.0424 
-L 394.904922 251.0424 
+    <path d="M 395.886016 280.4256 
+L 500.511016 280.4256 
+L 500.511016 251.0424 
+L 395.886016 251.0424 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #f67c4a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 185.654922 309.8088 
-L 290.279922 309.8088 
-L 290.279922 280.4256 
-L 185.654922 280.4256 
+    <path d="M 186.636016 309.8088 
+L 291.261016 309.8088 
+L 291.261016 280.4256 
+L 186.636016 280.4256 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.279922 309.8088 
-L 394.904922 309.8088 
-L 394.904922 280.4256 
-L 290.279922 280.4256 
+    <path d="M 291.261016 309.8088 
+L 395.886016 309.8088 
+L 395.886016 280.4256 
+L 291.261016 280.4256 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 394.904922 309.8088 
-L 499.529922 309.8088 
-L 499.529922 280.4256 
-L 394.904922 280.4256 
+    <path d="M 395.886016 309.8088 
+L 500.511016 309.8088 
+L 500.511016 280.4256 
+L 395.886016 280.4256 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 185.654922 339.192 
-L 290.279922 339.192 
-L 290.279922 309.8088 
-L 185.654922 309.8088 
+    <path d="M 186.636016 339.192 
+L 291.261016 339.192 
+L 291.261016 309.8088 
+L 186.636016 309.8088 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.279922 339.192 
-L 394.904922 339.192 
-L 394.904922 309.8088 
-L 290.279922 309.8088 
+    <path d="M 291.261016 339.192 
+L 395.886016 339.192 
+L 395.886016 309.8088 
+L 291.261016 309.8088 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 394.904922 339.192 
-L 499.529922 339.192 
-L 499.529922 309.8088 
-L 394.904922 309.8088 
+    <path d="M 395.886016 339.192 
+L 500.511016 339.192 
+L 500.511016 309.8088 
+L 395.886016 309.8088 
 z
-" clip-path="url(#pc603ec41b9)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p1f9872afb5)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(118.642188 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(225.926406 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(304.498516 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(402.850234 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(114.579922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(226.516172 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(334.957422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(439.582422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.218047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(226.516172 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(337.502422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(439.582422 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(96.911172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.892266 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(226.516172 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(337.502422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(439.582422 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(117.943672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(118.924766 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(226.516172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(337.502422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(439.582422 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(126.481172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.462266 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(226.516172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(337.502422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(439.582422 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(109.787422 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(110.768516 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(226.516172 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(337.502422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(439.582422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.289297 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.270391 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(225.315547 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.296641 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1853,36 +1853,15 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 34 -->
-    <g transform="translate(337.026172 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 33 -->
+    <g transform="translate(338.007266 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 153 -->
-    <g transform="translate(438.868047 267.9415) scale(0.08 -0.08)">
+    <!-- 168 -->
+    <g transform="translate(439.849141 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1898,40 +1877,84 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-35" d="M 678 4666 
-L 3669 4666 
-L 3669 3781 
-L 1638 3781 
-L 1638 3059 
-Q 1775 3097 1914 3117 
-Q 2053 3138 2203 3138 
-Q 3056 3138 3531 2711 
-Q 4006 2284 4006 1522 
-Q 4006 766 3489 337 
-Q 2972 -91 2053 -91 
-Q 1656 -91 1267 -14 
-Q 878 63 494 219 
-L 494 1166 
-Q 875 947 1217 837 
-Q 1559 728 1863 728 
-Q 2300 728 2551 942 
-Q 2803 1156 2803 1522 
-Q 2803 1891 2551 2103 
-Q 2300 2316 1863 2316 
-Q 1603 2316 1309 2248 
-Q 1016 2181 678 2041 
-L 678 4666 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(94.404297 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.385391 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1996,7 +2019,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(226.516172 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2006,21 +2029,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(337.502422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(442.127422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(122.625547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2031,7 +2054,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(226.516172 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2041,13 +2064,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(340.047422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.217422 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2063,7 +2086,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(150.131641 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.112734 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2136,36 +2159,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-73"/>
     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(59.521484 0)"/>
@@ -2207,7 +2200,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-19T10:21:38Z  ·  Linux chungus x86_64  ·  commit f47f4e53  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2345,16 +2338,16 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2394,110 +2387,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3205.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3269.53125 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3331.054688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3394.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3458.300781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3490.087891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3521.875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3553.662109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3585.449219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3617.236328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3645.019531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3706.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3767.822266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3831.201172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3894.677734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3933.541016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(3994.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4053.902344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4115.425781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4156.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4190.230469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4218.013672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4279.537109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4340.816406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4404.195312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4467.818359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4501.509766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4560.689453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4624.3125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4656.099609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4719.722656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4783.345703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4815.132812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4878.755859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4914.839844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4953.703125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5008.683594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5072.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5104.09375 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5135.880859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5167.667969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5199.455078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5231.242188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5270.451172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5333.830078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5372.693359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5433.875 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5497.253906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5560.730469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5624.109375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5687.585938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5750.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5790.173828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5821.960938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5905.75 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5937.537109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6034.949219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6096.472656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6159.949219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6187.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6249.011719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6312.390625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6344.177734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6396.277344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6459.65625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6520.935547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6584.412109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6636.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6699.890625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6761.072266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6800.28125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6833.972656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6865.759766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6906.873047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6968.152344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7007.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7035.144531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7096.326172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7128.113281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7155.896484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7207.996094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7239.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7303.259766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7364.783203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7403.992188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7465.515625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7504.878906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7602.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7630.074219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7693.453125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7721.236328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7773.335938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7812.544922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7840.328125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc603ec41b9">
-   <rect x="81.029922" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p1f9872afb5">
+   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-19T10:21:38Z",
+  "date": "2026-06-20T12:25:48Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "f47f4e53",
+  "git_commit": "a19271bf",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 40.43,
-   "decompress_mbps": 112.96
+   "compress_mbps": 39.68,
+   "decompress_mbps": 126.92
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 37.24,
-   "decompress_mbps": 125.67
+   "compress_mbps": 37.47,
+   "decompress_mbps": 139.53
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.45,
-   "decompress_mbps": 138.94
+   "compress_mbps": 34.06,
+   "decompress_mbps": 155.07
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 27.38,
-   "decompress_mbps": 144.17
+   "compress_mbps": 27.6,
+   "decompress_mbps": 160.98
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 26.73,
-   "decompress_mbps": 147.61
+   "compress_mbps": 26.81,
+   "decompress_mbps": 165.43
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 24.83,
-   "decompress_mbps": 154.39
+   "compress_mbps": 24.71,
+   "decompress_mbps": 172.51
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 9.24,
-   "decompress_mbps": 153.07
+   "compress_mbps": 9.38,
+   "decompress_mbps": 171.27
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.03,
-   "decompress_mbps": 152.83
+   "compress_mbps": 9.1,
+   "decompress_mbps": 172.33
   },
   {
    "compressor": "native",
@@ -95,7 +95,7 @@
    "out_size": 52111,
    "ratio": 0.3426,
    "compress_mbps": 1.25,
-   "decompress_mbps": 153.53
+   "decompress_mbps": 172.52
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 37.23,
-   "decompress_mbps": 110.6
+   "compress_mbps": 37.1,
+   "decompress_mbps": 122.99
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 33.95,
-   "decompress_mbps": 115.43
+   "compress_mbps": 34.3,
+   "decompress_mbps": 128.57
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 32.09,
-   "decompress_mbps": 122.92
+   "compress_mbps": 32.32,
+   "decompress_mbps": 136.82
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.32,
-   "decompress_mbps": 130.49
+   "compress_mbps": 25.49,
+   "decompress_mbps": 144.86
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 24.64,
-   "decompress_mbps": 136.93
+   "compress_mbps": 24.84,
+   "decompress_mbps": 153.18
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.6,
-   "decompress_mbps": 138.2
+   "compress_mbps": 23.69,
+   "decompress_mbps": 154.5
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.95,
-   "decompress_mbps": 138.96
+   "compress_mbps": 8.9,
+   "decompress_mbps": 155.69
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.79,
-   "decompress_mbps": 139.66
+   "compress_mbps": 8.89,
+   "decompress_mbps": 156.26
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 1.36,
-   "decompress_mbps": 139.08
+   "compress_mbps": 1.37,
+   "decompress_mbps": 155.37
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 33.5,
-   "decompress_mbps": 112.39
+   "compress_mbps": 33.7,
+   "decompress_mbps": 132.6
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 32.38,
-   "decompress_mbps": 117.65
+   "compress_mbps": 32.75,
+   "decompress_mbps": 139.43
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 31.45,
-   "decompress_mbps": 120.69
+   "compress_mbps": 31.59,
+   "decompress_mbps": 141.97
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 29.8,
-   "decompress_mbps": 120.39
+   "compress_mbps": 30.24,
+   "decompress_mbps": 142.66
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 29.13,
-   "decompress_mbps": 123.45
+   "compress_mbps": 29.8,
+   "decompress_mbps": 148.83
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 28.51,
-   "decompress_mbps": 123.31
+   "compress_mbps": 28.94,
+   "decompress_mbps": 148.54
   },
   {
    "compressor": "native",
@@ -255,7 +255,7 @@
    "out_size": 7929,
    "ratio": 0.3223,
    "compress_mbps": 9.67,
-   "decompress_mbps": 124.98
+   "decompress_mbps": 150.21
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.67,
-   "decompress_mbps": 124.94
+   "compress_mbps": 9.65,
+   "decompress_mbps": 150.65
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 1.61,
-   "decompress_mbps": 125.46
+   "compress_mbps": 1.64,
+   "decompress_mbps": 150.71
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 23.04,
-   "decompress_mbps": 83.47
+   "compress_mbps": 22.94,
+   "decompress_mbps": 103.02
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 22.53,
-   "decompress_mbps": 85.32
+   "compress_mbps": 23.1,
+   "decompress_mbps": 106.47
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.28,
-   "decompress_mbps": 87.26
+   "compress_mbps": 22.09,
+   "decompress_mbps": 108.64
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.17,
-   "decompress_mbps": 89.47
+   "compress_mbps": 21.22,
+   "decompress_mbps": 111.5
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.13,
-   "decompress_mbps": 90.43
+   "compress_mbps": 21.27,
+   "decompress_mbps": 112.95
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 20.77,
-   "decompress_mbps": 90.85
+   "compress_mbps": 21.19,
+   "decompress_mbps": 113.72
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.03,
-   "decompress_mbps": 90.97
+   "compress_mbps": 7.06,
+   "decompress_mbps": 113.99
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.01,
-   "decompress_mbps": 89.5
+   "compress_mbps": 7.03,
+   "decompress_mbps": 113.43
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3027,
    "ratio": 0.2715,
-   "compress_mbps": 1.52,
-   "decompress_mbps": 91.12
+   "compress_mbps": 1.54,
+   "decompress_mbps": 113.45
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.2,
-   "decompress_mbps": 40.01
+   "compress_mbps": 11.3,
+   "decompress_mbps": 52.0
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.16,
-   "decompress_mbps": 40.22
+   "compress_mbps": 11.13,
+   "decompress_mbps": 52.14
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.17,
-   "decompress_mbps": 40.24
+   "compress_mbps": 11.02,
+   "decompress_mbps": 52.43
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.02,
-   "decompress_mbps": 40.85
+   "compress_mbps": 11.0,
+   "decompress_mbps": 53.06
   },
   {
    "compressor": "native",
@@ -415,7 +415,7 @@
    "out_size": 1213,
    "ratio": 0.326,
    "compress_mbps": 11.04,
-   "decompress_mbps": 41.33
+   "decompress_mbps": 53.83
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.01,
-   "decompress_mbps": 41.11
+   "compress_mbps": 10.94,
+   "decompress_mbps": 53.73
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.81,
-   "decompress_mbps": 41.26
+   "compress_mbps": 3.77,
+   "decompress_mbps": 53.74
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.8,
-   "decompress_mbps": 41.23
+   "compress_mbps": 3.78,
+   "decompress_mbps": 53.56
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 1.21,
-   "decompress_mbps": 41.32
+   "compress_mbps": 1.23,
+   "decompress_mbps": 53.79
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 62.71,
-   "decompress_mbps": 176.34
+   "compress_mbps": 62.65,
+   "decompress_mbps": 197.93
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 60.11,
-   "decompress_mbps": 215.5
+   "compress_mbps": 59.78,
+   "decompress_mbps": 234.54
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 58.35,
-   "decompress_mbps": 232.4
+   "compress_mbps": 57.82,
+   "decompress_mbps": 253.1
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 55.63,
-   "decompress_mbps": 245.47
+   "compress_mbps": 55.52,
+   "decompress_mbps": 268.46
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 54.84,
-   "decompress_mbps": 174.14
+   "compress_mbps": 54.58,
+   "decompress_mbps": 189.62
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 51.91,
-   "decompress_mbps": 172.53
+   "compress_mbps": 51.64,
+   "decompress_mbps": 190.1
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 9.5,
-   "decompress_mbps": 155.01
+   "compress_mbps": 9.63,
+   "decompress_mbps": 168.16
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.49,
-   "decompress_mbps": 153.26
+   "compress_mbps": 7.59,
+   "decompress_mbps": 167.37
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 0.97,
-   "decompress_mbps": 152.29
+   "compress_mbps": 0.95,
+   "decompress_mbps": 165.3
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 44.15,
-   "decompress_mbps": 121.31
+   "compress_mbps": 43.13,
+   "decompress_mbps": 133.92
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 40.2,
-   "decompress_mbps": 128.99
+   "compress_mbps": 39.41,
+   "decompress_mbps": 142.51
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 37.41,
-   "decompress_mbps": 144.22
+   "compress_mbps": 36.51,
+   "decompress_mbps": 159.43
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 29.03,
-   "decompress_mbps": 149.3
+   "compress_mbps": 28.83,
+   "decompress_mbps": 165.58
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 28.4,
-   "decompress_mbps": 155.99
+   "compress_mbps": 27.88,
+   "decompress_mbps": 173.65
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 26.35,
-   "decompress_mbps": 157.53
+   "compress_mbps": 26.07,
+   "decompress_mbps": 174.78
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 10.02,
-   "decompress_mbps": 157.48
+   "compress_mbps": 9.93,
+   "decompress_mbps": 175.25
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.94,
-   "decompress_mbps": 157.94
+   "compress_mbps": 9.9,
+   "decompress_mbps": 175.78
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 138661,
    "ratio": 0.3249,
-   "compress_mbps": 1.29,
-   "decompress_mbps": 157.97
+   "compress_mbps": 1.3,
+   "decompress_mbps": 175.77
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 37.16,
-   "decompress_mbps": 107.4
+   "compress_mbps": 37.66,
+   "decompress_mbps": 117.9
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 33.87,
-   "decompress_mbps": 116.26
+   "compress_mbps": 34.29,
+   "decompress_mbps": 128.42
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 31.32,
-   "decompress_mbps": 122.08
+   "compress_mbps": 31.08,
+   "decompress_mbps": 134.83
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195796,
    "ratio": 0.4063,
-   "compress_mbps": 23.09,
-   "decompress_mbps": 128.05
+   "compress_mbps": 23.02,
+   "decompress_mbps": 141.65
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 22.41,
-   "decompress_mbps": 134.76
+   "compress_mbps": 22.28,
+   "decompress_mbps": 150.1
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 20.83,
-   "decompress_mbps": 137.9
+   "compress_mbps": 20.59,
+   "decompress_mbps": 153.22
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 8.53,
-   "decompress_mbps": 138.25
+   "compress_mbps": 8.44,
+   "decompress_mbps": 153.78
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.47,
-   "decompress_mbps": 138.57
+   "compress_mbps": 8.41,
+   "decompress_mbps": 153.79
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.23,
-   "decompress_mbps": 138.91
+   "compress_mbps": 1.25,
+   "decompress_mbps": 153.71
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 117.18,
-   "decompress_mbps": 331.51
+   "compress_mbps": 116.22,
+   "decompress_mbps": 368.05
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 104.3,
-   "decompress_mbps": 346.28
+   "compress_mbps": 103.34,
+   "decompress_mbps": 384.27
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 90.61,
-   "decompress_mbps": 361.92
+   "compress_mbps": 89.43,
+   "decompress_mbps": 403.92
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 72.95,
-   "decompress_mbps": 335.12
+   "compress_mbps": 71.92,
+   "decompress_mbps": 369.09
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 70.22,
-   "decompress_mbps": 356.1
+   "compress_mbps": 69.43,
+   "decompress_mbps": 393.57
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 63.78,
-   "decompress_mbps": 375.83
+   "compress_mbps": 62.69,
+   "decompress_mbps": 415.82
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53495,
    "ratio": 0.1042,
-   "compress_mbps": 19.18,
-   "decompress_mbps": 395.8
+   "compress_mbps": 18.56,
+   "decompress_mbps": 437.7
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 17.02,
-   "decompress_mbps": 417.84
+   "compress_mbps": 16.36,
+   "decompress_mbps": 465.78
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 0.96,
-   "decompress_mbps": 424.12
+   "compress_mbps": 0.95,
+   "decompress_mbps": 474.79
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.66,
-   "decompress_mbps": 84.7
+   "compress_mbps": 26.27,
+   "decompress_mbps": 95.25
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 26.17,
-   "decompress_mbps": 88.4
+   "compress_mbps": 25.84,
+   "decompress_mbps": 99.26
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.52,
-   "decompress_mbps": 92.03
+   "compress_mbps": 25.22,
+   "decompress_mbps": 103.64
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.34,
-   "decompress_mbps": 89.75
+   "compress_mbps": 23.35,
+   "decompress_mbps": 100.8
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.9,
-   "decompress_mbps": 95.41
+   "compress_mbps": 22.89,
+   "decompress_mbps": 107.67
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.88,
-   "decompress_mbps": 96.65
+   "compress_mbps": 21.64,
+   "decompress_mbps": 108.85
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13035,
    "ratio": 0.3409,
-   "compress_mbps": 5.85,
-   "decompress_mbps": 96.37
+   "compress_mbps": 5.81,
+   "decompress_mbps": 110.66
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.47,
-   "decompress_mbps": 100.12
+   "compress_mbps": 5.46,
+   "decompress_mbps": 114.32
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.21,
-   "decompress_mbps": 98.55
+   "compress_mbps": 1.2,
+   "decompress_mbps": 111.97
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.93,
-   "decompress_mbps": 42.5
+   "compress_mbps": 12.92,
+   "decompress_mbps": 55.42
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.91,
-   "decompress_mbps": 43.11
+   "compress_mbps": 12.82,
+   "decompress_mbps": 56.32
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.97,
-   "decompress_mbps": 43.15
+   "compress_mbps": 12.79,
+   "decompress_mbps": 56.07
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.76,
-   "decompress_mbps": 43.8
+   "compress_mbps": 12.55,
+   "decompress_mbps": 56.78
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.68,
-   "decompress_mbps": 43.94
+   "compress_mbps": 12.76,
+   "decompress_mbps": 57.62
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.78,
-   "decompress_mbps": 44.01
+   "compress_mbps": 12.62,
+   "decompress_mbps": 57.47
   },
   {
    "compressor": "native",
@@ -975,7 +975,7 @@
    "out_size": 1729,
    "ratio": 0.409,
    "compress_mbps": 4.19,
-   "decompress_mbps": 44.01
+   "decompress_mbps": 57.5
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.18,
-   "decompress_mbps": 43.48
+   "compress_mbps": 4.16,
+   "decompress_mbps": 56.88
   },
   {
    "compressor": "native",
@@ -995,7 +995,7 @@
    "out_size": 1696,
    "ratio": 0.4012,
    "compress_mbps": 1.4,
-   "decompress_mbps": 43.83
+   "decompress_mbps": 57.42
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 37.83,
-   "decompress_mbps": 107.89
+   "compress_mbps": 36.8,
+   "decompress_mbps": 119.48
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 34.67,
-   "decompress_mbps": 118.08
+   "compress_mbps": 33.51,
+   "decompress_mbps": 128.19
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 33.5,
-   "decompress_mbps": 129.61
+   "compress_mbps": 32.93,
+   "decompress_mbps": 141.83
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.39,
-   "decompress_mbps": 132.97
+   "compress_mbps": 25.41,
+   "decompress_mbps": 144.09
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 24.94,
-   "decompress_mbps": 138.25
+   "compress_mbps": 24.68,
+   "decompress_mbps": 149.81
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 23.02,
-   "decompress_mbps": 141.57
+   "compress_mbps": 22.94,
+   "decompress_mbps": 155.13
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 8.99,
-   "decompress_mbps": 145.0
+   "compress_mbps": 8.84,
+   "decompress_mbps": 159.53
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.98,
-   "decompress_mbps": 144.92
+   "compress_mbps": 8.94,
+   "decompress_mbps": 151.79
   },
   {
    "compressor": "native",
@@ -4055,7 +4055,7 @@
    "out_size": 3712344,
    "ratio": 0.3642,
    "compress_mbps": 1.25,
-   "decompress_mbps": 147.1
+   "decompress_mbps": 160.89
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 50.73,
-   "decompress_mbps": 98.89
+   "compress_mbps": 50.11,
+   "decompress_mbps": 109.48
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 47.75,
-   "decompress_mbps": 103.96
+   "compress_mbps": 47.49,
+   "decompress_mbps": 113.81
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 45.74,
-   "decompress_mbps": 108.05
+   "compress_mbps": 44.6,
+   "decompress_mbps": 118.57
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 37.98,
-   "decompress_mbps": 112.15
+   "compress_mbps": 38.29,
+   "decompress_mbps": 121.51
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 36.72,
-   "decompress_mbps": 117.08
+   "compress_mbps": 36.59,
+   "decompress_mbps": 129.68
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 32.57,
-   "decompress_mbps": 119.87
+   "compress_mbps": 32.58,
+   "decompress_mbps": 133.53
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 19177172,
    "ratio": 0.3744,
-   "compress_mbps": 7.51,
-   "decompress_mbps": 119.11
+   "compress_mbps": 7.55,
+   "decompress_mbps": 132.09
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.92,
-   "decompress_mbps": 121.51
+   "compress_mbps": 6.98,
+   "decompress_mbps": 133.69
   },
   {
    "compressor": "native",
@@ -4145,7 +4145,7 @@
    "out_size": 18518350,
    "ratio": 0.3615,
    "compress_mbps": 1.17,
-   "decompress_mbps": 120.81
+   "decompress_mbps": 133.1
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 51.85,
-   "decompress_mbps": 96.48
+   "compress_mbps": 51.18,
+   "decompress_mbps": 104.37
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 47.58,
-   "decompress_mbps": 98.09
+   "compress_mbps": 47.03,
+   "decompress_mbps": 107.27
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 42.79,
-   "decompress_mbps": 100.01
+   "compress_mbps": 42.09,
+   "decompress_mbps": 108.91
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.34,
-   "decompress_mbps": 94.1
+   "compress_mbps": 31.14,
+   "decompress_mbps": 100.95
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 29.77,
-   "decompress_mbps": 100.12
+   "compress_mbps": 29.4,
+   "decompress_mbps": 107.95
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.32,
-   "decompress_mbps": 101.87
+   "compress_mbps": 27.19,
+   "decompress_mbps": 110.06
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3609769,
    "ratio": 0.362,
-   "compress_mbps": 8.41,
-   "decompress_mbps": 104.26
+   "compress_mbps": 8.43,
+   "decompress_mbps": 109.54
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.1,
-   "decompress_mbps": 105.03
+   "compress_mbps": 8.04,
+   "decompress_mbps": 111.83
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 1.0,
-   "decompress_mbps": 104.58
+   "compress_mbps": 0.98,
+   "decompress_mbps": 115.32
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 118.92,
-   "decompress_mbps": 378.75
+   "compress_mbps": 115.44,
+   "decompress_mbps": 420.5
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 101.6,
-   "decompress_mbps": 433.26
+   "compress_mbps": 102.54,
+   "decompress_mbps": 469.25
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 89.24,
-   "decompress_mbps": 481.53
+   "compress_mbps": 87.59,
+   "decompress_mbps": 525.66
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 79.1,
-   "decompress_mbps": 498.23
+   "compress_mbps": 78.22,
+   "decompress_mbps": 538.47
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 77.27,
-   "decompress_mbps": 559.1
+   "compress_mbps": 76.54,
+   "decompress_mbps": 606.23
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 71.32,
-   "decompress_mbps": 598.64
+   "compress_mbps": 70.87,
+   "decompress_mbps": 653.11
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3123611,
    "ratio": 0.0931,
-   "compress_mbps": 25.93,
-   "decompress_mbps": 593.33
+   "compress_mbps": 25.82,
+   "decompress_mbps": 651.66
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.82,
-   "decompress_mbps": 598.5
+   "compress_mbps": 22.57,
+   "decompress_mbps": 654.54
   },
   {
    "compressor": "native",
@@ -4325,7 +4325,7 @@
    "out_size": 2868751,
    "ratio": 0.0855,
    "compress_mbps": 0.77,
-   "decompress_mbps": 572.28
+   "decompress_mbps": 635.2
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 37.18,
-   "decompress_mbps": 66.16
+   "compress_mbps": 35.88,
+   "decompress_mbps": 72.27
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 36.01,
-   "decompress_mbps": 67.59
+   "compress_mbps": 35.63,
+   "decompress_mbps": 74.7
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 35.04,
-   "decompress_mbps": 73.22
+   "compress_mbps": 34.63,
+   "decompress_mbps": 80.56
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 28.97,
-   "decompress_mbps": 73.73
+   "compress_mbps": 29.33,
+   "decompress_mbps": 81.54
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 29.13,
-   "decompress_mbps": 74.99
+   "compress_mbps": 28.95,
+   "decompress_mbps": 84.67
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 28.05,
-   "decompress_mbps": 78.0
+   "compress_mbps": 27.74,
+   "decompress_mbps": 85.95
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3165678,
    "ratio": 0.5146,
-   "compress_mbps": 6.78,
-   "decompress_mbps": 79.25
+   "compress_mbps": 6.91,
+   "decompress_mbps": 87.79
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.75,
-   "decompress_mbps": 79.17
+   "compress_mbps": 6.8,
+   "decompress_mbps": 88.77
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 1.42,
-   "decompress_mbps": 78.12
+   "compress_mbps": 1.45,
+   "decompress_mbps": 88.41
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 53.09,
-   "decompress_mbps": 95.33
+   "compress_mbps": 52.37,
+   "decompress_mbps": 100.23
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 49.65,
-   "decompress_mbps": 98.65
+   "compress_mbps": 49.3,
+   "decompress_mbps": 103.88
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 49.23,
-   "decompress_mbps": 102.56
+   "compress_mbps": 48.31,
+   "decompress_mbps": 106.54
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 44.88,
-   "decompress_mbps": 102.63
+   "compress_mbps": 44.95,
+   "decompress_mbps": 107.56
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 44.9,
-   "decompress_mbps": 100.15
+   "compress_mbps": 45.03,
+   "decompress_mbps": 104.38
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 44.18,
-   "decompress_mbps": 100.76
+   "compress_mbps": 44.51,
+   "decompress_mbps": 104.38
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 11.63,
-   "decompress_mbps": 103.21
+   "compress_mbps": 12.02,
+   "decompress_mbps": 107.11
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 11.89,
-   "decompress_mbps": 102.08
+   "compress_mbps": 12.03,
+   "decompress_mbps": 105.89
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 1.74,
-   "decompress_mbps": 101.88
+   "compress_mbps": 1.76,
+   "decompress_mbps": 106.4
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 47.35,
-   "decompress_mbps": 133.46
+   "compress_mbps": 45.3,
+   "decompress_mbps": 145.81
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 41.4,
-   "decompress_mbps": 147.61
+   "compress_mbps": 41.76,
+   "decompress_mbps": 161.19
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1977555,
    "ratio": 0.2984,
-   "compress_mbps": 36.07,
-   "decompress_mbps": 157.83
+   "compress_mbps": 36.17,
+   "decompress_mbps": 177.56
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 26.56,
-   "decompress_mbps": 166.08
+   "compress_mbps": 26.41,
+   "decompress_mbps": 181.87
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.56,
-   "decompress_mbps": 175.1
+   "compress_mbps": 24.14,
+   "decompress_mbps": 190.93
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.46,
-   "decompress_mbps": 180.29
+   "compress_mbps": 20.31,
+   "decompress_mbps": 199.65
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1843401,
    "ratio": 0.2782,
-   "compress_mbps": 8.42,
-   "decompress_mbps": 196.93
+   "compress_mbps": 8.35,
+   "decompress_mbps": 199.68
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.76,
-   "decompress_mbps": 195.64
+   "compress_mbps": 7.73,
+   "decompress_mbps": 215.64
   },
   {
    "compressor": "native",
@@ -4595,7 +4595,7 @@
    "out_size": 1724560,
    "ratio": 0.2602,
    "compress_mbps": 0.91,
-   "decompress_mbps": 195.4
+   "decompress_mbps": 211.06
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 66.26,
-   "decompress_mbps": 195.86
+   "compress_mbps": 65.82,
+   "decompress_mbps": 216.33
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 59.53,
-   "decompress_mbps": 204.71
+   "compress_mbps": 59.68,
+   "decompress_mbps": 227.91
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 55.62,
-   "decompress_mbps": 215.37
+   "compress_mbps": 53.72,
+   "decompress_mbps": 238.38
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 46.71,
-   "decompress_mbps": 224.9
+   "compress_mbps": 46.19,
+   "decompress_mbps": 249.5
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 45.31,
-   "decompress_mbps": 232.56
+   "compress_mbps": 45.2,
+   "decompress_mbps": 259.7
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 42.61,
-   "decompress_mbps": 238.48
+   "compress_mbps": 42.02,
+   "decompress_mbps": 264.49
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5409010,
    "ratio": 0.2503,
-   "compress_mbps": 13.26,
-   "decompress_mbps": 226.5
+   "compress_mbps": 13.27,
+   "decompress_mbps": 247.44
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.77,
-   "decompress_mbps": 226.79
+   "compress_mbps": 12.81,
+   "decompress_mbps": 253.69
   },
   {
    "compressor": "native",
@@ -4685,7 +4685,7 @@
    "out_size": 5169629,
    "ratio": 0.2393,
    "compress_mbps": 1.3,
-   "decompress_mbps": 236.01
+   "decompress_mbps": 259.35
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 32.3,
-   "decompress_mbps": 90.87
+   "compress_mbps": 31.32,
+   "decompress_mbps": 104.75
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 30.6,
-   "decompress_mbps": 93.94
+   "compress_mbps": 30.72,
+   "decompress_mbps": 107.75
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 29.62,
-   "decompress_mbps": 97.14
+   "compress_mbps": 29.6,
+   "decompress_mbps": 112.27
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 25.21,
-   "decompress_mbps": 99.69
+   "compress_mbps": 25.0,
+   "decompress_mbps": 114.03
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 24.6,
-   "decompress_mbps": 99.4
+   "compress_mbps": 24.39,
+   "decompress_mbps": 117.25
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 24.02,
-   "decompress_mbps": 102.46
+   "compress_mbps": 24.03,
+   "decompress_mbps": 118.88
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5429379,
    "ratio": 0.7487,
-   "compress_mbps": 6.12,
-   "decompress_mbps": 103.13
+   "compress_mbps": 6.15,
+   "decompress_mbps": 119.72
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.0,
-   "decompress_mbps": 104.28
+   "compress_mbps": 6.14,
+   "decompress_mbps": 118.62
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 1.55,
-   "decompress_mbps": 102.13
+   "compress_mbps": 1.57,
+   "decompress_mbps": 119.29
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 49.81,
-   "decompress_mbps": 141.27
+   "compress_mbps": 49.47,
+   "decompress_mbps": 156.46
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 46.52,
-   "decompress_mbps": 151.05
+   "compress_mbps": 46.05,
+   "decompress_mbps": 166.15
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 43.2,
-   "decompress_mbps": 161.8
+   "compress_mbps": 42.93,
+   "decompress_mbps": 178.98
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 35.67,
-   "decompress_mbps": 170.1
+   "compress_mbps": 35.34,
+   "decompress_mbps": 188.16
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 34.3,
-   "decompress_mbps": 175.77
+   "compress_mbps": 34.06,
+   "decompress_mbps": 194.94
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 31.23,
-   "decompress_mbps": 180.97
+   "compress_mbps": 30.99,
+   "decompress_mbps": 199.28
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 11.65,
-   "decompress_mbps": 180.9
+   "compress_mbps": 11.59,
+   "decompress_mbps": 198.89
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.42,
-   "decompress_mbps": 180.53
+   "compress_mbps": 11.35,
+   "decompress_mbps": 200.22
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11638957,
    "ratio": 0.2807,
-   "compress_mbps": 1.2,
-   "decompress_mbps": 182.11
+   "compress_mbps": 1.21,
+   "decompress_mbps": 198.22
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 32.47,
-   "decompress_mbps": 52.74
+   "compress_mbps": 31.97,
+   "decompress_mbps": 58.24
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 32.11,
-   "decompress_mbps": 58.1
+   "compress_mbps": 32.0,
+   "decompress_mbps": 64.12
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 32.12,
-   "decompress_mbps": 61.87
+   "compress_mbps": 31.99,
+   "decompress_mbps": 68.69
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 30.61,
-   "decompress_mbps": 60.73
+   "compress_mbps": 30.55,
+   "decompress_mbps": 67.6
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.55,
-   "decompress_mbps": 62.46
+   "compress_mbps": 30.52,
+   "decompress_mbps": 69.27
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.41,
-   "decompress_mbps": 63.25
+   "compress_mbps": 30.19,
+   "decompress_mbps": 70.52
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.64,
-   "decompress_mbps": 62.7
+   "compress_mbps": 4.76,
+   "decompress_mbps": 71.46
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.68,
-   "decompress_mbps": 62.38
+   "compress_mbps": 4.75,
+   "decompress_mbps": 71.59
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 1.64,
-   "decompress_mbps": 63.41
+   "compress_mbps": 1.68,
+   "decompress_mbps": 70.35
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 95.06,
-   "decompress_mbps": 274.47
+   "compress_mbps": 95.1,
+   "decompress_mbps": 291.35
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 84.84,
-   "decompress_mbps": 295.51
+   "compress_mbps": 85.52,
+   "decompress_mbps": 325.65
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 76.41,
-   "decompress_mbps": 330.01
+   "compress_mbps": 76.89,
+   "decompress_mbps": 360.99
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 61.88,
-   "decompress_mbps": 327.68
+   "compress_mbps": 63.34,
+   "decompress_mbps": 363.56
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 61.79,
-   "decompress_mbps": 363.5
+   "compress_mbps": 62.13,
+   "decompress_mbps": 398.31
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 56.76,
-   "decompress_mbps": 389.5
+   "compress_mbps": 57.81,
+   "decompress_mbps": 427.19
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 675427,
    "ratio": 0.1264,
-   "compress_mbps": 21.41,
-   "decompress_mbps": 401.44
+   "compress_mbps": 21.68,
+   "decompress_mbps": 444.63
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.16,
-   "decompress_mbps": 407.83
+   "compress_mbps": 20.33,
+   "decompress_mbps": 451.62
   },
   {
    "compressor": "native",
@@ -5045,7 +5045,7 @@
    "out_size": 637424,
    "ratio": 0.1192,
    "compress_mbps": 0.97,
-   "decompress_mbps": 430.0
+   "decompress_mbps": 473.88
   },
   {
    "compressor": "zlib",


### PR DESCRIPTION
This PR folds the native DEFLATE decode table's two parallel scalar arrays (`syms : Array UInt16` + `lens : Array UInt8`) into one packed `Array UInt32`, libdeflate-style: each entry holds the codeword length in the low byte and the symbol in bits 8–23, so a per-symbol decode reads one tagged-scalar array slot and extracts both fields with register shifts (`lenAt` / `symAt`) instead of two reads into two arrays / two cache lines. The packed table is kept behind an equivalence to the split projections — `buildTable_lenAt` / `buildTable_symAt` recover `(tableEntry …).2` / `(tableEntry …).1` via `unpackLen`/`unpackSym` of `packEntry` — so every decode proof transfers with a mechanical `lens[i]!`→`lenAt i`, `syms[i]!`→`symAt i` rewrite and no new `sorry`.

Two design points the [#2650](https://github.com/kim-em/lean-zip/issues/2650) comment warned about:

- **The length is the low byte deliberately.** Only the length flows into the well-founded recursions' termination measure (`cnt - len`), and extracting it must avoid a shift: a `>>>` on the stuck array read `packed[idx]!` forces `Nat.shiftRight`/`Nat.div` during the equation compiler's `whnf`, which loops on the opaque value. The low byte extracts with `toUInt8` (a width truncation, no `Nat.div`), so `unpackLen` stays inert under `whnf`; the symbol uses a shift but never enters a measure.
- **`UInt32`, not `UInt64`.** On a 64-bit target `lean_box_uint32` is a tagged scalar stored inline in the array (no allocation), like the old `UInt8`/`UInt16` arrays; `lean_box_uint64` heap-allocates a boxed word per entry, so an `Array UInt64` would pointer-chase through `lean_ctor_get` on every read, re-introducing the boxing [#2650](https://github.com/kim-em/lean-zip/issues/2650) removed. A `UInt32` holds len (8) + symbol (16) with room to spare — this is also libdeflate's `u32` entry width.

The source reads each slot through `lenAt`/`symAt`, which name the same `packed[idx]!` element; the compiler CSEs the shared read, so the fastloop literal path lowers to one `lean_array_get` plus shifts (verified in the generated C). Measured ~+10% native decode throughput on the Canterbury corpus (median of 3): alice29 160→176, lcet10 142→156, plrabn12 142→156, ptt5 399→436, sum 96→109 MB/s.

Phase 3 of [#2668](https://github.com/kim-em/lean-zip/issues/2668). Closes [#2670](https://github.com/kim-em/lean-zip/issues/2670).

🤖 Prepared with Claude Code