### PR TITLE
perf(decode): fuse overlapping back-ref copy into one copySlice

### DIFF
--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -354,17 +354,20 @@ decreasing_by
     (a `memcpy`) instead of `length` per-byte `push`es / bounds-checks / modular
     indices. For an **overlapping** back-reference (`k = 0 ∧ length > distance`,
     the RLE case) the copy is the periodic extension of the `distance`-byte window,
-    built by `fillDouble` (a handful of memcpys) instead of `length` per-byte
-    `push`es. A partial copy (`k ≠ 0`, never produced by the decoders) falls back
-    to the per-byte `copyLoopGo`. All three are proven equal to `copyLoopGo` via
-    `copyLoop_eq_ofFn`, so every decode correctness proof is unaffected. -/
+    built by `fillDouble` (a handful of memcpys). The `length` bytes of that fill
+    are copied straight into `buf`'s tail with a single `copySlice` (one `memcpy`,
+    no trailing `extract` + `append`), since the fill is a distinct array so there
+    is no self-aliasing. A partial copy (`k ≠ 0`, never produced by the decoders)
+    falls back to the per-byte `copyLoopGo`. All three are proven equal to
+    `copyLoopGo` via `copyLoop_eq_ofFn`, so every decode correctness proof is
+    unaffected. -/
 def copyLoop (buf : ByteArray) (start distance : Nat)
     (k length : Nat)
     (hd_pos : distance > 0 := by omega) (hsd : start + distance ≤ buf.size := by omega) : ByteArray :=
   if k = 0 ∧ length ≤ distance then
     buf ++ buf.extract start (start + length)
   else if k = 0 then
-    buf ++ (fillDouble (buf.extract start (start + distance)) length).extract 0 length
+    (fillDouble (buf.extract start (start + distance)) length).copySlice 0 buf buf.size length false
   else
     copyLoopGo buf start distance k length hd_pos hsd
 

--- a/Zip/Spec/DecodeCorrect.lean
+++ b/Zip/Spec/DecodeCorrect.lean
@@ -599,6 +599,17 @@ private theorem fillDouble_get (seed : ByteArray) (length : Nat) :
         append_self_getElem! seed (i % (seed.size + seed.size)) hpos (Nat.mod_lt i (by omega)),
         Nat.mod_mod_of_dvd i ⟨2, by omega⟩]
 
+/-- Copying the `length`-byte prefix of a *distinct* array `fill` into `buf`'s
+    tail with one `copySlice` equals `buf ++ fill.extract 0 length`. Used to drop
+    the redundant trailing `extract` + `append` in `copyLoop`'s overlapping case:
+    because `fill` is not `buf`, there is no self-aliasing, so a single `copySlice`
+    (one `memcpy`) suffices. Holds for any `length` — the destination suffix is
+    empty because the write starts at `buf.size`. -/
+private theorem copySlice_prefix_eq_append {fill buf : ByteArray} {length : Nat} :
+    fill.copySlice 0 buf buf.size length false = buf ++ fill.extract 0 length := by
+  rw [ByteArray.copySlice_eq_append, ByteArray.extract_zero_size, Nat.zero_add,
+      ByteArray.size_data (a := buf), ByteArray.extract_add_left, ByteArray.append_empty]
+
 /-- The native copy loop produces the same result as the spec's `List.ofFn`
     for LZ77 back-references. `copyLoop` dispatches: the non-overlapping case
     (`length ≤ distance`) is the contiguous slice `[start, start+length)`
@@ -638,7 +649,7 @@ theorem copyLoop_eq_ofFn
       have hge : length ≤ (Zip.Native.Inflate.fillDouble
           (output.extract (output.size - distance) (output.size - distance + distance)) length).size :=
         fillDouble_size_ge _ _ (by rw [hseed_size]; exact hd_pos)
-      rw [ByteArray.data_append, Array.toList_append]
+      rw [copySlice_prefix_eq_append, ByteArray.data_append, Array.toList_append]
       congr 1
       have hext := extract_data_toList_ofFn (Zip.Native.Inflate.fillDouble
         (output.extract (output.size - distance) (output.size - distance + distance)) length)

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pe16209b2d1)">
+   <g clip-path="url(#pc102a006e0)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEUlEQVR4nO3YT4pl5R3H4brVtxtpiiYK/mtCkEBCBpmHkDVk4kJcgbtwBYLgyKmIGWaWJcREQsBWTNmdbsrqsvr2Pc4yFz4vv3h5nhV8Dwfe8znv7vj04+2Mn5ebq+kF69w8m16wxPbidnrCMrsHb0xPWOPuK9ML1jk/n16wxoub6QXr7E7znW1PHk1PWOY03xgAwCCBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2//r7HJ6wxIvjjfTE5Z5+xe/np6wzMX21vSEJXbfP56esMxfn/99esISv7z3xvSEZQ7H2+kJS1y9PN1z//Z4mJ6wxB8e/Gp6wjJusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2e/bDJ9v0iBWeH66mJyzz+vH+9IR1DrfTC9a4upxesM6bv51esMTVdj09YZlTPR9f3y6mJyzz6Ozx9IQlHl7+d3rCMm6wAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa/eHI5vWGJi/296Qnr3HwzvWCZ7erp9IQ1jsfpBcvs7n87PWGJUz5DLvYPpiesce+V6QXLPHx+Oz1hie366+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI7bfLb6Y38FMdj9ML4H+2r76cnrDGuf/Pnx1nI/9HnCAAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ27/3n39Pb1jiyc3L6QnL/O3Rs+kJy3z67p+mJyzx1v13pics8/sPP5qesMSff/Pa9IRl/vnkZnoCP9Fnn/9jesIS1x+8Pz1hGTdYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENsdjn/Zpkes8PJ4mJ6wzPnudLv4zs319IQ17uynF6zz/ePpBUscX304PWGZbTtOT1jizgnfGbzYTvObdvdwms91duYGCwAgJ7AAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL78216wiLn++kFy5x/++X0hGW2Z99NT1jjcJhesMz2uz9OT1ji/IT/P4+76QWL/HA9vWCZu7en+WzbV19MT1jmdE8QAIAhAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIPYjq2KMAzI9Ph4AAAAASUVORK5CYII=" id="imaged071bd05d6" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3Yz6rcdx3H4TMnk1DCIdhC/xhEpKC4cF9Kr6EbL8Qr6F30CgqCK7ciunTnJWgtIjQt7WnShNNkejKZnzv3hdeXjx2e5wrew8BnXvPdnZ7+Ybvgx+VwM71gncOz6QVLbC9vpycss3vw1vSENe6+Nr1gncvL6QVrvDxML1hnd57f2fbk0fSEZc7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+39fXE9vWOLl6TA9YZmf/uTd6QnLXG3vTE9YYvfd4+kJy/ztxT+mJyzxs3tvTU9Y5ni6nZ6wxM2r8737t6fj9IQl3nvw8+kJy3jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNju2fd/3KZHrPDieDM9YZk3T/enJ6xzvJ1esMbN9fSCdd7+1fSCJW6259MTljnX+/jmdjU9YZlHF4+nJyzx8Prb6QnLeMECAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2P7qyfX0hiWu9vemJ6xz+HJ6wTLbzdPpCWucTtMLltnd/2p6whLnfEOu9g+mJ6xx77XpBcs8fHE7PWGJ7fkX0xOW8YIFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDbb9dfTm/ghzqdphfA/2yffzY9YY1L/z9/dNxG/o+4IAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDb/+7r/0xvWOLJ4dX0hGX+/ujZ9IRl/vTbD6YnLPHO/V9MT1jmN5/8fnrCEh/+8o3pCcv868lhegI/0J//8un0hCWef/zR9IRlvGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbHc8/XWbHrHCq9NxesIyl7vz7eI7h+fTE9a4s59esM53j6cXLHF6/eH0hGW27TQ9YYk7Z/xm8HI7z9+0u8fz/FwXF16wAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILa/PNfGutxPL1jm8qvPpicssz37ZnrCGsfj9IJltl+/Pz1hibO9jRcXF6fd9IJFbg/TC5a5+/3N9IQlts//OT1hmfO9IAAAQwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEDsv2cHiwZH5S3pAAAAAElFTkSuQmCC" id="imagee4d630b3b3" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m79cfb91616" d="M 0 0 
+       <path id="mfac6236116" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m79cfb91616" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m79cfb91616" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m79cfb91616" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m79cfb91616" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m79cfb91616" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m79cfb91616" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m79cfb91616" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m79cfb91616" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m79cfb91616" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m79cfb91616" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m79cfb91616" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfac6236116" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m30e8105fa0" d="M 0 0 
+       <path id="m84eb3296ce" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84eb3296ce" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84eb3296ce" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84eb3296ce" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84eb3296ce" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84eb3296ce" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84eb3296ce" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84eb3296ce" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m30e8105fa0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m84eb3296ce" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,44 +1303,10 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -3 -->
+    <!-- -2 -->
     <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_21">
@@ -1484,17 +1450,17 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- +3 -->
+    <!-- +4 -->
     <g transform="translate(306.76443 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -2 -->
+    <!-- -1 -->
     <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_27">
@@ -1505,19 +1471,65 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -19 -->
+    <!-- -17 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -35 -->
+    <!-- -34 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1561,18 +1573,6 @@ z
    <g id="text_35">
     <!-- -17 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
@@ -2178,18 +2178,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image5105204d9b" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imaged1c84249b3" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m5c84dbce03" d="M 0 0 
+       <path id="m778963ca20" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m778963ca20" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m778963ca20" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2226,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m778963ca20" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2240,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m778963ca20" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2253,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m778963ca20" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2266,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m778963ca20" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2279,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5c84dbce03" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m778963ca20" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2940,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-21T13:19:57Z  ·  Linux chungus x86_64  ·  commit 6206cfe6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.977734 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3008,16 +3008,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3056,109 +3056,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3414.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3478.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3637.011719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3726.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.597656 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.976562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3953.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4135.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4176.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4210.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4299.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.591797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.970703 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.59375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4521.285156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.464844 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4644.087891 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.498047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4803.121094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.908203 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.615234 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.478516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5092.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.869141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5251.017578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.46875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.650391 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5517.029297 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.505859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.884766 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5707.361328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.949219 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.525391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5957.3125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6116.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.787109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6332.166016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6416.052734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.710938 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6604.1875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6656.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.666016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.847656 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6820.056641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.748047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.535156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.648438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7027.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.919922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7116.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.771484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7323.035156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.767578 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7485.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.654297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7622.066406 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.849609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.228516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7741.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7793.111328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7832.320312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7860.103516 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe16209b2d1">
+  <clipPath id="pc102a006e0">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m017ae46f6a" d="M 0 0 
+       <path id="mbcf3fcb9fa" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m017ae46f6a" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbcf3fcb9fa" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m017ae46f6a" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbcf3fcb9fa" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m017ae46f6a" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbcf3fcb9fa" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m017ae46f6a" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbcf3fcb9fa" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m017ae46f6a" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbcf3fcb9fa" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m017ae46f6a" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbcf3fcb9fa" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m017ae46f6a" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbcf3fcb9fa" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="me7c02f062d" d="M 0 0 
+       <path id="mdbfefe197f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me7c02f062d" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbfefe197f" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me7c02f062d" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbfefe197f" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me7c02f062d" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdbfefe197f" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m8b8a645fd4" d="M 0 0 
+       <path id="m6b5d5c49e2" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m8b8a645fd4" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6b5d5c49e2" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(231.647908 177.010476) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(231.647908 176.192121) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(103.348822 331.711397) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(103.348822 331.302021) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1748,25 +1748,25 @@ L 162.880539 157.659557
 L 160.741445 165.081439 
 L 153.966678 183.30847 
 L 151.589614 194.354473 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="ma438fab564" d="M -2.5 2.5 
+     <path id="mc696eb0546" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#ma438fab564" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma438fab564" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8a3c2b4411)">
+     <use xlink:href="#mc696eb0546" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc696eb0546" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc696eb0546" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc696eb0546" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc696eb0546" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc696eb0546" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc696eb0546" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc696eb0546" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc696eb0546" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1779,24 +1779,24 @@ L 163.054314 161.207386
 L 162.210539 168.678909 
 L 159.303811 175.634901 
 L 157.793928 179.408171 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m1189e8c40f" d="M 0 -2.5 
+     <path id="mc0acfd95ff" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m1189e8c40f" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1189e8c40f" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8a3c2b4411)">
+     <use xlink:href="#mc0acfd95ff" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0acfd95ff" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0acfd95ff" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0acfd95ff" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0acfd95ff" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0acfd95ff" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0acfd95ff" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0acfd95ff" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0acfd95ff" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -1809,39 +1809,39 @@ L 148.722526 107.793132
 L 144.388162 121.197738 
 L 127.071247 144.456083 
 L 124.491988 152.059912 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mf60f1c6ca7" d="M -0 3.535534 
+     <path id="ma232a444c5" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#mf60f1c6ca7" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf60f1c6ca7" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8a3c2b4411)">
+     <use xlink:href="#ma232a444c5" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma232a444c5" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma232a444c5" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma232a444c5" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma232a444c5" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma232a444c5" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma232a444c5" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma232a444c5" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma232a444c5" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_78">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5d6f889b6c" d="M -0 2.5 
+     <path id="m680302ce2c" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m5d6f889b6c" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8a3c2b4411)">
+     <use xlink:href="#m680302ce2c" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_79">
@@ -1854,9 +1854,9 @@ L 161.916638 211.158991
 L 158.697104 214.041592 
 L 154.26679 230.364582 
 L 153.096464 236.337782 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="meac0638faf" d="M -0.833333 2.5 
+     <path id="m45efd25d69" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1871,16 +1871,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#meac0638faf" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meac0638faf" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8a3c2b4411)">
+     <use xlink:href="#m45efd25d69" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45efd25d69" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45efd25d69" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45efd25d69" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45efd25d69" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45efd25d69" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45efd25d69" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45efd25d69" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m45efd25d69" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_80">
@@ -1893,9 +1893,9 @@ L 197.547749 167.982576
 L 194.819287 169.49094 
 L 193.12279 177.004847 
 L 192.79794 181.853352 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7380496e1d" d="M -1.25 2.5 
+     <path id="m91de082ecc" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1910,16 +1910,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m7380496e1d" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7380496e1d" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8a3c2b4411)">
+     <use xlink:href="#m91de082ecc" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m91de082ecc" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m91de082ecc" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m91de082ecc" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m91de082ecc" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m91de082ecc" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m91de082ecc" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m91de082ecc" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m91de082ecc" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_81">
@@ -1932,9 +1932,9 @@ L 163.54283 144.396316
 L 160.174881 150.295858 
 L 154.179217 168.595905 
 L 152.4406 178.324207 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m6286642f26" d="M 0 -2.5 
+     <path id="m823dd3ac6b" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1947,16 +1947,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m6286642f26" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6286642f26" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p8a3c2b4411)">
+     <use xlink:href="#m823dd3ac6b" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m823dd3ac6b" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m823dd3ac6b" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m823dd3ac6b" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m823dd3ac6b" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m823dd3ac6b" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m823dd3ac6b" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m823dd3ac6b" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m823dd3ac6b" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_82">
@@ -1969,9 +1969,9 @@ L 258.25125 199.15685
 L 256.777056 204.107569 
 L 248.769854 218.250617 
 L 246.264594 228.00198 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mbf5e0f79bd" d="M 0 -2.5 
+     <path id="me54c38e53f" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1980,16 +1980,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#mbf5e0f79bd" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbf5e0f79bd" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p8a3c2b4411)">
+     <use xlink:href="#me54c38e53f" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me54c38e53f" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me54c38e53f" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me54c38e53f" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me54c38e53f" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me54c38e53f" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me54c38e53f" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me54c38e53f" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me54c38e53f" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -2012,7 +2012,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m486e54e1b3" d="M 0 3.5 
+      <path id="ma13c0ce085" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -2025,7 +2025,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m486e54e1b3" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma13c0ce085" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2088,7 +2088,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma438fab564" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc696eb0546" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2106,7 +2106,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m1189e8c40f" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc0acfd95ff" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2155,7 +2155,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mf60f1c6ca7" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma232a444c5" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2202,7 +2202,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5d6f889b6c" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m680302ce2c" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2222,7 +2222,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#meac0638faf" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m45efd25d69" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2280,7 +2280,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7380496e1d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m91de082ecc" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2349,7 +2349,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m6286642f26" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m823dd3ac6b" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2391,7 +2391,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mbf5e0f79bd" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me54c38e53f" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2461,26 +2461,26 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 226.647908 182.010476 
-L 214.084819 184.35903 
-L 206.266533 187.050863 
-L 187.75787 193.186538 
-L 186.58897 193.984995 
-L 184.505355 196.319133 
-L 152.30308 249.650734 
-L 150.950891 251.698077 
-L 98.348822 336.711397 
-" clip-path="url(#p1485ea9e7f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p1485ea9e7f)">
-     <use xlink:href="#m486e54e1b3" x="226.647908" y="182.010476" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="214.084819" y="184.35903" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="206.266533" y="187.050863" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="187.75787" y="193.186538" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="186.58897" y="193.984995" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="184.505355" y="196.319133" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="152.30308" y="249.650734" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="150.950891" y="251.698077" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m486e54e1b3" x="98.348822" y="336.711397" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 226.647908 181.192121 
+L 214.084819 183.706649 
+L 206.266533 186.04636 
+L 187.75787 192.663858 
+L 186.58897 193.558044 
+L 184.505355 195.693775 
+L 152.30308 249.251762 
+L 150.950891 251.105561 
+L 98.348822 336.302021 
+" clip-path="url(#p8a3c2b4411)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p8a3c2b4411)">
+     <use xlink:href="#ma13c0ce085" x="226.647908" y="181.192121" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma13c0ce085" x="214.084819" y="183.706649" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma13c0ce085" x="206.266533" y="186.04636" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma13c0ce085" x="187.75787" y="192.663858" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma13c0ce085" x="186.58897" y="193.558044" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma13c0ce085" x="184.505355" y="195.693775" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma13c0ce085" x="152.30308" y="249.251762" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma13c0ce085" x="150.950891" y="251.105561" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma13c0ce085" x="98.348822" y="336.302021" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2891,8 +2891,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-21T13:19:57Z  ·  Linux chungus x86_64  ·  commit 6206cfe6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.977734 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2918,6 +2918,36 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
 L 3169 4134 
@@ -2941,6 +2971,16 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -3000,46 +3040,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3078,16 +3078,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3126,109 +3126,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3414.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3478.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3637.011719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3726.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.597656 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.976562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3953.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4135.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4176.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4210.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4299.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.591797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.970703 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.59375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4521.285156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.464844 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4644.087891 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.498047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4803.121094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.908203 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.615234 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.478516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5092.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.869141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5251.017578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.46875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.650391 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5517.029297 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.505859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.884766 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5707.361328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.949219 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.525391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5957.3125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6116.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.787109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6332.166016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6416.052734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.710938 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6604.1875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6656.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.666016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.847656 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6820.056641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.748047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.535156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.648438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7027.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.919922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7116.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.771484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7323.035156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.767578 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7485.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.654297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7622.066406 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.849609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.228516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7741.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7793.111328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7832.320312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7860.103516 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1485ea9e7f">
+  <clipPath id="p8a3c2b4411">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p2f36b9bb58)">
+   <g clip-path="url(#p4affab9a06)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image24da510372" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI/UlEQVR4nO3Yv6plZx3H4b1nzjmcSXBAmfwhpWghSLBI4zTW3km6dClD+pS5Bs0NCCISG1FstBALQewkhJAZ42QmOefMPmt7CRPhlV/Yn+e5gu+Ctd714d1v//7FcXdqnn4+vWCp46PTep7dbrf717u/mp6w1D//+mx6wnI/++XPpycst//JW9MT1trfmV6w3pNPpxesd3l/esFSH732wfSE5U7wSwIA+ObEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2v768Ovj9IjVjrttesJS+xNs1vM7F9MTlrrZrqYnLHf+tz9NT1ju8OOH0xOWOmw30xOWe3Z4Mj1huQcndjw8v/9gesJyp/eXBQD4H4ghACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0s/NnX0xvWO/6q+kFax236QXr3bs/vWCpi+kB/wfHJ8+mJyx3/uXj6QlLnW+H6QnL3TvF8+7q6fSCpc7PTu/EczMEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCAtP1h++1xesRqx+M2PWGp7cSeZ7fb7c7vXExPWOr2eJiesNzdp4+nJ6z3nVenFyz1fLuZnrDco6tPpics9/r12fSEpbbvvjE9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tmfP/vD9Ibl7uz20xOWeuWlB9MTlrvdDtMTlrq4ezk9Ybm3f/f76QnLvf/TH05PWOpw3KYnLPfeH/8xPWG5h2+8PD1hqbfffDg9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbP7/9zXF6xGo3t1fTE5a6t7+cnsAL3OwP0xOW+8/159MTlvve5evTE5bajtv0hOW+uP5sesJyj68/nZ6w1Pfvvzk9YTk3QwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEjbb9vHx+kRwLfQ4WZ6wXpnF9MLeIGr26+mJyx3efel6Qm8gJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApJ3tjtv0hvX2Gu9b73AzvWCp7exsesJyf/nRO9MTlnvr7x9OT1jr7um9d18fnk5PWO7y0SfTE9Z69QfTC5ZTDQBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEj7LzN8iSvxbWn1AAAAAElFTkSuQmCC" id="image962c8f0594" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m47ec8d25a7" d="M 0 0 
+       <path id="m442c3f4938" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m47ec8d25a7" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m47ec8d25a7" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m442c3f4938" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m09f057a626" d="M 0 0 
+       <path id="m9d07636c7d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d07636c7d" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d07636c7d" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d07636c7d" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d07636c7d" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d07636c7d" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d07636c7d" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d07636c7d" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m09f057a626" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9d07636c7d" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8a35ff46db" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image7bf5ba0eb1" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m8b2eefb923" d="M 0 0 
+       <path id="m9a8e363000" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a8e363000" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a8e363000" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a8e363000" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a8e363000" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a8e363000" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a8e363000" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a8e363000" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a8e363000" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m8b2eefb923" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9a8e363000" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-21T13:19:57Z  ·  Linux chungus x86_64  ·  commit 6206cfe6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.977734 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2951,16 +2951,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3414.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3478.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3637.011719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3726.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.597656 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.976562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3953.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4135.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4176.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4210.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4299.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.591797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.970703 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.59375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4521.285156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.464844 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4644.087891 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.498047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4803.121094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.908203 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.615234 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.478516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5092.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.869141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5251.017578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.46875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.650391 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5517.029297 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.505859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.884766 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5707.361328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.949219 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.525391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5957.3125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6116.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.787109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6332.166016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6416.052734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.710938 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6604.1875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6656.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.666016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.847656 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6820.056641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.748047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.535156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.648438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7027.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.919922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7116.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.771484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7323.035156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.767578 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7485.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.654297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7622.066406 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.849609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.228516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7741.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7793.111328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7832.320312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7860.103516 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2f36b9bb58">
+  <clipPath id="p4affab9a06">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.444531pt" height="386.202469pt" viewBox="0 0 568.444531 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.022031 386.202469 
-L 569.022031 0 
+L 568.444531 386.202469 
+L 568.444531 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.636016 104.1264 
-L 291.261016 104.1264 
-L 291.261016 74.7432 
-L 186.636016 74.7432 
+    <path d="M 186.347266 104.1264 
+L 290.972266 104.1264 
+L 290.972266 74.7432 
+L 186.347266 74.7432 
 z
-" clip-path="url(#p71790097ce)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.261016 104.1264 
-L 395.886016 104.1264 
-L 395.886016 74.7432 
-L 291.261016 74.7432 
+    <path d="M 290.972266 104.1264 
+L 395.597266 104.1264 
+L 395.597266 74.7432 
+L 290.972266 74.7432 
 z
-" clip-path="url(#p71790097ce)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.886016 104.1264 
-L 500.511016 104.1264 
-L 500.511016 74.7432 
-L 395.886016 74.7432 
+    <path d="M 395.597266 104.1264 
+L 500.222266 104.1264 
+L 500.222266 74.7432 
+L 395.597266 74.7432 
 z
-" clip-path="url(#p71790097ce)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.636016 133.5096 
-L 291.261016 133.5096 
-L 291.261016 104.1264 
-L 186.636016 104.1264 
+    <path d="M 186.347266 133.5096 
+L 290.972266 133.5096 
+L 290.972266 104.1264 
+L 186.347266 104.1264 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.261016 133.5096 
-L 395.886016 133.5096 
-L 395.886016 104.1264 
-L 291.261016 104.1264 
+    <path d="M 290.972266 133.5096 
+L 395.597266 133.5096 
+L 395.597266 104.1264 
+L 290.972266 104.1264 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.886016 133.5096 
-L 500.511016 133.5096 
-L 500.511016 104.1264 
-L 395.886016 104.1264 
+    <path d="M 395.597266 133.5096 
+L 500.222266 133.5096 
+L 500.222266 104.1264 
+L 395.597266 104.1264 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.636016 162.8928 
-L 291.261016 162.8928 
-L 291.261016 133.5096 
-L 186.636016 133.5096 
+    <path d="M 186.347266 162.8928 
+L 290.972266 162.8928 
+L 290.972266 133.5096 
+L 186.347266 133.5096 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.261016 162.8928 
-L 395.886016 162.8928 
-L 395.886016 133.5096 
-L 291.261016 133.5096 
+    <path d="M 290.972266 162.8928 
+L 395.597266 162.8928 
+L 395.597266 133.5096 
+L 290.972266 133.5096 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.886016 162.8928 
-L 500.511016 162.8928 
-L 500.511016 133.5096 
-L 395.886016 133.5096 
+    <path d="M 395.597266 162.8928 
+L 500.222266 162.8928 
+L 500.222266 133.5096 
+L 395.597266 133.5096 
 z
-" clip-path="url(#p71790097ce)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.636016 192.276 
-L 291.261016 192.276 
-L 291.261016 162.8928 
-L 186.636016 162.8928 
+    <path d="M 186.347266 192.276 
+L 290.972266 192.276 
+L 290.972266 162.8928 
+L 186.347266 162.8928 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.261016 192.276 
-L 395.886016 192.276 
-L 395.886016 162.8928 
-L 291.261016 162.8928 
+    <path d="M 290.972266 192.276 
+L 395.597266 192.276 
+L 395.597266 162.8928 
+L 290.972266 162.8928 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.886016 192.276 
-L 500.511016 192.276 
-L 500.511016 162.8928 
-L 395.886016 162.8928 
+    <path d="M 395.597266 192.276 
+L 500.222266 192.276 
+L 500.222266 162.8928 
+L 395.597266 162.8928 
 z
-" clip-path="url(#p71790097ce)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.636016 221.6592 
-L 291.261016 221.6592 
-L 291.261016 192.276 
-L 186.636016 192.276 
+    <path d="M 186.347266 221.6592 
+L 290.972266 221.6592 
+L 290.972266 192.276 
+L 186.347266 192.276 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.261016 221.6592 
-L 395.886016 221.6592 
-L 395.886016 192.276 
-L 291.261016 192.276 
+    <path d="M 290.972266 221.6592 
+L 395.597266 221.6592 
+L 395.597266 192.276 
+L 290.972266 192.276 
 z
-" clip-path="url(#p71790097ce)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.886016 221.6592 
-L 500.511016 221.6592 
-L 500.511016 192.276 
-L 395.886016 192.276 
+    <path d="M 395.597266 221.6592 
+L 500.222266 221.6592 
+L 500.222266 192.276 
+L 395.597266 192.276 
 z
-" clip-path="url(#p71790097ce)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.636016 251.0424 
-L 291.261016 251.0424 
-L 291.261016 221.6592 
-L 186.636016 221.6592 
+    <path d="M 186.347266 251.0424 
+L 290.972266 251.0424 
+L 290.972266 221.6592 
+L 186.347266 221.6592 
 z
-" clip-path="url(#p71790097ce)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.261016 251.0424 
-L 395.886016 251.0424 
-L 395.886016 221.6592 
-L 291.261016 221.6592 
+    <path d="M 290.972266 251.0424 
+L 395.597266 251.0424 
+L 395.597266 221.6592 
+L 290.972266 221.6592 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #f99355; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.886016 251.0424 
-L 500.511016 251.0424 
-L 500.511016 221.6592 
-L 395.886016 221.6592 
+    <path d="M 395.597266 251.0424 
+L 500.222266 251.0424 
+L 500.222266 221.6592 
+L 395.597266 221.6592 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.636016 280.4256 
-L 291.261016 280.4256 
-L 291.261016 251.0424 
-L 186.636016 251.0424 
+    <path d="M 186.347266 280.4256 
+L 290.972266 280.4256 
+L 290.972266 251.0424 
+L 186.347266 251.0424 
 z
-" clip-path="url(#p71790097ce)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.261016 280.4256 
-L 395.886016 280.4256 
-L 395.886016 251.0424 
-L 291.261016 251.0424 
+    <path d="M 290.972266 280.4256 
+L 395.597266 280.4256 
+L 395.597266 251.0424 
+L 290.972266 251.0424 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.886016 280.4256 
-L 500.511016 280.4256 
-L 500.511016 251.0424 
-L 395.886016 251.0424 
+    <path d="M 395.597266 280.4256 
+L 500.222266 280.4256 
+L 500.222266 251.0424 
+L 395.597266 251.0424 
 z
-" clip-path="url(#p71790097ce)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.636016 309.8088 
-L 291.261016 309.8088 
-L 291.261016 280.4256 
-L 186.636016 280.4256 
+    <path d="M 186.347266 309.8088 
+L 290.972266 309.8088 
+L 290.972266 280.4256 
+L 186.347266 280.4256 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.261016 309.8088 
-L 395.886016 309.8088 
-L 395.886016 280.4256 
-L 291.261016 280.4256 
+    <path d="M 290.972266 309.8088 
+L 395.597266 309.8088 
+L 395.597266 280.4256 
+L 290.972266 280.4256 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.886016 309.8088 
-L 500.511016 309.8088 
-L 500.511016 280.4256 
-L 395.886016 280.4256 
+    <path d="M 395.597266 309.8088 
+L 500.222266 309.8088 
+L 500.222266 280.4256 
+L 395.597266 280.4256 
 z
-" clip-path="url(#p71790097ce)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.636016 339.192 
-L 291.261016 339.192 
-L 291.261016 309.8088 
-L 186.636016 309.8088 
+    <path d="M 186.347266 339.192 
+L 290.972266 339.192 
+L 290.972266 309.8088 
+L 186.347266 309.8088 
 z
-" clip-path="url(#p71790097ce)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.261016 339.192 
-L 395.886016 339.192 
-L 395.886016 309.8088 
-L 291.261016 309.8088 
+    <path d="M 290.972266 339.192 
+L 395.597266 339.192 
+L 395.597266 309.8088 
+L 290.972266 309.8088 
 z
-" clip-path="url(#p71790097ce)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.886016 339.192 
-L 500.511016 339.192 
-L 500.511016 309.8088 
-L 395.886016 309.8088 
+    <path d="M 395.597266 339.192 
+L 500.222266 339.192 
+L 500.222266 309.8088 
+L 395.597266 309.8088 
 z
-" clip-path="url(#p71790097ce)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#peff142e65d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.334531 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.61875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.190859 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.542578 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.272266 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.649766 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.910391 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.462266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.173516 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.768516 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.479766 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(118.924766 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(118.636016 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.270391 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(96.981641 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(226.296641 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.007891 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1699,8 +1699,8 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- 24 -->
-    <g transform="translate(338.007266 238.5583) scale(0.08 -0.08)">
+    <!-- 25 -->
+    <g transform="translate(337.718516 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1724,14 +1724,39 @@ Q 3472 2313 2841 1759
 L 1844 884 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 137 -->
-    <g transform="translate(439.849141 238.5583) scale(0.08 -0.08)">
+    <!-- 136 -->
+    <g transform="translate(439.560391 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1747,25 +1772,45 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(95.385391 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(95.096641 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1894,7 +1939,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(227.497266 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1904,14 +1949,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(338.483516 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(440.563516 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1919,7 +1964,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(97.892266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.603516 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1975,7 +2020,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1985,21 +2030,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.819766 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.317891 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2010,7 +2055,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2020,13 +2065,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.739766 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.909766 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2042,7 +2087,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.019766 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(133.731016 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2181,36 +2226,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2255,7 +2270,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-21T13:19:57Z  ·  Linux chungus x86_64  ·  commit 6206cfe6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2394,16 +2409,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2442,110 +2457,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3414.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3478.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3637.011719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3726.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.597656 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.976562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3953.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4135.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4176.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4210.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4299.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.591797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.970703 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.59375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4521.285156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.464844 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4644.087891 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.498047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4803.121094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.908203 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.615234 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.478516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5092.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.869141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5251.017578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.46875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.650391 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5517.029297 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.505859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.884766 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5707.361328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.949219 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.525391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5957.3125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6116.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.787109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6332.166016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6416.052734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.710938 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6604.1875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6656.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.666016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.847656 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6820.056641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.748047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.535156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.648438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7027.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.919922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7116.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.771484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7323.035156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.767578 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7485.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.654297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7622.066406 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.849609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.228516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7741.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7793.111328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7832.320312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7860.103516 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p71790097ce">
-   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="peff142e65d">
+   <rect x="81.722266" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p32e61e563f)">
+   <g clip-path="url(#pfa108ac475)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8ElEQVR4nO3Yv46ldR3H8T0zh1nYhbjKugRNNjZohQmRisY7oOAyKGntKa1t7b0BKo2ViTHaYQdBClgicWXZ7MyZOeMVWG1+7+/sk9frCj4nz5/f+zm7479/f31ryw7PphfwPI6X0wvW2p1ML1jr8mJ6wVp37k0vWOv8yfSCtU7PphfwPLZ+f57dmV6w1MZPPwAAbhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav+3w+fTG5ban5xOT1jqeH09PWGpB689mJ6w1Of//df0hLU2/on785fvTU9Y6nD7bHrCUn9/9On0hKV+ef+t6QlLnZ8dpycstds9nZ6w1MaPBwAAbhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaP3ztZ9Mblrp3+8H0hKW+efbl9ISlfvJ0299Ir77+9vSEpU53++kJSx1vHacnLPXjW/enJyx1ef9iesJSb9x5OD1hqcNx29fv7sW23y/bPt0BALhxBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9brftBv3u8O30hKVeOX11esJSV6//aHrCUl89/sf0hKWeXDybnrDUr3747vSEpS5Opxes9f3hu+kJPIf/nD+anrDW7QfTC5badn0CAHDjCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFK7qz9/dD09YqnjcXoB/H8nvgFfaN4vL7atP39bvz9dvxfaxq8eAAA3jQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1f+Ov/5zesNTJftuN/ejTb6YnLPW7D9+ZnrDUx3/5enrCUr9++IPpCUv94U+fTU9Y6jcf/GJ6wlK//eMX0xOWev+dN6cnLPXF4/PpCUu999O70xOW2nadAQBw4whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTucPXJ9fSIlU4vL6cnrHWyn16w1uWz6QVrnd2ZXrDWbuPfuNfH6QVrHTx/L7SrbZ9/h922n7+XNt4vGz8dAAC4aQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/fH6OL1hqdP92fSEpY676QVrnTz+dnrCUldnL09PWOr0cDE9gedx8XR6wVLfn1xOT1jq7tW2/2N6abft33fr/Mn0gqU2fvUAALhpBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn/AYWSfZp0uJWIAAAAAElFTkSuQmCC" id="image913226b9bf" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7UlEQVR4nO3YPW5cVQCG4Yw9cUJ+RCAhESBFNEAFUgQVDTugYBmUtPSU1LT0bIAKRIWEEHShIwoUkIiIkB/ZHnvMCqii8x7n6nlW8Fnn3jnv9Wr791cnZ5Zssz97Ac9iezR7wVirndkLxjo6nL1grAtXZi8Y6+Dx7AVj7e7NXsCzWPrzuXdh9oKhFn77AQBw2ghQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS6582d2ZvGGq9szt7wlDbk5PZE4a6fvn67AlD3fn399kTxlr4J+5b56/MnjDU5tze7AlD/Xzv9uwJQ7177c3ZE4Y62NvOnjDUavV09oShFn49AABw2ghQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT65uU3Zm8Y6sq567MnDHV//4/ZE4Z67emyv5EuXX1n9oShdlfr2ROG2p7Zzp4w1Ctnrs2eMNTRtcPZE4a6ceHm7AlDbbbLPr+Lh8v+fVn27Q4AwKkjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASK1Xq2U36KPNg9kThnph99LsCUMdX3159oSh/nz4y+wJQz0+3J89Yaj3Xnp/9oShDndnLxjryebR7Ak8g38O7s2eMNa567MXDLXs+gQA4NQRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApFbH3396MnvEUNvt7AXw/3Z8Az7X/L4835b+/i39+XR+z7WFnx4AAKeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILW+8eOvszcMtbNedmPfu31/9oShvvzk1uwJQ33+w1+zJwz14c0XZ08Y6uvvfps9YajPPn579oShvvj27uwJQ31069XZE4a6+/Bg9oShPnj94uwJQy27zgAAOHUEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqtTn+5mT2iJF2j45mTxhrZz17wVhH+7MXjLV3YfaCsVYL/8Y92c5eMNbG+/dcO172/bdZLfv9O7vwfln47QAAwGkjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASK23J9vZG4baPXt+9oShtmeWfX47Dx/MnjDU8d6yn8/do6PZE8baLvzvO3w6e8FQT3aWfX4Xj5f9P6azO+vZE8Y6eDx7wVDLfjoBADh1BCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn/AK7HgJoyMjBtAAAAAElFTkSuQmCC" id="imageaa0a26d66a" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mec6c2f9281" d="M 0 0 
+       <path id="m5dea6639da" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mec6c2f9281" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mec6c2f9281" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mec6c2f9281" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mec6c2f9281" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mec6c2f9281" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mec6c2f9281" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mec6c2f9281" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mec6c2f9281" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mec6c2f9281" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mec6c2f9281" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mec6c2f9281" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mec6c2f9281" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5dea6639da" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mc0e916c336" d="M 0 0 
+       <path id="mea20aca261" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea20aca261" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea20aca261" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea20aca261" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea20aca261" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea20aca261" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea20aca261" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea20aca261" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc0e916c336" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mea20aca261" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1201,8 +1201,69 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- -3 -->
+    <!-- -2 -->
     <g transform="translate(152.851996 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +4 -->
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -37 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1236,22 +1297,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- +3 -->
-    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -37 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1308,8 +1353,47 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- -10 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+    <!-- -9 -->
+    <g transform="translate(313.961591 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -12 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1325,86 +1409,15 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -11 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -26 -->
+    <!-- -25 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- +17 -->
-    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -15 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1433,37 +1446,32 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_31">
+   <g id="text_29">
+    <!-- +18 -->
+    <g transform="translate(431.175114 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
     <!-- -14 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -11 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
@@ -1550,38 +1558,6 @@ z
    <g id="text_43">
     <!-- +9 -->
     <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
@@ -1615,6 +1591,29 @@ z
    <g id="text_47">
     <!-- +305 -->
     <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -2193,18 +2192,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image72534f1d25" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagea9a5505314" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="ma2a229a83e" d="M 0 0 
+       <path id="m66845df870" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66845df870" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2227,7 +2226,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66845df870" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2241,7 +2240,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66845df870" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2255,7 +2254,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66845df870" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2268,7 +2267,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66845df870" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2281,7 +2280,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66845df870" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2294,7 +2293,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma2a229a83e" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m66845df870" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2910,8 +2909,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-21T13:19:57Z  ·  Linux chungus x86_64  ·  commit 6206cfe6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.977734 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3000,16 +2999,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3048,109 +3047,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3414.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3478.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3637.011719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3726.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.597656 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.976562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3953.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4135.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4176.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4210.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4299.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.591797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.970703 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.59375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4521.285156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.464844 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4644.087891 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.498047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4803.121094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.908203 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.615234 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.478516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5092.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.869141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5251.017578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.46875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.650391 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5517.029297 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.505859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.884766 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5707.361328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.949219 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.525391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5957.3125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6116.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.787109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6332.166016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6416.052734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.710938 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6604.1875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6656.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.666016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.847656 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6820.056641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.748047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.535156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.648438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7027.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.919922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7116.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.771484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7323.035156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.767578 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7485.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.654297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7622.066406 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.849609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.228516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7741.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7793.111328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7832.320312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7860.103516 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p32e61e563f">
+  <clipPath id="pfa108ac475">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mf932cfc11c" d="M 0 0 
+       <path id="m23f64392e7" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf932cfc11c" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23f64392e7" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf932cfc11c" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23f64392e7" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf932cfc11c" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23f64392e7" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf932cfc11c" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23f64392e7" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf932cfc11c" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23f64392e7" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf932cfc11c" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23f64392e7" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf932cfc11c" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23f64392e7" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mee54c87ccf" d="M 0 0 
+       <path id="mf9abad1301" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mee54c87ccf" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9abad1301" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mee54c87ccf" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9abad1301" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mee54c87ccf" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf9abad1301" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mddeb160c53" d="M 0 0 
+       <path id="m4f7468fcf8" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mddeb160c53" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f7468fcf8" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(262.531237 150.637342) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(262.531237 149.117306) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L9 -->
-    <g style="fill: #d62728" transform="translate(100.319203 352.56427) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(100.319203 352.164608) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
@@ -1702,25 +1702,25 @@ L 158.303164 172.157864
 L 149.489547 182.173164 
 L 140.563162 202.575355 
 L 138.984853 209.263476 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m50c0fa6663" d="M -2.5 2.5 
+     <path id="m42ef41c1b6" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m50c0fa6663" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m50c0fa6663" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3af40a48e5)">
+     <use xlink:href="#m42ef41c1b6" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42ef41c1b6" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42ef41c1b6" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42ef41c1b6" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42ef41c1b6" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42ef41c1b6" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42ef41c1b6" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42ef41c1b6" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m42ef41c1b6" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1733,24 +1733,24 @@ L 152.161413 174.830826
 L 146.720208 186.628416 
 L 143.994022 196.353927 
 L 142.666037 200.270771 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m9242dac054" d="M 0 -2.5 
+     <path id="m3bc12a509d" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m9242dac054" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9242dac054" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3af40a48e5)">
+     <use xlink:href="#m3bc12a509d" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bc12a509d" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bc12a509d" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bc12a509d" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bc12a509d" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bc12a509d" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bc12a509d" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bc12a509d" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3bc12a509d" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
@@ -1763,39 +1763,39 @@ L 145.830392 110.20084
 L 134.598477 125.76687 
 L 124.077268 149.129162 
 L 122.462976 157.203722 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m2af8fc868a" d="M -0 3.535534 
+     <path id="mdb87f9ed4c" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m2af8fc868a" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2af8fc868a" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3af40a48e5)">
+     <use xlink:href="#mdb87f9ed4c" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdb87f9ed4c" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdb87f9ed4c" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdb87f9ed4c" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdb87f9ed4c" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdb87f9ed4c" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdb87f9ed4c" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdb87f9ed4c" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdb87f9ed4c" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <path d="M 75.810937 396.236449 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m7e6694d5b1" d="M -0 2.5 
+     <path id="m0e30e38fd2" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m7e6694d5b1" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3af40a48e5)">
+     <use xlink:href="#m0e30e38fd2" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
@@ -1808,9 +1808,9 @@ L 164.441833 158.457887
 L 157.761315 167.001817 
 L 151.269082 181.244808 
 L 150.327087 186.982195 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mcbe58fd8a6" d="M -0.833333 2.5 
+     <path id="maa5bac2a13" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1825,16 +1825,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#mcbe58fd8a6" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcbe58fd8a6" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3af40a48e5)">
+     <use xlink:href="#maa5bac2a13" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa5bac2a13" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa5bac2a13" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa5bac2a13" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa5bac2a13" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa5bac2a13" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa5bac2a13" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa5bac2a13" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa5bac2a13" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
@@ -1847,9 +1847,9 @@ L 181.064802 166.690306
 L 179.282169 170.285179 
 L 177.719335 175.659634 
 L 177.643939 181.03308 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="m5b66e67a84" d="M -1.25 2.5 
+     <path id="m512659b72f" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1864,16 +1864,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m5b66e67a84" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b66e67a84" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3af40a48e5)">
+     <use xlink:href="#m512659b72f" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m512659b72f" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m512659b72f" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m512659b72f" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m512659b72f" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m512659b72f" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m512659b72f" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m512659b72f" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m512659b72f" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
@@ -1886,9 +1886,9 @@ L 160.37503 145.292152
 L 153.995779 152.427338 
 L 147.106887 167.637027 
 L 145.871703 174.910889 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="macb9df86c3" d="M 0 -2.5 
+     <path id="m97a9925f3e" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1901,16 +1901,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#macb9df86c3" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#macb9df86c3" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p3af40a48e5)">
+     <use xlink:href="#m97a9925f3e" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m97a9925f3e" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m97a9925f3e" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m97a9925f3e" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m97a9925f3e" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m97a9925f3e" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m97a9925f3e" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m97a9925f3e" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m97a9925f3e" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
@@ -1923,9 +1923,9 @@ L 213.541392 204.840226
 L 204.551957 212.456838 
 L 195.860087 228.889995 
 L 194.019853 234.405357 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
     <defs>
-     <path id="mdac33ce478" d="M 0 -2.5 
+     <path id="m20a9354abf" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1934,16 +1934,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#mdac33ce478" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdac33ce478" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3af40a48e5)">
+     <use xlink:href="#m20a9354abf" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20a9354abf" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20a9354abf" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20a9354abf" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20a9354abf" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20a9354abf" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20a9354abf" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20a9354abf" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m20a9354abf" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1966,7 +1966,7 @@ L 434.04625 353.9475
 L 442.04625 353.9475 
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <defs>
-      <path id="m1859526068" d="M 0 3.5 
+      <path id="m0582817a76" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1979,7 +1979,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m1859526068" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m0582817a76" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -2042,7 +2042,7 @@ L 434.04625 365.69
 L 442.04625 365.69 
 " style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m50c0fa6663" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m42ef41c1b6" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2060,7 +2060,7 @@ L 434.04625 377.4325
 L 442.04625 377.4325 
 " style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m9242dac054" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3bc12a509d" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2109,7 +2109,7 @@ L 434.04625 389.3975
 L 442.04625 389.3975 
 " style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2af8fc868a" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdb87f9ed4c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2156,7 +2156,7 @@ L 434.04625 401.14
 L 442.04625 401.14 
 " style="fill: none; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7e6694d5b1" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0e30e38fd2" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2176,7 +2176,7 @@ L 537.72375 353.9475
 L 545.72375 353.9475 
 " style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mcbe58fd8a6" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#maa5bac2a13" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -2234,7 +2234,7 @@ L 537.72375 365.69
 L 545.72375 365.69 
 " style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m5b66e67a84" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m512659b72f" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2303,7 +2303,7 @@ L 537.72375 377.4325
 L 545.72375 377.4325 
 " style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#macb9df86c3" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m97a9925f3e" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -2345,7 +2345,7 @@ L 537.72375 389.175
 L 545.72375 389.175 
 " style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#mdac33ce478" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m20a9354abf" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -2415,26 +2415,26 @@ z
     </g>
    </g>
    <g id="line2d_84">
-    <path d="M 257.531237 155.637342 
-L 236.23654 159.215188 
-L 222.073314 163.095774 
-L 202.315941 172.716799 
-L 199.905291 174.333319 
-L 195.893147 178.106216 
-L 157.982343 243.551047 
-L 157.246106 245.651483 
-L 95.319203 357.56427 
-" clip-path="url(#p82ad7000b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <g clip-path="url(#p82ad7000b3)">
-     <use xlink:href="#m1859526068" x="257.531237" y="155.637342" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="236.23654" y="159.215188" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="222.073314" y="163.095774" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="202.315941" y="172.716799" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="199.905291" y="174.333319" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="195.893147" y="178.106216" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="157.982343" y="243.551047" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="157.246106" y="245.651483" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1859526068" x="95.319203" y="357.56427" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <path d="M 257.531237 154.117306 
+L 236.23654 158.325017 
+L 222.073314 162.378169 
+L 202.315941 172.234836 
+L 199.905291 173.801624 
+L 195.893147 177.650782 
+L 157.982343 243.413735 
+L 157.246106 245.421167 
+L 95.319203 357.164608 
+" clip-path="url(#p3af40a48e5)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <g clip-path="url(#p3af40a48e5)">
+     <use xlink:href="#m0582817a76" x="257.531237" y="154.117306" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0582817a76" x="236.23654" y="158.325017" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0582817a76" x="222.073314" y="162.378169" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0582817a76" x="202.315941" y="172.234836" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0582817a76" x="199.905291" y="173.801624" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0582817a76" x="195.893147" y="177.650782" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0582817a76" x="157.982343" y="243.413735" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0582817a76" x="157.246106" y="245.421167" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m0582817a76" x="95.319203" y="357.164608" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2803,8 +2803,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
+   <!-- 2026-06-21T13:19:57Z  ·  Linux chungus x86_64  ·  commit 6206cfe6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.977734 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2830,6 +2830,36 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
 L 3169 4134 
@@ -2853,6 +2883,16 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2912,46 +2952,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -2990,16 +2990,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3038,109 +3038,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3414.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3478.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3637.011719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3726.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.597656 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.976562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3953.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4135.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4176.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4210.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4299.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.591797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.970703 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.59375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4521.285156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.464844 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4644.087891 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.498047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4803.121094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.908203 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.615234 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.478516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5092.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.869141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5251.017578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.46875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.650391 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5517.029297 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.505859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.884766 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5707.361328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.949219 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.525391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5957.3125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6116.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.787109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6332.166016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6416.052734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.710938 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6604.1875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6656.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.666016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.847656 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6820.056641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.748047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.535156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.648438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7027.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.919922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7116.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.771484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7323.035156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.767578 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7485.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.654297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7622.066406 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.849609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.228516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7741.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7793.111328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7832.320312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7860.103516 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p82ad7000b3">
+  <clipPath id="p3af40a48e5">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pdf9118cc88)">
+   <g clip-path="url(#p9c40e71967)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image193907e3da" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKA0lEQVR4nO3YvaufZx3H8XNyTpqQk+YkB43FKj6kiFCr4FKq4FQcRAdXHRz8C1ycnMTdwamToOAmxUWJQ8dCfbZOFusDPhBi06SxpMnJyfn5F7wHKRdf+fF6/QUfuG+u+31fu6c3XtjsbKHjH12fnrDE2eefmZ6wzO7V909PWGLzu99PT1hi95NPT09YYnPv7vSEZW5+88XpCUtc/c4XpycssXv0vukJaxzfm16wzOkvtvO8PzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPuf4xc30yNWOHjz5vSEJd64dGF6wjLvnLw9PWGJD751PD1hibfe+8T0hCVON6fTE5a5sn80PWGNW3+dXrDE3Svb+bwe/8sfpycss/nYs9MTlnCzCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2j+4dWN6wxoXLk8vWGKzOZ6esMwHXvrV9IQ1nv/C9IIlDt/41/SENU5Pphesc7Cl58e5i9MLlrj07+38Pt/+0LXpCctc+fur0xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApN2Hj65vpkessHfzz9MTlrjx+GPTE5Z5++Gd6QlLXPvbnekJS5x84jPTE5a4d3J3esIyh3uXpycssXn9l9MTlrj/0WemJyxx/tVXpics8+BTz01PWMLNIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJB2f/L6NzbTI1Y4On8wPWGJ1+7cmp6wzNe/95vpCUv89ttfmp6wxOG5w+kJS3zr5V9PT1jmc0+en56wxJevPTc9YYmX/vHK9IQlLp7dzvdwZ2dn58d/uj09YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaffjo+mZ6xAq3H9ycnrDEwf6l6QnLvHbnD9MTlnjq8tPTE5bYbE6nJyxx8WR7/6H/ebqd5+KTB09NT1ji/qN70xOW2NazY2dnZ2fvzP70hCW291QEAOBdE4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2t/b3Z/esMR79o6mJ6yx99j0gmUOzx1OT1jiYP/S9IQlHm1OpicscXp2e/+hn9hcmJ7A/2Bbv8/Hm/vTE5a5++Dm9IQltvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAACk/ekBq5x8/wfTE5bY/9pXpics8+GLH5+esMTm5Z9OT1hi79nPT09Y4503pxcsc/+7P5yesMSZr352esISZz7y6ekJS1z4+c+mJyxz4erR9IQl3CwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAASSwCAJDEIgAA6b+c5JUBDGQktwAAAABJRU5ErkJggg==" id="image4a2b3497f8" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m437818802e" d="M 0 0 
+       <path id="m4c968df5e4" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m437818802e" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m437818802e" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m437818802e" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m437818802e" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m437818802e" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m437818802e" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m437818802e" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m437818802e" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m437818802e" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m437818802e" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m437818802e" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m437818802e" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c968df5e4" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m00a7a1f506" d="M 0 0 
+       <path id="m685f087fb2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m685f087fb2" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m685f087fb2" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m685f087fb2" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m685f087fb2" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m685f087fb2" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m685f087fb2" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m685f087fb2" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m00a7a1f506" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m685f087fb2" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagece0c6a463b" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageee4a9fb272" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m634ef6ffb6" d="M 0 0 
+       <path id="m59992acdb4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m59992acdb4" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m59992acdb4" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m59992acdb4" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m59992acdb4" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m634ef6ffb6" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m59992acdb4" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-06-21T13:19:57Z  ·  Linux chungus x86_64  ·  commit 6206cfe6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.977734 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2870,16 +2870,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3414.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3478.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3637.011719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3726.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.597656 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.976562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3953.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4135.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4176.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4210.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4299.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.591797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.970703 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.59375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4521.285156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.464844 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4644.087891 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.498047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4803.121094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.908203 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.615234 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.478516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5092.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.869141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5251.017578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.46875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.650391 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5517.029297 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.505859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.884766 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5707.361328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.949219 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.525391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5957.3125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6116.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.787109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6332.166016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6416.052734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.710938 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6604.1875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6656.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.666016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.847656 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6820.056641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.748047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.535156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.648438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7027.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.919922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7116.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.771484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7323.035156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.767578 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7485.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.654297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7622.066406 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.849609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.228516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7741.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7793.111328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7832.320312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7860.103516 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pdf9118cc88">
+  <clipPath id="p9c40e71967">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.444531pt" height="386.202469pt" viewBox="0 0 568.444531 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.022031 386.202469 
-L 569.022031 0 
+L 568.444531 386.202469 
+L 568.444531 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.636016 104.1264 
-L 291.261016 104.1264 
-L 291.261016 74.7432 
-L 186.636016 74.7432 
+    <path d="M 186.347266 104.1264 
+L 290.972266 104.1264 
+L 290.972266 74.7432 
+L 186.347266 74.7432 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.261016 104.1264 
-L 395.886016 104.1264 
-L 395.886016 74.7432 
-L 291.261016 74.7432 
+    <path d="M 290.972266 104.1264 
+L 395.597266 104.1264 
+L 395.597266 74.7432 
+L 290.972266 74.7432 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.886016 104.1264 
-L 500.511016 104.1264 
-L 500.511016 74.7432 
-L 395.886016 74.7432 
+    <path d="M 395.597266 104.1264 
+L 500.222266 104.1264 
+L 500.222266 74.7432 
+L 395.597266 74.7432 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.636016 133.5096 
-L 291.261016 133.5096 
-L 291.261016 104.1264 
-L 186.636016 104.1264 
+    <path d="M 186.347266 133.5096 
+L 290.972266 133.5096 
+L 290.972266 104.1264 
+L 186.347266 104.1264 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.261016 133.5096 
-L 395.886016 133.5096 
-L 395.886016 104.1264 
-L 291.261016 104.1264 
+    <path d="M 290.972266 133.5096 
+L 395.597266 133.5096 
+L 395.597266 104.1264 
+L 290.972266 104.1264 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.886016 133.5096 
-L 500.511016 133.5096 
-L 500.511016 104.1264 
-L 395.886016 104.1264 
+    <path d="M 395.597266 133.5096 
+L 500.222266 133.5096 
+L 500.222266 104.1264 
+L 395.597266 104.1264 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.636016 162.8928 
-L 291.261016 162.8928 
-L 291.261016 133.5096 
-L 186.636016 133.5096 
+    <path d="M 186.347266 162.8928 
+L 290.972266 162.8928 
+L 290.972266 133.5096 
+L 186.347266 133.5096 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.261016 162.8928 
-L 395.886016 162.8928 
-L 395.886016 133.5096 
-L 291.261016 133.5096 
+    <path d="M 290.972266 162.8928 
+L 395.597266 162.8928 
+L 395.597266 133.5096 
+L 290.972266 133.5096 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.886016 162.8928 
-L 500.511016 162.8928 
-L 500.511016 133.5096 
-L 395.886016 133.5096 
+    <path d="M 395.597266 162.8928 
+L 500.222266 162.8928 
+L 500.222266 133.5096 
+L 395.597266 133.5096 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.636016 192.276 
-L 291.261016 192.276 
-L 291.261016 162.8928 
-L 186.636016 162.8928 
+    <path d="M 186.347266 192.276 
+L 290.972266 192.276 
+L 290.972266 162.8928 
+L 186.347266 162.8928 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.261016 192.276 
-L 395.886016 192.276 
-L 395.886016 162.8928 
-L 291.261016 162.8928 
+    <path d="M 290.972266 192.276 
+L 395.597266 192.276 
+L 395.597266 162.8928 
+L 290.972266 162.8928 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.886016 192.276 
-L 500.511016 192.276 
-L 500.511016 162.8928 
-L 395.886016 162.8928 
+    <path d="M 395.597266 192.276 
+L 500.222266 192.276 
+L 500.222266 162.8928 
+L 395.597266 162.8928 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.636016 221.6592 
-L 291.261016 221.6592 
-L 291.261016 192.276 
-L 186.636016 192.276 
+    <path d="M 186.347266 221.6592 
+L 290.972266 221.6592 
+L 290.972266 192.276 
+L 186.347266 192.276 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.261016 221.6592 
-L 395.886016 221.6592 
-L 395.886016 192.276 
-L 291.261016 192.276 
+    <path d="M 290.972266 221.6592 
+L 395.597266 221.6592 
+L 395.597266 192.276 
+L 290.972266 192.276 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.886016 221.6592 
-L 500.511016 221.6592 
-L 500.511016 192.276 
-L 395.886016 192.276 
+    <path d="M 395.597266 221.6592 
+L 500.222266 221.6592 
+L 500.222266 192.276 
+L 395.597266 192.276 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.636016 251.0424 
-L 291.261016 251.0424 
-L 291.261016 221.6592 
-L 186.636016 221.6592 
+    <path d="M 186.347266 251.0424 
+L 290.972266 251.0424 
+L 290.972266 221.6592 
+L 186.347266 221.6592 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.261016 251.0424 
-L 395.886016 251.0424 
-L 395.886016 221.6592 
-L 291.261016 221.6592 
+    <path d="M 290.972266 251.0424 
+L 395.597266 251.0424 
+L 395.597266 221.6592 
+L 290.972266 221.6592 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.886016 251.0424 
-L 500.511016 251.0424 
-L 500.511016 221.6592 
-L 395.886016 221.6592 
+    <path d="M 395.597266 251.0424 
+L 500.222266 251.0424 
+L 500.222266 221.6592 
+L 395.597266 221.6592 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.636016 280.4256 
-L 291.261016 280.4256 
-L 291.261016 251.0424 
-L 186.636016 251.0424 
+    <path d="M 186.347266 280.4256 
+L 290.972266 280.4256 
+L 290.972266 251.0424 
+L 186.347266 251.0424 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #f8864f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.261016 280.4256 
-L 395.886016 280.4256 
-L 395.886016 251.0424 
-L 291.261016 251.0424 
+    <path d="M 290.972266 280.4256 
+L 395.597266 280.4256 
+L 395.597266 251.0424 
+L 290.972266 251.0424 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.886016 280.4256 
-L 500.511016 280.4256 
-L 500.511016 251.0424 
-L 395.886016 251.0424 
+    <path d="M 395.597266 280.4256 
+L 500.222266 280.4256 
+L 500.222266 251.0424 
+L 395.597266 251.0424 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #f7844e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.636016 309.8088 
-L 291.261016 309.8088 
-L 291.261016 280.4256 
-L 186.636016 280.4256 
+    <path d="M 186.347266 309.8088 
+L 290.972266 309.8088 
+L 290.972266 280.4256 
+L 186.347266 280.4256 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.261016 309.8088 
-L 395.886016 309.8088 
-L 395.886016 280.4256 
-L 291.261016 280.4256 
+    <path d="M 290.972266 309.8088 
+L 395.597266 309.8088 
+L 395.597266 280.4256 
+L 290.972266 280.4256 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.886016 309.8088 
-L 500.511016 309.8088 
-L 500.511016 280.4256 
-L 395.886016 280.4256 
+    <path d="M 395.597266 309.8088 
+L 500.222266 309.8088 
+L 500.222266 280.4256 
+L 395.597266 280.4256 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.636016 339.192 
-L 291.261016 339.192 
-L 291.261016 309.8088 
-L 186.636016 309.8088 
+    <path d="M 186.347266 339.192 
+L 290.972266 339.192 
+L 290.972266 309.8088 
+L 186.347266 309.8088 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.261016 339.192 
-L 395.886016 339.192 
-L 395.886016 309.8088 
-L 291.261016 309.8088 
+    <path d="M 290.972266 339.192 
+L 395.597266 339.192 
+L 395.597266 309.8088 
+L 290.972266 309.8088 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.886016 339.192 
-L 500.511016 339.192 
-L 500.511016 309.8088 
-L 395.886016 309.8088 
+    <path d="M 395.597266 339.192 
+L 500.222266 339.192 
+L 500.222266 309.8088 
+L 395.597266 309.8088 
 z
-" clip-path="url(#p1f9872afb5)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc65e0334e9)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.334531 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.61875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.190859 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.542578 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.272266 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.649766 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.910391 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.892266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.603516 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(118.924766 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(118.636016 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.462266 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.173516 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(110.768516 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(110.479766 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(227.497266 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(338.483516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(440.563516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.274766 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.270391 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.981641 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.332 -->
-    <g transform="translate(226.296641 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.007891 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1853,15 +1853,36 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 33 -->
-    <g transform="translate(338.007266 267.9415) scale(0.08 -0.08)">
+    <!-- 34 -->
+    <g transform="translate(337.718516 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 168 -->
-    <g transform="translate(439.849141 267.9415) scale(0.08 -0.08)">
+    <!-- 164 -->
+    <g transform="translate(439.560391 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1907,54 +1928,15 @@ Q 2900 4744 3203 4694
 Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
-z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.385391 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.096641 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2019,7 +2001,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2029,21 +2011,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.194766 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.819766 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.317891 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2054,7 +2036,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.208516 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2064,13 +2046,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.739766 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.909766 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2086,7 +2068,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.112734 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(150.823984 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2200,7 +2182,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-06-20T12:25:48Z  ·  Linux chungus x86_64  ·  commit a19271bf  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-06-21T13:19:57Z  ·  Linux chungus x86_64  ·  commit 6206cfe6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2339,16 +2321,16 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2387,110 +2369,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3069.53125 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.154297 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3352.929688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3414.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3478.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3509.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3541.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3573.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3605.224609 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3637.011719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3664.794922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3726.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3787.597656 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3850.976562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3914.453125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3953.316406 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4014.498047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4073.677734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4135.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4176.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4210.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4237.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4299.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4360.591797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4423.970703 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4487.59375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4521.285156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4580.464844 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4644.087891 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4675.875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4739.498047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4803.121094 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4834.908203 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4898.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4934.615234 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4973.478516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5028.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5092.082031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5123.869141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5155.65625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5187.443359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5219.230469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5251.017578 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5353.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5392.46875 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5453.650391 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5517.029297 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5580.505859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5643.884766 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5707.361328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5770.740234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5809.949219 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5841.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5925.525391 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5957.3125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6054.724609 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6116.248047 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6179.724609 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6207.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6268.787109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6332.166016 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6363.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6416.052734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6479.431641 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6540.710938 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6604.1875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6656.287109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6719.666016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6780.847656 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6820.056641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6853.748047 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6885.535156 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6926.648438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6987.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7027.136719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7054.919922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7116.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7147.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7175.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7227.771484 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7259.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7323.035156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7384.558594 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.767578 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7485.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7524.654297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7622.066406 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7649.849609 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7713.228516 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7741.011719 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7793.111328 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7832.320312 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7860.103516 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1f9872afb5">
-   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pc65e0334e9">
+   <rect x="81.722266" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-06-20T12:25:48Z",
+  "date": "2026-06-21T13:19:57Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "a19271bf",
+  "git_commit": "6206cfe6",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 56868,
    "ratio": 0.3739,
-   "compress_mbps": 39.68,
-   "decompress_mbps": 126.92
+   "compress_mbps": 40.25,
+   "decompress_mbps": 126.38
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56050,
    "ratio": 0.3685,
-   "compress_mbps": 37.47,
-   "decompress_mbps": 139.53
+   "compress_mbps": 37.28,
+   "decompress_mbps": 139.41
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55543,
    "ratio": 0.3652,
-   "compress_mbps": 34.06,
-   "decompress_mbps": 155.07
+   "compress_mbps": 34.33,
+   "decompress_mbps": 154.21
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54765,
    "ratio": 0.3601,
-   "compress_mbps": 27.6,
-   "decompress_mbps": 160.98
+   "compress_mbps": 27.52,
+   "decompress_mbps": 159.75
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 26.81,
-   "decompress_mbps": 165.43
+   "compress_mbps": 26.78,
+   "decompress_mbps": 163.98
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54535,
    "ratio": 0.3586,
-   "compress_mbps": 24.71,
-   "decompress_mbps": 172.51
+   "compress_mbps": 24.98,
+   "decompress_mbps": 171.69
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 9.38,
-   "decompress_mbps": 171.27
+   "compress_mbps": 9.34,
+   "decompress_mbps": 169.1
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 9.1,
-   "decompress_mbps": 172.33
+   "compress_mbps": 9.21,
+   "decompress_mbps": 170.05
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52111,
    "ratio": 0.3426,
-   "compress_mbps": 1.25,
-   "decompress_mbps": 172.52
+   "compress_mbps": 1.26,
+   "decompress_mbps": 171.07
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 50489,
    "ratio": 0.4033,
-   "compress_mbps": 37.1,
-   "decompress_mbps": 122.99
+   "compress_mbps": 37.49,
+   "decompress_mbps": 121.91
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50023,
    "ratio": 0.3996,
-   "compress_mbps": 34.3,
-   "decompress_mbps": 128.57
+   "compress_mbps": 34.72,
+   "decompress_mbps": 127.31
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49768,
    "ratio": 0.3976,
-   "compress_mbps": 32.32,
-   "decompress_mbps": 136.82
+   "compress_mbps": 32.44,
+   "decompress_mbps": 135.71
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 49034,
    "ratio": 0.3917,
-   "compress_mbps": 25.49,
-   "decompress_mbps": 144.86
+   "compress_mbps": 25.5,
+   "decompress_mbps": 143.78
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 24.84,
-   "decompress_mbps": 153.18
+   "compress_mbps": 24.86,
+   "decompress_mbps": 151.11
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48934,
    "ratio": 0.3909,
-   "compress_mbps": 23.69,
-   "decompress_mbps": 154.5
+   "compress_mbps": 23.67,
+   "decompress_mbps": 152.71
   },
   {
    "compressor": "native",
@@ -165,7 +165,7 @@
    "out_size": 48634,
    "ratio": 0.3885,
    "compress_mbps": 8.9,
-   "decompress_mbps": 155.69
+   "decompress_mbps": 154.05
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 8.89,
-   "decompress_mbps": 156.26
+   "compress_mbps": 8.91,
+   "decompress_mbps": 154.58
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 1.37,
-   "decompress_mbps": 155.37
+   "compress_mbps": 1.39,
+   "decompress_mbps": 152.94
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8199,
    "ratio": 0.3333,
-   "compress_mbps": 33.7,
-   "decompress_mbps": 132.6
+   "compress_mbps": 34.07,
+   "decompress_mbps": 132.33
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8112,
    "ratio": 0.3297,
-   "compress_mbps": 32.75,
-   "decompress_mbps": 139.43
+   "compress_mbps": 32.98,
+   "decompress_mbps": 138.61
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8053,
    "ratio": 0.3273,
-   "compress_mbps": 31.59,
-   "decompress_mbps": 141.97
+   "compress_mbps": 32.18,
+   "decompress_mbps": 140.49
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7968,
    "ratio": 0.3239,
-   "compress_mbps": 30.24,
-   "decompress_mbps": 142.66
+   "compress_mbps": 30.55,
+   "decompress_mbps": 142.01
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 29.8,
-   "decompress_mbps": 148.83
+   "compress_mbps": 30.11,
+   "decompress_mbps": 147.29
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7949,
    "ratio": 0.3231,
-   "compress_mbps": 28.94,
-   "decompress_mbps": 148.54
+   "compress_mbps": 29.2,
+   "decompress_mbps": 146.68
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.67,
-   "decompress_mbps": 150.21
+   "compress_mbps": 9.73,
+   "decompress_mbps": 149.49
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 9.65,
-   "decompress_mbps": 150.65
+   "compress_mbps": 9.76,
+   "decompress_mbps": 148.87
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7727,
    "ratio": 0.3141,
-   "compress_mbps": 1.64,
-   "decompress_mbps": 150.71
+   "compress_mbps": 1.63,
+   "decompress_mbps": 147.97
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3282,
    "ratio": 0.2943,
-   "compress_mbps": 22.94,
-   "decompress_mbps": 103.02
+   "compress_mbps": 23.59,
+   "decompress_mbps": 101.46
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3227,
    "ratio": 0.2894,
-   "compress_mbps": 23.1,
-   "decompress_mbps": 106.47
+   "compress_mbps": 23.15,
+   "decompress_mbps": 104.61
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3183,
    "ratio": 0.2855,
-   "compress_mbps": 22.09,
-   "decompress_mbps": 108.64
+   "compress_mbps": 22.8,
+   "decompress_mbps": 105.97
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3147,
    "ratio": 0.2822,
-   "compress_mbps": 21.22,
-   "decompress_mbps": 111.5
+   "compress_mbps": 21.87,
+   "decompress_mbps": 109.74
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.27,
-   "decompress_mbps": 112.95
+   "compress_mbps": 21.68,
+   "decompress_mbps": 111.26
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3133,
    "ratio": 0.281,
-   "compress_mbps": 21.19,
-   "decompress_mbps": 113.72
+   "compress_mbps": 21.35,
+   "decompress_mbps": 112.09
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.06,
-   "decompress_mbps": 113.99
+   "compress_mbps": 7.12,
+   "decompress_mbps": 112.92
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 7.03,
-   "decompress_mbps": 113.43
+   "compress_mbps": 7.12,
+   "decompress_mbps": 112.83
   },
   {
    "compressor": "native",
@@ -365,7 +365,7 @@
    "out_size": 3027,
    "ratio": 0.2715,
    "compress_mbps": 1.54,
-   "decompress_mbps": 113.45
+   "decompress_mbps": 113.75
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1227,
    "ratio": 0.3298,
-   "compress_mbps": 11.3,
-   "decompress_mbps": 52.0
+   "compress_mbps": 11.76,
+   "decompress_mbps": 51.99
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1223,
    "ratio": 0.3287,
-   "compress_mbps": 11.13,
-   "decompress_mbps": 52.14
+   "compress_mbps": 11.64,
+   "decompress_mbps": 52.61
   },
   {
    "compressor": "native",
@@ -394,7 +394,7 @@
    "level": 3,
    "out_size": 1222,
    "ratio": 0.3284,
-   "compress_mbps": 11.02,
+   "compress_mbps": 11.58,
    "decompress_mbps": 52.43
   },
   {
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.0,
-   "decompress_mbps": 53.06
+   "compress_mbps": 11.48,
+   "decompress_mbps": 53.3
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.04,
-   "decompress_mbps": 53.83
+   "compress_mbps": 11.52,
+   "decompress_mbps": 53.66
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 10.94,
-   "decompress_mbps": 53.73
+   "compress_mbps": 11.43,
+   "decompress_mbps": 53.91
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.77,
-   "decompress_mbps": 53.74
+   "compress_mbps": 3.85,
+   "decompress_mbps": 54.06
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 3.78,
-   "decompress_mbps": 53.56
+   "compress_mbps": 3.87,
+   "decompress_mbps": 54.21
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1190,
    "ratio": 0.3198,
-   "compress_mbps": 1.23,
-   "decompress_mbps": 53.79
+   "compress_mbps": 1.24,
+   "decompress_mbps": 53.82
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 243674,
    "ratio": 0.2366,
-   "compress_mbps": 62.65,
-   "decompress_mbps": 197.93
+   "compress_mbps": 64.22,
+   "decompress_mbps": 202.54
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242564,
    "ratio": 0.2356,
-   "compress_mbps": 59.78,
-   "decompress_mbps": 234.54
+   "compress_mbps": 60.63,
+   "decompress_mbps": 240.19
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 57.82,
-   "decompress_mbps": 253.1
+   "compress_mbps": 59.78,
+   "decompress_mbps": 250.8
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239898,
    "ratio": 0.233,
-   "compress_mbps": 55.52,
-   "decompress_mbps": 268.46
+   "compress_mbps": 55.88,
+   "decompress_mbps": 271.18
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 54.58,
-   "decompress_mbps": 189.62
+   "compress_mbps": 54.6,
+   "decompress_mbps": 192.76
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 239606,
    "ratio": 0.2327,
-   "compress_mbps": 51.64,
-   "decompress_mbps": 190.1
+   "compress_mbps": 51.9,
+   "decompress_mbps": 192.36
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 9.63,
-   "decompress_mbps": 168.16
+   "compress_mbps": 9.69,
+   "decompress_mbps": 173.7
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 7.59,
-   "decompress_mbps": 167.37
+   "compress_mbps": 7.69,
+   "decompress_mbps": 172.43
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 0.95,
-   "decompress_mbps": 165.3
+   "compress_mbps": 0.96,
+   "decompress_mbps": 168.82
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 150916,
    "ratio": 0.3536,
-   "compress_mbps": 43.13,
-   "decompress_mbps": 133.92
+   "compress_mbps": 43.88,
+   "decompress_mbps": 130.92
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 148848,
    "ratio": 0.3488,
-   "compress_mbps": 39.41,
-   "decompress_mbps": 142.51
+   "compress_mbps": 40.02,
+   "decompress_mbps": 140.48
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 147739,
    "ratio": 0.3462,
-   "compress_mbps": 36.51,
-   "decompress_mbps": 159.43
+   "compress_mbps": 36.87,
+   "decompress_mbps": 155.2
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145779,
    "ratio": 0.3416,
-   "compress_mbps": 28.83,
-   "decompress_mbps": 165.58
+   "compress_mbps": 28.96,
+   "decompress_mbps": 162.5
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 27.88,
-   "decompress_mbps": 173.65
+   "compress_mbps": 27.95,
+   "decompress_mbps": 170.26
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145374,
    "ratio": 0.3407,
-   "compress_mbps": 26.07,
-   "decompress_mbps": 174.78
+   "compress_mbps": 26.24,
+   "decompress_mbps": 171.45
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 9.93,
-   "decompress_mbps": 175.25
+   "compress_mbps": 9.92,
+   "decompress_mbps": 171.74
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 9.9,
-   "decompress_mbps": 175.78
+   "compress_mbps": 9.89,
+   "decompress_mbps": 171.73
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 138661,
    "ratio": 0.3249,
-   "compress_mbps": 1.3,
-   "decompress_mbps": 175.77
+   "compress_mbps": 1.31,
+   "decompress_mbps": 171.09
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 202083,
    "ratio": 0.4194,
-   "compress_mbps": 37.66,
-   "decompress_mbps": 117.9
+   "compress_mbps": 37.2,
+   "decompress_mbps": 115.38
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199922,
    "ratio": 0.4149,
-   "compress_mbps": 34.29,
-   "decompress_mbps": 128.42
+   "compress_mbps": 34.37,
+   "decompress_mbps": 125.57
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198538,
    "ratio": 0.412,
-   "compress_mbps": 31.08,
-   "decompress_mbps": 134.83
+   "compress_mbps": 31.53,
+   "decompress_mbps": 131.2
   },
   {
    "compressor": "native",
@@ -675,7 +675,7 @@
    "out_size": 195796,
    "ratio": 0.4063,
    "compress_mbps": 23.02,
-   "decompress_mbps": 141.65
+   "decompress_mbps": 138.08
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 22.28,
-   "decompress_mbps": 150.1
+   "compress_mbps": 22.12,
+   "decompress_mbps": 146.48
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 194965,
    "ratio": 0.4046,
-   "compress_mbps": 20.59,
-   "decompress_mbps": 153.22
+   "compress_mbps": 20.68,
+   "decompress_mbps": 149.83
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 8.44,
-   "decompress_mbps": 153.78
+   "compress_mbps": 8.43,
+   "decompress_mbps": 149.88
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 8.41,
-   "decompress_mbps": 153.79
+   "compress_mbps": 8.4,
+   "decompress_mbps": 149.94
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.25,
-   "decompress_mbps": 153.71
+   "compress_mbps": 1.26,
+   "decompress_mbps": 152.38
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 58252,
    "ratio": 0.1135,
-   "compress_mbps": 116.22,
-   "decompress_mbps": 368.05
+   "compress_mbps": 118.92,
+   "decompress_mbps": 364.59
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 57685,
    "ratio": 0.1124,
-   "compress_mbps": 103.34,
-   "decompress_mbps": 384.27
+   "compress_mbps": 106.74,
+   "decompress_mbps": 377.4
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 57118,
    "ratio": 0.1113,
-   "compress_mbps": 89.43,
-   "decompress_mbps": 403.92
+   "compress_mbps": 92.24,
+   "decompress_mbps": 395.93
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55724,
    "ratio": 0.1086,
-   "compress_mbps": 71.92,
-   "decompress_mbps": 369.09
+   "compress_mbps": 73.39,
+   "decompress_mbps": 372.17
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 69.43,
-   "decompress_mbps": 393.57
+   "compress_mbps": 70.7,
+   "decompress_mbps": 394.33
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55441,
    "ratio": 0.108,
-   "compress_mbps": 62.69,
-   "decompress_mbps": 415.82
+   "compress_mbps": 64.4,
+   "decompress_mbps": 418.26
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53495,
    "ratio": 0.1042,
-   "compress_mbps": 18.56,
-   "decompress_mbps": 437.7
+   "compress_mbps": 19.19,
+   "decompress_mbps": 435.75
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 16.36,
-   "decompress_mbps": 465.78
+   "compress_mbps": 17.02,
+   "decompress_mbps": 461.75
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 51490,
    "ratio": 0.1003,
-   "compress_mbps": 0.95,
-   "decompress_mbps": 474.79
+   "compress_mbps": 0.97,
+   "decompress_mbps": 472.49
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 13822,
    "ratio": 0.3615,
-   "compress_mbps": 26.27,
-   "decompress_mbps": 95.25
+   "compress_mbps": 26.8,
+   "decompress_mbps": 95.33
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13760,
    "ratio": 0.3598,
-   "compress_mbps": 25.84,
-   "decompress_mbps": 99.26
+   "compress_mbps": 25.88,
+   "decompress_mbps": 99.64
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13727,
    "ratio": 0.359,
-   "compress_mbps": 25.22,
-   "decompress_mbps": 103.64
+   "compress_mbps": 25.44,
+   "decompress_mbps": 104.26
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13371,
    "ratio": 0.3497,
-   "compress_mbps": 23.35,
-   "decompress_mbps": 100.8
+   "compress_mbps": 23.15,
+   "decompress_mbps": 101.59
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 22.89,
-   "decompress_mbps": 107.67
+   "compress_mbps": 22.97,
+   "decompress_mbps": 108.14
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13369,
    "ratio": 0.3496,
-   "compress_mbps": 21.64,
-   "decompress_mbps": 108.85
+   "compress_mbps": 21.86,
+   "decompress_mbps": 108.87
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13035,
    "ratio": 0.3409,
-   "compress_mbps": 5.81,
-   "decompress_mbps": 110.66
+   "compress_mbps": 5.88,
+   "decompress_mbps": 110.07
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 5.46,
-   "decompress_mbps": 114.32
+   "compress_mbps": 5.52,
+   "decompress_mbps": 112.81
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12278,
    "ratio": 0.3211,
-   "compress_mbps": 1.2,
-   "decompress_mbps": 111.97
+   "compress_mbps": 1.22,
+   "decompress_mbps": 113.67
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1747,
    "ratio": 0.4133,
-   "compress_mbps": 12.92,
-   "decompress_mbps": 55.42
+   "compress_mbps": 13.1,
+   "decompress_mbps": 55.31
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1741,
    "ratio": 0.4119,
-   "compress_mbps": 12.82,
-   "decompress_mbps": 56.32
+   "compress_mbps": 13.14,
+   "decompress_mbps": 56.49
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1740,
    "ratio": 0.4116,
-   "compress_mbps": 12.79,
-   "decompress_mbps": 56.07
+   "compress_mbps": 13.11,
+   "decompress_mbps": 56.74
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.55,
-   "decompress_mbps": 56.78
+   "compress_mbps": 12.78,
+   "decompress_mbps": 56.68
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.76,
-   "decompress_mbps": 57.62
+   "compress_mbps": 12.89,
+   "decompress_mbps": 57.54
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.62,
-   "decompress_mbps": 57.47
+   "compress_mbps": 12.9,
+   "decompress_mbps": 57.11
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.19,
-   "decompress_mbps": 57.5
+   "compress_mbps": 4.24,
+   "decompress_mbps": 57.55
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 4.16,
-   "decompress_mbps": 56.88
+   "compress_mbps": 4.22,
+   "decompress_mbps": 57.61
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 1.4,
-   "decompress_mbps": 57.42
+   "compress_mbps": 1.41,
+   "decompress_mbps": 57.73
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4020171,
    "ratio": 0.3944,
-   "compress_mbps": 36.8,
-   "decompress_mbps": 119.48
+   "compress_mbps": 37.91,
+   "decompress_mbps": 120.69
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3970599,
    "ratio": 0.3896,
-   "compress_mbps": 33.51,
-   "decompress_mbps": 128.19
+   "compress_mbps": 34.54,
+   "decompress_mbps": 129.98
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3943113,
    "ratio": 0.3869,
-   "compress_mbps": 32.93,
-   "decompress_mbps": 141.83
+   "compress_mbps": 33.67,
+   "decompress_mbps": 143.61
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3888008,
    "ratio": 0.3815,
-   "compress_mbps": 25.41,
-   "decompress_mbps": 144.09
+   "compress_mbps": 25.65,
+   "decompress_mbps": 147.14
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 24.68,
-   "decompress_mbps": 149.81
+   "compress_mbps": 24.85,
+   "decompress_mbps": 152.3
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3873339,
    "ratio": 0.38,
-   "compress_mbps": 22.94,
-   "decompress_mbps": 155.13
+   "compress_mbps": 23.02,
+   "decompress_mbps": 156.37
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 8.84,
-   "decompress_mbps": 159.53
+   "compress_mbps": 9.05,
+   "decompress_mbps": 160.17
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 8.94,
-   "decompress_mbps": 151.79
+   "compress_mbps": 9.08,
+   "decompress_mbps": 159.86
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3712344,
    "ratio": 0.3642,
-   "compress_mbps": 1.25,
-   "decompress_mbps": 160.89
+   "compress_mbps": 1.27,
+   "decompress_mbps": 161.26
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 20776195,
    "ratio": 0.4056,
-   "compress_mbps": 50.11,
-   "decompress_mbps": 109.48
+   "compress_mbps": 51.31,
+   "decompress_mbps": 111.06
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20636431,
    "ratio": 0.4029,
-   "compress_mbps": 47.49,
-   "decompress_mbps": 113.81
+   "compress_mbps": 48.59,
+   "decompress_mbps": 113.8
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20554782,
    "ratio": 0.4013,
-   "compress_mbps": 44.6,
-   "decompress_mbps": 118.57
+   "compress_mbps": 45.9,
+   "decompress_mbps": 118.83
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20408622,
    "ratio": 0.3984,
-   "compress_mbps": 38.29,
-   "decompress_mbps": 121.51
+   "compress_mbps": 38.61,
+   "decompress_mbps": 125.05
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 36.59,
-   "decompress_mbps": 129.68
+   "compress_mbps": 37.15,
+   "decompress_mbps": 130.6
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 20370310,
    "ratio": 0.3977,
-   "compress_mbps": 32.58,
-   "decompress_mbps": 133.53
+   "compress_mbps": 32.92,
+   "decompress_mbps": 135.1
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 19177172,
    "ratio": 0.3744,
-   "compress_mbps": 7.55,
-   "decompress_mbps": 132.09
+   "compress_mbps": 7.49,
+   "decompress_mbps": 134.3
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 6.98,
-   "decompress_mbps": 133.69
+   "compress_mbps": 6.95,
+   "decompress_mbps": 136.85
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18518350,
    "ratio": 0.3615,
-   "compress_mbps": 1.17,
-   "decompress_mbps": 133.1
+   "compress_mbps": 1.19,
+   "decompress_mbps": 135.71
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3771859,
    "ratio": 0.3783,
-   "compress_mbps": 51.18,
-   "decompress_mbps": 104.37
+   "compress_mbps": 52.23,
+   "decompress_mbps": 106.37
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3733442,
    "ratio": 0.3744,
-   "compress_mbps": 47.03,
-   "decompress_mbps": 107.27
+   "compress_mbps": 47.99,
+   "decompress_mbps": 109.61
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708043,
    "ratio": 0.3719,
-   "compress_mbps": 42.09,
-   "decompress_mbps": 108.91
+   "compress_mbps": 42.52,
+   "decompress_mbps": 110.7
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3713154,
    "ratio": 0.3724,
-   "compress_mbps": 31.14,
-   "decompress_mbps": 100.95
+   "compress_mbps": 31.32,
+   "decompress_mbps": 104.95
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 29.4,
-   "decompress_mbps": 107.95
+   "compress_mbps": 29.87,
+   "decompress_mbps": 111.03
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3701198,
    "ratio": 0.3712,
-   "compress_mbps": 27.19,
-   "decompress_mbps": 110.06
+   "compress_mbps": 27.35,
+   "decompress_mbps": 113.3
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3609769,
    "ratio": 0.362,
-   "compress_mbps": 8.43,
-   "decompress_mbps": 109.54
+   "compress_mbps": 8.39,
+   "decompress_mbps": 115.22
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 8.04,
-   "decompress_mbps": 111.83
+   "compress_mbps": 8.19,
+   "decompress_mbps": 115.26
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3520112,
    "ratio": 0.3531,
-   "compress_mbps": 0.98,
-   "decompress_mbps": 115.32
+   "compress_mbps": 1.0,
+   "decompress_mbps": 118.58
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3555940,
    "ratio": 0.106,
-   "compress_mbps": 115.44,
-   "decompress_mbps": 420.5
+   "compress_mbps": 120.96,
+   "decompress_mbps": 420.09
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3447001,
    "ratio": 0.1027,
-   "compress_mbps": 102.54,
-   "decompress_mbps": 469.25
+   "compress_mbps": 104.36,
+   "decompress_mbps": 458.81
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3338834,
    "ratio": 0.0995,
-   "compress_mbps": 87.59,
-   "decompress_mbps": 525.66
+   "compress_mbps": 88.47,
+   "decompress_mbps": 508.56
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3233721,
    "ratio": 0.0964,
-   "compress_mbps": 78.22,
-   "decompress_mbps": 538.47
+   "compress_mbps": 79.51,
+   "decompress_mbps": 531.7
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 76.54,
-   "decompress_mbps": 606.23
+   "compress_mbps": 77.55,
+   "decompress_mbps": 592.77
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3207256,
    "ratio": 0.0956,
-   "compress_mbps": 70.87,
-   "decompress_mbps": 653.11
+   "compress_mbps": 71.5,
+   "decompress_mbps": 632.7
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3123611,
    "ratio": 0.0931,
-   "compress_mbps": 25.82,
-   "decompress_mbps": 651.66
+   "compress_mbps": 26.0,
+   "decompress_mbps": 633.79
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 22.57,
-   "decompress_mbps": 654.54
+   "compress_mbps": 22.72,
+   "decompress_mbps": 657.53
   },
   {
    "compressor": "native",
@@ -4324,8 +4324,8 @@
    "level": 9,
    "out_size": 2868751,
    "ratio": 0.0855,
-   "compress_mbps": 0.77,
-   "decompress_mbps": 635.2
+   "compress_mbps": 0.78,
+   "decompress_mbps": 598.8
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3285977,
    "ratio": 0.5341,
-   "compress_mbps": 35.88,
-   "decompress_mbps": 72.27
+   "compress_mbps": 37.53,
+   "decompress_mbps": 72.84
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3273720,
    "ratio": 0.5321,
-   "compress_mbps": 35.63,
-   "decompress_mbps": 74.7
+   "compress_mbps": 36.13,
+   "decompress_mbps": 74.33
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3266820,
    "ratio": 0.531,
-   "compress_mbps": 34.63,
-   "decompress_mbps": 80.56
+   "compress_mbps": 35.05,
+   "decompress_mbps": 78.03
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3238141,
    "ratio": 0.5263,
-   "compress_mbps": 29.33,
-   "decompress_mbps": 81.54
+   "compress_mbps": 29.54,
+   "decompress_mbps": 81.79
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 28.95,
-   "decompress_mbps": 84.67
+   "compress_mbps": 28.86,
+   "decompress_mbps": 85.67
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3235481,
    "ratio": 0.5259,
-   "compress_mbps": 27.74,
-   "decompress_mbps": 85.95
+   "compress_mbps": 27.96,
+   "decompress_mbps": 87.39
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3165678,
    "ratio": 0.5146,
-   "compress_mbps": 6.91,
-   "decompress_mbps": 87.79
+   "compress_mbps": 6.92,
+   "decompress_mbps": 89.32
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 6.8,
-   "decompress_mbps": 88.77
+   "compress_mbps": 6.83,
+   "decompress_mbps": 89.82
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3017696,
    "ratio": 0.4905,
-   "compress_mbps": 1.45,
-   "decompress_mbps": 88.41
+   "compress_mbps": 1.46,
+   "decompress_mbps": 88.8
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3788537,
    "ratio": 0.3756,
-   "compress_mbps": 52.37,
-   "decompress_mbps": 100.23
+   "compress_mbps": 53.62,
+   "decompress_mbps": 104.42
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3760350,
    "ratio": 0.3728,
-   "compress_mbps": 49.3,
-   "decompress_mbps": 103.88
+   "compress_mbps": 49.7,
+   "decompress_mbps": 108.22
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3754713,
    "ratio": 0.3723,
-   "compress_mbps": 48.31,
-   "decompress_mbps": 106.54
+   "compress_mbps": 47.79,
+   "decompress_mbps": 111.88
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3707210,
    "ratio": 0.3676,
-   "compress_mbps": 44.95,
-   "decompress_mbps": 107.56
+   "compress_mbps": 44.93,
+   "decompress_mbps": 110.83
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 45.03,
-   "decompress_mbps": 104.38
+   "compress_mbps": 45.18,
+   "decompress_mbps": 107.92
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3706877,
    "ratio": 0.3675,
-   "compress_mbps": 44.51,
-   "decompress_mbps": 104.38
+   "compress_mbps": 44.84,
+   "decompress_mbps": 108.78
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.02,
-   "decompress_mbps": 107.11
+   "compress_mbps": 12.05,
+   "decompress_mbps": 111.18
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 12.03,
-   "decompress_mbps": 105.89
+   "compress_mbps": 12.13,
+   "decompress_mbps": 109.94
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3647083,
    "ratio": 0.3616,
-   "compress_mbps": 1.76,
-   "decompress_mbps": 106.4
+   "compress_mbps": 1.77,
+   "decompress_mbps": 113.15
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2075987,
    "ratio": 0.3133,
-   "compress_mbps": 45.3,
-   "decompress_mbps": 145.81
+   "compress_mbps": 47.26,
+   "decompress_mbps": 146.83
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2018042,
    "ratio": 0.3045,
-   "compress_mbps": 41.76,
-   "decompress_mbps": 161.19
+   "compress_mbps": 41.98,
+   "decompress_mbps": 161.49
   },
   {
    "compressor": "native",
@@ -4535,7 +4535,7 @@
    "out_size": 1977555,
    "ratio": 0.2984,
    "compress_mbps": 36.17,
-   "decompress_mbps": 177.56
+   "decompress_mbps": 176.98
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1911442,
    "ratio": 0.2884,
-   "compress_mbps": 26.41,
-   "decompress_mbps": 181.87
+   "compress_mbps": 26.54,
+   "decompress_mbps": 181.91
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 24.14,
-   "decompress_mbps": 190.93
+   "compress_mbps": 24.23,
+   "decompress_mbps": 194.64
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1883325,
    "ratio": 0.2842,
-   "compress_mbps": 20.31,
-   "decompress_mbps": 199.65
+   "compress_mbps": 20.1,
+   "decompress_mbps": 150.74
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1843401,
    "ratio": 0.2782,
-   "compress_mbps": 8.35,
-   "decompress_mbps": 199.68
+   "compress_mbps": 8.42,
+   "decompress_mbps": 217.53
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 7.73,
-   "decompress_mbps": 215.64
+   "compress_mbps": 7.68,
+   "decompress_mbps": 213.4
   },
   {
    "compressor": "native",
@@ -4595,7 +4595,7 @@
    "out_size": 1724560,
    "ratio": 0.2602,
    "compress_mbps": 0.91,
-   "decompress_mbps": 211.06
+   "decompress_mbps": 215.77
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6091028,
    "ratio": 0.2819,
-   "compress_mbps": 65.82,
-   "decompress_mbps": 216.33
+   "compress_mbps": 66.39,
+   "decompress_mbps": 216.01
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6008304,
    "ratio": 0.2781,
-   "compress_mbps": 59.68,
-   "decompress_mbps": 227.91
+   "compress_mbps": 60.16,
+   "decompress_mbps": 227.16
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 5963161,
    "ratio": 0.276,
-   "compress_mbps": 53.72,
-   "decompress_mbps": 238.38
+   "compress_mbps": 55.26,
+   "decompress_mbps": 240.17
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5886640,
    "ratio": 0.2724,
-   "compress_mbps": 46.19,
-   "decompress_mbps": 249.5
+   "compress_mbps": 46.63,
+   "decompress_mbps": 249.82
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 45.2,
-   "decompress_mbps": 259.7
+   "compress_mbps": 45.33,
+   "decompress_mbps": 256.3
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5873572,
    "ratio": 0.2718,
-   "compress_mbps": 42.02,
-   "decompress_mbps": 264.49
+   "compress_mbps": 42.5,
+   "decompress_mbps": 263.98
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5409010,
    "ratio": 0.2503,
-   "compress_mbps": 13.27,
-   "decompress_mbps": 247.44
+   "compress_mbps": 13.24,
+   "decompress_mbps": 251.36
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 12.81,
-   "decompress_mbps": 253.69
+   "compress_mbps": 12.85,
+   "decompress_mbps": 252.75
   },
   {
    "compressor": "native",
@@ -4685,7 +4685,7 @@
    "out_size": 5169629,
    "ratio": 0.2393,
    "compress_mbps": 1.3,
-   "decompress_mbps": 259.35
+   "decompress_mbps": 265.64
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5553060,
    "ratio": 0.7657,
-   "compress_mbps": 31.32,
-   "decompress_mbps": 104.75
+   "compress_mbps": 32.29,
+   "decompress_mbps": 100.46
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533873,
    "ratio": 0.7631,
-   "compress_mbps": 30.72,
-   "decompress_mbps": 107.75
+   "compress_mbps": 31.25,
+   "decompress_mbps": 103.94
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 29.6,
-   "decompress_mbps": 112.27
+   "compress_mbps": 29.96,
+   "decompress_mbps": 107.34
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5500073,
    "ratio": 0.7584,
-   "compress_mbps": 25.0,
-   "decompress_mbps": 114.03
+   "compress_mbps": 25.35,
+   "decompress_mbps": 110.39
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 24.39,
-   "decompress_mbps": 117.25
+   "compress_mbps": 24.95,
+   "decompress_mbps": 111.76
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5497402,
    "ratio": 0.7581,
-   "compress_mbps": 24.03,
-   "decompress_mbps": 118.88
+   "compress_mbps": 24.21,
+   "decompress_mbps": 113.39
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5429379,
    "ratio": 0.7487,
-   "compress_mbps": 6.15,
-   "decompress_mbps": 119.72
+   "compress_mbps": 6.2,
+   "decompress_mbps": 114.36
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 6.14,
-   "decompress_mbps": 118.62
+   "compress_mbps": 6.24,
+   "decompress_mbps": 114.78
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 1.57,
-   "decompress_mbps": 119.29
+   "compress_mbps": 1.58,
+   "decompress_mbps": 115.26
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 12821463,
    "ratio": 0.3093,
-   "compress_mbps": 49.47,
-   "decompress_mbps": 156.46
+   "compress_mbps": 50.27,
+   "decompress_mbps": 156.7
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12582079,
    "ratio": 0.3035,
-   "compress_mbps": 46.05,
-   "decompress_mbps": 166.15
+   "compress_mbps": 46.39,
+   "decompress_mbps": 166.97
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12448952,
    "ratio": 0.3003,
-   "compress_mbps": 42.93,
-   "decompress_mbps": 178.98
+   "compress_mbps": 43.39,
+   "decompress_mbps": 180.12
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12257878,
    "ratio": 0.2957,
-   "compress_mbps": 35.34,
-   "decompress_mbps": 188.16
+   "compress_mbps": 35.26,
+   "decompress_mbps": 189.3
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 34.06,
-   "decompress_mbps": 194.94
+   "compress_mbps": 34.31,
+   "decompress_mbps": 195.41
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12184501,
    "ratio": 0.2939,
-   "compress_mbps": 30.99,
-   "decompress_mbps": 199.28
+   "compress_mbps": 31.29,
+   "decompress_mbps": 198.74
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 11.59,
-   "decompress_mbps": 198.89
+   "compress_mbps": 11.55,
+   "decompress_mbps": 198.82
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 11.35,
-   "decompress_mbps": 200.22
+   "compress_mbps": 11.41,
+   "decompress_mbps": 194.44
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11638957,
    "ratio": 0.2807,
-   "compress_mbps": 1.21,
-   "decompress_mbps": 198.22
+   "compress_mbps": 1.22,
+   "decompress_mbps": 201.93
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6392156,
    "ratio": 0.7543,
-   "compress_mbps": 31.97,
-   "decompress_mbps": 58.24
+   "compress_mbps": 32.66,
+   "decompress_mbps": 59.57
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392125,
    "ratio": 0.7543,
-   "compress_mbps": 32.0,
-   "decompress_mbps": 64.12
+   "compress_mbps": 32.77,
+   "decompress_mbps": 65.95
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392122,
    "ratio": 0.7543,
-   "compress_mbps": 31.99,
-   "decompress_mbps": 68.69
+   "compress_mbps": 32.75,
+   "decompress_mbps": 70.06
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368721,
    "ratio": 0.7515,
-   "compress_mbps": 30.55,
-   "decompress_mbps": 67.6
+   "compress_mbps": 30.99,
+   "decompress_mbps": 68.36
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.52,
-   "decompress_mbps": 69.27
+   "compress_mbps": 31.23,
+   "decompress_mbps": 69.7
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 30.19,
-   "decompress_mbps": 70.52
+   "compress_mbps": 31.15,
+   "decompress_mbps": 70.91
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.76,
-   "decompress_mbps": 71.46
+   "compress_mbps": 4.74,
+   "decompress_mbps": 71.49
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 4.75,
-   "decompress_mbps": 71.59
+   "compress_mbps": 4.7,
+   "decompress_mbps": 71.86
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 1.68,
-   "decompress_mbps": 70.35
+   "compress_mbps": 1.69,
+   "decompress_mbps": 70.83
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 793301,
    "ratio": 0.1484,
-   "compress_mbps": 95.1,
-   "decompress_mbps": 291.35
+   "compress_mbps": 97.92,
+   "decompress_mbps": 288.46
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 762011,
    "ratio": 0.1426,
-   "compress_mbps": 85.52,
-   "decompress_mbps": 325.65
+   "compress_mbps": 87.5,
+   "decompress_mbps": 323.7
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 743137,
    "ratio": 0.139,
-   "compress_mbps": 76.89,
-   "decompress_mbps": 360.99
+   "compress_mbps": 77.84,
+   "decompress_mbps": 344.91
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 725534,
    "ratio": 0.1357,
-   "compress_mbps": 63.34,
-   "decompress_mbps": 363.56
+   "compress_mbps": 64.62,
+   "decompress_mbps": 355.89
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 62.13,
-   "decompress_mbps": 398.31
+   "compress_mbps": 62.57,
+   "decompress_mbps": 391.71
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 715547,
    "ratio": 0.1339,
-   "compress_mbps": 57.81,
-   "decompress_mbps": 427.19
+   "compress_mbps": 58.26,
+   "decompress_mbps": 425.13
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 675427,
    "ratio": 0.1264,
-   "compress_mbps": 21.68,
-   "decompress_mbps": 444.63
+   "compress_mbps": 21.73,
+   "decompress_mbps": 438.47
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 20.33,
-   "decompress_mbps": 451.62
+   "compress_mbps": 20.22,
+   "decompress_mbps": 444.05
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 9,
    "out_size": 637424,
    "ratio": 0.1192,
-   "compress_mbps": 0.97,
-   "decompress_mbps": 473.88
+   "compress_mbps": 0.96,
+   "decompress_mbps": 443.5
   },
   {
    "compressor": "zlib",


### PR DESCRIPTION
This PR fuses the redundant trailing `extract` + `append` in `copyLoop`'s overlapping (RLE) branch into a single `copySlice`. The overlapping back-reference copy was `buf ++ (fillDouble seed length).extract 0 length`, which materializes a `length`-byte slice (an allocation plus a memcpy) and then appends it (a second memcpy). Because the `fillDouble` result is a distinct array from `buf`, its `length`-byte prefix copies straight into `buf`'s tail with one `copySlice` (one memcpy, no intermediate) — `fill` and `buf` are different objects, so there is no self-aliasing. The new `copySlice_prefix_eq_append` helper proves the two forms equal, so `copyLoop_eq_ofFn` and the whole decode-correctness chain carry over with a one-line proof change. Measured ~8-17% native decode speedup on RLE-heavy inputs (period 1-64, 8 MB each), correctness preserved.

The hot non-overlapping case (`length <= distance`) is deliberately left unchanged. A single-pass self-append there would need `buf.copySlice start buf buf.size length false`, with `buf` as both the borrowed source and the owned destination. That is **safe** (no use-after-free — valgrind clean) but **quadratic**: because `buf` is passed both borrowed and owned, the compiler inserts a protective `inc`, so the destination is non-exclusive inside the call and `lean_copy_sarray` duplicates the whole buffer every call (O(size) per back-reference). An efficient single pass needs a new `ByteArray.copyWithin`-style primitive in Lean core that takes the buffer as a single owned argument (a prototype measured ~28-38% decode speedup); that cannot be done in pure Lean and is out of scope here — see issue #2675 for the upstream writeup.

Refs #2675.

🤖 Prepared with Claude Code