### PR TITLE
feat(decode): canonical O(n) decode-table build + correctness foundation

### DIFF
--- a/Zip.lean
+++ b/Zip.lean
@@ -28,6 +28,7 @@ import Zip.Spec.BlockSizeModel
 import Zip.Spec.HuffmanCorrect
 import Zip.Spec.HuffmanCorrectLoop
 import Zip.Spec.InflateTable
+import Zip.Spec.InflateCanonical
 import Zip.Spec.HuffmanEncodeCorrect
 import Zip.Spec.DecodeCorrect
 import Zip.Spec.DecodeComplete

--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -239,6 +239,80 @@ def buildTable (tree : HuffTree) : DecodeTable where
   packed := Array.ofFn (n := 2 ^ fastBits) (fun i : Fin (2 ^ fastBits) =>
     packEntry (tableEntry tree i.val).1 (tableEntry tree i.val).2)
 
+/-! ## Canonical O(n) table construction (libdeflate `build_decode_table`)
+
+`buildTable` walks `tree` once per slot — `O(2^fastBits · depth)` with a tree
+that itself costs an allocation per block. The libdeflate construction fills the
+table directly from the code lengths, with no tree: assign each symbol its
+canonical codeword (RFC 1951 §3.2.2, the same `nextCode` recurrence the tree
+build uses), then write that symbol's `(sym, len)` into every table slot whose
+low `len` bits are the codeword read LSB-first. A length-`len` codeword owns a
+contiguous arithmetic progression of `2^(fastBits - len)` slots at stride
+`2^len` starting from the bit-reversed codeword, so the whole fill is
+`O(num_syms + 2^fastBits)`.
+
+`buildCanonicalLoop` mirrors `HuffTree.insertLoop` step for step — same
+`nextCode` threading, same per-symbol code `c` — so the table it fills is
+provably equal to `buildTable (fromLengthsTree lengths)` (`Zip.Spec.InflateTable`,
+`buildTableCanonical_eq`): the two constructions assign identical codewords, and
+filling the slots of a codeword is the table-side image of inserting its leaf.
+The proof is the format-independent core of #2671; the tree stays the spec, the
+canonical build is proven equal to it, so there is no trust gap. -/
+
+/-- Reverse the low `n` bits of `x` (bit `j` of the result is bit `n-1-j` of `x`).
+    A length-`len` canonical codeword is written MSB-first into the bitstream, so
+    the decoder — which peeks LSB-first — sees `bitReverse code len 0`. -/
+def bitReverse (x : Nat) : Nat → Nat → Nat
+  | 0, acc => acc
+  | n + 1, acc => bitReverse (x / 2) n (acc * 2 + x % 2)
+
+/-- Write `entry` into the `count` slots `base, base + stride, …` of `packed`
+    (the slots one length-`len` codeword owns: `stride = 2^len`,
+    `count = 2^(fastBits - len)`). Linear in `count`; in-place when `packed` is
+    uniquely referenced. -/
+def fillSlots (packed : Array UInt32) (base stride count : Nat) (entry : UInt32) :
+    Array UInt32 :=
+  if count = 0 then packed
+  else fillSlots (packed.set! base entry) (base + stride) stride (count - 1) entry
+termination_by count
+
+/-- The canonical table-fill loop: for each symbol from `start`, look up its
+    canonical code `c = nextCode[len]` (advancing `nextCode[len]`, exactly as
+    `HuffTree.insertLoop` does), and — for codes that fit the `fastBits` window —
+    fill its slots. Codes longer than `fastBits` advance `nextCode` but fill no
+    slot (they reach the table as the sentinel `0`, the long-code fallback), and
+    `len = 0` symbols are skipped entirely. -/
+def buildCanonicalLoop (lengths : Array UInt8) (nextCode : Array UInt32)
+    (start : Nat) (packed : Array UInt32) : Array UInt32 :=
+  if h : start < lengths.size then
+    let len := lengths[start]
+    if hlen : 0 < len.toNat ∧ len.toNat < nextCode.size then
+      let c := nextCode[len.toNat]'hlen.2
+      let nextCode' := nextCode.set! len.toNat (c + 1)
+      if len.toNat ≤ fastBits then
+        let base := bitReverse c.toNat len.toNat 0
+        let packed' := fillSlots packed base (2 ^ len.toNat)
+          (2 ^ (fastBits - len.toNat)) (packEntry start.toUInt16 len)
+        buildCanonicalLoop lengths nextCode' (start + 1) packed'
+      else
+        buildCanonicalLoop lengths nextCode' (start + 1) packed
+    else
+      buildCanonicalLoop lengths nextCode (start + 1) packed
+  else packed
+termination_by lengths.size - start
+
+/-- Build the `2^fastBits`-entry decode table directly from the code lengths,
+    libdeflate-style — canonical fill, no Huffman tree, no per-slot tree walk.
+    Proven equal to `buildTable (fromLengthsTree lengths)`
+    (`Zip.Spec.InflateTable.buildTableCanonical_eq`), so it is a drop-in for the
+    tree-built table with every decode proof transferring unchanged. -/
+def buildTableCanonical (lengths : Array UInt8) (maxBits : Nat := 15) : DecodeTable where
+  packed :=
+    let lsList := lengths.toList.map UInt8.toNat
+    let blCount := Huffman.Spec.countLengths lsList maxBits
+    let nextCode : Array UInt32 := (Huffman.Spec.nextCodes blCount maxBits).map (·.toUInt32)
+    buildCanonicalLoop lengths nextCode 0 (Array.replicate (2 ^ fastBits) (packEntry 0 0))
+
 /-- Bits remaining in the reader from its current `(pos, bitOff)`. -/
 def bitsAvail (br : BitReader) : Nat :=
   if br.pos ≥ br.data.size then 0 else (br.data.size - br.pos) * 8 - br.bitOff

--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -252,12 +252,16 @@ contiguous arithmetic progression of `2^(fastBits - len)` slots at stride
 `O(num_syms + 2^fastBits)`.
 
 `buildCanonicalLoop` mirrors `HuffTree.insertLoop` step for step — same
-`nextCode` threading, same per-symbol code `c` — so the table it fills is
-provably equal to `buildTable (fromLengthsTree lengths)` (`Zip.Spec.InflateTable`,
-`buildTableCanonical_eq`): the two constructions assign identical codewords, and
-filling the slots of a codeword is the table-side image of inserting its leaf.
-The proof is the format-independent core of #2671; the tree stays the spec, the
-canonical build is proven equal to it, so there is no trust gap. -/
+`nextCode` threading, same per-symbol code `c` — so the table it fills equals
+`buildTable (fromLengthsTree lengths)`: the two constructions assign identical
+codewords, and filling the slots of a codeword is the table-side image of
+inserting its leaf. The formal equality theorem (`buildTableCanonical_eq`) is the
+format-independent core of #2671 and lands in a follow-up — its supporting lemmas
+(bit-reversal, the `cwOf`/`bitReverse` slot bridge, the `fillSlots`
+characterization) are already in `Zip.Spec.InflateCanonical`, and a differential
+conformance test witnesses the equality at runtime across every code-length
+regime. The canonical build is not yet on the decode path, so there is no trust
+gap; wiring it in waits on the equality proof. -/
 
 /-- Reverse the low `n` bits of `x` (bit `j` of the result is bit `n-1-j` of `x`).
     A length-`len` canonical codeword is written MSB-first into the bitstream, so
@@ -303,9 +307,10 @@ termination_by lengths.size - start
 
 /-- Build the `2^fastBits`-entry decode table directly from the code lengths,
     libdeflate-style — canonical fill, no Huffman tree, no per-slot tree walk.
-    Proven equal to `buildTable (fromLengthsTree lengths)`
-    (`Zip.Spec.InflateTable.buildTableCanonical_eq`), so it is a drop-in for the
-    tree-built table with every decode proof transferring unchanged. -/
+    Equal to `buildTable (fromLengthsTree lengths)` (formal theorem
+    `buildTableCanonical_eq` forthcoming; witnessed at runtime by the
+    `InflateTable` canonical conformance test), so once proven it is a drop-in for
+    the tree-built table with every decode proof transferring unchanged. -/
 def buildTableCanonical (lengths : Array UInt8) (maxBits : Nat := 15) : DecodeTable where
   packed :=
     let lsList := lengths.toList.map UInt8.toNat

--- a/Zip/Spec/InflateCanonical.lean
+++ b/Zip/Spec/InflateCanonical.lean
@@ -6,20 +6,27 @@ import Zip.Spec.HuffmanCorrectLoop
 
 `HuffTree.buildTableCanonical lengths` fills the fast decode table directly from
 the code lengths (libdeflate `build_decode_table`): no Huffman tree, no per-slot
-tree walk. This file proves it equal to `buildTable (fromLengthsTree lengths)`,
-so the canonical build is a drop-in for the tree-built table and every decode
-proof transfers unchanged — there is no `@[implemented_by]` trust gap.
+tree walk. The goal is to prove it equal to `buildTable (fromLengthsTree lengths)`,
+so the canonical build becomes a drop-in for the tree-built table with every
+decode proof transferring unchanged and no `@[implemented_by]` trust gap.
 
-The proof runs `buildCanonicalLoop` in lockstep with `HuffTree.insertLoop`: the
-invariant is `packed = (buildTable tree).packed`, preserved step for step. Each
-symbol's fill (`fillSlots`) is the table-side image of inserting its leaf, and
-codes longer than `fastBits` change neither the tree's fast window nor the table.
+This file develops the format-independent **foundation** of that proof. The
+planned route (per #2671) characterizes each table slot by the canonical code
+table `allCodes`: slot `idx` holds `packEntry sym len` iff some `(sym, cw)` with
+`len = cw.length ≤ fastBits` and `cwOf idx len = cw` is in `allCodes`, else the
+sentinel `packEntry 0 0`. `buildTable`'s side follows from the existing
+`hasLeaf_of_tableEntry_go` / `fromLengths_leaf_spec` / `fromLengths_hasLeaf`
+bridge; the canonical loop's side from a table-local `nextCode` invariant. The
+final equality theorem (`buildTableCanonical_eq`) and the decode rewiring land in
+a follow-up; a differential conformance test already witnesses the equality at
+runtime.
 
-This file builds bottom-up:
+The foundation lemmas here, bottom-up:
 1. `bitReverse` arithmetic — the bit-reversed codeword indexes the fast table.
-2. `cwOf`/`bitReverse` bridge — slot `idx` lies on a codeword's path iff
-   `idx % 2^len` is the bit-reversed code.
-3. `fillSlots` — what the slot-fill writes and preserves.
+2. `cwOf`/`bitReverse` bridge (`cwOf_eq_iff_mod`) — slot `idx` lies on a
+   codeword's path iff `idx % 2^len` is the bit-reversed code.
+3. `fillSlots` — what the slot-fill writes (`fillSlots_getElem_eq`) and
+   preserves (`fillSlots_getElem_ne`, `fillSlots_size`).
 -/
 
 namespace Zip.Native.HuffTree
@@ -157,5 +164,56 @@ theorem cwOf_eq_iff_mod (idx c len : Nat) :
     simp only [Nat.succ_ne_zero, ↓reduceIte, Nat.add_sub_cancel]
     rw [ih (packed.set! base entry) (base + stride)]
     simp
+
+/-- A slot not on the fill's arithmetic progression `{base + j·stride : j < count}`
+    keeps its old value. -/
+theorem fillSlots_getElem_ne (packed : Array UInt32) (base stride count idx : Nat)
+    (entry : UInt32) (h : ∀ j < count, idx ≠ base + j * stride) :
+    (fillSlots packed base stride count entry)[idx]! = packed[idx]! := by
+  induction count generalizing packed base with
+  | zero => simp [fillSlots]
+  | succ n ih =>
+    rw [fillSlots]
+    simp only [Nat.succ_ne_zero, ↓reduceIte, Nat.add_sub_cancel]
+    rw [ih (packed.set! base entry) (base + stride) (by
+      intro j hj
+      have hne := h (j + 1) (by omega)
+      have e : base + (j + 1) * stride = base + stride + j * stride := by
+        rw [Nat.succ_mul]; omega
+      rw [e] at hne; exact hne)]
+    have hb : idx ≠ base := by have := h 0 (Nat.zero_lt_succ n); simpa using this
+    rw [Array.set!_eq_setIfInBounds]
+    by_cases hlt : idx < packed.size
+    · rw [getElem!_pos _ idx (by rw [Array.size_setIfInBounds]; exact hlt),
+          getElem!_pos _ idx hlt, Array.getElem_setIfInBounds hlt, if_neg (Ne.symm hb)]
+    · rw [getElem!_neg _ idx (by rw [Array.size_setIfInBounds]; exact hlt),
+          getElem!_neg _ idx hlt]
+
+/-- A slot on the fill's arithmetic progression `base + j·stride` (`j < count`,
+    in bounds) holds the fill value. -/
+theorem fillSlots_getElem_eq (packed : Array UInt32) (base stride count j : Nat)
+    (entry : UInt32) (hstride : 0 < stride) (hj : j < count)
+    (hbound : base + j * stride < packed.size) :
+    (fillSlots packed base stride count entry)[base + j * stride]! = entry := by
+  induction count generalizing packed base j with
+  | zero => omega
+  | succ n ih =>
+    rw [fillSlots]
+    simp only [Nat.succ_ne_zero, ↓reduceIte, Nat.add_sub_cancel]
+    match j with
+    | 0 =>
+      rw [show base + 0 * stride = base from by omega]
+      rw [fillSlots_getElem_ne (packed.set! base entry) (base + stride) stride n base entry
+        (fun k _ => by omega)]
+      have hbase : base < packed.size := by have := hbound; omega
+      rw [Array.set!_eq_setIfInBounds,
+          getElem!_pos _ base (by rw [Array.size_setIfInBounds]; exact hbase),
+          Array.getElem_setIfInBounds_self]
+    | j' + 1 =>
+      have e : base + (j' + 1) * stride = base + stride + j' * stride := by
+        rw [Nat.succ_mul]; omega
+      rw [e]
+      exact ih (packed.set! base entry) (base + stride) j' (by omega)
+        (by rw [Array.size_set!, ← e]; exact hbound)
 
 end Zip.Native.HuffTree

--- a/Zip/Spec/InflateCanonical.lean
+++ b/Zip/Spec/InflateCanonical.lean
@@ -1,0 +1,161 @@
+import Zip.Spec.InflateTable
+import Zip.Spec.HuffmanCorrectLoop
+
+/-!
+# Canonical O(n) decode-table build: equivalence to the tree-built table
+
+`HuffTree.buildTableCanonical lengths` fills the fast decode table directly from
+the code lengths (libdeflate `build_decode_table`): no Huffman tree, no per-slot
+tree walk. This file proves it equal to `buildTable (fromLengthsTree lengths)`,
+so the canonical build is a drop-in for the tree-built table and every decode
+proof transfers unchanged — there is no `@[implemented_by]` trust gap.
+
+The proof runs `buildCanonicalLoop` in lockstep with `HuffTree.insertLoop`: the
+invariant is `packed = (buildTable tree).packed`, preserved step for step. Each
+symbol's fill (`fillSlots`) is the table-side image of inserting its leaf, and
+codes longer than `fastBits` change neither the tree's fast window nor the table.
+
+This file builds bottom-up:
+1. `bitReverse` arithmetic — the bit-reversed codeword indexes the fast table.
+2. `cwOf`/`bitReverse` bridge — slot `idx` lies on a codeword's path iff
+   `idx % 2^len` is the bit-reversed code.
+3. `fillSlots` — what the slot-fill writes and preserves.
+-/
+
+namespace Zip.Native.HuffTree
+
+open Huffman.Spec (natToBits)
+
+/-! ## `bitReverse` arithmetic -/
+
+/-- The accumulator of `bitReverse` separates as a high-order summand: reversing
+    `n` bits of `x` onto `acc` is `acc` shifted up by `n` plus the bare reversal. -/
+theorem bitReverse_acc (x n acc : Nat) :
+    bitReverse x n acc = acc * 2 ^ n + bitReverse x n 0 := by
+  induction n generalizing x acc with
+  | zero => simp [bitReverse]
+  | succ n ih =>
+    simp only [bitReverse]
+    rw [ih (x / 2) (acc * 2 + x % 2), ih (x / 2) (0 * 2 + x % 2), Nat.zero_mul,
+        Nat.zero_add, Nat.pow_succ, Nat.mul_comm (2 ^ n) 2, Nat.add_mul,
+        Nat.mul_assoc acc 2 (2 ^ n)]
+    omega
+
+/-- The bare reversal of `n` bits fits in `n` bits. -/
+theorem bitReverse_lt (x n : Nat) : bitReverse x n 0 < 2 ^ n := by
+  induction n generalizing x with
+  | zero => simp [bitReverse]
+  | succ n ih =>
+    simp only [bitReverse]
+    rw [bitReverse_acc, Nat.pow_succ]
+    have hr := ih (x / 2)
+    rcases Nat.mod_two_eq_zero_or_one x with h | h <;> rw [h] <;> omega
+
+/-- Bit `i` (`i < n`) of the `n`-bit reversal of `x` is bit `n-1-i` of `x`:
+    `bitReverse` reverses the low `n` bits. -/
+theorem bitReverse_testBit (x n i : Nat) (hi : i < n) :
+    (bitReverse x n 0).testBit i = x.testBit (n - 1 - i) := by
+  induction n generalizing x i with
+  | zero => omega
+  | succ n ih =>
+    have hR : bitReverse x (n + 1) 0 = 2 ^ n * (x % 2) + bitReverse (x / 2) n 0 := by
+      simp only [bitReverse]
+      rw [bitReverse_acc, Nat.zero_mul, Nat.zero_add, Nat.mul_comm (x % 2) (2 ^ n)]
+    rw [hR, Nat.testBit_two_pow_mul_add _ (bitReverse_lt (x / 2) n)]
+    rcases Nat.lt_or_ge i n with hlt | hge
+    · rw [if_pos hlt, ih (x / 2) i hlt, ← Nat.testBit_succ]
+      congr 1; omega
+    · have hin : i = n := by omega
+      subst hin
+      rw [if_neg (by omega), Nat.sub_self, show i + 1 - 1 - i = 0 from by omega,
+          Nat.testBit_zero, Nat.testBit_zero, show x % 2 % 2 = x % 2 from by omega]
+
+/-! ## `cwOf` / `bitReverse` bridge
+
+`tableEntry` walks the table index LSB-first, so slot `idx` lies on the path of a
+length-`len` codeword `c` exactly when `cwOf idx len = natToBits c len`. The
+canonical fill writes the slots `idx` with `idx % 2^len = bitReverse c len 0`;
+these two descriptions coincide. -/
+
+/-- `(natToBits c len)[j]` (MSB-first) is bit `len-1-j` of `c`. -/
+theorem natToBits_getElem (c len j : Nat) (hj : j < len) :
+    (natToBits c len)[j]'(by rw [Huffman.Spec.natToBits_length]; exact hj)
+      = c.testBit (len - 1 - j) := by
+  induction len generalizing j with
+  | zero => omega
+  | succ n ih =>
+    match j with
+    | 0 => simp only [natToBits, List.getElem_cons_zero, Nat.add_sub_cancel, Nat.sub_zero]
+    | j + 1 =>
+      have hstep : (natToBits c (n + 1))[j + 1]'(by rw [Huffman.Spec.natToBits_length]; omega)
+          = (natToBits c n)[j]'(by rw [Huffman.Spec.natToBits_length]; omega) := by
+        simp only [natToBits, List.getElem_cons_succ]
+      rw [hstep, ih j (by omega)]; congr 1; omega
+
+/-- `cwOf` depends only on the low `k` bits of `bits` (it reads them LSB-first). -/
+theorem cwOf_mod (bits k : Nat) : cwOf (bits % 2 ^ k) k = cwOf bits k := by
+  apply List.ext_getElem (by simp only [cwOf_length])
+  intro j h₁ _
+  rw [cwOf_length] at h₁
+  rw [cwOf_getElem (bits % 2 ^ k) k j h₁, cwOf_getElem bits k j h₁,
+      Nat.testBit_mod_two_pow]
+  simp [h₁]
+
+/-- The bit-reversed code is the unique low-`len`-bits value whose `cwOf` path is
+    the codeword `natToBits c len`. -/
+theorem cwOf_bitReverse (c len : Nat) :
+    cwOf (bitReverse c len 0) len = natToBits c len := by
+  apply List.ext_getElem (by rw [cwOf_length, Huffman.Spec.natToBits_length])
+  intro j h₁ _
+  rw [cwOf_length] at h₁
+  rw [cwOf_getElem (bitReverse c len 0) len j h₁, bitReverse_testBit _ _ _ h₁,
+      natToBits_getElem c len j h₁]
+
+/-- Two `cwOf` paths of the same length agree iff the low bits agree. -/
+theorem cwOf_mod_eq_of_cwOf_eq (a b len : Nat) (h : cwOf a len = cwOf b len) :
+    a % 2 ^ len = b % 2 ^ len := by
+  apply Nat.eq_of_testBit_eq
+  intro i
+  rw [Nat.testBit_mod_two_pow, Nat.testBit_mod_two_pow]
+  by_cases hi : i < len
+  · simp only [hi, decide_true, Bool.true_and]
+    have ha : (cwOf a len)[i]? = some (a.testBit i) := by
+      rw [List.getElem?_eq_getElem (by rw [cwOf_length]; exact hi), cwOf_getElem a len i hi]
+    have hb : (cwOf b len)[i]? = some (b.testBit i) := by
+      rw [List.getElem?_eq_getElem (by rw [cwOf_length]; exact hi), cwOf_getElem b len i hi]
+    rw [h, hb] at ha
+    exact (Option.some.inj ha).symm
+  · simp [hi]
+
+/-- The slot-fill membership condition: slot `idx` lies on the path of a
+    length-`len` codeword `c` (`cwOf idx len = natToBits c len`) iff its low
+    `len` bits are the bit-reversed code. -/
+theorem cwOf_eq_iff_mod (idx c len : Nat) :
+    cwOf idx len = natToBits c len ↔ idx % 2 ^ len = bitReverse c len 0 := by
+  constructor
+  · intro h
+    have h2 : cwOf (idx % 2 ^ len) len = cwOf (bitReverse c len 0) len := by
+      rw [cwOf_mod, h, ← cwOf_bitReverse]
+    have h3 := cwOf_mod_eq_of_cwOf_eq _ _ _ h2
+    rwa [Nat.mod_eq_of_lt (Nat.mod_lt idx (Nat.two_pow_pos len)),
+        Nat.mod_eq_of_lt (bitReverse_lt c len)] at h3
+  · intro h
+    have hbr := cwOf_bitReverse c len
+    rw [← h] at hbr
+    exact (cwOf_mod idx len).symm.trans hbr
+
+/-! ## `fillSlots` -/
+
+/-- `fillSlots` preserves the array size. -/
+@[simp] theorem fillSlots_size (packed : Array UInt32) (base stride count : Nat)
+    (entry : UInt32) :
+    (fillSlots packed base stride count entry).size = packed.size := by
+  induction count generalizing packed base with
+  | zero => simp [fillSlots]
+  | succ n ih =>
+    rw [fillSlots]
+    simp only [Nat.succ_ne_zero, ↓reduceIte, Nat.add_sub_cancel]
+    rw [ih (packed.set! base entry) (base + stride)]
+    simp
+
+end Zip.Native.HuffTree

--- a/ZipTest.lean
+++ b/ZipTest.lean
@@ -50,6 +50,7 @@ def main : IO Unit := do
   ZipTest.NativeChecksum.tests
   ZipTest.NativeInflate.tests
   ZipTest.InflateTable.tests
+  ZipTest.InflateTable.canonicalTests
   ZipTest.NativeGzip.tests
   ZipTest.NativeIntegration.tests
   ZipTest.NativeScale.tests

--- a/ZipTest/InflateTable.lean
+++ b/ZipTest/InflateTable.lean
@@ -125,8 +125,10 @@ private def lengthVectors : Array (String × Array UInt8) := Id.run do
 
 /-- Differential check: the canonical O(n) table build (`buildTableCanonical`)
     produces the exact same packed table as the tree-built `buildTable`, for
-    every code-length regime. This is the runtime witness of the proven equality
-    `Zip.Spec.InflateTable.buildTableCanonical_eq`. -/
+    every code-length regime. This is the runtime witness of the equality
+    `buildTableCanonical lengths = buildTable (fromLengthsTree lengths)` whose
+    formal proof (`buildTableCanonical_eq`) lands in a follow-up; its supporting
+    lemmas are already in `Zip.Spec.InflateCanonical`. -/
 def canonicalTests : IO Unit := do
   IO.println "  InflateTable canonical-build tests (canonical fill vs tree build)..."
   let mut checks : Nat := 0

--- a/ZipTest/InflateTable.lean
+++ b/ZipTest/InflateTable.lean
@@ -107,4 +107,44 @@ def tests : IO Unit := do
       | none => checks := checks + 1
   IO.println s!"    {checks} (tree × stream) batches matched; tables={trees.size}"
 
+/-- The code-length vectors exercised by the canonical-build conformance check,
+    spanning every regime: short codes only, codes on the `fastBits` boundary,
+    codes past it (sentinel slots), a 1…15 mix, and the RFC fixed code lengths. -/
+private def lengthVectors : Array (String × Array UInt8) := Id.run do
+  let mut acc : Array (String × Array UInt8) := #[]
+  for d in [1, 4, 8, 9, 10, 12] do
+    acc := acc.push (s!"complete-{d}", completeLengths d)
+  acc := acc.push ("spine-1..15", spineLengths)
+  acc := acc.push ("fixed-lit", Zip.Native.Inflate.fixedLitLengths)
+  acc := acc.push ("fixed-dist", Zip.Native.Inflate.fixedDistLengths)
+  -- A sparse, irregular *incomplete* code (Kraft sum < 1, so some ≤ fastBits
+  -- slots stay sentinel) mixing short codes with one length-10 fallback code —
+  -- the realistic dynamic-block shape.
+  acc := acc.push ("sparse", #[3, 3, 2, 0, 4, 4, 0, 0, 2, 10, 10] ++ Array.replicate 5 (0 : UInt8))
+  return acc
+
+/-- Differential check: the canonical O(n) table build (`buildTableCanonical`)
+    produces the exact same packed table as the tree-built `buildTable`, for
+    every code-length regime. This is the runtime witness of the proven equality
+    `Zip.Spec.InflateTable.buildTableCanonical_eq`. -/
+def canonicalTests : IO Unit := do
+  IO.println "  InflateTable canonical-build tests (canonical fill vs tree build)..."
+  let mut checks : Nat := 0
+  for (label, lengths) in lengthVectors do
+    match HuffTree.fromLengths lengths 15 with
+    | .error e => throw (IO.userError s!"[{label}] fromLengths failed: {e}")
+    | .ok tree =>
+      let treeTable := tree.buildTable
+      let canonTable := HuffTree.buildTableCanonical lengths 15
+      unless treeTable.packed == canonTable.packed do
+        -- Report the first divergent slot for diagnosis.
+        let mut bad : Option Nat := none
+        for i in [:treeTable.packed.size] do
+          if bad.isNone && treeTable.packed[i]! != canonTable.packed[i]! then
+            bad := some i
+        throw (IO.userError
+          s!"[{label}] canonical table differs from tree table at slot {bad}")
+      checks := checks + 1
+  IO.println s!"    {checks} length vectors: canonical build matches tree build"
+
 end ZipTest.InflateTable

--- a/progress/20260621T120449Z_issue-2671.md
+++ b/progress/20260621T120449Z_issue-2671.md
@@ -1,0 +1,49 @@
+# 2026-06-21 — #2671 canonical O(n) decode-table build (foundation)
+
+Session type: feature (issue #2671, "canonical O(n) table build + subtables, retire the HuffTree", Phase 4 of #2668).
+
+## Scope decision
+
+#2671 is the project's explicitly-flagged "heaviest proof" and a multi-session
+epic (canonical build + subtables + walkTree/HuffTree retirement + wider root
+table). #2674 (fold length base+extra into the packed entry) was closed
+NOT_PLANNED, so the packed-entry format from #2673 is final — no coordination
+needed. This session front-loads the **format-independent canonical-build core**
+(the slice #2671's coordination comment recommends) and lands it as a
+no-trust-gap foundation PR; the formal equality proof + decode wiring and the
+subtables go to follow-ups.
+
+## Accomplished
+
+- `HuffTree.buildTableCanonical` (+ `bitReverse`, `fillSlots`, `buildCanonicalLoop`)
+  in `Zip/Native/Inflate.lean`: libdeflate-style canonical fill, O(num_syms +
+  2^fastBits), no tree, no per-slot tree walk. `buildCanonicalLoop` mirrors
+  `insertLoop` step-for-step (same `nextCode`, same per-symbol code).
+- Differential conformance test (`ZipTest/InflateTable.lean` `canonicalTests`):
+  `buildTableCanonical lengths == (fromLengthsTree lengths).buildTable` across 10
+  code-length regimes (incomplete, fixed lit/dist, fastBits boundary, >9-bit).
+  PASSES.
+- `Zip/Spec/InflateCanonical.lean` foundation lemmas (all compile, no `sorry`):
+  `bitReverse_acc/_lt/_testBit`, `natToBits_getElem`, `cwOf_mod`,
+  `cwOf_bitReverse`, `cwOf_mod_eq_of_cwOf_eq`, `cwOf_eq_iff_mod` (the slot bridge),
+  `fillSlots_size/_getElem_ne/_getElem_eq`.
+
+## Second opinion (Codex)
+
+Confirmed: use the **allCodes-pointwise** route for `buildTableCanonical_eq`
+(avoids the `private` `nc_invariant_step`/`insertLoop_forward` wall); the
+foundation-PR split is reasonable since it is not on the decode path (no trust
+gap); correctness of the `>fastBits` advance-but-don't-fill and incomplete-code
+branches is sound. Also flagged (fixed): comments that spoke as if
+`buildTableCanonical_eq` already existed.
+
+## Remaining (follow-ups)
+
+1. `buildTableCanonical_eq` via the allCodes route + wire `buildTableCanonical`
+   into `decodeHuffmanFastBuf` (delivers the perf win) — new issue.
+2. Subtables for >fastBits codes + retire `walkTree`/`HuffTree` from the fast
+   path + wider root table — remaining #2671/#2668 scope.
+
+## Metrics
+
+sorry count in `Zip/`: unchanged (0 added). Build + tests green under nix-shell.


### PR DESCRIPTION
This PR adds `HuffTree.buildTableCanonical`, a libdeflate-style canonical O(n) decode-table build that fills the fast table directly from the code lengths — no Huffman tree, no per-slot tree walk — as the format-independent foundation of #2671 (Phase 4 of #2668). It assigns each symbol its canonical codeword via the same `nextCode` recurrence the tree build uses, then writes that symbol's `(sym, len)` into the contiguous arithmetic progression of `2^(fastBits-len)` slots the codeword owns (stride `2^len`, starting from the bit-reversed code), so the whole build is `O(num_syms + 2^fastBits)` instead of `buildTable`'s `O(2^fastBits · depth)` per-slot tree walk.

`buildCanonicalLoop` mirrors `HuffTree.insertLoop` step for step (same `nextCode` threading, same per-symbol code), so the table it fills equals `buildTable (fromLengthsTree lengths)`. A differential conformance test (`ZipTest/InflateTable.lean`) witnesses that equality at runtime across every code-length regime: incomplete codes, the RFC fixed literal/length and distance codes, codes on the `fastBits` boundary, and codes past it. The format-independent supporting lemmas land in `Zip/Spec/InflateCanonical.lean` — `bitReverse` arithmetic, the `cwOf`/`bitReverse` slot bridge (`cwOf_eq_iff_mod`: a slot lies on a codeword's path iff its low `len` bits are the bit-reversed code), and the `fillSlots` getElem characterization — with no `sorry`.

The canonical build is deliberately not yet on the decode path, so there is no trust gap: the tree-built table stays the spec. The formal equality theorem `buildTableCanonical_eq` and the decode rewiring (which delivers the throughput win) follow in a dedicated issue, using the `allCodes`-pointwise proof route; the subtables and `walkTree`/`HuffTree` retirement remain in the broader #2671/#2668 scope.

Part of #2671.

🤖 Prepared with Claude Code
