### PR TITLE
refactor(decode): make Inflate.inflate itself the tree-free decoder

### DIFF
--- a/Zip/Archive.lean
+++ b/Zip/Archive.lean
@@ -1237,7 +1237,7 @@ private def readEntryData (h : IO.FS.Handle) (entry : Entry) (label : String)
         -- above `nativePresizeCap` simply keep a few of their doublings.
         let sizeHint := min (min entry.uncompressedSize.toNat maxEntrySize.toNat)
           (min (compData.size * 1100) nativePresizeCap)
-        match (Zip.Native.Inflate.inflateRawTreeFree compData 0 maxEntrySize.toNat sizeHint).map Prod.fst with
+        match Zip.Native.Inflate.inflate compData maxEntrySize.toNat (sizeHint := sizeHint) with
         | .ok data => pure data
         | .error msg => throw (IO.userError s!"zip: native inflate failed for {label}: {msg}")
       else RawDeflate.decompress compData maxEntrySize

--- a/Zip/Native/Gzip.lean
+++ b/Zip/Native/Gzip.lean
@@ -35,7 +35,7 @@ termination_by data.size - pos
     non-empty output (the inner inflate guards compare
     `output.size + len > maxOutputSize`). The outer-loop guard raises an
     `Except` error containing `"Gzip: total output exceeds maximum size"`;
-    the inner per-member `Inflate.inflateRawTreeFree` call also enforces the
+    the inner per-member `Inflate.inflateRaw` call also enforces the
     bound and may surface `"Inflate: output exceeds maximum size"` first.
     See `SECURITY_INVENTORY.md` *Decompression Limit Inventory*. -/
 def decompress (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
@@ -79,7 +79,7 @@ def decompress (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
       if pos > data.size then throw "Gzip: header extends past end of input"
       -- Inflate (cap each member to remaining budget so total stays within maxOutputSize)
       let memberMax := maxOutputSize - result.size
-      let (decompressed, endPos) ← Inflate.inflateRawTreeFree data pos memberMax
+      let (decompressed, endPos) ← Inflate.inflateRaw data pos memberMax
       pos := endPos
       -- Parse trailer: CRC32 (4 bytes LE) + ISIZE (4 bytes LE)
       if pos + 8 > data.size then throw "Gzip: truncated trailer"
@@ -132,7 +132,7 @@ namespace ZlibDecode
     Returns the decompressed data.
 
     `maxOutputSize` (default 1 GiB) is forwarded to the inner
-    `Inflate.inflateRawTreeFree`; this layer adds no separate guard. Unlike the
+    `Inflate.inflateRaw`; this layer adds no separate guard. Unlike the
     FFI path, where `maxDecompressedSize := 0` means unlimited, here `0`
     rejects any non-empty output (the inflate guards compare
     `output.size + len > maxOutputSize`). Overflow raises an `Except`
@@ -158,7 +158,7 @@ def decompress (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024) :
     if flg &&& 0x20 != 0 then
       throw "Zlib: preset dictionaries not supported"
     -- Inflate
-    let (decompressed, endPos) ← Inflate.inflateRawTreeFree data pos maxOutputSize
+    let (decompressed, endPos) ← Inflate.inflateRaw data pos maxOutputSize
     pos := endPos
     -- Parse trailer: Adler32 (4 bytes big-endian)
     if hT : pos + 4 ≤ data.size then
@@ -230,7 +230,7 @@ def detectFormat (data : ByteArray) : CompressFormat :=
 /-- Decompress data by auto-detecting the format (gzip, zlib, or raw deflate).
 
     `maxOutputSize` (default 1 GiB) is forwarded to whichever of
-    `GzipDecode.decompress`, `ZlibDecode.decompress`, or `Inflate.inflateTreeFree`
+    `GzipDecode.decompress`, `ZlibDecode.decompress`, or `Inflate.inflate`
     the dispatch picks based on `detectFormat`. The surfaced error
     substring depends on the dispatch: `"Gzip: total output exceeds
     maximum size"` (gzip outer guard), or `"Inflate: output exceeds
@@ -243,7 +243,7 @@ def decompressAuto (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024
   match detectFormat data with
   | .gzip => GzipDecode.decompress data maxOutputSize
   | .zlib => ZlibDecode.decompress data maxOutputSize
-  | .rawDeflate => Inflate.inflateTreeFree data maxOutputSize
+  | .rawDeflate => Inflate.inflate data maxOutputSize
 
 /-- Compress data with format selection.
     Default: gzip format, level 1 (fixed Huffman). -/

--- a/Zip/Native/Inflate.lean
+++ b/Zip/Native/Inflate.lean
@@ -1286,7 +1286,7 @@ decreasing_by all_goals omega
     affects the produced bytes or the `maxOutputSize` bomb guard, so every inflate
     correctness proof transfers unchanged (`ByteArray.emptyWithCapacity n` is
     definitionally `{ data := Array.empty }` for every `n`). -/
-def inflateRaw (data : ByteArray) (startPos : Nat := 0)
+def inflateRawReference (data : ByteArray) (startPos : Nat := 0)
     (maxOutputSize : Nat := 1024 * 1024 * 1024) (sizeHint : Nat := 0) :
     Except String (ByteArray × Nat) := do
   let br : BitReader := { data, pos := startPos, bitOff := 0 }
@@ -1305,26 +1305,25 @@ def inflateRaw (data : ByteArray) (startPos : Nat := 0)
 
     `sizeHint` pre-reserves output capacity when the decompressed size is known;
     `0` (the default) reserves nothing. See `inflateRaw`. -/
-def inflate (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024)
+def inflateReference (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024)
     (sizeHint : Nat := 0) :
     Except String ByteArray := do
-  let (output, _) ← inflateRaw data 0 maxOutputSize sizeHint
+  let (output, _) ← inflateRawReference data 0 maxOutputSize sizeHint
   return output
 
-/-- The output capacity hint is computationally inert: `inflateRaw` with any
-    `sizeHint` equals `inflateRaw` with the default `sizeHint := 0`, because
+/-- The output capacity hint is computationally inert: `inflateRawReference` with any
+    `sizeHint` equals it with the default `sizeHint := 0`, because
     `ByteArray.emptyWithCapacity n` reduces to `{ data := Array.empty }` for every
-    `n` (capacity is a runtime-only allocation hint). So every theorem proved about
-    the `sizeHint := 0` form — correctness, suffix invariance, end-position bounds —
-    transfers verbatim to any hinted call (e.g. the ZIP decoder's). -/
-@[simp] theorem inflateRaw_sizeHint_eq (data : ByteArray) (startPos maxOutputSize sizeHint : Nat) :
-    inflateRaw data startPos maxOutputSize sizeHint = inflateRaw data startPos maxOutputSize :=
+    `n` (capacity is a runtime-only allocation hint). -/
+@[simp] theorem inflateRawReference_sizeHint_eq (data : ByteArray)
+    (startPos maxOutputSize sizeHint : Nat) :
+    inflateRawReference data startPos maxOutputSize sizeHint
+      = inflateRawReference data startPos maxOutputSize :=
   rfl
 
-/-- `inflate` with any `sizeHint` equals `inflate` with the default `0`; see
-    `inflateRaw_sizeHint_eq`. -/
-@[simp] theorem inflate_sizeHint_eq (data : ByteArray) (maxOutputSize sizeHint : Nat) :
-    inflate data maxOutputSize sizeHint = inflate data maxOutputSize :=
+/-- `inflateReference` with any `sizeHint` equals it with the default `0`. -/
+@[simp] theorem inflateReference_sizeHint_eq (data : ByteArray) (maxOutputSize sizeHint : Nat) :
+    inflateReference data maxOutputSize sizeHint = inflateReference data maxOutputSize :=
   rfl
 
 end Inflate

--- a/Zip/Native/InflateTreeFree.lean
+++ b/Zip/Native/InflateTreeFree.lean
@@ -1,27 +1,27 @@
 import Zip.Native.Inflate
 
 /-!
-# Tree-free canonical decode (conformance/benchmark prototype)
+# Tree-free canonical decode — the production DEFLATE decoder
 
-A DEFLATE Huffman decoder that builds **no** Huffman tree: the fast ≤9-bit codes
-go through the canonical 9-bit table (`buildTableCanonicalFast`), and the rare
->9-bit codes go through a canonical bit-by-bit decode keyed off the per-length
-`count` / `firstCode` / sorted-symbol arrays — never a tree walk. This isolates
-the *build-phase* win (skip `fromLengths`/`insertLoop`).
+This file defines the **production** decoders `Inflate.inflate` / `inflateRaw`: a
+DEFLATE Huffman decode that builds **no** Huffman tree. The fast ≤9-bit codes go
+through the canonical 9-bit table (`buildTableCanonicalFast`), and the rare >9-bit
+codes go through a canonical bit-by-bit decode keyed off the per-length
+`count` / `firstCode` / sorted-symbol arrays — never a tree walk. This skips the
+`fromLengths`/`insertLoop` build entirely (the ~7% decode win).
 
 The decode loops are well-founded (`termination_by`, mirroring the verified
 `goFusedP`/`goFusedPU`/`inflateLoop`); the canonical structures and their
 correctness are proven in `Zip.Spec.InflateTreeFreeCorrect`.
 
 `decodeDynamicLengthsOnly` runs the same `HuffTree.validateLengths`
-(`maxBits`/Kraft) check `decodeDynamicTrees` does, so the tree-free path's
-accept-set is **exactly** the verified `Inflate.inflate`'s — proven as the
-two-sided `inflateTreeFree_ok_iff` (`inflateTreeFree data = .ok out ↔
-inflate data = .ok out`) and `inflateRawTreeFree_ok_iff`. The production
-decompression entry points (gzip/zlib/raw-deflate/ZIP) decode through this
-tree-free path; the accept-set equality guarantees the `native ⊆ FFI`
-posture is preserved. `Inflate.inflate`/`inflateRaw` remain as the verified
-reference the tree-free decoder is proven equal to.
+(`maxBits`/Kraft) check `decodeDynamicTrees` does, so the production decoder's
+accept-set is **exactly** the verified reference's
+(`Inflate.inflateReference` / `inflateRawReference`, in `Zip.Native.Inflate`) —
+proven as the two-sided `inflate_ok_iff_reference`
+(`inflate data = .ok out ↔ inflateReference data = .ok out`) and
+`inflateRaw_ok_iff_reference`. Every decode-correctness theorem about the
+reference therefore transfers, and the `native ⊆ FFI` posture is preserved.
 -/
 
 namespace Zip.Native
@@ -366,25 +366,42 @@ def inflateLoopTreeFree (br : BitReader) (output : ByteArray) (maxOut dataSize :
   termination_by dataSize * 8 - br.bitPos
   decreasing_by all_goals omega
 
-/-- Tree-free `inflateRaw` (no Huffman tree built anywhere on the decode path):
-    the production fast-path counterpart of `Inflate.inflateRaw`, starting at byte
-    offset `startPos` and returning the byte-aligned position after the last block.
-    Builds no fixed Huffman trees (the tree-free loop reads `fixedLit/DistLengths`
-    directly). Proven accept-set equal to `Inflate.inflateRaw`
-    (`Zip.Spec.InflateTreeFreeCorrect.inflateRawTreeFree_ok_iff`). -/
-def inflateRawTreeFree (data : ByteArray) (startPos : Nat := 0)
-    (maxOut : Nat := 1024 * 1024 * 1024) (sizeHint : Nat := 0) :
+/-- Inflate a raw DEFLATE stream starting at byte offset `startPos`, returning the
+    decompressed data and the byte-aligned position after the last block. **This is
+    the production decoder**: a tree-free canonical Huffman decode that builds no
+    Huffman tree anywhere on the decode path (the loop reads `fixedLit/DistLengths`
+    directly and decodes through the canonical table + `walkCanonical` fallback).
+    Proven accept-set equal to the verified reference `inflateRawReference`
+    (`Zip.Spec.InflateTreeFreeCorrect.inflateRaw_ok_iff_reference`), so every downstream
+    correctness theorem transfers. `maxOutputSize` (default 1 GiB) caps output;
+    `sizeHint` pre-reserves capacity (computationally inert — see
+    `inflateRaw_sizeHint_eq`). -/
+def inflateRaw (data : ByteArray) (startPos : Nat := 0)
+    (maxOutputSize : Nat := 1024 * 1024 * 1024) (sizeHint : Nat := 0) :
     Except String (ByteArray × Nat) := do
   let br : BitReader := { data, pos := startPos, bitOff := 0 }
-  inflateLoopTreeFree br (ByteArray.emptyWithCapacity sizeHint) maxOut data.size
+  inflateLoopTreeFree br (ByteArray.emptyWithCapacity sizeHint) maxOutputSize data.size
 
-/-- Tree-free `inflate` (no Huffman tree built anywhere on the decode path).
-    Conformance-checked against `Inflate.inflate`. -/
-def inflateTreeFree (data : ByteArray) (maxOut : Nat := 1024 * 1024 * 1024) :
+/-- Inflate a raw DEFLATE stream (whole buffer). **The production decoder** — the
+    tree-free counterpart of the reference `inflateReference`, proven accept-set
+    equal to it (`Zip.Spec.InflateTreeFreeCorrect.inflate_ok_iff_reference`). -/
+def inflate (data : ByteArray) (maxOutputSize : Nat := 1024 * 1024 * 1024)
+    (sizeHint : Nat := 0) :
     Except String ByteArray := do
-  let br : BitReader := { data, pos := 0, bitOff := 0 }
-  let (output, _) ← inflateLoopTreeFree br ByteArray.empty maxOut data.size
+  let (output, _) ← inflateRaw data 0 maxOutputSize sizeHint
   return output
+
+/-- The output capacity hint is computationally inert (`ByteArray.emptyWithCapacity n`
+    reduces to `{ data := Array.empty }` for every `n`). -/
+@[simp] theorem inflateRaw_sizeHint_eq (data : ByteArray)
+    (startPos maxOutputSize sizeHint : Nat) :
+    inflateRaw data startPos maxOutputSize sizeHint = inflateRaw data startPos maxOutputSize :=
+  rfl
+
+/-- `inflate` with any `sizeHint` equals it with the default `0`. -/
+@[simp] theorem inflate_sizeHint_eq (data : ByteArray) (maxOutputSize sizeHint : Nat) :
+    inflate data maxOutputSize sizeHint = inflate data maxOutputSize :=
+  rfl
 
 end Inflate
 end Zip.Native

--- a/Zip/Spec/Deflate.lean
+++ b/Zip/Spec/Deflate.lean
@@ -16,7 +16,7 @@ The specification is structured in layers:
 4. **Stream decode**: sequence of blocks terminated by a final block
 
 The key correctness theorem `inflate_correct` (in `Zip.Spec.InflateCorrect`)
-proves that `Zip.Native.Inflate.inflate` agrees with this specification.
+proves that `Zip.Native.Inflate.inflateReference` agrees with this specification.
 -/
 
 namespace Deflate.Spec

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -587,7 +587,7 @@ theorem decode_deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (leve
     input, for any `maxOutputSize` large enough to hold it. -/
 theorem inflate_deflateDynamicBlocksSC (data : ByteArray) (chunkSize : Nat) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlocksSC data chunkSize level) maxOutputSize =
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksSC data chunkSize level) maxOutputSize =
       .ok data := by
   have hlen : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega
@@ -759,7 +759,7 @@ theorem decode_deflateDynamicBlocksShared (data : ByteArray) (tokChunk : Nat) (l
     input, for any `maxOutputSize` large enough to hold it. -/
 theorem inflate_deflateDynamicBlocksShared (data : ByteArray) (tokChunk : Nat) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlocksShared data tokChunk level) maxOutputSize =
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksShared data tokChunk level) maxOutputSize =
       .ok data := by
   have hlen : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega
@@ -1138,7 +1138,7 @@ theorem decode_deflateDynamicBlocksSharedAt (data : ByteArray)
 theorem inflate_deflateDynamicBlocksSharedAt (data : ByteArray)
     (choose : Array LZ77Token → List Nat) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlocksSharedAt data choose level) maxOutputSize =
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksSharedAt data choose level) maxOutputSize =
       .ok data := by
   have hlen : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega
@@ -1312,7 +1312,7 @@ theorem decode_deflateDynamicBlocksOptimal (data : ByteArray) (tokChunk : Nat) :
     recovers the input, for any `maxOutputSize` large enough to hold it. -/
 theorem inflate_deflateDynamicBlocksOptimal (data : ByteArray) (tokChunk : Nat)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlocksOptimal data tokChunk) maxOutputSize =
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlocksOptimal data tokChunk) maxOutputSize =
       .ok data := by
   have hlen : data.data.toList.length ≤ maxOutputSize := by
     simp only [Array.length_toList, ByteArray.size_data]; omega

--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -515,7 +515,7 @@ theorem inflate_deflateDynamicBlock (data : ByteArray) (tokens : Array LZ77Token
     (hempty : data.size = 0 → tokens = #[])
     (hresolve : Deflate.Spec.resolveLZ77 (tokensToSymbols tokens) [] = some data.data.toList)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamicBlock data tokens) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateDynamicBlock data tokens) maxOutputSize = .ok data := by
   have hspec := deflateDynamicBlock_spec data tokens htok_enc hempty
   match hspec with
   | ⟨litLens, distLens, headerBits, symBits, hv_lit, hv_dist,
@@ -557,7 +557,7 @@ theorem inflate_deflateDynamicBlock (data : ByteArray) (tokens : Array LZ77Token
     large enough to hold the input. -/
 theorem inflate_deflateDynamic (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateDynamic data) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateDynamic data) maxOutputSize = .ok data := by
   unfold deflateDynamic
   exact inflate_deflateDynamicBlock data (lz77GreedyIter data)
     (fun t ht => lz77Greedy_encodable data 32768 (by omega) (by omega) t

--- a/Zip/Spec/DeflateFixedCorrect.lean
+++ b/Zip/Spec/DeflateFixedCorrect.lean
@@ -335,12 +335,12 @@ theorem inflate_complete (bytes : ByteArray) (result : List UInt8)
     (maxOutputSize : Nat)
     (hsize : result.length ≤ maxOutputSize)
     (hdec : decode (bytesToBits bytes) = some result) :
-    Zip.Native.Inflate.inflate bytes maxOutputSize =
+    Zip.Native.Inflate.inflateReference bytes maxOutputSize =
     .ok ⟨⟨result⟩⟩ := by
   -- Unfold inflate: it calls inflateRaw then discards endPos
-  simp only [Inflate.inflate, bind, Except.bind]
+  simp only [Inflate.inflateReference, bind, Except.bind]
   -- Unfold inflateRaw
-  simp only [Inflate.inflateRaw, ByteArray.emptyWithCapacity_eq_empty, bind, Except.bind]
+  simp only [Inflate.inflateRawReference, ByteArray.emptyWithCapacity_eq_empty, bind, Except.bind]
   -- Build fixed Huffman trees (computationally verified to succeed)
   obtain ⟨fixedLit, hflit⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedLit_ok
   obtain ⟨fixedDist, hfdist⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedDist_ok
@@ -374,7 +374,7 @@ private theorem inflate_of_encodeFixed_spec (compressed data : ByteArray)
     (hspec : ∃ bits, Deflate.Spec.encodeFixed syms = some bits ∧
       Deflate.Spec.bytesToBits compressed = bits ++
         List.replicate ((8 - bits.length % 8) % 8) false) :
-    Zip.Native.Inflate.inflate compressed maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference compressed maxOutputSize = .ok data := by
   obtain ⟨bits_enc, henc_fixed, hbytes⟩ := hspec
   simp only [Deflate.Spec.encodeFixed] at henc_fixed
   cases henc_syms : Deflate.Spec.encodeSymbols Deflate.Spec.fixedLitLengths
@@ -401,7 +401,7 @@ private theorem inflate_of_encodeFixed_spec (compressed data : ByteArray)
     `maxOutputSize` large enough to hold the input. -/
 theorem inflate_deflateFixed (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateFixed data) maxOutputSize = .ok data :=
+    Zip.Native.Inflate.inflateReference (deflateFixed data) maxOutputSize = .ok data :=
   inflate_of_encodeFixed_spec (deflateFixed data) data
     (tokensToSymbols (lz77Greedy data)) maxOutputSize hsize
     (lz77Greedy_resolves data 32768 (by omega))
@@ -599,7 +599,7 @@ theorem lz77GreedyIter_eq_lz77Greedy (data : ByteArray) (ws : Nat) :
     Follows from `lz77GreedyIter_eq_lz77Greedy` + `inflate_deflateFixed`. -/
 theorem inflate_deflateFixedIter (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateFixedIter data) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateFixedIter data) maxOutputSize = .ok data := by
   unfold deflateFixedIter
   rw [lz77GreedyIter_eq_lz77Greedy]
   exact inflate_deflateFixed data maxOutputSize hsize
@@ -617,7 +617,7 @@ theorem inflate_deflateFixedBlock (data : ByteArray) (tokens : Array LZ77Token)
     (hempty : data.size = 0 → tokens = #[])
     (hresolve : resolveLZ77 (tokensToSymbols tokens) [] = some data.data.toList)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateFixedBlock data tokens) maxOutputSize = .ok data :=
+    Zip.Native.Inflate.inflateReference (deflateFixedBlock data tokens) maxOutputSize = .ok data :=
   inflate_of_encodeFixed_spec (deflateFixedBlock data tokens) data (tokensToSymbols tokens)
     maxOutputSize hsize hresolve (tokensToSymbols_validSymbolList _)
     (deflateFixedBlock_spec data tokens
@@ -663,7 +663,7 @@ theorem deflateLazy_spec (data : ByteArray) :
     `maxOutputSize` large enough to hold the input. -/
 theorem inflate_deflateLazy (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateLazy data) maxOutputSize = .ok data :=
+    Zip.Native.Inflate.inflateReference (deflateLazy data) maxOutputSize = .ok data :=
   inflate_of_encodeFixed_spec (deflateLazy data) data
     (tokensToSymbols (lz77Lazy data)) maxOutputSize hsize
     (lz77Lazy_resolves data 32768 (by omega))
@@ -824,7 +824,7 @@ theorem deflateLazyIter_eq_deflateLazy (data : ByteArray) :
     Follows from `deflateLazyIter_eq_deflateLazy` + `inflate_deflateLazy`. -/
 theorem inflate_deflateLazyIter (data : ByteArray)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateLazyIter data) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateLazyIter data) maxOutputSize = .ok data := by
   rw [deflateLazyIter_eq_deflateLazy]
   exact inflate_deflateLazy data maxOutputSize hsize
 

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -55,9 +55,9 @@ private theorem cRes (data : ByteArray) (level : UInt8) :
 set_option maxRecDepth 8000 in
 /-- `pickSmaller` of two byte arrays that both roundtrip also roundtrips. -/
 theorem inflate_pickSmaller (a b dataOut : ByteArray) (m : Nat)
-    (ha : Zip.Native.Inflate.inflate a m = .ok dataOut)
-    (hb : Zip.Native.Inflate.inflate b m = .ok dataOut) :
-    Zip.Native.Inflate.inflate (pickSmaller a b) m = .ok dataOut := by
+    (ha : Zip.Native.Inflate.inflateReference a m = .ok dataOut)
+    (hb : Zip.Native.Inflate.inflateReference b m = .ok dataOut) :
+    Zip.Native.Inflate.inflateReference (pickSmaller a b) m = .ok dataOut := by
   unfold pickSmaller; split <;> assumption
 
 /-- `pickSmaller` preserves any predicate on the bit stream both candidates meet. -/
@@ -70,7 +70,7 @@ theorem pickSmaller_bytesToBits {P : List Bool → Prop} (a b : ByteArray)
     `deflateRaw` cases without the stored-block fallback. -/
 theorem inflate_deflateCompressed (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateCompressed data level) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateCompressed data level) maxOutputSize = .ok data := by
   unfold deflateCompressed
   dsimp only []
   split
@@ -88,7 +88,7 @@ set_option maxRecDepth 8000 in
     elaborator to whnf the nested size comparison. -/
 theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateRawBase data level) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateRawBase data level) maxOutputSize = .ok data := by
   rw [← deflateRawBase_def]
   unfold deflateRawBaseTokens
   dsimp only []
@@ -111,7 +111,7 @@ theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
     block-split candidates are covered by the `pickSmaller` cases. -/
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
-    Zip.Native.Inflate.inflate (deflateRaw data level) maxOutputSize = .ok data := by
+    Zip.Native.Inflate.inflateReference (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
   dsimp only []
   rw [deflateRawBaseP_def, lzMatchP_map, deflateDynamicBlocksSharedSized_eq,

--- a/Zip/Spec/DeflateStoredCorrect.lean
+++ b/Zip/Spec/DeflateStoredCorrect.lean
@@ -751,8 +751,8 @@ theorem deflateStoredPure_size (data : ByteArray) :
 theorem inflate_deflateStoredPure (data : ByteArray)
     (maxOutputSize : Nat)
     (h : data.size ≤ maxOutputSize) :
-    Inflate.inflate (deflateStoredPure data) maxOutputSize = .ok data := by
-  simp only [Inflate.inflate, Inflate.inflateRaw, ByteArray.emptyWithCapacity_eq_empty,
+    Inflate.inflateReference (deflateStoredPure data) maxOutputSize = .ok data := by
+  simp only [Inflate.inflateReference, Inflate.inflateRawReference, ByteArray.emptyWithCapacity_eq_empty,
     bind, Except.bind]
   -- Handle fromLengths calls
   have ⟨fixedLit, hfl⟩ := fromLengths_fixedLit_ok

--- a/Zip/Spec/GzipCorrect.lean
+++ b/Zip/Spec/GzipCorrect.lean
@@ -37,7 +37,7 @@ def decompressSingle (data : ByteArray)
   unless flg == 0 do throw "Gzip: unsupported flags (single-member only)"
   -- Skip MTIME (4) + XFL (1) + OS (1) = 6 bytes at offset 4–9
   -- Inflate the DEFLATE stream starting at byte 10
-  let (decompressed, endPos) ← Inflate.inflateRaw data 10 maxOutputSize
+  let (decompressed, endPos) ← Inflate.inflateRawReference data 10 maxOutputSize
   -- Parse trailer at endPos: CRC32 (4 bytes LE) + ISIZE (4 bytes LE)
   if endPos + 8 > data.size then throw "Gzip: truncated trailer"
   let expectedCrc := Binary.readUInt32LE data endPos
@@ -143,12 +143,12 @@ theorem bytesToBits_drop_prefix_three (a b c : ByteArray) :
     `bytesToBits deflated`. -/
 theorem inflate_to_spec_decode (deflated : ByteArray) (result : ByteArray)
     (maxOutputSize : Nat)
-    (h : Inflate.inflate deflated maxOutputSize = .ok result) :
+    (h : Inflate.inflateReference deflated maxOutputSize = .ok result) :
     Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits deflated) [] =
       some result.data.toList := by
-  simp only [Inflate.inflate, bind, Except.bind] at h
-  cases hinf : Inflate.inflateRaw deflated 0 maxOutputSize with
+  simp only [Inflate.inflateReference, bind, Except.bind] at h
+  cases hinf : Inflate.inflateRawReference deflated 0 maxOutputSize with
   | error e => exact nomatch (hinf ▸ h)
   | ok p =>
     simp only [hinf, pure, Except.pure, Except.ok.injEq] at h
@@ -177,7 +177,7 @@ theorem inflateRaw_framing (data : ByteArray) (level : UInt8) (maxOutputSize : N
     (hspec_go : Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits (Deflate.deflateRaw data level)) [] =
       some data.data.toList) :
-    Inflate.inflateRaw (header ++ Deflate.deflateRaw data level ++ trailer) H maxOutputSize =
+    Inflate.inflateRawReference (header ++ Deflate.deflateRaw data level ++ trailer) H maxOutputSize =
       .ok (⟨⟨data.data.toList⟩⟩, H + (Deflate.deflateRaw data level).size) := by
   -- Spec decode on (header ++ deflated) at offset H, via prefix drop
   have hspec_hd : Deflate.Spec.decode.go
@@ -191,7 +191,7 @@ theorem inflateRaw_framing (data : ByteArray) (level : UInt8) (maxOutputSize : N
       data.data.toList hdata_le hspec_hd
   -- endPos' is exactly the size of (header ++ deflated)
   have hep_exact : endPos' = (header ++ Deflate.deflateRaw data level).size := by
-    have h' : Inflate.inflateRaw (header ++ Deflate.deflateRaw data level)
+    have h' : Inflate.inflateRawReference (header ++ Deflate.deflateRaw data level)
         header.size maxOutputSize = .ok (⟨⟨data.data.toList⟩⟩, endPos') := by
       rw [hhsz]; exact hinflRaw'
     exact inflateRaw_endPos_eq header (Deflate.deflateRaw data level) _ _ _ h'
@@ -211,7 +211,7 @@ theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     GzipDecode.decompressSingle (GzipEncode.compress data level) maxOutputSize = .ok data := by
   -- DEFLATE roundtrip: inflate ∘ deflateRaw = id
-  have hinfl : Inflate.inflate (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
+  have hinfl : Inflate.inflateReference (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
     Deflate.inflate_deflateRaw data level _ hsize
   -- Spec decode on deflated
   have hspec_go : Deflate.Spec.decode.go
@@ -226,7 +226,7 @@ theorem gzip_decompressSingle_compress (data : ByteArray) (level : UInt8)
     rw [GzipEncode.compress_size]; omega
   -- Native inflate at offset 10 consumes exactly the DEFLATE stream (framing lemma)
   obtain ⟨header, trailer, hhsz, _, hceq⟩ := GzipEncode.compress_eq data level
-  have hinflRaw : Inflate.inflateRaw (GzipEncode.compress data level) 10 maxOutputSize =
+  have hinflRaw : Inflate.inflateRawReference (GzipEncode.compress data level) 10 maxOutputSize =
       .ok (⟨⟨data.data.toList⟩⟩, 10 + (Deflate.deflateRaw data level).size) := by
     rw [hceq]
     exact inflateRaw_framing data level maxOutputSize header trailer 10 hhsz hdata_le hspec_go

--- a/Zip/Spec/InflateBufCorrect.lean
+++ b/Zip/Spec/InflateBufCorrect.lean
@@ -2019,11 +2019,11 @@ theorem inflateLoopBuf_eq (fixedLit fixedDist : HuffTree) (maxOut dataSize : Nat
           simp only [hhf]; exact tail o' br' hp' hl' (by rw [hd', hd3]; exact hdata₂)
     · simp only [bind, Except.bind]
 
-/-- **`InflateBuf.inflate` equals the verified `Inflate.inflate`.** The wide-buffer
+/-- **`InflateBuf.inflate` equals the verified `Inflate.inflateReference`.** The wide-buffer
     decoder is a drop-in replacement with no trust gap. -/
 theorem inflate_eq (data : ByteArray) (maxOut : Nat) (sizeHint : Nat := 0) :
-    InflateBuf.inflate data maxOut sizeHint = Inflate.inflate data maxOut sizeHint := by
-  unfold InflateBuf.inflate Inflate.inflate Inflate.inflateRaw
+    InflateBuf.inflate data maxOut sizeHint = Inflate.inflateReference data maxOut sizeHint := by
+  unfold InflateBuf.inflate Inflate.inflateReference Inflate.inflateRawReference
   cases hfl : HuffTree.fromLengths Inflate.fixedLitLengths with
   | error e => simp only [hfl, bind, Except.bind]
   | ok fixedLit =>

--- a/Zip/Spec/InflateBufRoundtrip.lean
+++ b/Zip/Spec/InflateBufRoundtrip.lean
@@ -6,7 +6,7 @@ import Zip.Spec.DeflateFixedCorrect
 
 `InflateBuf.inflate` (the wide-buffer DEFLATE decompressor) inverts the native
 fixed-Huffman compressor `deflateFixed`, by transferring `Inflate`'s roundtrip
-theorem across the proven equality `InflateBuf.inflate = Inflate.inflate`.
+theorem across the proven equality `InflateBuf.inflate = Inflate.inflateReference`.
 -/
 
 namespace Zip.Native.InflateBuf

--- a/Zip/Spec/InflateCorrect.lean
+++ b/Zip/Spec/InflateCorrect.lean
@@ -6,7 +6,7 @@ import Zip.Spec.InflateBufCorrect
 # DEFLATE Stream-Level Correctness
 
 Proves the main correctness theorem: the native pure-Lean DEFLATE
-decompressor (`Zip.Native.Inflate.inflateRaw`) agrees with the formal
+decompressor (`Zip.Native.Inflate.inflateRawReference`) agrees with the formal
 bitstream specification (`Deflate.Spec.decode`).
 
 This file handles the block loop (`inflateLoop_correct`) and the
@@ -659,13 +659,13 @@ theorem inflateLoop_correct (br : ZipCommon.BitReader)
     the formal specification also succeeds and produces the same output. -/
 theorem inflate_correct (data : ByteArray) (startPos maxOutputSize : Nat)
     (result : ByteArray) (endPos : Nat)
-    (h : Zip.Native.Inflate.inflateRaw data startPos maxOutputSize =
+    (h : Zip.Native.Inflate.inflateRawReference data startPos maxOutputSize =
       .ok (result, endPos)) :
     Deflate.Spec.decode
       ((Deflate.Spec.bytesToBits data).drop (startPos * 8)) =
       some result.data.toList := by
   -- Unfold inflateRaw
-  simp only [Zip.Native.Inflate.inflateRaw, bind, Except.bind] at h
+  simp only [Zip.Native.Inflate.inflateRawReference, bind, Except.bind] at h
   -- Build fixed trees
   cases hflit : Zip.Native.HuffTree.fromLengths
       Zip.Native.Inflate.fixedLitLengths with
@@ -692,11 +692,11 @@ theorem inflate_correct (data : ByteArray) (startPos maxOutputSize : Nat)
     the spec `decode` applied to the full bitstream. -/
 theorem inflate_correct' (data : ByteArray) (maxOutputSize : Nat)
     (result : ByteArray)
-    (h : Zip.Native.Inflate.inflate data maxOutputSize = .ok result) :
+    (h : Zip.Native.Inflate.inflateReference data maxOutputSize = .ok result) :
     Deflate.Spec.decode (Deflate.Spec.bytesToBits data) =
       some result.data.toList := by
-  simp only [Zip.Native.Inflate.inflate, bind, Except.bind] at h
-  cases hinf : Zip.Native.Inflate.inflateRaw data 0 maxOutputSize with
+  simp only [Zip.Native.Inflate.inflateReference, bind, Except.bind] at h
+  cases hinf : Zip.Native.Inflate.inflateRawReference data 0 maxOutputSize with
   | error e => exact nomatch (hinf ▸ h)
   | ok p =>
     simp only [hinf, pure, Except.pure, Except.ok.injEq] at h

--- a/Zip/Spec/InflateLoopBounds.lean
+++ b/Zip/Spec/InflateLoopBounds.lean
@@ -416,9 +416,9 @@ theorem inflateLoop_complete_ext (br : BitReader) (output : ByteArray)
 /-- After a successful `inflateRaw`, the returned endPos ≤ data.size. -/
 theorem inflateRaw_endPos_le (data : ByteArray) (startPos maxOut : Nat)
     (result : ByteArray) (endPos : Nat)
-    (h : Inflate.inflateRaw data startPos maxOut = .ok (result, endPos)) :
+    (h : Inflate.inflateRawReference data startPos maxOut = .ok (result, endPos)) :
     endPos ≤ data.size := by
-  simp only [Inflate.inflateRaw, bind, Except.bind] at h
+  simp only [Inflate.inflateRawReference, bind, Except.bind] at h
   cases hflit : HuffTree.fromLengths Inflate.fixedLitLengths with
   | error e => simp only [hflit] at h; exact nomatch h
   | ok fixedLit =>
@@ -481,7 +481,7 @@ private theorem alignToByte_pos_ge_of_toBits_short (br : BitReader)
     endPos = `(prefix ++ deflated).size` exactly. -/
 theorem inflateRaw_endPos_ge (pfx deflated : ByteArray)
     (maxOut : Nat) (result : ByteArray) (endPos : Nat)
-    (h : Inflate.inflateRaw (pfx ++ deflated) pfx.size maxOut =
+    (h : Inflate.inflateRawReference (pfx ++ deflated) pfx.size maxOut =
       .ok (result, endPos))
     (hspec : Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits deflated) [] =
@@ -493,7 +493,7 @@ theorem inflateRaw_endPos_ge (pfx deflated : ByteArray)
     (hmax : result.data.toList.length ≤ maxOut) :
     endPos ≥ (pfx ++ deflated).size := by
   obtain ⟨pad_remaining, hgoR_pad, hpadlen⟩ := hpad
-  simp only [Inflate.inflateRaw, bind, Except.bind] at h
+  simp only [Inflate.inflateRawReference, bind, Except.bind] at h
   cases hflit : HuffTree.fromLengths Inflate.fixedLitLengths with
   | error e => simp only [hflit] at h; exact nomatch h
   | ok fixedLit =>
@@ -541,7 +541,7 @@ theorem inflateRaw_endPos_ge (pfx deflated : ByteArray)
 /-- endPos exactness: combining ≤ and ≥ gives equality. -/
 theorem inflateRaw_endPos_eq (pfx deflated : ByteArray)
     (maxOut : Nat) (result : ByteArray) (endPos : Nat)
-    (h : Inflate.inflateRaw (pfx ++ deflated) pfx.size maxOut =
+    (h : Inflate.inflateRawReference (pfx ++ deflated) pfx.size maxOut =
       .ok (result, endPos))
     (hspec : Deflate.Spec.decode.go
       (Deflate.Spec.bytesToBits deflated) [] =
@@ -568,9 +568,9 @@ theorem inflateRaw_complete (data : ByteArray) (startPos maxOutputSize : Nat)
         ((Deflate.Spec.bytesToBits data).drop (startPos * 8)) [] =
         some result) :
     ∃ endPos,
-      Inflate.inflateRaw data startPos maxOutputSize =
+      Inflate.inflateRawReference data startPos maxOutputSize =
         .ok (⟨⟨result⟩⟩, endPos) := by
-  simp only [Inflate.inflateRaw, bind, Except.bind]
+  simp only [Inflate.inflateRawReference, bind, Except.bind]
   obtain ⟨fixedLit, hflit⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedLit_ok
   obtain ⟨fixedDist, hfdist⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedDist_ok
   rw [hflit, hfdist]

--- a/Zip/Spec/InflateRawSuffix.lean
+++ b/Zip/Spec/InflateRawSuffix.lean
@@ -577,9 +577,9 @@ private theorem inflateLoop_append_suffix (br : BitReader) (suffix : ByteArray)
     succeeds on data ++ suffix with the same result and endPos. -/
 theorem inflateRaw_append_suffix (data suffix : ByteArray) (startPos maxOut : Nat)
     (result : ByteArray) (endPos : Nat)
-    (h : Inflate.inflateRaw data startPos maxOut = .ok (result, endPos)) :
-    Inflate.inflateRaw (data ++ suffix) startPos maxOut = .ok (result, endPos) := by
-  simp only [Inflate.inflateRaw, bind, Except.bind] at h ⊢
+    (h : Inflate.inflateRawReference data startPos maxOut = .ok (result, endPos)) :
+    Inflate.inflateRawReference (data ++ suffix) startPos maxOut = .ok (result, endPos) := by
+  simp only [Inflate.inflateRawReference, bind, Except.bind] at h ⊢
   cases hflit : HuffTree.fromLengths Inflate.fixedLitLengths with
   | error e => simp only [hflit] at h; exact nomatch h
   | ok fixedLit =>

--- a/Zip/Spec/InflateTreeFreeCorrect.lean
+++ b/Zip/Spec/InflateTreeFreeCorrect.lean
@@ -6,14 +6,15 @@ import Zip.Native.InflateTreeFree
 /-!
 # Tree-free canonical decode: correctness
 
-Proves that the tree-free canonical decoder (`Zip.Native.InflateTreeFree`) has
-**exactly the same accept-set** as the verified `Inflate.inflate`, producing
+Proves that the production tree-free decoder (`Inflate.inflate` / `inflateRaw`,
+defined in `Zip.Native.InflateTreeFree`) has **exactly the same accept-set** as the
+verified reference (`Inflate.inflateReference` / `inflateRawReference`), producing
 identical output, with the tree (`fromLengthsTree lengths`) as a **proof-only**
 object — never built at runtime. The top-level statements are the two-sided
-`inflateTreeFree_ok_iff` (`inflateTreeFree data = .ok out ↔ inflate data = .ok
-out`) and `inflateRawTreeFree_ok_iff`, built from the forward direction
-(`inflateTreeFree_of_inflate`, present since #2681) and the backward direction
-(`inflate_of_inflateTreeFree`) the closed code-length validation gap enables:
+`inflate_ok_iff_reference` (`inflate data = .ok out ↔ inflateReference data = .ok
+out`) and `inflateRaw_ok_iff_reference`, built from the forward direction
+(`inflate_of_inflateReference`, present since #2681) and the backward direction
+(`inflateReference_of_inflate`) the closed code-length validation gap enables:
 `decodeDynamicLengthsOnly` now runs the same `validateLengths` (`maxBits`/Kraft)
 check `decodeDynamicTrees` does, so on malformed dynamic length sets both paths
 reject. The chain, bottom-up:
@@ -1872,17 +1873,48 @@ theorem inflateLoopTreeFree_ok_iff (data : ByteArray)
   ⟨inflateLoop_of_inflateLoopTreeFree data hflv hflb hfdv hfdb maxOut br output hpos hple hds r,
    inflateLoopTreeFree_of_inflateLoop data hflv hflb hfdv hfdb maxOut br output hpos hple hds r⟩
 
+/-- The fixed lit/dist code lengths are valid (the `fromLengths` of the fixed
+    tables always succeeds), packaged for the bridge lemmas below. -/
+private theorem fixedLitLengths_valid' :
+    Huffman.Spec.ValidLengths (fixedLitLengths.toList.map UInt8.toNat) 15 := by
+  obtain ⟨fixedLit, hfl⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedLit_ok
+  exact Deflate.Correctness.fromLengths_valid fixedLitLengths 15 fixedLit hfl
+
+private theorem fixedDistLengths_valid' :
+    Huffman.Spec.ValidLengths (fixedDistLengths.toList.map UInt8.toNat) 15 := by
+  obtain ⟨fixedDist, hfd⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedDist_ok
+  exact Deflate.Correctness.fromLengths_valid fixedDistLengths 15 fixedDist hfd
+
+/-- The verified reference `inflateRawReference` is the fixed-tree-built block loop
+    (the `fromLengths` of the fixed code lengths always succeeds, yielding the
+    canonical trees). The concrete `fromLengthsTree` term stays opaque. -/
+theorem inflateRawReference_eq_loop (data : ByteArray) (sp mo sh : Nat) :
+    Inflate.inflateRawReference data sp mo sh
+      = Inflate.inflateLoop { data, pos := sp, bitOff := 0 } (ByteArray.emptyWithCapacity sh)
+          (HuffTree.fromLengthsTree fixedLitLengths 15) (HuffTree.fromLengthsTree fixedDistLengths 15)
+          mo data.size := by
+  rw [Inflate.inflateRawReference,
+      HuffTree.fromLengths_ok_of_valid fixedLitLengths 15 fixedLitLengths_valid',
+      HuffTree.fromLengths_ok_of_valid fixedDistLengths 15 fixedDistLengths_valid']
+  rfl
+
+/-- The production `inflateRaw` is the tree-free block loop. -/
+theorem inflateRaw_eq_loop (data : ByteArray) (sp mo sh : Nat) :
+    Inflate.inflateRaw data sp mo sh
+      = Inflate.inflateLoopTreeFree { data, pos := sp, bitOff := 0 }
+          (ByteArray.emptyWithCapacity sh) mo data.size := rfl
+
 set_option maxRecDepth 4096 in
-/-- **Top-level forward correctness.** Whenever the verified `Inflate.inflate`
-    succeeds, the tree-free `Inflate.inflateTreeFree` produces the same bytes — so
+/-- **Top-level forward correctness.** Whenever the verified `Inflate.inflateReference`
+    succeeds, the tree-free `Inflate.inflate` produces the same bytes — so
     the tree-free decoder (which never builds a Huffman tree at runtime) is a
     correct drop-in for the trusted decoder on every successful decode. The fixed
     Huffman trees exist only in the proof; `fromLengths fixedLitLengths` succeeding
     inside `inflateRaw` supplies their validity. -/
-theorem inflateTreeFree_of_inflate (data : ByteArray) (maxOut sizeHint : Nat) {out : ByteArray}
-    (h : Inflate.inflate data maxOut sizeHint = .ok out) :
-    Inflate.inflateTreeFree data maxOut = .ok out := by
-  rw [Inflate.inflate, Inflate.inflateRaw] at h
+theorem inflate_of_inflateReference (data : ByteArray) (maxOut sizeHint : Nat) {out : ByteArray}
+    (h : Inflate.inflateReference data maxOut sizeHint = .ok out) :
+    Inflate.inflate data maxOut = .ok out := by
+  rw [Inflate.inflateReference, Inflate.inflateRawReference] at h
   simp only [bind, Except.bind] at h
   obtain ⟨pr, hraw, hret⟩ := bindOk h; obtain ⟨output, restPos⟩ := pr
   simp only [pure, Except.pure, Except.ok.injEq] at hret; subst hret
@@ -1899,49 +1931,24 @@ theorem inflateTreeFree_of_inflate (data : ByteArray) (maxOut sizeHint : Nat) {o
   have hbody := inflateLoopTreeFree_of_inflateLoop data hflv (by decide) hfdv (by decide) maxOut
     { data, pos := 0, bitOff := 0 } ByteArray.empty (Or.inl rfl) (Nat.zero_le _) rfl
     (output, restPos) (by rw [hfleq, hfdeq] at hloop; exact hloop)
-  rw [Inflate.inflateTreeFree]
-  simp only [hbody, bind, Except.bind, pure, Except.pure]
-
-/-- The fixed lit/dist code lengths are valid (the `fromLengths` of the fixed
-    tables always succeeds), packaged for the bridge lemmas below. -/
-private theorem fixedLitLengths_valid' :
-    Huffman.Spec.ValidLengths (fixedLitLengths.toList.map UInt8.toNat) 15 := by
-  obtain ⟨fixedLit, hfl⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedLit_ok
-  exact Deflate.Correctness.fromLengths_valid fixedLitLengths 15 fixedLit hfl
-
-private theorem fixedDistLengths_valid' :
-    Huffman.Spec.ValidLengths (fixedDistLengths.toList.map UInt8.toNat) 15 := by
-  obtain ⟨fixedDist, hfd⟩ := Zip.Spec.DeflateStoredCorrect.fromLengths_fixedDist_ok
-  exact Deflate.Correctness.fromLengths_valid fixedDistLengths 15 fixedDist hfd
-
-/-- `inflateRaw` is the fixed-tree-built block loop (the `fromLengths` of the fixed
-    code lengths always succeeds, yielding the canonical trees). The concrete
-    `fromLengthsTree` term stays opaque — never kernel-evaluated. -/
-theorem inflateRaw_eq_loop (data : ByteArray) (sp mo sh : Nat) :
-    Inflate.inflateRaw data sp mo sh
-      = Inflate.inflateLoop { data, pos := sp, bitOff := 0 } (ByteArray.emptyWithCapacity sh)
-          (HuffTree.fromLengthsTree fixedLitLengths 15) (HuffTree.fromLengthsTree fixedDistLengths 15)
-          mo data.size := by
-  rw [Inflate.inflateRaw,
-      HuffTree.fromLengths_ok_of_valid fixedLitLengths 15 fixedLitLengths_valid',
-      HuffTree.fromLengths_ok_of_valid fixedDistLengths 15 fixedDistLengths_valid']
-  rfl
-
-/-- `inflateRawTreeFree` is the tree-free block loop. -/
-theorem inflateRawTreeFree_eq_loop (data : ByteArray) (sp mo sh : Nat) :
-    Inflate.inflateRawTreeFree data sp mo sh
-      = Inflate.inflateLoopTreeFree { data, pos := sp, bitOff := 0 }
-          (ByteArray.emptyWithCapacity sh) mo data.size := rfl
+  -- fold the tree-free loop result back through the production `inflateRaw`
+  have hrawp : Inflate.inflateRaw data 0 maxOut 0 = .ok (output, restPos) := by
+    rw [inflateRaw_eq_loop,
+        show ByteArray.emptyWithCapacity 0 = ByteArray.empty from by
+          simp [ByteArray.emptyWithCapacity, ByteArray.empty]]
+    exact hbody
+  rw [Inflate.inflate]
+  simp only [hrawp, bind, Except.bind, pure, Except.pure]
 
 set_option maxRecDepth 4096 in
 /-- **Top-level backward correctness.** Whenever the tree-free decoder succeeds,
-    the verified `Inflate.inflate` succeeds with the same bytes. With the validation
-    gap closed this is the converse of `inflateTreeFree_of_inflate`, so the two
+    the verified `Inflate.inflateReference` succeeds with the same bytes. With the validation
+    gap closed this is the converse of `inflate_of_inflateReference`, so the two
     decoders accept exactly the same inputs (`native ⊆ FFI` is preserved). -/
-theorem inflate_of_inflateTreeFree (data : ByteArray) (maxOut : Nat) {out : ByteArray}
-    (h : Inflate.inflateTreeFree data maxOut = .ok out) :
-    Inflate.inflate data maxOut = .ok out := by
-  rw [Inflate.inflateTreeFree] at h
+theorem inflateReference_of_inflate (data : ByteArray) (maxOut : Nat) {out : ByteArray}
+    (h : Inflate.inflate data maxOut = .ok out) :
+    Inflate.inflateReference data maxOut = .ok out := by
+  rw [Inflate.inflate] at h
   simp only [bind, Except.bind] at h
   obtain ⟨pr, hloop, hret⟩ := bindOk h; obtain ⟨output, restPos⟩ := pr
   simp only [pure, Except.pure, Except.ok.injEq] at hret; subst hret
@@ -1951,31 +1958,31 @@ theorem inflate_of_inflateTreeFree (data : ByteArray) (maxOut : Nat) {out : Byte
     (output, restPos) hloop
   -- fold the verified-decoder result back through `inflateRaw` without evaluating
   -- the concrete fixed `fromLengthsTree` (kept opaque via `exact hbody`)
-  have hraw : Inflate.inflateRaw data 0 maxOut 0 = .ok (output, restPos) := by
-    rw [inflateRaw_eq_loop,
+  have hraw : Inflate.inflateRawReference data 0 maxOut 0 = .ok (output, restPos) := by
+    rw [inflateRawReference_eq_loop,
         show ByteArray.emptyWithCapacity 0 = ByteArray.empty from by
           simp [ByteArray.emptyWithCapacity, ByteArray.empty]]
     exact hbody
-  rw [Inflate.inflate]
+  rw [Inflate.inflateReference]
   simp only [hraw, bind, Except.bind, pure, Except.pure]
 
 /-- **Top-level accept-set equality.** `inflateTreeFree` and `inflate` succeed on
     exactly the same inputs with the same output. This is the bridge the production
     switch rides on: any theorem about `inflate`'s success set transfers to the
     tree-free decoder, and `native ⊆ FFI` is preserved. -/
-theorem inflateTreeFree_ok_iff (data : ByteArray) (maxOut : Nat) (out : ByteArray) :
-    Inflate.inflateTreeFree data maxOut = .ok out ↔ Inflate.inflate data maxOut = .ok out :=
-  ⟨inflate_of_inflateTreeFree data maxOut,
-   fun h => inflateTreeFree_of_inflate data maxOut 0 h⟩
+theorem inflate_ok_iff_reference (data : ByteArray) (maxOut : Nat) (out : ByteArray) :
+    Inflate.inflate data maxOut = .ok out ↔ Inflate.inflateReference data maxOut = .ok out :=
+  ⟨inflateReference_of_inflate data maxOut,
+   fun h => inflate_of_inflateReference data maxOut 0 h⟩
 
 set_option maxRecDepth 4096 in
 /-- **`inflateRaw` accept-set equality.** For an in-bounds start position the
     tree-free `inflateRawTreeFree` and verified `inflateRaw` succeed on exactly the
     same inputs with the same output and end position. -/
-theorem inflateRawTreeFree_ok_iff (data : ByteArray) (sp mo sh : Nat)
+theorem inflateRaw_ok_iff_reference (data : ByteArray) (sp mo sh : Nat)
     (hle : sp ≤ data.size) (p : ByteArray × Nat) :
-    Inflate.inflateRawTreeFree data sp mo sh = .ok p ↔ Inflate.inflateRaw data sp mo sh = .ok p := by
-  rw [inflateRaw_eq_loop, inflateRawTreeFree_eq_loop]
+    Inflate.inflateRaw data sp mo sh = .ok p ↔ Inflate.inflateRawReference data sp mo sh = .ok p := by
+  rw [inflateRaw_eq_loop, inflateRawReference_eq_loop]
   exact inflateLoopTreeFree_ok_iff data fixedLitLengths_valid' (by decide)
     fixedDistLengths_valid' (by decide) mo
     { data, pos := sp, bitOff := 0 } (ByteArray.emptyWithCapacity sh) (Or.inl rfl) hle rfl p

--- a/Zip/Spec/ZlibCorrect.lean
+++ b/Zip/Spec/ZlibCorrect.lean
@@ -33,7 +33,7 @@ def decompressSingle (data : ByteArray)
   unless cmf &&& 0x0F == 8 do throw "Zlib: unsupported compression method"
   unless cmf >>> 4 ≤ 7 do throw "Zlib: invalid window size"
   unless flg &&& 0x20 == 0 do throw "Zlib: preset dictionaries not supported"
-  let (decompressed, endPos) ← Inflate.inflateRaw data 2 maxOutputSize
+  let (decompressed, endPos) ← Inflate.inflateRawReference data 2 maxOutputSize
   if endPos + 4 > data.size then throw "Zlib: truncated trailer"
   let b0 := data[endPos]!.toUInt32
   let b1 := data[endPos + 1]!.toUInt32
@@ -148,7 +148,7 @@ theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     ZlibDecode.decompressSingle (ZlibEncode.compress data level) maxOutputSize = .ok data := by
   -- DEFLATE roundtrip: inflate ∘ deflateRaw = id
-  have hinfl : Inflate.inflate (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
+  have hinfl : Inflate.inflateReference (Deflate.deflateRaw data level) maxOutputSize = .ok data :=
     Deflate.inflate_deflateRaw data level _ hsize
   -- Spec decode on deflated
   have hspec_go : Deflate.Spec.decode.go
@@ -163,7 +163,7 @@ theorem zlib_decompressSingle_compress (data : ByteArray) (level : UInt8)
     rw [ZlibEncode.compress_size]; omega
   -- Native inflate at offset 2 consumes exactly the DEFLATE stream (framing lemma)
   obtain ⟨header, trailer, hhsz, _, hceq⟩ := ZlibEncode.compress_eq data level
-  have hinflRaw : Inflate.inflateRaw (ZlibEncode.compress data level) 2 maxOutputSize =
+  have hinflRaw : Inflate.inflateRawReference (ZlibEncode.compress data level) 2 maxOutputSize =
       .ok (⟨⟨data.data.toList⟩⟩, 2 + (Deflate.deflateRaw data level).size) := by
     rw [hceq]
     exact inflateRaw_framing data level maxOutputSize header trailer 2 hhsz hdata_le hspec_go

--- a/ZipBenchReport.lean
+++ b/ZipBenchReport.lean
@@ -179,9 +179,8 @@ def nativeCompress (data : ByteArray) (level : Nat) : IO ByteArray :=
   pure (Zip.Native.Deflate.deflateRaw data level.toUInt8)
 
 def nativeDecompress (data : ByteArray) (origSize : Nat) : IO ByteArray :=
-  -- Measure the shipped production decode path (tree-free), with the same
-  -- output presizing as the production callers.
-  match (Zip.Native.Inflate.inflateRawTreeFree data (sizeHint := origSize)).map Prod.fst with
+  -- `Inflate.inflate` is the shipped production decode path (tree-free).
+  match Zip.Native.Inflate.inflate data (sizeHint := origSize) with
   | .ok b => pure b
   | .error e => throw (IO.userError e)
 
@@ -328,11 +327,11 @@ def runZopfliCeiling (outPath : String) : IO Unit := do
   IO.eprintln s!"Wrote {rows.length} zopfli rows → {outPath}"
 
 /-- Decode `ref`, optionally pre-sizing the output to `hint` (`0` = no hint).
-    Measures the shipped production decode path (tree-free).
+    `Inflate.inflate` is the shipped production decode path (tree-free).
     `@[noinline]` keeps the pure decode call from being hoisted out of the
     timed loop (it is otherwise loop-invariant), so each timed call really decodes. -/
 @[noinline] def decodeForAB (ref : ByteArray) (hint : Nat) : IO Nat := do
-  match (Zip.Native.Inflate.inflateRawTreeFree ref (sizeHint := hint)).map Prod.fst with
+  match Zip.Native.Inflate.inflate ref (sizeHint := hint) with
   | .ok b => sink b
   | .error e => throw (IO.userError e)
 

--- a/ZipTest/FuzzInflate.lean
+++ b/ZipTest/FuzzInflate.lean
@@ -223,8 +223,8 @@ private def oneIteration (state : UInt64) : IO UInt64 := do
   tryFFI "Gzip.decompress" (Gzip.decompress input defaultMaxOutput.toUInt64)
   tryFFI "RawDeflate.decompress" (RawDeflate.decompress input defaultMaxOutput.toUInt64)
   -- Whole-buffer native paths.
-  tryNative "Zip.Native.Inflate.inflateTreeFree"
-    (Zip.Native.Inflate.inflateTreeFree input defaultMaxOutput)
+  tryNative "Zip.Native.Inflate.inflate"
+    (Zip.Native.Inflate.inflate input defaultMaxOutput)
   tryNative "Zip.Native.GzipDecode.decompress"
     (Zip.Native.GzipDecode.decompress input defaultMaxOutput)
   tryNative "Zip.Native.ZlibDecode.decompress"
@@ -424,7 +424,7 @@ private def oneDiffIter (state : UInt64) (c : Census) : IO (UInt64 × Census) :=
     return (s1, { c with skipped := c.skipped + 1 })
   -- The base stream is the verified encoder's output, so it must
   -- round-trip through both decoders — assert it as extra conformance.
-  match Zip.Native.Inflate.inflateTreeFree stream defaultMaxOutput with
+  match Zip.Native.Inflate.inflate stream defaultMaxOutput with
   | .error e => throw (IO.userError s!"[diff-fuzz] base native inflate failed: {e}")
   | .ok r =>
     unless r == payload do
@@ -440,7 +440,7 @@ private def oneDiffIter (state : UInt64) (c : Census) : IO (UInt64 × Census) :=
     return (s2, { c with skipped := c.skipped + 1 })
   let bitIdx := 3 + s2.toNat % (span - 3)
   let mutated := flipBit stream bitIdx
-  let nativeRes := Zip.Native.Inflate.inflateTreeFree mutated defaultMaxOutput
+  let nativeRes := Zip.Native.Inflate.inflate mutated defaultMaxOutput
   let ffiRes ← ffiVerdict mutated
   let c := { c with mutated := c.mutated + 1 }
   match nativeRes, ffiRes with
@@ -562,7 +562,7 @@ private def oneTruncIter (state : UInt64) (c : DecodeCensus) :
     return (s3, c)
   let cut := s3.toNat % stream.size
   let truncated := stream.extract 0 cut
-  let native := Zip.Native.Inflate.inflateTreeFree truncated defaultMaxOutput
+  let native := Zip.Native.Inflate.inflate truncated defaultMaxOutput
   let ffi ← ffiVerdict truncated
   let c ← foldVerdict "trunc-deflate" native ffi c
   return (s3, c)
@@ -620,7 +620,7 @@ private def oneRandomIter (state : UInt64) (c : DecodeCensus) :
   let s0 := xorshift64 state
   let size := pick decodeSizeClasses s0
   let (data, s1) := genBytes s0 size
-  let native := Zip.Native.Inflate.inflateTreeFree data defaultMaxOutput
+  let native := Zip.Native.Inflate.inflate data defaultMaxOutput
   let ffi ← ffiVerdict data
   let c ← foldVerdict "random-deflate" native ffi c
   return (s1, c)


### PR DESCRIPTION
This PR makes `Inflate.inflate` / `Inflate.inflateRaw` *themselves* the tree-free production decoder (the literal API form Kim asked for as a follow-up to #2683), rather than routing each caller onto a separately-named tree-free entry point. Stacked on `issue-2682` (#2683); when that merges this rebases onto master.

The tree-free canonical decoder takes over the canonical names (defined in `Zip.Native.InflateTreeFree`), and the old tree-building implementation is kept — renamed — as the verified reference `Inflate.inflateReference` / `inflateRawReference` (`inflateLoop` and its theorems are untouched, still the reference loop). Because the canonical names now resolve to the tree-free path, every direct user, benchmark, and test of `Inflate.inflate` gets the decode win with no per-caller switch, so this reverts #2683's caller-by-caller routing (gzip/zlib/ZIP/`decompressAuto` go back to plain `inflate`/`inflateRaw`).

The verified spec tree is restated about the reference via a mechanical `Inflate.inflate`/`inflateRaw` → `inflateReference`/`inflateRawReference` rename across the proof files — each file stays self-contained, so there are no new cross-imports and no import-DAG cycles (the equivalence bridge sits at the top of the DAG and would otherwise be unusable by the early roundtrip-proof files). `Zip.Spec.InflateTreeFreeCorrect` proves the standalone bridge `inflate_ok_iff_reference` (`inflate data = .ok out ↔ inflateReference data = .ok out`) and `inflateRaw_ok_iff_reference`, so every decode-correctness / completeness / roundtrip theorem about the reference transfers to the production decoder, and the `native ⊆ FFI` posture is preserved.

`nix-shell --run "lake build && lake exe test"` green; no `sorry`; the FuzzInflate native census (now exercising the tree-free `Inflate.inflate` directly) is unchanged — native-accept/FFI-reject 1, zero silent corruption. Decode throughput is byte-for-byte the same tree-free loop as #2683 (only renamed), so the ~7% win and the dashboard refresh carry over unchanged; no separate perf graphs needed.

🤖 Prepared with Claude Code